### PR TITLE
Require website inquiry contact fields

### DIFF
--- a/infra/cloudflare_worker/sanitize.test.mjs
+++ b/infra/cloudflare_worker/sanitize.test.mjs
@@ -6,9 +6,18 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { sanitize } from "./worker.js";
+import { sanitize, missingContact } from "./worker.js";
 
-const BASE = { event_date: "2026-09-20", guest_count_estimate: 15 };
+// WORKER_CONTACT_REQUIREMENTS_V1: sanitize() now rejects a missing/empty
+// email or phone, so BASE carries both — every existing structural test
+// below exercises its own concern (allowlist, truncation, trimming …)
+// against an otherwise-valid, contact-complete payload.
+const BASE = {
+  event_date: "2026-09-20",
+  guest_count_estimate: 15,
+  email: "info@musterfirma.de",
+  phone: "0151 2345678",
+};
 
 test("website_form fields pass through the allowlist", () => {
   const out = sanitize({
@@ -91,10 +100,64 @@ test("invalid event_date format is still rejected", () => {
 });
 
 test("guest_count_estimate digit-string coercion still works", () => {
-  const out = sanitize({ event_date: "2026-09-20", guest_count_estimate: "15" });
+  const out = sanitize({ ...BASE, guest_count_estimate: "15" });
   assert.equal(out.guest_count_estimate, 15);
 });
 
 test("non-integer guest_count_estimate is still rejected", () => {
   assert.equal(sanitize({ event_date: "2026-09-20", guest_count_estimate: "abc" }), null);
+});
+
+// -- WORKER_CONTACT_REQUIREMENTS_V1: email/phone required -------------------
+
+test("missing email is rejected", () => {
+  const { email, ...rest } = BASE;
+  assert.equal(sanitize(rest), null);
+});
+
+test("empty email is rejected", () => {
+  assert.equal(sanitize({ ...BASE, email: "" }), null);
+});
+
+test("whitespace-only email is rejected", () => {
+  assert.equal(sanitize({ ...BASE, email: "   " }), null);
+});
+
+test("missing phone is rejected", () => {
+  const { phone, ...rest } = BASE;
+  assert.equal(sanitize(rest), null);
+});
+
+test("empty phone is rejected", () => {
+  assert.equal(sanitize({ ...BASE, phone: "" }), null);
+});
+
+test("whitespace-only phone is rejected", () => {
+  assert.equal(sanitize({ ...BASE, phone: "   " }), null);
+});
+
+test("valid request with both email and phone (trimmed) is accepted", () => {
+  const out = sanitize({ ...BASE, email: "  info@musterfirma.de  ", phone: "  0151 2345678  " });
+  assert.ok(out !== null);
+  assert.equal(out.email, "info@musterfirma.de");
+  assert.equal(out.phone, "0151 2345678");
+});
+
+test("missingContact: true when raw email is absent, empty, or whitespace-only", () => {
+  assert.equal(missingContact({ phone: "0151 2345678" }), true);
+  assert.equal(missingContact({ phone: "0151 2345678", email: "" }), true);
+  assert.equal(missingContact({ phone: "0151 2345678", email: "   " }), true);
+});
+
+test("missingContact: true when raw phone is absent, empty, or whitespace-only", () => {
+  assert.equal(missingContact({ email: "info@musterfirma.de" }), true);
+  assert.equal(missingContact({ email: "info@musterfirma.de", phone: "" }), true);
+  assert.equal(missingContact({ email: "info@musterfirma.de", phone: "   " }), true);
+});
+
+test("missingContact: false when both raw email and phone are non-empty", () => {
+  assert.equal(
+    missingContact({ email: "info@musterfirma.de", phone: "0151 2345678" }),
+    false
+  );
 });

--- a/infra/cloudflare_worker/worker.js
+++ b/infra/cloudflare_worker/worker.js
@@ -76,7 +76,28 @@ function sanitize(raw) {
   if (out.guest_count_estimate !== undefined && !Number.isInteger(out.guest_count_estimate)) {
     return null;
   }
+  // WORKER_CONTACT_REQUIREMENTS_V1: email and phone are required and must be
+  // non-empty after trim — the intake endpoint now rejects incomplete
+  // submissions anyway (INQUIRY_CONTACT_COMPLETENESS_V1), so failing fast
+  // here saves a round trip and lets fetch() return a specific message.
+  if (typeof out.email !== "string" || out.email === "") {
+    return null;
+  }
+  if (typeof out.phone !== "string" || out.phone === "") {
+    return null;
+  }
   return out;
+}
+
+// Re-derives, from the raw (pre-sanitize) body, whether sanitize()'s null
+// return was specifically caused by a missing/empty email or phone — so
+// fetch() can return the more specific "email and phone required" message
+// instead of the generic invalid-payload one, without sanitize() having to
+// leak its rejection reason.
+function missingContact(raw) {
+  const email = typeof raw.email === "string" ? raw.email.trim() : "";
+  const phone = typeof raw.phone === "string" ? raw.phone.trim() : "";
+  return email === "" || phone === "";
 }
 
 export default {
@@ -96,6 +117,9 @@ export default {
     }
     const clean = sanitize(raw);
     if (clean === null) {
+      if (missingContact(raw)) {
+        return new Response("email and phone required", { status: 422 });
+      }
       return new Response("invalid inquiry payload", { status: 422 });
     }
     const upstream = await fetch(env.UPSTREAM_URL, {
@@ -113,7 +137,7 @@ export default {
   },
 };
 
-// Named export purely for testability (sanitize.test.mjs) — inert to the
+// Named exports purely for testability (sanitize.test.mjs) — inert to the
 // Workers runtime, which only ever invokes the default export's fetch()
 // handler. Does not change deployed behavior.
-export { sanitize };
+export { sanitize, missingContact };


### PR DESCRIPTION
Requires non-empty email and phone in the Cloudflare Worker before forwarding website inquiries. Adds targeted Worker tests. No Core, database, deployment, or upstream-response handling changes.