### PR TITLE
Redesign Arbeitszentrale dashboard and add operative orders view

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -13,7 +13,7 @@ import os
 from datetime import date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 
 from catering_system.domain.inquiry import (
@@ -117,8 +117,8 @@ from catering_system.services.calendar_projection_service import (
 from catering_system.services.task_projection_service import TaskProjectionService
 from catering_system.services.work_center_service import WorkCenterService
 from catering_system.ui.office_panel_dashboard import (
-    WorkCenterDashboardUi,
-    render_work_center_arbeitszentrale,
+    ArbeitszentraleData,
+    render_arbeitszentrale,
 )
 from catering_system.ui.office_panel_contact_detail import render_kontakt_detail
 from catering_system.ui.office_panel_contacts_list import render_kontakte_list
@@ -526,23 +526,45 @@ class OfficePanel:
     ) -> str:
         return render_kalender_list(self._calendar_list_rows(), context=context)
 
+    def _contact_check_open_count(self) -> int:
+        """Open (non-rejected, unconverted) inquiries with incomplete contacts.
+
+        Presentation-side aggregation over repo-shaped reads only — works
+        identically in direct and remote mode (remote inquiry list rows carry
+        the customer snapshot since INQUIRY_CONTACT_COMPLETENESS_V1 §10).
+        """
+        converted = {
+            order.source_inquiry_id
+            for order in self._orders.list_orders()
+            if order.cancelled_at is None
+        }
+        return sum(
+            1
+            for inquiry in self._inquiries.list_all()
+            if inquiry.crm_stage != "Abgelehnt / verloren"
+            and inquiry.inquiry_id not in converted
+            and derive_inquiry_contact_completeness(inquiry) != "complete"
+        )
+
     def _render_v2_arbeitszentrale(
         self,
         *,
         missed_calls_open: int,
         context: OfficePageContext,
+        kalender_view: str = "woche",
     ) -> str:
         operating_today = api_views.berlin_today()
-        iso = operating_today.isocalendar()
-        week = self.wochenuebersicht.get_week_overview(iso.year, iso.week)
         snapshot = self.build_work_center_snapshot(missed_calls_open)
-        return render_work_center_arbeitszentrale(
-            snapshot,
-            ui=WorkCenterDashboardUi(
+        return render_arbeitszentrale(
+            ArbeitszentraleData(
                 context=context,
                 today=operating_today,
-                week_order_count=len(week.entries),
-            ),
+                snapshot=snapshot,
+                tasks=self._task_list_rows(),
+                calendar_entries=self._calendar_list_rows(),
+                contact_check_open=self._contact_check_open_count(),
+                kalender_view=kalender_view,
+            )
         )
 
     def _offer_list_rows(self) -> list[dict[str, object]]:
@@ -1159,12 +1181,14 @@ class OfficePanel:
         *,
         rueckruf_error: str | None = None,
         context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
+        kalender_view: str = "woche",
     ) -> str:
         missed_calls_open = self._missed_calls_open(rueckruf_items, rueckruf_error)
         if self._ui_version == "v2":
             return self._render_v2_arbeitszentrale(
                 missed_calls_open=missed_calls_open,
                 context=context,
+                kalender_view=kalender_view,
             )
         if self._remote is not None:
             return self._render_remote_queue(
@@ -1687,6 +1711,159 @@ class OfficePanel:
             + "</table>"
         )
         return _page("Aufträge", body, active_section="orders", context=context)
+
+    _ORDERS_ZEITRAUM_LABELS = (
+        ("heute", "Heute"),
+        ("woche", "Diese Woche"),
+        ("monat", "Dieser Monat"),
+        ("", "Alle"),
+    )
+
+    def _orders_row_data(self, order: Order) -> dict[str, object]:
+        """Operative row facts for one order — repo-shaped reads only."""
+        versions = self._orders.list_order_versions(order.order_id)
+        target = next(
+            (
+                v
+                for v in versions
+                if v.order_version_id == order.candidate_order_version_id
+            ),
+            None,
+        )
+        if target is None and versions:
+            target = max(versions, key=lambda v: v.version_number)
+        inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+        kunde = "–"
+        if inquiry is not None:
+            kunde = (
+                (inquiry.intake_subject or "").strip()
+                or inquiry.location_text.strip()
+                or order.order_id[:8]
+            )
+        if order.cancelled_at is not None:
+            schritt = "Storniert"
+        else:
+            action = api_views.resolve_next_action(order, versions)
+            if action is not None and action["action"] == "print-confirm":
+                schritt = "Küchendruck bestätigen"
+            elif action is not None and action["action"] == "effective":
+                schritt = "Version wirksam setzen"
+            else:
+                evaluation = self.core.evaluate_ready_to_send(order.order_id)
+                if evaluation.ready:
+                    schritt = "Bereit zum Versand"
+                else:
+                    schritt = (
+                        _ready_to_send_blocker_label(evaluation.reasons[0])
+                        if evaluation.reasons
+                        else "–"
+                    )
+        return {
+            "order_id": order.order_id,
+            "event_date": target.event_date if target is not None else None,
+            "uhrzeit": target.time_window_text if target is not None else "–",
+            "kunde": kunde,
+            "gaeste": target.guest_count_estimate if target is not None else None,
+            "schritt": schritt,
+        }
+
+    @staticmethod
+    def _orders_zeitraum_match(
+        event_date: date | None, zeitraum: str, today: date
+    ) -> bool:
+        if not zeitraum:
+            return True
+        if event_date is None:
+            return False
+        if zeitraum == "heute":
+            return event_date == today
+        if zeitraum == "woche":
+            return event_date.isocalendar()[:2] == today.isocalendar()[:2]
+        if zeitraum == "monat":
+            return (event_date.year, event_date.month) == (today.year, today.month)
+        return True
+
+    def render_orders(
+        self,
+        q: str = "",
+        zeitraum: str = "",
+        *,
+        context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
+    ) -> str:
+        """Alle Aufträge — operative list, deliberately not a CRM table."""
+        if zeitraum not in {"", "heute", "woche", "monat"}:
+            zeitraum = ""
+        today = api_views.berlin_today()
+        needle = q.strip().lower()
+
+        rows_data = []
+        for order in self._orders.list_orders():
+            row = self._orders_row_data(order)
+            if not self._orders_zeitraum_match(
+                cast("date | None", row["event_date"]), zeitraum, today
+            ):
+                continue
+            if needle and not any(
+                needle in str(row[key]).lower()
+                for key in ("kunde", "order_id", "uhrzeit")
+            ):
+                continue
+            rows_data.append(row)
+        rows_data.sort(
+            key=lambda row: (
+                cast("date | None", row["event_date"]) or date.max,
+                str(row["uhrzeit"]),
+                str(row["order_id"]),
+            )
+        )
+
+        filter_links = "".join(
+            f'<a href="/orders?{urlencode({"zeitraum": key, "q": q} if key else {"q": q})}"'
+            + (' aria-current="true"' if key == zeitraum else "")
+            + f">{_e(label)}</a>"
+            for key, label in self._ORDERS_ZEITRAUM_LABELS
+        )
+        search_box = (
+            '<form method="get" action="/orders" class="searchbox">'
+            + (
+                f'<input type="hidden" name="zeitraum" value="{_e(zeitraum)}">'
+                if zeitraum
+                else ""
+            )
+            + f'<input type="text" name="q" value="{_e(q)}" '
+            'placeholder="Suche: Kunde / Auftrag">'
+            '<button type="submit">Suchen</button>'
+            + (
+                f' <a href="/orders?{urlencode({"zeitraum": zeitraum})}">Zurücksetzen</a>'
+                if q
+                else ""
+            )
+            + "</form>"
+        )
+
+        table_rows = []
+        for row in rows_data:
+            event_date = cast("date | None", row["event_date"])
+            datum = event_date.strftime("%d.%m.%Y") if event_date else "–"
+            gaeste = f"{row['gaeste']} Gäste" if row["gaeste"] else "–"
+            table_rows.append(
+                f"<tr><td>{_e(datum)}</td><td>{_e(str(row['uhrzeit']))}</td>"
+                f"<td>{_e(str(row['kunde']))}</td><td>{_e(gaeste)}</td>"
+                f"<td>{_e(str(row['schritt']))}</td>"
+                f'<td><a href="/order/{_e(str(row["order_id"]))}">Öffnen</a></td></tr>'
+            )
+
+        body = (
+            '<nav class="dashboard-calendar-toggle" aria-label="Zeitraum">'
+            + filter_links
+            + "</nav>"
+            + search_box
+            + "<table><tr><th>Datum</th><th>Uhrzeit</th><th>Kunde</th>"
+            "<th>Gäste</th><th>Nächster Schritt</th><th>Aktion</th></tr>"
+            + "".join(table_rows or ['<tr><td colspan="6">keine Aufträge</td></tr>'])
+            + "</table>"
+        )
+        return _page("Alle Aufträge", body, active_section="orders", context=context)
 
     # -- inquiries -------------------------------------------------------
 

--- a/src/catering_system/ui/office_panel_dashboard.py
+++ b/src/catering_system/ui/office_panel_dashboard.py
@@ -1,9 +1,17 @@
-"""Arbeitszentrale dashboard — WorkCenterSnapshot presentation only (5A-2)."""
+"""Arbeitszentrale dashboard — presentation over existing read projections.
+
+Every number and row here is derived from already-shipped, mode-parity data
+sources (WorkCenterSnapshot, task projection rows, calendar projection rows,
+Inquiry contact completeness). No new domain concepts, no writes — the same
+inputs render byte-identically in direct and remote mode.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import date
+import calendar as _calendar
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import date, timedelta
 
 from catering_system.domain.work_center import WorkCenterSnapshot
 from catering_system.ui.office_panel_views import (
@@ -29,125 +37,342 @@ _MONTHS = (
 )
 _WEEKDAYS = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
 
+# Task-category → monochrome sprite icon (office_panel_shell.py sprite).
+_TASK_ICONS = {
+    "verify": "phone",
+    "convert": "doc",
+    "convert_accepted": "doc",
+    "order_print": "printer",
+    "order_effective": "check",
+    "payment": "briefcase",
+}
+
+_MAX_NEXT_TASKS = 6
+_MAX_NEXT_EVENTS = 5
+
 
 @dataclass(frozen=True)
-class WorkCenterDashboardUi:
+class ArbeitszentraleData:
+    """View model for the office dashboard; plain rows, no service handles."""
+
     context: OfficePageContext
     today: date
-    week_order_count: int
+    snapshot: WorkCenterSnapshot
+    tasks: list[dict[str, object]] = field(default_factory=list)
+    calendar_entries: list[dict[str, object]] = field(default_factory=list)
+    contact_check_open: int = 0
+    kalender_view: str = "woche"
 
 
-def _card_action(href: str, label: str) -> str:
-    return f'<a class="wc-card-action" href="{_e(href)}">{_e(label)}</a>'
+def _icon(name: str) -> str:
+    return f'<svg aria-hidden="true"><use href="#office-i-{name}"></use></svg>'
 
 
-def _rueckrufe_card(snapshot: WorkCenterSnapshot) -> str:
-    total = snapshot.rueckrufe_open + snapshot.missed_calls_open
-    return (
-        '<section class="wc-card" aria-labelledby="wc-rueckrufe">'
-        '<div class="wc-card-head"><span class="wc-card-mark" aria-hidden="true">'
-        '🔴</span><h2 id="wc-rueckrufe">Rückrufe</h2></div>'
-        '<hr class="wc-card-rule">'
-        f'<p class="wc-card-summary"><strong>{total}</strong> offen</p>'
-        '<ul class="wc-card-lines">'
-        f"<li><span>📞 Kunden-Rückrufe</span><strong>{snapshot.rueckrufe_open}</strong></li>"
-        f"<li><span>☎ Verpasste Anrufe</span><strong>{snapshot.missed_calls_open}</strong></li>"
-        "</ul>" + _card_action("/rueckruf", "Öffnen") + "</section>"
-    )
+def _task_counts(tasks: list[dict[str, object]]) -> Counter[str]:
+    return Counter(str(task.get("category", "")) for task in tasks)
 
 
-def _angebote_card(snapshot: WorkCenterSnapshot) -> str:
-    return (
-        '<section class="wc-card" aria-labelledby="wc-angebote">'
-        '<div class="wc-card-head"><span class="wc-card-mark" aria-hidden="true">'
-        '📥</span><h2 id="wc-angebote">Angebote</h2></div>'
-        '<hr class="wc-card-rule">'
-        f"<p>{snapshot.offers_waiting} warten auf Antwort</p>"
-        f"<p>{snapshot.offers_accepted} angenommen</p>"
-        + _card_action("/angebote", "Angebote öffnen")
-        + "</section>"
-    )
-
-
-def _auftraege_card(snapshot: WorkCenterSnapshot, ui: WorkCenterDashboardUi) -> str:
-    count = ui.week_order_count
-    label = f"{count} diese Woche" if count != 1 else "1 diese Woche"
-    return (
-        '<section class="wc-card" aria-labelledby="wc-auftraege">'
-        '<div class="wc-card-head"><span class="wc-card-mark" aria-hidden="true">'
-        '🍽</span><h2 id="wc-auftraege">Aufträge</h2></div>'
-        '<hr class="wc-card-rule">'
-        f'<p class="wc-card-summary">{_e(label)}</p>'
-        f"<p>{snapshot.pending_order_changes} Änderungen warten auf Küchendruck</p>"
-        + _card_action("/auftraege", "Aufträge öffnen")
-        + "</section>"
-    )
-
-
-def _aufgaben_card(snapshot: WorkCenterSnapshot) -> str:
-    body = (
-        f"<p>{snapshot.open_tasks} offene Aufgaben</p>"
-        if snapshot.open_tasks
-        else "<p>Keine offenen Aufgaben</p>"
-    )
-    return (
-        '<section class="wc-card" aria-labelledby="wc-aufgaben">'
-        '<div class="wc-card-head"><span class="wc-card-mark" aria-hidden="true">'
-        '🟡</span><h2 id="wc-aufgaben">Aufgaben</h2></div>'
-        '<hr class="wc-card-rule">'
-        + body
-        + _card_action("/aufgaben", "Öffnen")
-        + "</section>"
-    )
-
-
-def _kalender_card(snapshot: WorkCenterSnapshot) -> str:
-    body = (
-        f"<p>{snapshot.today_calendar_entries} Termine heute</p>"
-        if snapshot.today_calendar_entries
-        else "<p>Keine Termine heute</p>"
-    )
-    return (
-        '<section class="wc-card" aria-labelledby="wc-kalender">'
-        '<div class="wc-card-head"><span class="wc-card-mark" aria-hidden="true">'
-        '📅</span><h2 id="wc-kalender">Kalender</h2></div>'
-        '<hr class="wc-card-rule">'
-        + body
-        + _card_action("/kalender", "Öffnen")
-        + "</section>"
-    )
-
-
-def render_work_center_arbeitszentrale(
-    snapshot: WorkCenterSnapshot,
-    *,
-    ui: WorkCenterDashboardUi,
+def _attention_card(
+    *, icon: str, name: str, count: int, label: str, href: str, action: str
 ) -> str:
-    """Render the v2 Arbeitszentrale from WorkCenterSnapshot facts only."""
+    return (
+        '<article class="dashboard-attention-card">'
+        f'<span class="dashboard-attention-icon">{_icon(icon)}</span>'
+        f'<span class="dashboard-attention-name">{_e(name)}</span>'
+        f"<strong>{count}</strong>"
+        f"<span>{_e(label)}</span>"
+        f'<a href="{_e(href)}">{_e(action)}</a>'
+        "</article>"
+    )
 
+
+def _attention_section(data: ArbeitszentraleData) -> str:
+    counts = _task_counts(data.tasks)
+    snapshot = data.snapshot
+    cards: list[str] = []
+    rueckrufe = snapshot.rueckrufe_open + snapshot.missed_calls_open
+    if rueckrufe:
+        cards.append(
+            _attention_card(
+                icon="phone",
+                name="Rückrufe",
+                count=rueckrufe,
+                label="Rückrufe erforderlich",
+                href="/rueckruf",
+                action="Öffnen",
+            )
+        )
+    neue_anfragen = counts["convert"] + counts["convert_accepted"]
+    if neue_anfragen:
+        cards.append(
+            _attention_card(
+                icon="doc",
+                name="Neue Anfragen",
+                count=neue_anfragen,
+                label="Anfragen prüfen",
+                href="/anfragen",
+                action="Öffnen",
+            )
+        )
+    auftraege = counts["order_effective"] + counts["payment"]
+    if auftraege:
+        cards.append(
+            _attention_card(
+                icon="check",
+                name="Aufträge",
+                count=auftraege,
+                label="nächster Schritt",
+                href="/auftraege",
+                action="Öffnen",
+            )
+        )
+    if counts["order_print"]:
+        cards.append(
+            _attention_card(
+                icon="printer",
+                name="Küchendruck",
+                count=counts["order_print"],
+                label="prüfen",
+                href="/aufgaben",
+                action="Öffnen",
+            )
+        )
+    if data.contact_check_open:
+        cards.append(
+            _attention_card(
+                icon="users",
+                name="Kundenprüfung",
+                count=data.contact_check_open,
+                label="offen",
+                href="/anfragen",
+                action="Öffnen",
+            )
+        )
+    if not cards:
+        body = '<p class="dashboard-empty">Aktuell braucht nichts Aufmerksamkeit.</p>'
+    else:
+        body = f'<div class="dashboard-attention">{"".join(cards)}</div>'
+    return "<h2>Was braucht Aufmerksamkeit?</h2>" + body
+
+
+def _task_rows(tasks: list[dict[str, object]]) -> str:
+    rows: list[str] = []
+    for task in tasks[:_MAX_NEXT_TASKS]:
+        icon = _TASK_ICONS.get(str(task.get("category", "")), "doc")
+        href = str(task.get("action_href", ""))
+        rows.append(
+            '<div class="dashboard-work-row">'
+            f'<span class="dashboard-work-kind">{_icon(icon)}</span>'
+            '<div class="dashboard-work-copy">'
+            f'<h3><a href="{_e(href)}">{_e(str(task.get("title", "")))}</a></h3>'
+            f"<p>{_e(str(task.get('subtitle', '')))}</p></div>"
+            f'<a class="dashboard-button secondary" href="{_e(href)}">'
+            f"{_e(str(task.get('action_label', 'Öffnen')))}</a>"
+            "</div>"
+        )
+    if not rows:
+        return '<p class="dashboard-empty">Keine offenen Schritte.</p>'
+    return "".join(rows)
+
+
+def _next_step_by_entity(
+    tasks: list[dict[str, object]],
+) -> dict[tuple[str, str], str]:
+    steps: dict[tuple[str, str], str] = {}
+    for task in tasks:
+        key = (str(task.get("entity_type", "")), str(task.get("entity_id", "")))
+        steps.setdefault(key, str(task.get("title", "")))
+    return steps
+
+
+def _event_rows(data: ArbeitszentraleData) -> str:
+    steps = _next_step_by_entity(data.tasks)
+    rows: list[str] = []
+    for entry in data.calendar_entries:
+        event_date = date.fromisoformat(str(entry["event_date"]))
+        if event_date < data.today:
+            continue
+        if len(rows) >= _MAX_NEXT_EVENTS:
+            break
+        key = (str(entry.get("entity_type", "")), str(entry.get("entity_id", "")))
+        next_step = steps.get(key) or str(entry.get("status_label", ""))
+        guest_count = entry.get("guest_count_estimate")
+        meta_parts = [
+            part
+            for part in (
+                str(entry.get("time_window_text", "")).strip(),
+                f"{guest_count} Gäste" if guest_count else "",
+                next_step,
+            )
+            if part
+        ]
+        href = str(entry.get("action_href", ""))
+        rows.append(
+            '<div class="dashboard-event-row">'
+            '<span class="dashboard-date-tile">'
+            f"<strong>{event_date.day}</strong>"
+            f"<span>{_e(_MONTHS[event_date.month][:3])}</span></span>"
+            '<div class="dashboard-event-copy">'
+            f'<h3><a href="{_e(href)}">{_e(str(entry.get("title", "")))}</a></h3>'
+            f"<p>{_e(' · '.join(meta_parts))}</p></div>"
+            f'<a class="dashboard-button secondary" href="{_e(href)}">Öffnen</a>'
+            "</div>"
+        )
+    if not rows:
+        return '<p class="dashboard-empty">Keine anstehenden Veranstaltungen.</p>'
+    return "".join(rows)
+
+
+def _entries_per_day(entries: list[dict[str, object]]) -> Counter[date]:
+    return Counter(date.fromisoformat(str(entry["event_date"])) for entry in entries)
+
+
+def _calendar_toggle(view: str) -> str:
+    woche = ' aria-current="true"' if view != "monat" else ""
+    monat = ' aria-current="true"' if view == "monat" else ""
+    return (
+        '<nav class="dashboard-calendar-toggle" aria-label="Kalenderansicht">'
+        f'<a href="/"{woche}>Diese Woche</a>'
+        f'<a href="/?kalender=monat"{monat}>Dieser Monat</a></nav>'
+    )
+
+
+def _week_strip(data: ArbeitszentraleData) -> str:
+    per_day = _entries_per_day(data.calendar_entries)
+    monday = data.today - timedelta(days=data.today.weekday())
+    cells: list[str] = []
+    for offset in range(7):
+        day = monday + timedelta(days=offset)
+        classes = (
+            "dashboard-week-day today" if day == data.today else "dashboard-week-day"
+        )
+        count = per_day.get(day, 0)
+        badge = f"<small>{count}</small>" if count else ""
+        cells.append(
+            f'<span class="{classes}">{_WEEKDAYS[offset]}'
+            f"<strong>{day.day}</strong>{badge}</span>"
+        )
+    return f'<div class="dashboard-week-days">{"".join(cells)}</div>'
+
+
+def _month_grid(data: ArbeitszentraleData) -> str:
+    per_day = _entries_per_day(data.calendar_entries)
+    year, month = data.today.year, data.today.month
+    first_weekday, day_count = _calendar.monthrange(year, month)
+    cells: list[str] = [
+        f'<span class="dashboard-month-head">{label}</span>' for label in _WEEKDAYS
+    ]
+    cells.extend(
+        '<span class="dashboard-month-day outside"></span>'
+        for _blank in range(first_weekday)
+    )
+    for day_number in range(1, day_count + 1):
+        day = date(year, month, day_number)
+        classes = (
+            "dashboard-month-day today" if day == data.today else "dashboard-month-day"
+        )
+        count = per_day.get(day, 0)
+        badge = f"<small>{count}</small>" if count else ""
+        cells.append(f'<span class="{classes}">{day_number}{badge}</span>')
+    return (
+        f'<div class="dashboard-month-days" aria-label="{_MONTHS[month]} {year}">'
+        + "".join(cells)
+        + "</div>"
+    )
+
+
+def _calendar_card(data: ArbeitszentraleData) -> str:
+    if data.kalender_view == "monat":
+        body = _month_grid(data)
+        subtitle = f"{_MONTHS[data.today.month]} {data.today.year}"
+    else:
+        body = _week_strip(data)
+        iso = data.today.isocalendar()
+        subtitle = f"KW {iso.week}"
+    return (
+        '<section class="dashboard-card" id="diese-woche">'
+        '<div class="dashboard-card-head"><div>'
+        f"<h2>Kalender</h2><p>{_e(subtitle)}</p></div>"
+        + _calendar_toggle(data.kalender_view)
+        + "</div>"
+        + body
+        + "</section>"
+    )
+
+
+def _systemstatus_card() -> str:
+    # Honest presentation only: the panel has no live probes for the other
+    # services — "Core" is truthful (this page rendered from Core data),
+    # everything else states plainly that no live check exists yet. No
+    # ok/unavailable coloring on purpose (approved design: no status colors).
+    def row(name: str, state: str) -> str:
+        return (
+            '<div class="dashboard-service-state">'
+            f"<strong>{_e(name)}</strong><span>{_e(state)}</span></div>"
+        )
+
+    return (
+        '<section class="dashboard-card">'
+        '<div class="dashboard-card-head"><div><h2>Systemstatus</h2>'
+        "<p>Betriebsdienste im Überblick.</p></div></div>"
+        + row("Core", "Verbunden — Daten geladen.")
+        + row("Website Intake", "Keine Live-Prüfung eingerichtet.")
+        + row("Kiosk", "Keine Live-Prüfung eingerichtet.")
+        + row("Drucker", "Keine Live-Prüfung eingerichtet.")
+        + "</section>"
+    )
+
+
+def render_arbeitszentrale(data: ArbeitszentraleData) -> str:
+    """Render the v2 Arbeitszentrale (Heute im Büro) from projection rows."""
+
+    today = data.today
     header_date = (
-        f"{_WEEKDAYS[ui.today.weekday()]}, {ui.today.day}. "
-        f"{_MONTHS[ui.today.month]} {ui.today.year}"
+        f"{_WEEKDAYS[today.weekday()]}, {today.day}. "
+        f"{_MONTHS[today.month]} {today.year}"
+    )
+    header = (
+        '<header class="dashboard-page-header"><div>'
+        f'<div class="dashboard-eyebrow">{_e(header_date)}</div>'
+        "<h1>Heute im Büro</h1>"
+        "<p>Anfragen, Rückrufe und operative Aufgaben im Blick.</p></div>"
+        '<div class="dashboard-header-actions">'
+        '<a class="dashboard-button secondary" href="/orders">Alle Aufträge</a>'
+        '<a class="dashboard-button" href="/inquiry/new">+ Neue Anfrage</a>'
+        "</div></header>"
+    )
+    main_column = (
+        '<div class="dashboard-main">'
+        '<section class="dashboard-card">'
+        '<div class="dashboard-card-head"><div>'
+        "<h2>Was als Nächstes ansteht</h2>"
+        "<p>Die wichtigsten offenen Schritte.</p></div>"
+        '<a class="dashboard-text-link" href="/aufgaben">Alle Aufgaben</a></div>'
+        + _task_rows(data.tasks)
+        + "</section>"
+        '<section class="dashboard-card">'
+        '<div class="dashboard-card-head"><div>'
+        "<h2>Nächste Veranstaltungen</h2>"
+        "<p>Kommende Termine mit nächstem Schritt.</p></div>"
+        '<a class="dashboard-text-link" href="/kalender">Kalender öffnen</a></div>'
+        + _event_rows(data)
+        + "</section></div>"
+    )
+    side_column = (
+        '<div class="dashboard-side">'
+        + _calendar_card(data)
+        + _systemstatus_card()
+        + "</div>"
     )
     body = (
-        '<div class="wc-page">'
-        '<header class="wc-page-header">'
-        f'<div class="wc-eyebrow">{_e(header_date)}</div>'
-        "<h1>Arbeitszentrale</h1>"
-        "<p>Überblick über Rückrufe, Angebote und Aufträge im Büro.</p>"
-        "</header>"
-        '<div class="wc-cards">'
-        + _rueckrufe_card(snapshot)
-        + _angebote_card(snapshot)
-        + _auftraege_card(snapshot, ui)
-        + _aufgaben_card(snapshot)
-        + _kalender_card(snapshot)
-        + "</div></div>"
+        header
+        + _attention_section(data)
+        + f'<div class="dashboard-layout">{main_column}{side_column}</div>'
     )
     return _page(
         "Arbeitszentrale",
         body,
         active_section="home",
-        context=ui.context,
+        context=data.context,
         show_title=False,
     )

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -350,11 +350,13 @@ def make_office_panel_handler(
                     rueckruf_count=len(items) if items is not None else None,
                     csrf_token=csrf_token,
                 )
+                kalender_view = parse_qs(parsed.query).get("kalender", ["woche"])[0]
                 self._html(
                     panel.render_queue(
                         items,
                         rueckruf_error=error,
                         context=context,
+                        kalender_view=kalender_view,
                     )
                 )
                 return
@@ -377,6 +379,15 @@ def make_office_panel_handler(
             elif parts == ["auftraege"]:
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_auftraege(search_query, context=context))
+            elif parts == ["orders"]:
+                query = parse_qs(parsed.query)
+                self._html(
+                    panel.render_orders(
+                        query.get("q", [""])[0],
+                        query.get("zeitraum", [""])[0],
+                        context=context,
+                    )
+                )
             elif parts == ["proposal-preview"]:
                 self._html(render_proposal_preview_form(context=context))
             elif parts == ["inquiry", "new"]:

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -49,6 +49,14 @@ stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
 stroke-linejoin="round"><path d="M16 19v-1a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v1M12
 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm8 8v-1a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0
 7.75"/></symbol>
+<symbol id="office-i-printer" viewBox="0 0 24 24" fill="none"
+stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+stroke-linejoin="round"><path d="M7 8V3h10v5M7 17H4v-6a1 1 0 0 1 1-1h14a1 1 0
+0 1 1 1v6h-3M7 14h10v7H7z"/></symbol>
+<symbol id="office-i-check" viewBox="0 0 24 24" fill="none"
+stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+stroke-linejoin="round"><path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5
+-9 2.5 2.5 5-5"/></symbol>
 </svg>"""
 
 OFFICE_PANEL_STYLE = """
@@ -376,7 +384,7 @@ svg { display: block; }
 .dashboard-button.secondary:hover { background: var(--accent-soft); }
 .dashboard-attention {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(215px, 1fr));
   gap: 16px;
 }
 .dashboard-attention-card {
@@ -402,6 +410,12 @@ svg { display: block; }
   background: var(--accent-soft);
 }
 .dashboard-attention-icon.warm { color: #805836; background: #f5ece4; }
+.dashboard-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-top: 6px;
+}
 .dashboard-attention-icon svg,
 .dashboard-work-kind svg { width: 20px; height: 20px; }
 .dashboard-attention-card > strong {
@@ -411,6 +425,10 @@ svg { display: block; }
 .dashboard-attention-card > span:not(.dashboard-attention-icon) {
   color: var(--muted);
   font-size: 12px;
+}
+.dashboard-attention-card > span.dashboard-attention-name {
+  color: var(--ink);
+  font-weight: 750;
 }
 .dashboard-attention-card > a {
   margin-top: 9px;
@@ -518,6 +536,66 @@ svg { display: block; }
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 4px;
   padding: 19px;
+}
+.dashboard-calendar-toggle {
+  display: inline-flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding: 3px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--canvas);
+}
+.dashboard-card-head .dashboard-calendar-toggle { margin-bottom: 0; }
+.dashboard-calendar-toggle a {
+  padding: 4px 10px;
+  border-radius: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+.dashboard-calendar-toggle a[aria-current="true"] {
+  color: var(--accent-deep);
+  background: var(--surface);
+}
+.dashboard-month-days {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 3px;
+  padding: 19px;
+}
+.dashboard-month-head {
+  padding: 2px 0 6px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+}
+.dashboard-month-day {
+  display: grid;
+  justify-items: center;
+  align-content: start;
+  gap: 2px;
+  min-height: 44px;
+  padding: 5px 2px;
+  border-radius: 9px;
+  color: var(--ink);
+  font-size: 12px;
+}
+.dashboard-month-day.outside { color: var(--line); }
+.dashboard-month-day.today { color: var(--accent-deep); background: var(--accent-soft); }
+.dashboard-month-day small {
+  display: grid;
+  place-items: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 99px;
+  color: #fff;
+  background: var(--accent);
+  font-size: 9px;
+  font-weight: 800;
 }
 .dashboard-week-day {
   position: relative;
@@ -1376,7 +1454,6 @@ svg { display: block; }
     overflow-x: auto;
     white-space: nowrap;
   }
-  .dashboard-attention { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .dashboard-layout { grid-template-columns: 1fr; }
   .dashboard-side { grid-template-columns: 1fr 1fr; }
   .inquiry-hero { grid-template-columns: 1fr; }
@@ -1401,7 +1478,6 @@ svg { display: block; }
   .office-content form.inline { display: inline-block; margin: 3px 0; }
   .dashboard-page-header { display: grid; }
   .dashboard-page-header .dashboard-button { justify-self: start; }
-  .dashboard-attention,
   .dashboard-side { grid-template-columns: 1fr; }
   .dashboard-work-row { grid-template-columns: 38px minmax(0, 1fr); }
   .dashboard-work-row > form,

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -168,7 +168,22 @@ def test_v2_shell_is_local_no_js_and_has_complete_inline_icon_sprite() -> None:
 
     references = set(re.findall(r'<use href="#(office-i-[^"]+)"', body))
     symbols = set(re.findall(r'<symbol id="(office-i-[^"]+)"', body))
-    assert references == symbols
+    # The shared sprite also carries dashboard-only icons, so a bare page
+    # references a subset. The explicit inventory below still guards against
+    # dead sprite entries — extend it only together with a page that uses
+    # the new icon (see test_office_panel_dashboard.py).
+    assert references <= symbols
+    assert symbols == {
+        "office-i-grid",
+        "office-i-doc",
+        "office-i-briefcase",
+        "office-i-calendar",
+        "office-i-phone",
+        "office-i-import",
+        "office-i-users",
+        "office-i-printer",
+        "office-i-check",
+    }
     assert all(body.count(f'<symbol id="{symbol}"') == 1 for symbol in symbols)
 
 

--- a/tests/unit/test_office_panel_dashboard.py
+++ b/tests/unit/test_office_panel_dashboard.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
+
+from catering_system.ui.office_api_views import berlin_today
 
 from catering_system.domain.work_center import WorkCenterSnapshot
 from catering_system.repositories.in_memory_inquiry_repository import (
@@ -12,68 +14,248 @@ from catering_system.repositories.in_memory_order_repository import (
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.ui.office_panel import OfficePageContext, OfficePanel
 from catering_system.ui.office_panel_dashboard import (
-    WorkCenterDashboardUi,
-    render_work_center_arbeitszentrale,
+    ArbeitszentraleData,
+    render_arbeitszentrale,
 )
 
 
 def _snapshot(**overrides: int) -> WorkCenterSnapshot:
     values = {
-        "rueckrufe_open": 3,
-        "missed_calls_open": 2,
-        "offers_waiting": 2,
-        "offers_accepted": 1,
-        "upcoming_orders": 4,
+        "rueckrufe_open": 0,
+        "missed_calls_open": 0,
+        "offers_waiting": 0,
+        "offers_accepted": 0,
+        "upcoming_orders": 0,
         "open_tasks": 0,
         "today_calendar_entries": 0,
+        "pending_order_changes": 0,
     }
     values.update(overrides)
     return WorkCenterSnapshot(**values)
 
 
-def _ui(*, week_order_count: int = 4) -> WorkCenterDashboardUi:
-    return WorkCenterDashboardUi(
-        context=OfficePageContext(csrf_token="csrf-real"),
-        today=date(2026, 7, 15),
-        week_order_count=week_order_count,
-    )
+def _task(
+    *,
+    category: str = "order_print",
+    title: str = "Druck bestätigen",
+    subtitle: str = "Business Lunch",
+    entity_type: str = "order",
+    entity_id: str = "order-1",
+    action_label: str = "Auftrag öffnen",
+    action_href: str = "/order/order-1",
+) -> dict[str, object]:
+    return {
+        "task_id": f"{entity_type}:{entity_id}:{category}",
+        "category": category,
+        "title": title,
+        "subtitle": subtitle,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "action_label": action_label,
+        "action_href": action_href,
+        "due_at": None,
+        "urgency": "normal",
+        "opened_at": "2026-07-01T08:00:00+00:00",
+    }
 
 
-def test_work_center_dashboard_renders_cards_and_links() -> None:
-    page = render_work_center_arbeitszentrale(_snapshot(), ui=_ui())
+def _entry(
+    *,
+    event_date: str = "2026-07-20",
+    title: str = "Business Lunch",
+    entity_type: str = "order",
+    entity_id: str = "order-1",
+    guest_count: int | None = 28,
+    time_window: str = "12:00",
+) -> dict[str, object]:
+    return {
+        "entry_id": f"cal-{entity_id}",
+        "entry_kind": "event_confirmed",
+        "status_label": "Bestätigt",
+        "title": title,
+        "event_date": event_date,
+        "time_window_text": time_window,
+        "location_text": "Hamburg",
+        "guest_count_estimate": guest_count,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "action_label": "Auftrag öffnen",
+        "action_href": f"/order/{entity_id}",
+        "source_inquiry_id": "inq-1",
+    }
 
-    assert "<h1>Arbeitszentrale</h1>" in page
-    assert "Rückrufe" in page
-    assert "<strong>5</strong> offen" in page
-    assert "Kunden-Rückrufe" in page
-    assert "Verpasste Anrufe" in page
-    assert 'href="/rueckruf"' in page
-    assert "2 warten auf Antwort" in page
-    assert "1 angenommen" in page
-    assert 'href="/angebote"' in page
-    assert "4 diese Woche" in page
-    assert 'href="/auftraege"' in page
-    assert "Keine offenen Aufgaben" in page
-    assert 'href="/aufgaben"' in page
-    assert "Keine Termine heute" in page
-    assert 'href="/kalender"' in page
+
+def _data(**overrides: object) -> ArbeitszentraleData:
+    values: dict[str, object] = {
+        "context": OfficePageContext(csrf_token="csrf-real"),
+        "today": date(2026, 7, 15),
+        "snapshot": _snapshot(),
+        "tasks": [],
+        "calendar_entries": [],
+        "contact_check_open": 0,
+        "kalender_view": "woche",
+    }
+    values.update(overrides)
+    return ArbeitszentraleData(**values)  # type: ignore[arg-type]
+
+
+def test_dashboard_header_title_subtitle_and_actions() -> None:
+    page = render_arbeitszentrale(_data())
+
+    assert "<h1>Heute im Büro</h1>" in page
+    assert "Anfragen, Rückrufe und operative Aufgaben im Blick." in page
+    assert 'href="/orders">Alle Aufträge</a>' in page
+    assert 'href="/inquiry/new">+ Neue Anfrage</a>' in page
     assert "<form" not in page
     assert "<script" not in page
 
 
-def test_work_center_dashboard_placeholder_sections_when_counts_present() -> None:
-    page = render_work_center_arbeitszentrale(
-        _snapshot(open_tasks=2, today_calendar_entries=1),
-        ui=_ui(),
+def test_attention_cards_render_only_for_positive_counts() -> None:
+    page = render_arbeitszentrale(
+        _data(
+            snapshot=_snapshot(rueckrufe_open=1, missed_calls_open=1),
+            tasks=[_task(category="order_print")],
+            contact_check_open=1,
+        )
     )
 
-    assert "2 offene Aufgaben" in page
-    assert 'href="/aufgaben"' in page
-    assert "1 Termine heute" in page
-    assert 'href="/kalender"' in page
+    assert "Was braucht Aufmerksamkeit?" in page
+    assert "Rückrufe erforderlich" in page
+    assert ">2</strong>" in page  # 1 + 1 missed
+    assert "Küchendruck" in page
+    assert '<use href="#office-i-printer">' in page
+    assert "Kundenprüfung" in page
+    # no matching tasks -> cards absent
+    assert "Neue Anfragen" not in page
+    assert "nächster Schritt" not in page
 
 
-def test_v2_panel_uses_work_center_snapshot() -> None:
+def test_attention_empty_state_without_any_counts() -> None:
+    page = render_arbeitszentrale(_data())
+
+    assert "Aktuell braucht nichts Aufmerksamkeit." in page
+    assert '<article class="dashboard-attention-card">' not in page
+
+
+def test_attention_cards_from_task_categories() -> None:
+    page = render_arbeitszentrale(
+        _data(
+            tasks=[
+                _task(category="convert", entity_type="inquiry", entity_id="i1"),
+                _task(category="convert_accepted", entity_type="offer", entity_id="o1"),
+                _task(category="order_effective", entity_id="order-2"),
+                _task(category="payment", entity_id="order-3"),
+            ]
+        )
+    )
+
+    assert "Neue Anfragen" in page
+    assert "Anfragen prüfen" in page
+    assert "Aufträge" in page
+    assert "nächster Schritt" in page
+    assert '<use href="#office-i-check">' in page
+    assert "Küchendruck" not in page
+
+
+def test_next_steps_lists_tasks_with_action_links() -> None:
+    page = render_arbeitszentrale(
+        _data(
+            tasks=[
+                _task(
+                    category="verify",
+                    title="Rückrufprüfung durchführen",
+                    subtitle="Müller GmbH",
+                    entity_type="inquiry",
+                    entity_id="i1",
+                    action_label="Anfrage öffnen",
+                    action_href="/inquiry/i1",
+                )
+            ]
+        )
+    )
+
+    assert "Was als Nächstes ansteht" in page
+    assert "Rückrufprüfung durchführen" in page
+    assert "Müller GmbH" in page
+    assert 'href="/inquiry/i1">Anfrage öffnen</a>' in page
+
+
+def test_next_steps_empty_state() -> None:
+    page = render_arbeitszentrale(_data())
+    assert "Keine offenen Schritte." in page
+
+
+def test_events_join_next_step_from_tasks() -> None:
+    page = render_arbeitszentrale(
+        _data(
+            tasks=[_task(category="order_print", entity_id="order-1")],
+            calendar_entries=[
+                _entry(event_date="2026-07-20", entity_id="order-1"),
+                _entry(
+                    event_date="2026-07-01",
+                    entity_id="order-past",
+                    title="Vergangenes Event",
+                ),
+            ],
+        )
+    )
+
+    assert "Nächste Veranstaltungen" in page
+    assert "Business Lunch" in page
+    assert "28 Gäste" in page
+    # joined next step from the matching task, not the bare status label
+    assert "Druck bestätigen" in page
+    # past events are not listed
+    assert "Vergangenes Event" not in page
+
+
+def test_events_fall_back_to_status_label() -> None:
+    page = render_arbeitszentrale(_data(calendar_entries=[_entry(entity_id="order-9")]))
+    assert "Bestätigt" in page
+
+
+def test_calendar_week_strip_with_counts_and_toggle() -> None:
+    page = render_arbeitszentrale(
+        _data(calendar_entries=[_entry(event_date="2026-07-17")])
+    )
+
+    assert "dashboard-week-days" in page
+    assert 'href="/?kalender=monat"' in page
+    assert "Diese Woche" in page
+    assert "Dieser Monat" in page
+    # 2026-07-15 is a Wednesday; the 17th (Friday) carries one entry badge
+    assert "<strong>17</strong><small>1</small>" in page
+    assert 'id="diese-woche"' in page
+
+
+def test_calendar_month_view() -> None:
+    page = render_arbeitszentrale(
+        _data(
+            kalender_view="monat",
+            calendar_entries=[_entry(event_date="2026-07-20")],
+        )
+    )
+
+    assert "dashboard-month-days" in page
+    assert "Juli 2026" in page
+    assert ">20<small>1</small>" in page
+    assert '<div class="dashboard-week-days">' not in page
+
+
+def test_systemstatus_block_is_neutral_and_separate() -> None:
+    page = render_arbeitszentrale(_data())
+
+    assert "Systemstatus" in page
+    assert "Website Intake" in page
+    assert "Kiosk" in page
+    assert "Drucker" in page
+    assert "Keine Live-Prüfung eingerichtet." in page
+    # no colored status classes inside the dashboard
+    assert 'class="dashboard-service-state ok"' not in page
+    assert 'class="dashboard-service-state unavailable"' not in page
+
+
+def test_v2_panel_renders_new_dashboard() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     InquiryService(inquiries).create_inquiry(
@@ -93,9 +275,12 @@ def test_v2_panel_uses_work_center_snapshot() -> None:
         [{"call_id": "c1", "phone": "0401"}]
     )
 
-    assert '<div class="wc-page">' in page
-    assert "Kunden-Rückrufe" in page
-    assert "Verpasste Anrufe" in page
+    assert "<h1>Heute im Büro</h1>" in page
+    # one pending verification + one missed call -> Rückrufe card shows 2
+    assert "Rückrufe erforderlich" in page
+    assert ">2</strong>" in page
+    # verification inquiry with no contacts counts into Kundenprüfung
+    assert "Kundenprüfung" in page
 
 
 def test_feature_flag_keeps_legacy_default_and_changes_only_dashboard() -> None:
@@ -118,6 +303,69 @@ def test_feature_flag_keeps_legacy_default_and_changes_only_dashboard() -> None:
     v2 = OfficePanel(inquiries, orders, ui_version="v2").render_queue([])
 
     assert "Büro-Übersicht" in legacy
-    assert '<div class="wc-page">' not in legacy
-    assert '<div class="wc-page">' in v2
+    assert "Heute im Büro" not in legacy
+    assert "<h1>Heute im Büro</h1>" in v2
     assert "Arbeitszentrale" in v2
+
+
+# -- /orders (Alle Aufträge) -------------------------------------------------
+
+
+def _panel_with_order(event_date: date) -> OfficePanel:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    panel = OfficePanel(inquiries, orders, ui_version="v2")
+    inquiry = panel.inquiry_service.create_inquiry(
+        event_date=event_date,
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="12:00",
+        location_text="Hamburg",
+        guest_count_estimate=28,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        intake_subject="Business Lunch",
+        contact_email="kunde@example.com",
+        contact_phone="030 1234567",
+    )
+    panel.order_service.convert_inquiry_to_order(inquiry)
+    return panel
+
+
+def test_orders_view_lists_operative_row() -> None:
+    panel = _panel_with_order(berlin_today())
+    page = panel.render_orders()
+
+    assert "Alle Aufträge" in page
+    assert "Business Lunch" in page
+    assert "28 Gäste" in page
+    assert "Küchendruck bestätigen" in page
+    assert ">Öffnen</a>" in page
+    for label in ("Heute", "Diese Woche", "Dieser Monat", "Alle"):
+        assert label in page
+    # operative view stays narrow — exactly the six agreed columns
+    assert page.count("<th>") == 6
+
+
+def test_orders_view_zeitraum_filters_by_event_date() -> None:
+    panel = _panel_with_order(berlin_today() + timedelta(days=400))
+
+    assert "Business Lunch" in panel.render_orders()
+    heute = panel.render_orders(zeitraum="heute")
+    assert "Business Lunch" not in heute
+    assert "keine Aufträge" in heute
+
+
+def test_orders_view_heute_filter_matches_today() -> None:
+    panel = _panel_with_order(berlin_today())
+    page = panel.render_orders(zeitraum="heute")
+    assert "Business Lunch" in page
+
+
+def test_orders_view_search_by_kunde() -> None:
+    panel = _panel_with_order(berlin_today())
+
+    assert "Business Lunch" in panel.render_orders(q="business")
+    assert "keine Aufträge" in panel.render_orders(q="zzz-nichts")

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -487,7 +487,7 @@ def test_v2_dashboard_parity_direct_vs_remote(tmp_path: Path) -> None:
         r_status, r_html = _get(f"{remote_url}/")
         assert d_status == r_status == 200
         _assert_same_modulo_remote_fields(d_html, r_html)
-        assert '<div class="wc-page">' in d_html
+        assert "<h1>Heute im Büro</h1>" in d_html
         assert "_command_id" not in d_html
         assert "_command_id" not in r_html
     finally:


### PR DESCRIPTION
## Summary
- Rebuilds the v2 Arbeitszentrale as "Heute im Büro": dynamic attention cards (rendered only when count > 0, responsive auto-fit grid, monochrome stroke icons, no status colors), a "Was als Nächstes ansteht" task list, a calendar card with a server-side Diese Woche / Dieser Monat toggle, a "Nächste Veranstaltungen" list with next-step join, and a separate small Systemstatus block.
- Adds an operative /orders view (Alle Aufträge): Heute / Diese Woche / Dieser Monat / Alle filters, Kunde/Auftrag search, exactly six columns (Datum, Uhrzeit, Kunde, Gäste, Nächster Schritt, Aktion) — deliberately not a CRM table.
- Presentation layer only: all numbers and rows come from existing read projections (WorkCenterSnapshot, task projection, calendar projection, inquiry contact completeness). No Core, business-logic, repository, or schema changes; the sidebar, fonts, spacing, and style system stay as they are.

## Scope notes
- A Versandfreigabe attention card is intentionally omitted: the only available source (per-order ready-to-send evaluation) would cost N remote API calls per dashboard load. The grid is dynamic, so the card can be added once a cheap counter exists in the snapshot (separate slice).
- Systemstatus is honest: Core shows a real "connected" fact; Website Intake / Kiosk / Drucker state plainly that no live probe exists yet.

## Test plan
- [x] tests/unit/test_office_panel_dashboard.py rewritten for the new renderer (18 tests incl. /orders filters and search)
- [x] Direct-vs-remote dashboard parity suite green (34 passed) — the new data sources render byte-identically in both modes
- [x] Affected suites green: 195 passed (office panel, work center, task/calendar projections, Wochenübersicht)
- [x] ruff check, ruff format, mypy clean (same as CI quality gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)