### PR TITLE
INQUIRY_TO_ORDER_CONVERSION_GATE_V1

### DIFF
--- a/src/catering_system/domain/inquiry.py
+++ b/src/catering_system/domain/inquiry.py
@@ -263,11 +263,11 @@ def derive_inquiry_office_state(
         if offer is not None
         else None
     )
-    if inquiry.crm_stage == "Abgelehnt / verloren" or has_active_order:
+    if inquiry.crm_stage == "Abgelehnt / verloren" or has_order:
         return InquiryOfficeState(
             is_open=False, next_action=None, offer=offer_projection
         )
-    is_open = not has_order
+    is_open = True
     if (
         inquiry.call_verification_required
         and inquiry.call_verification_status != "verified"

--- a/src/catering_system/repositories/in_memory_order_repository.py
+++ b/src/catering_system/repositories/in_memory_order_repository.py
@@ -22,6 +22,14 @@ class InMemoryOrderRepository:
             raise KeyError(order.order_id)
         if version.order_version_id in self._versions:
             raise KeyError(version.order_version_id)
+        if any(
+            existing.source_inquiry_id == order.source_inquiry_id
+            for existing in self._orders.values()
+        ):
+            raise ValueError(
+                "inquiry already has a linked order "
+                f"(source_inquiry_id={order.source_inquiry_id!r})"
+            )
         next_orders = dict(self._orders)
         next_versions = dict(self._versions)
         next_versions[version.order_version_id] = version

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -323,7 +323,7 @@ class OfferService:
                 )
             return offer, order, order_version
 
-        if self._has_active_order(offer.source_inquiry_id):
+        if self._has_linked_order(offer.source_inquiry_id):
             raise ValueError(
                 f"active order blocks conversion (inquiry_id={offer.source_inquiry_id!r})"
             )
@@ -371,6 +371,12 @@ class OfferService:
     def _has_active_order(self, inquiry_id: str) -> bool:
         return any(
             order.source_inquiry_id == inquiry_id and order.cancelled_at is None
+            for order in self._order_repository.list_orders()
+        )
+
+    def _has_linked_order(self, inquiry_id: str) -> bool:
+        return any(
+            order.source_inquiry_id == inquiry_id
             for order in self._order_repository.list_orders()
         )
 

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -56,8 +56,15 @@ class OrderService:
     def convert_inquiry_to_order(self, inquiry: Inquiry) -> tuple[Order, OrderVersion]:
         """Create Order + v1 after the Core inquiry conversion gate passes.
 
+        Idempotent: if any Order already exists for the inquiry, return that
+        Order and its initial version instead of creating another. Order
+        existence is authoritative for “already converted”.
         The application command owns the accompanying Inquiry stage update.
         """
+        existing = self.orders_for_inquiry(inquiry.inquiry_id)
+        if existing:
+            return self._existing_conversion_result(existing)
+
         if not inquiry_allows_order_conversion(inquiry):
             raise ValueError(
                 "inquiry_to_order conversion blocked "
@@ -97,6 +104,30 @@ class OrderService:
             order_id,
             version.version_number,
         )
+        return order, version
+
+    def orders_for_inquiry(self, inquiry_id: str) -> list[Order]:
+        return [
+            order
+            for order in self._order_repository.list_orders()
+            if order.source_inquiry_id == inquiry_id
+        ]
+
+    def _existing_conversion_result(
+        self, existing: list[Order]
+    ) -> tuple[Order, OrderVersion]:
+        active = [order for order in existing if order.cancelled_at is None]
+        candidates = active or existing
+        order = sorted(candidates, key=lambda item: (item.created_at, item.order_id))[0]
+        versions = self._order_repository.list_order_versions(order.order_id)
+        version = next(
+            (item for item in versions if item.version_number == 1),
+            None,
+        )
+        if version is None:
+            raise ValueError(
+                f"linked order {order.order_id!r} is missing initial version"
+            )
         return order, version
 
     def create_order_from_offer_version(

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -1018,7 +1018,12 @@ class OfficeApi:
             for order in self.orders.list_orders()
             if order.source_inquiry_id == inquiry.inquiry_id
         ]
-        has_active_order = any(order.cancelled_at is None for order in linked_orders)
+        if linked_orders:
+            order, version = self.order_service.convert_inquiry_to_order(inquiry)
+            return 200, {
+                "order_id": order.order_id,
+                "order_version_id": version.order_version_id,
+            }
         offer = self.offers.get_by_source_inquiry_id(inquiry.inquiry_id)
         state = views.inquiry_office_state(
             inquiry,
@@ -1026,8 +1031,6 @@ class OfficeApi:
             offer=offer,
             today=views.berlin_today(),
         )
-        if has_active_order:
-            raise ApiError(409, "already_converted")
         if inquiry.crm_stage == "Abgelehnt / verloren":
             raise ApiError(422, "inquiry_rejected")
         if offer is not None and offer_blocks_direct_inquiry_conversion(
@@ -1041,11 +1044,24 @@ class OfficeApi:
         try:
             order, version = self.order_service.convert_inquiry_to_order(inquiry)
         except sqlite3.IntegrityError:
-            # Recognized only when the re-query confirms the cause (pack §4.5)
-            if self._active_order_for_inquiry(inquiry.inquiry_id) is not None:
-                raise ApiError(409, "already_converted") from None
+            # Race: another writer created the order — return it idempotently.
+            if self.order_service.orders_for_inquiry(inquiry.inquiry_id):
+                order, version = self.order_service.convert_inquiry_to_order(inquiry)
+                return 200, {
+                    "order_id": order.order_id,
+                    "order_version_id": version.order_version_id,
+                }
             raise
         except ValueError as exc:
+            message = str(exc)
+            if "contact information incomplete" in message:
+                raise ApiError(422, "contact_information_incomplete") from exc
+            if "already has a linked order" in message:
+                order, version = self.order_service.convert_inquiry_to_order(inquiry)
+                return 200, {
+                    "order_id": order.order_id,
+                    "order_version_id": version.order_version_id,
+                }
             raise ApiError(422, "verification_gate_blocked") from exc
         self.inquiry_service.update_inquiry(
             inquiry.inquiry_id,

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -570,11 +570,8 @@ class OfficePanel:
         return render_kalender_list(self._calendar_list_rows(), context=context)
 
     def _converted_inquiry_ids(self) -> set[str]:
-        return {
-            order.source_inquiry_id
-            for order in self._orders.list_orders()
-            if order.cancelled_at is None
-        }
+        """Inquiry IDs that already have any linked Order (active or cancelled)."""
+        return {order.source_inquiry_id for order in self._orders.list_orders()}
 
     def _open_inquiries_count(self) -> int:
         """Open inquiries without a linked active order (direct and remote)."""
@@ -1365,7 +1362,7 @@ class OfficePanel:
             return (
                 f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
                 f"{_csrf_input(context)}{self._command_fields()}"
-                "<button>In Auftrag umwandeln</button></form>"
+                "<button>Auftrag erstellen</button></form>"
             )
         if state.next_action == "offer-pending":
             return '<span class="muted">Angebot ausstehend</span>'
@@ -1700,7 +1697,7 @@ class OfficePanel:
                 action = (
                     f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
                     f"{_csrf_input(context)}{self._command_fields()}"
-                    "<button>In Auftrag umwandeln</button></form>"
+                    "<button>Auftrag erstellen</button></form>"
                 )
             elif action_name == "offer-pending":
                 action = '<span class="muted">Angebot ausstehend</span>'
@@ -2290,12 +2287,15 @@ class OfficePanel:
                 + (" (storniert)" if o.cancelled_at is not None else "")
                 for o in existing
             )
-            convert += f"<p>Auftrag vorhanden: {links}</p>"
+            convert += (
+                f"<p>Auftrag vorhanden: {links} — "
+                f'<a href="/order/{_e(existing[0].order_id)}">Auftrag öffnen</a></p>'
+            )
         if state.next_action == "convert":
             convert += (
                 f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
                 f"{_csrf_input(context)}{self._command_fields()}"
-                "<button>In Auftrag umwandeln</button></form>"
+                "<button>Auftrag erstellen</button></form>"
             )
         elif state.next_action == "offer-pending":
             convert += '<p class="muted">Angebot ausstehend</p>'
@@ -2429,7 +2429,8 @@ class OfficePanel:
     def convert_inquiry_to_order(self, inquiry_id: str) -> tuple[Order, OrderVersion]:
         """Run the truthful gate and stage transition as one direct command.
 
-        Remote mode delegates the same atomic command to Core Office API.
+        Idempotent: an existing linked Order is returned instead of creating
+        another. Remote mode delegates the same atomic command to Core Office API.
         """
 
         def work() -> tuple[Order, OrderVersion]:
@@ -2441,16 +2442,13 @@ class OfficePanel:
                 for order in self._orders.list_orders()
                 if order.source_inquiry_id == inquiry_id
             ]
-            has_active_order = any(
-                order.cancelled_at is None for order in linked_orders
-            )
+            if linked_orders:
+                return self.order_service.convert_inquiry_to_order(inquiry)
             state = self._inquiry_office_state(
                 inquiry,
                 linked_orders,
                 inquiry_id=inquiry_id,
             )
-            if has_active_order:
-                raise ValueError("inquiry already converted")
             if inquiry.crm_stage == "Abgelehnt / verloren":
                 raise ValueError("rejected inquiry cannot be converted")
             offer = self._offers.get_by_source_inquiry_id(inquiry_id)

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -164,7 +164,7 @@ def _primary_action(
             "Auftragsprozess gestartet."
         )
         path = "convert"
-        label = "In Auftrag umwandeln"
+        label = "Auftrag erstellen"
     elif inquiry_shows_convert_accepted_button(state):
         return (
             '<section class="inquiry-next-step">'
@@ -217,10 +217,10 @@ def _linked_orders(linked_orders: Sequence[Order]) -> str:
     links = []
     for order in linked_orders:
         if order.cancelled_at is None:
-            label = "Aktiven Auftrag öffnen"
+            label = "Auftrag öffnen"
             status = "Aktiver Auftrag"
         else:
-            label = "Stornierten Auftrag öffnen"
+            label = "Auftrag öffnen"
             status = "Storniert"
         links.append(
             '<li><span class="inquiry-order-status">'

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -2304,7 +2304,7 @@ class _RemoteOrderService:
             f"/office/v1/inquiries/{quote(inquiry.inquiry_id, safe='')}/convert",
             {},
             {},
-            expected={201},
+            expected={200, 201},
             result_keys={"order_id", "order_version_id"},
         )
         order_id = _uuid4(result["order_id"])

--- a/tests/unit/test_core_transaction.py
+++ b/tests/unit/test_core_transaction.py
@@ -250,18 +250,18 @@ def test_fingerprint_distinguishes_every_command_dimension() -> None:
 # --- orders migration 6: partial unique active-order index (pack §6.2) ---
 
 
-def test_second_active_order_for_same_inquiry_hits_the_index(shared) -> None:
+def test_second_convert_is_idempotent_for_same_inquiry(shared) -> None:
     connection, inquiries, orders, _ledger = shared
     executor = CoreCommandExecutor(connection)
     inq = _inquiry()
     executor.run(lambda: inquiries.save(inq))
-    executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
-    with pytest.raises(sqlite3.IntegrityError):
-        executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
+    first = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
+    second = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
+    assert second[0].order_id == first[0].order_id
     assert len([o for o in orders.list_orders() if o.cancelled_at is None]) == 1
 
 
-def test_reconvert_after_storno_still_works(shared) -> None:
+def test_convert_after_storno_returns_existing_order(shared) -> None:
     connection, inquiries, orders, _ledger = shared
     executor = CoreCommandExecutor(connection)
     core = OperationalCoreService(orders)
@@ -270,9 +270,8 @@ def test_reconvert_after_storno_still_works(shared) -> None:
     first = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
     executor.run(lambda: core.cancel_order(first[0].order_id))
     second = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
-    assert second[0].order_id != first[0].order_id
-    active = [o for o in orders.list_orders() if o.cancelled_at is None]
-    assert [o.order_id for o in active] == [second[0].order_id]
+    assert second[0].order_id == first[0].order_id
+    assert len(orders.list_orders()) == 1
 
 
 def test_migration_6_aborts_on_existing_active_duplicates(tmp_path: Path) -> None:

--- a/tests/unit/test_inquiry_office_state.py
+++ b/tests/unit/test_inquiry_office_state.py
@@ -213,7 +213,7 @@ def test_converted_inquiry_is_closed_and_active_order_blocks_action() -> None:
     assert state.next_action is None
 
 
-def test_cancelled_order_stays_out_of_queue_but_allows_existing_reconversion() -> None:
+def test_cancelled_order_stays_out_of_queue_and_blocks_reconversion() -> None:
     state = derive_inquiry_office_state(
         _inquiry(crm_stage="Bestätigt / Auftrag"),
         has_order=True,
@@ -221,7 +221,7 @@ def test_cancelled_order_stays_out_of_queue_but_allows_existing_reconversion() -
         today=_TODAY,
     )
     assert state.is_open is False
-    assert state.next_action == "convert"
+    assert state.next_action is None
 
 
 def test_prepared_offer_projects_offer_pending_not_legacy_convert() -> None:
@@ -264,7 +264,7 @@ def test_accepted_offer_projects_convert_accepted() -> None:
     assert state.offer.acceptance_id == _ACCEPTANCE_ID
 
 
-def test_converted_offer_after_storno_projects_convert_accepted_replay() -> None:
+def test_converted_offer_after_storno_has_no_new_conversion_action() -> None:
     state = derive_inquiry_office_state(
         _inquiry(crm_stage="Bestätigt / Auftrag"),
         has_order=True,
@@ -277,7 +277,7 @@ def test_converted_offer_after_storno_projects_convert_accepted_replay() -> None
         today=_TODAY,
     )
     assert state.is_open is False
-    assert state.next_action == "convert-accepted"
+    assert state.next_action is None
 
 
 def test_convert_accepted_button_only_for_accepted_not_converted() -> None:
@@ -301,7 +301,8 @@ def test_convert_accepted_button_only_for_accepted_not_converted() -> None:
     )
     assert inquiry_shows_convert_accepted_button(accepted) is True
     assert inquiry_shows_convert_accepted_button(converted) is False
-    assert inquiry_allows_convert_accepted_command(converted) is True
+    assert inquiry_allows_convert_accepted_command(converted) is False
+    assert converted.next_action is None
 
 
 def test_verify_still_wins_over_offer_pending() -> None:

--- a/tests/unit/test_inquiry_to_order_conversion_gate.py
+++ b/tests/unit/test_inquiry_to_order_conversion_gate.py
@@ -1,0 +1,200 @@
+"""Unit tests — INQUIRY_TO_ORDER_CONVERSION_GATE_V1."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from catering_system.domain.contact_projection import derive_contact_status
+from catering_system.domain.inquiry import derive_inquiry_office_state
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_offer_repository import (
+    InMemoryOfferRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_service import OrderService
+from catering_system.ui.office_panel import OfficePanel
+
+_TODAY = date(2026, 7, 15)
+
+
+def _inquiry(
+    repo: InMemoryInquiryRepository,
+    *,
+    crm_stage: str = "Neue Anfrage",
+    call_verification_required: bool = False,
+    call_verification_status: str = "not_required",
+    email: str = "kunde@example.invalid",
+    phone: str = "+49301234567",
+):
+    return InquiryService(repo).create_inquiry(
+        event_date=date(2026, 8, 1),
+        inquiry_source="manual",
+        crm_stage=crm_stage,  # type: ignore[arg-type]
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+        call_verification_required=call_verification_required,
+        call_verification_status=call_verification_status,  # type: ignore[arg-type]
+        contact_email=email,
+        contact_phone=phone,
+        intake_message=f"Firma: GateCo\nE-Mail: {email}\nTelefon: {phone}\n",
+    )
+
+
+def test_valid_inquiry_creates_exactly_one_order() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    assert version.version_number == 1
+    assert order.source_inquiry_id == inquiry.inquiry_id
+    assert len(orders.list_orders()) == 1
+    assert len(orders.list_order_versions(order.order_id)) == 1
+
+
+def test_repeated_conversion_returns_same_order_without_new_version() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    service = OrderService(orders)
+    first_order, first_version = service.convert_inquiry_to_order(inquiry)
+    second_order, second_version = service.convert_inquiry_to_order(inquiry)
+    assert second_order.order_id == first_order.order_id
+    assert second_version.order_version_id == first_version.order_version_id
+    assert len(orders.list_orders()) == 1
+    assert len(orders.list_order_versions(first_order.order_id)) == 1
+
+
+def test_cancelled_order_blocks_second_order_and_returns_existing() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    service = OrderService(orders)
+    first_order, first_version = service.convert_inquiry_to_order(inquiry)
+    OperationalCoreService(orders).cancel_order(first_order.order_id)
+    second_order, second_version = service.convert_inquiry_to_order(inquiry)
+    assert second_order.order_id == first_order.order_id
+    assert second_version.order_version_id == first_version.order_version_id
+    assert len(orders.list_orders()) == 1
+
+
+def test_rejected_inquiry_is_blocked() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries, crm_stage="Abgelehnt / verloren")
+    with pytest.raises(ValueError, match="conversion blocked"):
+        OrderService(orders).convert_inquiry_to_order(inquiry)
+    assert orders.list_orders() == []
+
+
+def test_incomplete_inquiry_is_blocked() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = InquiryService(inquiries).create_inquiry(
+        event_date=date(2026, 8, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+    )
+    with pytest.raises(ValueError, match="contact information incomplete"):
+        OrderService(orders).convert_inquiry_to_order(inquiry)
+
+
+def test_verification_required_but_pending_is_blocked() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(
+        inquiries,
+        call_verification_required=True,
+        call_verification_status="pending",
+    )
+    with pytest.raises(ValueError, match="conversion blocked"):
+        OrderService(orders).convert_inquiry_to_order(inquiry)
+
+
+def test_order_existence_closes_open_queue() -> None:
+    state = derive_inquiry_office_state(
+        _inquiry(InMemoryInquiryRepository()),
+        has_order=True,
+        has_active_order=False,
+        today=_TODAY,
+    )
+    assert state.is_open is False
+    assert state.next_action is None
+
+
+def test_converted_inquiry_leaves_open_queue_but_stays_in_history() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    OrderService(orders).convert_inquiry_to_order(inquiry)
+    InquiryService(inquiries).update_inquiry(
+        inquiry.inquiry_id, crm_stage="Bestätigt / Auftrag"
+    )
+    panel = OfficePanel(inquiries, orders, offer_repo=InMemoryOfferRepository())
+    queue = panel.render_queue(None)
+    assert inquiry.inquiry_id not in queue or "Offene Anfragen" in queue
+    # open-inquiry counter excludes converted
+    assert panel._open_inquiries_count() == 0  # noqa: SLF001
+    detail = panel.render_inquiry(inquiry.inquiry_id) or ""
+    assert inquiry.inquiry_id[:8] in detail or "Auftrag" in detail
+    assert "Auftrag öffnen" in detail or "Auftrag vorhanden" in detail
+
+
+def test_contact_status_becomes_kunde_after_conversion() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    assert derive_contact_status(linked_order_count=0) == "interessent"
+    OrderService(orders).convert_inquiry_to_order(inquiry)
+    assert derive_contact_status(linked_order_count=1) == "kunde"
+
+
+def test_in_memory_repository_rejects_duplicate_linked_order() -> None:
+    from datetime import UTC, datetime
+    import uuid
+
+    from catering_system.domain.order import Order, OrderVersion
+
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    OrderService(orders).convert_inquiry_to_order(inquiry)
+    now = datetime.now(UTC)
+    order_id = str(uuid.uuid4())
+    with pytest.raises(ValueError, match="already has a linked order"):
+        orders.save_order_with_initial_version(
+            Order(
+                order_id=order_id,
+                source_inquiry_id=inquiry.inquiry_id,
+                created_at=now,
+                updated_at=now,
+            ),
+            OrderVersion(
+                order_version_id=str(uuid.uuid4()),
+                order_id=order_id,
+                version_number=1,
+                created_at=now,
+                event_date=inquiry.event_date,
+                time_window_text=inquiry.time_window_text,
+                location_text=inquiry.location_text,
+                guest_count_estimate=inquiry.guest_count_estimate,
+                planning_mode=inquiry.planning_mode,
+            ),
+        )

--- a/tests/unit/test_kitchen_print_error_paths.py
+++ b/tests/unit/test_kitchen_print_error_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from dataclasses import replace
 
 import pytest
 
@@ -79,7 +80,7 @@ def test_request_print_rejects_conflicting_existing_job_id() -> None:
     orders, service, order_id, version_id = _service()
     service.request_print(order_id, version_id, print_job_id=JOB_1)
     other_order, other_version = OrderService(orders).convert_inquiry_to_order(
-        _inquiry()
+        replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
     )
     with pytest.raises(
         ValueError, match="print_job_id already exists with different facts"

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -99,6 +99,9 @@ def _seed(db_path: Path) -> dict[str, str]:
     ids["version_cancelled"] = v1c.order_version_id
     ids["inquiry_cancelled_order"] = cancelled_src.inquiry_id
 
+    offer_ready = make_inquiry(location_text="Angebot-Stadt")
+    ids["inquiry_offer_ready"] = offer_ready.inquiry_id
+
     website = make_inquiry(
         inquiry_source="website_form",
         intake_external_ref="web-ref-001",
@@ -280,11 +283,11 @@ def test_queue_view_attention_counts_and_tops(api) -> None:
         "auftraege_top",
         "pausiert_top",
     }
-    # seed world: 3 open inquiries plus 1 rejected inquiry without an order;
+    # seed world: 4 open inquiries plus 1 rejected inquiry without an order;
     # 1 order without print;
     # 2 not effective (unprinted + none), 2 blocked, 1 cancelled
     assert body["attention"] == {
-        "neue_anfragen": 3,
+        "neue_anfragen": 4,
         "druck_fehlt": 1,
         "nicht_wirksam": 1,
         "versand_blockiert": 1,
@@ -297,6 +300,7 @@ def test_queue_view_attention_counts_and_tops(api) -> None:
     }
     assert top_actions[ids["inquiry_verify"]] == "verify"
     assert top_actions[ids["inquiry_convertible"]] == "convert"
+    assert top_actions[ids["inquiry_offer_ready"]] == "convert"
     assert top_actions[ids["inquiry_website"]] == "verify"
     assert ids["inquiry_rejected"] not in top_actions
     (blocked_row,) = body["auftraege_top"]
@@ -585,10 +589,11 @@ def test_list_calendar_schema(api) -> None:
     status, body, _h = _get(f"{base}/office/v1/calendar?from=2026-10-01&to=2026-10-31")
     assert status == 200
     assert isinstance(body["entries"], list)
-    assert len(body["entries"]) == 5
+    assert len(body["entries"]) == 6
     by_inquiry = {row["source_inquiry_id"]: row for row in body["entries"]}
     assert ids["inquiry_rejected"] not in by_inquiry
     assert ids["inquiry_cancelled_order"] not in by_inquiry
+    assert ids["inquiry_offer_ready"] in by_inquiry
     assert by_inquiry[ids["inquiry_printed"]]["entry_kind"] == "event_confirmed"
     assert by_inquiry[ids["inquiry_unprinted"]]["entry_kind"] == "event_planned"
     row = next(row for row in body["entries"] if row["entry_kind"] == "event_confirmed")
@@ -653,7 +658,7 @@ def test_inquiry_list_rows_and_search(api) -> None:
     status, body, _h = _get(f"{base}/office/v1/inquiries")
     assert status == 200
     assert set(body) == {"inquiries", "total_count", "limit", "offset"}
-    assert body["total_count"] == 7
+    assert body["total_count"] == 8
     by_id = {row["inquiry_id"]: row for row in body["inquiries"]}
     row = by_id[ids["inquiry_printed"]]
     assert row["linked_order_id"] == ids["order_ready"]
@@ -661,6 +666,8 @@ def test_inquiry_list_rows_and_search(api) -> None:
     cancelled_row = by_id[ids["inquiry_cancelled_order"]]
     assert cancelled_row["linked_order_id"] is None  # only ACTIVE orders link
     assert cancelled_row["orders_total_count"] == 1
+    assert by_id[ids["inquiry_offer_ready"]]["linked_order_id"] is None
+    assert by_id[ids["inquiry_offer_ready"]]["orders_total_count"] == 0
 
     status, body, _h = _get(f"{base}/office/v1/inquiries?q=Sommerfest")
     assert body["total_count"] == 1
@@ -689,7 +696,7 @@ def test_pagination_slices_with_honest_total(api) -> None:
     base, _ids, _db = api
     status, body, _h = _get(f"{base}/office/v1/inquiries?limit=2&offset=4")
     assert status == 200
-    assert body["total_count"] == 7
+    assert body["total_count"] == 8
     assert len(body["inquiries"]) == 2
     assert (body["limit"], body["offset"]) == (2, 4)
 
@@ -1052,9 +1059,10 @@ def test_verify_then_convert_flow_with_gates(api) -> None:
     )
     assert status == 200
     assert detail_after_rejection["crm_stage"] == "Bestätigt / Auftrag"
-    # second convert while active: 409
+    # second convert while active: idempotent success (same order)
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert (status, body["error"]) == (409, "already_converted")
+    assert status == 200
+    assert set(body) >= {"order_id", "order_version_id"}
 
 
 def test_rejected_inquiry_cannot_convert(api) -> None:
@@ -1065,17 +1073,21 @@ def test_rejected_inquiry_cannot_convert(api) -> None:
     assert (status, body["error"]) == (422, "inquiry_rejected")
 
 
-def test_reconvert_after_storno_via_api(api) -> None:
+def test_convert_after_storno_returns_existing_order_via_api(api) -> None:
     base, ids, _db = api
     inquiry_id = ids["inquiry_cancelled_order"]  # its only order is cancelled
+    status, first, _h = _get(f"{base}/office/v1/inquiries/{inquiry_id}")
+    assert status == 200
+    existing_order_id = first["orders"][0]["order_id"]
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert status == 201
+    assert status == 200
+    assert body["order_id"] == existing_order_id
 
 
 def test_legacy_convert_blocked_with_prepared_offer(api) -> None:
     base, ids, db = api
     offer_id, _version_id = _prepare_offer(api)
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
     assert (status, body["error"]) == (422, "offer_blocks_conversion")
     conn = sqlite3.connect(db)
@@ -1098,7 +1110,7 @@ def test_legacy_convert_blocked_with_prepared_offer(api) -> None:
 def test_legacy_convert_blocked_with_accepted_offer(api) -> None:
     base, ids, db = api
     offer_id, _version_id, _acceptance_id, _variant_id = _prepare_send_accept(api)
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
     assert (status, body["error"]) == (422, "offer_blocks_conversion")
     conn = sqlite3.connect(db)
@@ -1128,7 +1140,7 @@ def test_legacy_convert_without_offer_still_works(api) -> None:
 
 def test_legacy_convert_allowed_with_expired_offer(api) -> None:
     base, ids, db = api
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     snapshot = _valid_offer_snapshot(inquiry_id=inquiry_id)
     snapshot["valid_until"] = "2020-01-01"
     snapshot["snapshot_hash"] = compute_snapshot_hash(snapshot)
@@ -2198,7 +2210,7 @@ _MARK_SENT_ARGS = {
 
 def _prepare_offer(api: tuple[str, dict[str, str], Path]) -> tuple[str, str]:
     base, ids, _db = api
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     status, body, _h = _post(
         f"{base}/office/v1/inquiries/{inquiry_id}/prepare-offer",
         args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
@@ -2509,22 +2521,47 @@ def test_convert_accepted_rejects_wrong_variant_or_acceptance(api) -> None:
     assert (status, body["error"]) == (422, "conversion_blocked")
 
 
-def test_convert_accepted_active_order_without_link_blocks(api) -> None:
+def test_convert_accepted_linked_order_without_link_blocks(api) -> None:
     base, ids, db = api
-    offer_id, version_id, acceptance_id, variant_id = _prepare_send_accept(api)
     inquiry_id = ids["inquiry_cancelled_order"]
-    inquiries = SQLiteInquiryRepository(db)
-    orders = SQLiteOrderRepository(db)
-    inquiry = inquiries.get_by_id(inquiry_id)
-    assert inquiry is not None
-    OrderService(orders).convert_inquiry_to_order(inquiry)
-    inquiries.close()
-    orders.close()
+    # Prepare/accept on the cancelled inquiry so a linked Order exists without
+    # conversion_link; convert-accepted must not create another Order.
+    status, prepared, _h = _post(
+        f"{base}/office/v1/inquiries/{inquiry_id}/prepare-offer",
+        args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
+    )
+    assert status == 201
+    offer_id = prepared["offer_id"]
+    version_id = prepared["offer_version_id"]
+    assert (
+        _post(_mark_sent_url(base, offer_id, version_id), args=_MARK_SENT_ARGS)[0]
+        == 200
+    )
+    status, accepted, _h = _post(
+        _record_acceptance_url(base, offer_id, version_id),
+        args=_RECORD_ACCEPTANCE_ARGS,
+    )
+    assert status == 200
     status, body, _h = _post(
         _convert_accepted_url(base, offer_id, version_id),
-        args={"accepted_variant_id": variant_id, "acceptance_id": acceptance_id},
+        args={
+            "accepted_variant_id": accepted["accepted_variant_id"],
+            "acceptance_id": accepted["acceptance_id"],
+        },
     )
     assert (status, body["error"]) == (409, "already_converted")
+    orders = SQLiteOrderRepository(db)
+    assert (
+        len(
+            [
+                order
+                for order in orders.list_orders()
+                if order.source_inquiry_id == inquiry_id
+            ]
+        )
+        == 1
+    )
+    orders.close()
 
 
 def test_convert_accepted_storno_replay_same_order(api) -> None:
@@ -2872,7 +2909,7 @@ def _make_effective_offer_order(
     ensure_recipient_email: bool = True,
 ) -> tuple[str, str]:
     base, ids, _db = api
-    resolved_inquiry = inquiry_id or ids["inquiry_cancelled_order"]
+    resolved_inquiry = inquiry_id or ids["inquiry_offer_ready"]
     if ensure_recipient_email:
         _ensure_inquiry_recipient_email(base, resolved_inquiry)
     resolved_snapshot = snapshot or _unique_offer_snapshot(inquiry_id=resolved_inquiry)
@@ -3060,7 +3097,7 @@ def test_confirmation_document_preview_escapes_html_but_preserves_json_text(
     malicious = "<script>alert(1)</script>"
     rich = "<b>Test</b>"
     amp = "A&B"
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     detail = _get(f"{base}/office/v1/inquiries/{inquiry_id}")[1]
     _post(
         f"{base}/office/v1/inquiries/{inquiry_id}/update",
@@ -3178,7 +3215,7 @@ def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
 
 def test_confirmation_document_missing_recipient_is_allowed(api) -> None:
     base, ids, db = api
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     detail = _get(f"{base}/office/v1/inquiries/{inquiry_id}")[1]
     _post(
         f"{base}/office/v1/inquiries/{inquiry_id}/update",

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -390,7 +390,7 @@ def test_unverified_inquiry_shows_progression_block_and_convert_fails(
         "Rückrufprüfung noch nicht erfüllt" in body
     )  # B7 vocabulary, human label, on inquiry view
     assert "Telefonisch verifiziert" in body
-    assert "In Auftrag umwandeln" not in body
+    assert "Auftrag erstellen" not in body
     with pytest.raises(urllib.error.HTTPError) as exc:
         _post(f"{panel}/inquiry/{iid}/convert", {})
     assert exc.value.code == 400
@@ -453,7 +453,7 @@ def test_converted_inquiry_shows_order_link_instead_of_button(panel: str) -> Non
     oid = _convert(panel, iid)
     _status, body = _get(f"{panel}/inquiry/{iid}")
     assert "Auftrag vorhanden" in body and oid[:8] in body
-    assert "In Auftrag umwandeln" not in body
+    assert "Auftrag erstellen" not in body
     assert '<select name="crm_stage">' not in body
     assert '<input type="hidden" name="crm_stage" value="Bestätigt / Auftrag">' in body
 
@@ -498,7 +498,7 @@ def test_rejected_inquiry_is_closed_without_queue_or_actions(panel: str) -> None
     _status, detail = _get(f"{panel}/inquiry/{iid}")
     assert "Anfrage wurde abgelehnt" in detail
     assert "Telefonisch verifiziert" not in detail
-    assert "In Auftrag umwandeln" not in detail
+    assert "Auftrag erstellen" not in detail
     _status, dashboard = _get(f"{panel}/")
     assert _attention_counts(dashboard)["Offene Anfragen prüfen"] == 0
 
@@ -528,13 +528,13 @@ def test_v2_inquiry_detail_ready_to_convert_and_verification_required(
     assert "<h1>Sommerfest HafenCity</h1>" in ready
     assert "Bereit für Auftrag" in ready
     assert f'action="/inquiry/{ready_id}/convert"' in ready
-    assert "In Auftrag umwandeln" in ready
+    assert "Auftrag erstellen" in ready
     assert "Telefonisch verifiziert" not in ready
     assert "Rückruf erforderlich" in verify
     assert "Rückrufprüfung noch nicht erfüllt" in verify
     assert f'action="/inquiry/{verify_id}/verify"' in verify
     assert "Telefonisch verifiziert" in verify
-    assert "In Auftrag umwandeln" not in verify
+    assert "Auftrag erstellen" not in verify
 
 
 def test_v2_inquiry_detail_rejected_has_no_primary_action(
@@ -581,15 +581,15 @@ def test_v2_inquiry_detail_active_and_cancelled_order_history(
 
     assert "Auftrag vorhanden" in active
     assert f'href="/order/{active_order_id}"' in active
-    assert "Aktiven Auftrag öffnen" in active
+    assert "Auftrag öffnen" in active
     assert f'action="/inquiry/{active_inquiry_id}/convert"' not in active
     assert '<select name="crm_stage">' not in active
     assert (
         '<input type="hidden" name="crm_stage" value="Bestätigt / Auftrag">' in active
     )
     assert f'href="/order/{cancelled_order_id}"' in cancelled
-    assert "Stornierten Auftrag öffnen" in cancelled
-    assert f'action="/inquiry/{cancelled_inquiry_id}/convert"' in cancelled
+    assert "Auftrag öffnen" in cancelled
+    assert f'action="/inquiry/{cancelled_inquiry_id}/convert"' not in cancelled
 
     visible_active = html.unescape(re.sub(r"<[^>]+>", " ", active))
     visible_cancelled = html.unescape(re.sub(r"<[^>]+>", " ", cancelled))
@@ -1151,18 +1151,19 @@ def test_cancelled_print_sheet_shows_storniert_banner(panel: str) -> None:
     assert "STORNIERT" in sheet  # kitchen must see the cancellation on the sheet
 
 
-def test_reconvert_possible_after_storno(panel: str) -> None:
-    """A cancelled order must not suppress the convert button (Storno semantics)."""
+def test_convert_after_storno_returns_existing_order(panel: str) -> None:
+    """Order existence remains authoritative — Storno does not unlock a second Order."""
     iid = _create_inquiry(panel)
     oid = _convert(panel, iid)
     _post(f"{panel}/order/{oid}/cancel", {})
     _status, body = _get(f"{panel}/inquiry/{iid}")
     assert "(storniert)" in body
-    assert "In Auftrag umwandeln" in body  # button back after Storno
+    assert "Auftrag erstellen" not in body
+    assert "Auftrag öffnen" in body
     oid2 = _convert(panel, iid)
-    assert oid2 != oid
+    assert oid2 == oid
     _status, body = _get(f"{panel}/inquiry/{iid}")
-    assert "In Auftrag umwandeln" not in body  # active order suppresses it again
+    assert "Auftrag erstellen" not in body
 
 
 def test_xss_escaped_in_views(panel: str) -> None:
@@ -1790,7 +1791,7 @@ def test_dashboard_queues_capped_at_five_with_alle_anzeigen_link(panel: str) -> 
         _create_inquiry(panel)
     _status, body = _get(f"{panel}/")
     assert _attention_counts(body)["Offene Anfragen prüfen"] == 7
-    assert body.count("<button>In Auftrag umwandeln</button>") == 5
+    assert body.count("<button>Auftrag erstellen</button>") == 5
     assert '<a href="/anfragen">Alle anzeigen</a>' in body
     _status, full_body = _get(f"{panel}/anfragen")
     assert full_body.count("<tr>") == 8  # header row + all 7, not just top 5

--- a/tests/unit/test_office_panel_convert_accepted.py
+++ b/tests/unit/test_office_panel_convert_accepted.py
@@ -104,11 +104,26 @@ def _seed(db_path: Path) -> dict[str, str]:
     )
     cancelled_order, _version = order_service.convert_inquiry_to_order(cancelled_src)
     core.cancel_order(cancelled_order.order_id)
+    offer_ready = inquiry_service.create_inquiry(
+        event_date=date(2026, 10, 3),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="abends",
+        location_text="Angebot-Stadt",
+        guest_count_estimate=40,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="kunde@example.com",
+        contact_phone="+49301234567",
+    )
     inquiries.close()
     orders.close()
     return {
         "inquiry_convertible": inquiry.inquiry_id,
         "inquiry_cancelled_order": cancelled_src.inquiry_id,
+        "inquiry_offer_ready": offer_ready.inquiry_id,
     }
 
 
@@ -370,7 +385,7 @@ def test_accepted_offer_button_creates_order_and_disappears(direct_world) -> Non
 
 def test_converted_storno_shows_open_link_not_create_button(direct_world) -> None:
     panel_url, api_url, ids, db = direct_world
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_offer_ready"]
     _accept_offer_via_api(api_url, inquiry_id)
 
     offers = SQLiteOfferRepository(db)
@@ -400,8 +415,8 @@ def test_converted_storno_shows_open_link_not_create_button(direct_world) -> Non
 
     _status, detail = _get(f"{panel_url}/inquiry/{inquiry_id}")
     assert "Angenommenes Angebot in Auftrag überführen" not in detail
-    assert "Auftrag bereits erstellt" in detail
-    assert "Stornierten Auftrag öffnen" in detail
+    assert "Auftrag öffnen" in detail
+    assert "Auftrag erstellen" not in detail
 
 
 def test_convert_accepted_replay_does_not_create_second_order(direct_world) -> None:

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -402,7 +402,7 @@ def test_legacy_convert_offer_gate_parity_direct_vs_remote(tmp_path: Path) -> No
     convert while a Prepared Offer blocks the inquiry path."""
     db = tmp_path / "offer-gate.db"
     ids = _seed(db)
-    inquiry_id = ids["inquiry_cancelled_order"]
+    inquiry_id = ids["inquiry_convertible"]
 
     api_url, api_server = _start_api_server(db)
     try:
@@ -877,9 +877,35 @@ def test_v2_remote_inquiry_detail_preserves_linked_order_truncation_warning(
     )
     order_service = OrderService(orders)
     core = OperationalCoreService(orders)
-    for _index in range(51):
-        order, _version = order_service.convert_inquiry_to_order(inquiry)
-        core.cancel_order(order.order_id)
+    first, version = order_service.convert_inquiry_to_order(inquiry)
+    core.cancel_order(first.order_id)
+    from datetime import UTC, datetime
+    import uuid
+    from catering_system.domain.order import Order, OrderVersion
+
+    now = datetime.now(UTC)
+    for _index in range(50):
+        order_id = str(uuid.uuid4())
+        orders.save_order_with_initial_version(
+            Order(
+                order_id=order_id,
+                source_inquiry_id=inquiry.inquiry_id,
+                created_at=now,
+                updated_at=now,
+                cancelled_at=now,
+            ),
+            OrderVersion(
+                order_version_id=str(uuid.uuid4()),
+                order_id=order_id,
+                version_number=1,
+                created_at=now,
+                event_date=inquiry.event_date,
+                time_window_text=inquiry.time_window_text,
+                location_text=inquiry.location_text,
+                guest_count_estimate=inquiry.guest_count_estimate,
+                planning_mode=inquiry.planning_mode,
+            ),
+        )
     inquiries.close()
     orders.close()
 
@@ -891,8 +917,8 @@ def test_v2_remote_inquiry_detail_preserves_linked_order_truncation_warning(
         assert status == 200
         assert "Unvollständige Ansicht" in body
         assert "Nicht alle 51 verknüpften Aufträge" in body
-        assert "Stornierten Auftrag öffnen" in body
-        assert "In Auftrag umwandeln" in body
+        assert "Auftrag öffnen" in body
+        assert "Auftrag erstellen" not in body
     finally:
         panel_server.shutdown()
         panel_server.server_close()
@@ -1046,7 +1072,7 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
     status, converted_inquiry_html = _get(f"{base}/inquiry/{inquiry_id}")
     assert status == 200
     assert "Bestätigt / Auftrag" in converted_inquiry_html
-    assert "In Auftrag umwandeln" not in converted_inquiry_html
+    assert "Auftrag erstellen" not in converted_inquiry_html
     assert '<select name="crm_stage">' not in converted_inquiry_html
     assert (
         '<input type="hidden" name="crm_stage" value="Bestätigt / Auftrag">'
@@ -1203,7 +1229,7 @@ def test_verify_flow_through_remote_panel(remote_world) -> None:
 
     _status, detail_html = _get(f"{base}/inquiry/{inquiry_id}")
     assert "Telefonisch verifiziert" not in detail_html  # button gone once verified
-    assert "In Auftrag umwandeln" in detail_html  # convert now offered
+    assert "Auftrag erstellen" in detail_html  # convert now offered
 
 
 def test_idempotent_retry_same_command_id_and_preconditions(remote_world) -> None:

--- a/tests/unit/test_operational_core_service.py
+++ b/tests/unit/test_operational_core_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, replace
 from datetime import date, datetime, timezone
 
 import pytest
@@ -98,7 +98,12 @@ def test_confirm_kitchen_print_is_idempotent() -> None:
 def test_confirm_kitchen_print_rejects_foreign_or_unknown_version() -> None:
     _repo, osvc, core, _events = _setup()
     order_a, _va = osvc.convert_inquiry_to_order(_sample_inquiry())
-    order_b, vb = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order_b, vb = osvc.convert_inquiry_to_order(
+        replace(
+            _sample_inquiry(),
+            inquiry_id="22222222-2222-4222-8222-222222222222",
+        )
+    )
     with pytest.raises(ValueError):
         core.confirm_kitchen_print(order_a.order_id, vb.order_version_id)
     with pytest.raises(ValueError):

--- a/tests/unit/test_progression_service.py
+++ b/tests/unit/test_progression_service.py
@@ -813,7 +813,12 @@ def test_state_signature_eligible_and_blocked_missing_shapes() -> None:
     order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     sig_ok = prog.get_order_progression_state_signature(order.order_id)
-    order2, _v1b = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order2, _v1b = osvc.convert_inquiry_to_order(
+        replace(
+            _sample_inquiry(),
+            inquiry_id="22222222-2222-4222-8222-222222222222",
+        )
+    )
     sig_blocked = prog.get_order_progression_state_signature(order2.order_id)
     assert sig_ok is not None and sig_blocked is not None
     assert (


### PR DESCRIPTION
## Summary
- Make Inquiry → Order conversion idempotent: any linked Order is authoritative; repeated convert returns the same Order/v1 (no duplicate Order or OrderVersion).
- Close “Offene Anfragen” membership whenever an Order exists (including cancelled); Inquiry history/contact views stay intact.
- Office Panel shows “Auftrag erstellen” only when conversion is allowed, otherwise clear blockers or “Auftrag öffnen”; offer convert-accepted cannot create a second Order for the same Inquiry.

## Test plan
- [x] `ruff check src tests`
- [x] `ruff format --check src tests`
- [x] `mypy src/catering_system`
- [x] `coverage run -m pytest -q` && `coverage report` (≥90%, observed 90.4%, 1540 passed)
- [ ] Manual: convert eligible Inquiry → appears as Order; repeat convert → same Order; converted Inquiry leaves Offene Anfragen; rejected/incomplete stay blocked


Made with [Cursor](https://cursor.com)