### PR TITLE
CALLBACK_CONTACT_RESOLUTION_V1 — resolve Rückrufe from Core contacts

### DIFF
--- a/src/catering_system/ui/callback_contact_resolution.py
+++ b/src/catering_system/ui/callback_contact_resolution.py
@@ -1,0 +1,67 @@
+"""Resolve missed-call callbacks against local Core contact projections."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from urllib.parse import quote
+
+from catering_system.intake.intake_contact import normalize_phone
+
+_AMBIGUOUS_LABEL = "Mehrdeutig – Kundenprüfung"
+_UNKNOWN_LABEL = "Unbekannt"
+
+
+def build_phone_contact_index(
+    contacts: Sequence[Mapping[str, object]],
+) -> dict[str, list[Mapping[str, object]]]:
+    """Index local contacts by canonical normalized phone."""
+
+    index: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for contact in contacts:
+        phone = normalize_phone(str(contact.get("phone") or ""))
+        if not phone:
+            continue
+        index[phone].append(contact)
+    return dict(index)
+
+
+def resolve_core_contact_fields(
+    item: Mapping[str, object],
+    phone_index: Mapping[str, list[Mapping[str, object]]],
+) -> dict[str, object]:
+    """Derive Office Panel contact display fields from Core truth."""
+
+    phone = normalize_phone(
+        str(item.get("normalized_phone") or item.get("phone") or "")
+    )
+    if not phone:
+        return {"core_contact_label": _UNKNOWN_LABEL, "core_contact_href": None}
+
+    matches = phone_index.get(phone, [])
+    if not matches:
+        return {"core_contact_label": _UNKNOWN_LABEL, "core_contact_href": None}
+    if len(matches) > 1:
+        return {"core_contact_label": _AMBIGUOUS_LABEL, "core_contact_href": None}
+
+    contact = matches[0]
+    contact_key = str(contact["contact_key"])
+    display_name = str(contact.get("display_name") or "–")
+    return {
+        "core_contact_label": display_name,
+        "core_contact_href": f"/kontakt/{quote(contact_key, safe='')}",
+    }
+
+
+def enrich_missed_board_with_core_contacts(
+    items: list[dict],
+    contacts: Sequence[Mapping[str, object]],
+) -> list[dict]:
+    """Attach Core-derived contact fields; Auerswald contact fields stay untouched."""
+
+    phone_index = build_phone_contact_index(contacts)
+    enriched: list[dict] = []
+    for item in items:
+        resolved = resolve_core_contact_fields(item, phone_index)
+        enriched.append({**item, **resolved})
+    return enriched

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -116,6 +116,9 @@ from catering_system.services.calendar_projection_service import (
 )
 from catering_system.services.task_projection_service import TaskProjectionService
 from catering_system.services.work_center_service import WorkCenterService
+from catering_system.ui.callback_contact_resolution import (
+    enrich_missed_board_with_core_contacts,
+)
 from catering_system.ui.office_panel_dashboard import (
     ArbeitszentraleData,
     render_arbeitszentrale,
@@ -224,6 +227,20 @@ _RUECKRUF_SUBTITLE = (
 )
 
 
+def _format_rueckruf_contact_cell(item: dict) -> str:
+    """Prefer Core-resolved contact display over Auerswald callback metadata."""
+
+    label = item.get("core_contact_label")
+    if label is not None:
+        href = item.get("core_contact_href")
+        if href:
+            return f'<a href="{_e(href)}">{_e(label)}</a>'
+        return _e(label)
+    if item.get("contact_found"):
+        return _e(item["contact_name"])
+    return "Unbekannt"
+
+
 def render_rueckruf(
     items: list[dict] | None,
     error: str | None,
@@ -245,7 +262,7 @@ def render_rueckruf(
         )
     rows = []
     for it in items:
-        contact = _e(it["contact_name"]) if it.get("contact_found") else "Unbekannt"
+        contact = _format_rueckruf_contact_cell(it)
         rows.append(
             "<tr>"
             f"<td>{_e(it.get('date', ''))}</td>"
@@ -820,6 +837,9 @@ class OfficePanel:
         )
         return api_views.contact_list_view(service.list_contacts())
 
+    def enrich_rueckruf_items(self, items: list[dict]) -> list[dict]:
+        return enrich_missed_board_with_core_contacts(items, self._contact_list_rows())
+
     def render_kontakte(
         self, *, context: OfficePageContext = _EMPTY_PAGE_CONTEXT
     ) -> str:
@@ -1326,9 +1346,7 @@ class OfficePanel:
         if rueckruf_items is not None:
             rows = []
             for it in rueckruf_items[:5]:
-                contact = (
-                    _e(it["contact_name"]) if it.get("contact_found") else "Unbekannt"
-                )
+                contact = _format_rueckruf_contact_cell(it)
                 phone = it.get("phone", "")
                 rows.append(
                     f"<li>{_e(it.get('date', ''))} {_e(it.get('time', ''))} — "
@@ -1477,11 +1495,7 @@ class OfficePanel:
         if rueckruf_items is not None:
             rows = []
             for item in rueckruf_items[:5]:
-                contact = (
-                    _e(item["contact_name"])
-                    if item.get("contact_found")
-                    else "Unbekannt"
-                )
+                contact = _format_rueckruf_contact_cell(item)
                 phone = item.get("phone", "")
                 rows.append(
                     f"<li>{_e(item.get('date', ''))} {_e(item.get('time', ''))} — "

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -251,6 +251,14 @@ def make_office_panel_handler(
                 csrf_token=csrf_token,
             )
 
+        def _fetch_enriched_missed_board(self) -> tuple[list[dict] | None, str | None]:
+            items, error = fetch_missed_board(
+                auerswald_url, auerswald_user, auerswald_password
+            )
+            if items is not None:
+                items = panel.enrich_rueckruf_items(items)
+            return items, error
+
         def _error_page(self, message: str, status: int = 400) -> None:
             self._html(
                 _page(
@@ -333,9 +341,7 @@ def make_office_panel_handler(
                         )
                     )
                     return
-                items, error = fetch_missed_board(
-                    auerswald_url, auerswald_user, auerswald_password
-                )
+                items, error = self._fetch_enriched_missed_board()
                 context = OfficePageContext(
                     rueckruf_count=len(items) if items is not None else None,
                     csrf_token=csrf_token,
@@ -343,9 +349,7 @@ def make_office_panel_handler(
                 self._html(render_rueckruf(items, error, context=context))
                 return
             if not parts:
-                items, error = fetch_missed_board(
-                    auerswald_url, auerswald_user, auerswald_password
-                )
+                items, error = self._fetch_enriched_missed_board()
                 context = OfficePageContext(
                     rueckruf_count=len(items) if items is not None else None,
                     csrf_token=csrf_token,

--- a/tests/unit/test_callback_contact_resolution.py
+++ b/tests/unit/test_callback_contact_resolution.py
@@ -1,0 +1,153 @@
+"""Unit tests — callback contact resolution against Core contacts (V1)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from catering_system.intake.intake_contact import normalize_phone
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_offer_repository import (
+    InMemoryOfferRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.ui import office_api_views as api_views
+from catering_system.ui.callback_contact_resolution import (
+    enrich_missed_board_with_core_contacts,
+    resolve_core_contact_fields,
+)
+from catering_system.ui.office_panel import OfficePanel, _format_rueckruf_contact_cell
+from catering_system.services.contact_projection_service import ContactProjectionService
+
+_PHONE_E164 = "+4917642795029"
+_JKART_MESSAGE = f"Firma: JK-art\nTelefon: {_PHONE_E164}\n"
+
+
+def _contact_rows(inquiries: InMemoryInquiryRepository) -> list[dict[str, object]]:
+    service = ContactProjectionService(
+        inquiries,
+        InMemoryOfferRepository(),
+        InMemoryOrderRepository(),
+        today=lambda: date(2026, 7, 15),
+    )
+    return api_views.contact_list_view(service.list_contacts())
+
+
+def _save_inquiry(
+    repo: InMemoryInquiryRepository,
+    *,
+    intake_message: str,
+    customer_linkage: dict[str, str] | None = None,
+) -> None:
+    InquiryService(repo).create_inquiry(
+        event_date=date(2026, 8, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage=customer_linkage or {},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        intake_message=intake_message,
+    )
+
+
+def _missed_item(**overrides: object) -> dict:
+    item = {
+        "call_id": "21.07.26|09:00:00|+4917642795029",
+        "date": "21.07.26",
+        "time": "09:00:00",
+        "phone": "017642795029",
+        "normalized_phone": _PHONE_E164,
+        "contact_found": True,
+        "contact_name": "Auerswald Stub Name",
+        "contact_url": "https://example.invalid/hubspot",
+        "reason": "Nicht angenommen",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_normalize_phone_matches_german_local_to_e164() -> None:
+    assert normalize_phone("017642795029") == _PHONE_E164
+    assert normalize_phone(_PHONE_E164) == _PHONE_E164
+
+
+def test_exact_e164_match_resolves_unique_contact() -> None:
+    inquiries = InMemoryInquiryRepository()
+    _save_inquiry(inquiries, intake_message=_JKART_MESSAGE)
+    contacts = _contact_rows(inquiries)
+
+    resolved = resolve_core_contact_fields(
+        _missed_item(phone=_PHONE_E164),
+        {normalize_phone(_PHONE_E164): contacts},
+    )
+
+    assert resolved["core_contact_label"] == "JK-art"
+    assert resolved["core_contact_href"] == "/kontakt/intake%3Aphone%3A%2B4917642795029"
+
+
+def test_german_local_callback_matches_normalized_core_phone() -> None:
+    inquiries = InMemoryInquiryRepository()
+    _save_inquiry(inquiries, intake_message=_JKART_MESSAGE)
+    contacts = _contact_rows(inquiries)
+
+    enriched = enrich_missed_board_with_core_contacts(
+        [_missed_item(normalized_phone="", phone="017642795029")],
+        contacts,
+    )
+
+    assert enriched[0]["core_contact_label"] == "JK-art"
+    assert "/kontakt/intake%3Aphone%3A%2B4917642795029" in str(
+        enriched[0]["core_contact_href"]
+    )
+
+
+def test_no_match_remains_unbekannt() -> None:
+    resolved = resolve_core_contact_fields(_missed_item(), {})
+    assert resolved["core_contact_label"] == "Unbekannt"
+    assert resolved["core_contact_href"] is None
+
+
+def test_duplicate_phone_is_mehrdeutig() -> None:
+    inquiries = InMemoryInquiryRepository()
+    _save_inquiry(inquiries, intake_message=_JKART_MESSAGE)
+    _save_inquiry(
+        inquiries,
+        intake_message=_JKART_MESSAGE,
+        customer_linkage={"customer_id": "cust-other"},
+    )
+    contacts = _contact_rows(inquiries)
+
+    enriched = enrich_missed_board_with_core_contacts([_missed_item()], contacts)
+
+    assert enriched[0]["core_contact_label"] == "Mehrdeutig – Kundenprüfung"
+    assert enriched[0]["core_contact_href"] is None
+
+
+def test_unique_match_renders_contact_detail_link() -> None:
+    inquiries = InMemoryInquiryRepository()
+    _save_inquiry(inquiries, intake_message=_JKART_MESSAGE)
+    panel = OfficePanel(inquiries, InMemoryOrderRepository(), ui_version="v2")
+    enriched = panel.enrich_rueckruf_items([_missed_item()])
+
+    html = _format_rueckruf_contact_cell(enriched[0])
+    assert 'href="/kontakt/intake%3Aphone%3A%2B4917642795029"' in html
+    assert ">JK-art</a>" in html
+
+
+def test_auerswald_contact_name_does_not_override_core_truth() -> None:
+    inquiries = InMemoryInquiryRepository()
+    _save_inquiry(inquiries, intake_message=_JKART_MESSAGE)
+    panel = OfficePanel(inquiries, InMemoryOrderRepository())
+    enriched = panel.enrich_rueckruf_items([_missed_item()])
+
+    html = _format_rueckruf_contact_cell(enriched[0])
+    assert "Auerswald Stub Name" not in html
+    assert "JK-art" in html

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -1241,7 +1241,14 @@ _AUERSWALD_ITEMS = [
 ]
 
 
-def _make_auerswald_stub(resolved: list, hits: list | None = None) -> HTTPServer:
+def _make_auerswald_stub(
+    resolved: list,
+    hits: list | None = None,
+    *,
+    board_items: list[dict] | None = None,
+) -> HTTPServer:
+    items_source = _AUERSWALD_ITEMS if board_items is None else board_items
+
     class StubHandler(BaseHTTPRequestHandler):
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002
             pass
@@ -1253,9 +1260,7 @@ def _make_auerswald_stub(resolved: list, hits: list | None = None) -> HTTPServer
                 # Mirrors the real auerswald-sync: resolved calls drop out of
                 # the board on the next fetch (build_missed_board_items()
                 # excludes resolved_call_ids).
-                remaining = [
-                    it for it in _AUERSWALD_ITEMS if it["call_id"] not in resolved
-                ]
+                remaining = [it for it in items_source if it["call_id"] not in resolved]
                 payload = json.dumps({"items": remaining}).encode()
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
@@ -1346,6 +1351,68 @@ def test_rueckruf_lists_items_from_auerswald_stub() -> None:
         )
         assert status == 200 and final_url == f"{base}/rueckruf"
         assert resolved == [_AUERSWALD_ITEMS[0]["call_id"]]
+    finally:
+        server.shutdown()
+        server.server_close()
+        stub.shutdown()
+        stub.server_close()
+
+
+def test_rueckruf_resolves_local_core_contact_over_auerswald_name() -> None:
+    from catering_system.services.inquiry_service import InquiryService
+
+    board_items = [
+        {
+            **_AUERSWALD_ITEMS[0],
+            "phone": "017642795029",
+            "normalized_phone": "+4917642795029",
+            "contact_found": True,
+            "contact_name": "Auerswald Wrong Name",
+            "contact_url": "https://example.invalid/contact",
+        }
+    ]
+    resolved: list = []
+    stub = _make_auerswald_stub(resolved, board_items=board_items)
+    stub_thread = threading.Thread(target=stub.serve_forever, daemon=True)
+    stub_thread.start()
+    stub_host, stub_port = stub.server_address[:2]
+
+    inquiry_repo = InMemoryInquiryRepository()
+    order_repo = InMemoryOrderRepository()
+    InquiryService(inquiry_repo).create_inquiry(
+        event_date=date(2026, 8, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        intake_message="Firma: JK-art\nTelefon: +4917642795029\n",
+    )
+    server = create_office_panel_server(
+        inquiry_repo,
+        order_repo,
+        _PASSWORD,
+        host="127.0.0.1",
+        port=0,
+        auerswald_url=f"http://{stub_host}:{stub_port}",
+        auerswald_user="office",
+        auerswald_password="secret",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    base = f"http://{host}:{port}"
+    try:
+        status, body = _get(f"{base}/rueckruf")
+        assert status == 200
+        assert ">JK-art</a>" in body
+        assert 'href="/kontakt/intake%3Aphone%3A%2B4917642795029"' in body
+        assert "Auerswald Wrong Name" not in body
+        assert "Unbekannt" not in body
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- Enrich missed-board callbacks in the Office Panel with local Core contact matches by normalized phone.
- Rückrufliste and dashboard callback sections now show Core truth: unique match links to `/kontakt/...`, no match stays `Unbekannt`, duplicates show `Mehrdeutig – Kundenprüfung`.
- Auerswald Sync remains unchanged; no schema changes; CSP unchanged.

## Root cause
Rückrufliste rendered `contact_found` / `contact_name` from Auerswald metadata only. Local Core contacts (already visible on `/kontakte`) were never joined by normalized phone.

## Test plan
- [x] Unit tests: E.164 match, German local format, no match, duplicate phone, unique link, Auerswald override
- [x] Integration: `/rueckruf` shows `JK-art` link for production-like phone
- [x] Full pytest: 1475 passed
- [x] Ruff clean
- [x] Mypy clean (149 source files)


Made with [Cursor](https://cursor.com)