### PR TITLE
Remove legacy Inquiry→Order creation (REMOVE_LEGACY_ORDER_CREATION_V1)

### DIFF
--- a/src/catering_system/domain/inquiry.py
+++ b/src/catering_system/domain/inquiry.py
@@ -67,7 +67,7 @@ CALL_VERIFICATION_STATUSES: tuple[CallVerificationStatus, ...] = (
 CALL_VERIFICATION_STATUS_SET: frozenset[str] = frozenset(CALL_VERIFICATION_STATUSES)
 
 InquiryOfficeNextAction = Literal[
-    "verify", "convert", "convert-accepted", "offer-pending"
+    "verify", "prepare-offer", "convert-accepted", "offer-pending"
 ]
 
 
@@ -314,7 +314,7 @@ def derive_inquiry_office_state(
             )
     if inquiry_allows_order_conversion(inquiry) and contact_complete:
         return InquiryOfficeState(
-            is_open=is_open, next_action="convert", offer=offer_projection
+            is_open=is_open, next_action="prepare-offer", offer=offer_projection
         )
     return InquiryOfficeState(is_open=is_open, next_action=None, offer=offer_projection)
 

--- a/src/catering_system/domain/task_projection.py
+++ b/src/catering_system/domain/task_projection.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 TaskCategory = Literal[
     "verify",
-    "convert",
+    "prepare_offer",
     "convert_accepted",
     "order_print",
     "order_effective",
@@ -68,6 +68,6 @@ def _sort_tier(task: TaskProjection) -> int:
         return 4
     if task.category == "payment":
         return 5
-    if task.category == "convert":
+    if task.category == "prepare_offer":
         return 6
     raise AssertionError(f"unexpected task category: {task.category!r}")

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -16,11 +16,7 @@ from datetime import date, datetime, timezone
 
 from catering_system.domain.inquiry import (
     Inquiry,
-    inquiry_allows_order_conversion,
     validate_planning_mode,
-)
-from catering_system.domain.inquiry_contact_completeness import (
-    inquiry_contact_complete,
 )
 from catering_system.domain.offer import OfferVersion as CommercialOfferVersion
 from catering_system.domain.operational_core_events import (
@@ -54,57 +50,16 @@ class OrderService:
             self._event_sink(event)
 
     def convert_inquiry_to_order(self, inquiry: Inquiry) -> tuple[Order, OrderVersion]:
-        """Create Order + v1 after the Core inquiry conversion gate passes.
+        """Compatibility lookup only — never creates an Order.
 
-        Idempotent: if any Order already exists for the inquiry, return that
-        Order and its initial version instead of creating another. Order
-        existence is authoritative for “already converted”.
-        The application command owns the accompanying Inquiry stage update.
+        If a linked Order already exists, return it (prefer active). Otherwise
+        raise: Order creation requires an Accepted Offer via
+        ``create_order_from_offer_version`` / ``convert_accepted_offer``.
         """
         existing = self.orders_for_inquiry(inquiry.inquiry_id)
         if existing:
             return self._existing_conversion_result(existing)
-
-        if not inquiry_allows_order_conversion(inquiry):
-            raise ValueError(
-                "inquiry_to_order conversion blocked "
-                f"(inquiry_id={inquiry.inquiry_id!r}, "
-                f"crm_stage={inquiry.crm_stage!r}, "
-                f"call_verification_required={inquiry.call_verification_required!r}, "
-                f"call_verification_status={inquiry.call_verification_status!r})"
-            )
-        if not inquiry_contact_complete(inquiry):
-            raise ValueError(
-                "inquiry contact information incomplete "
-                f"(inquiry_id={inquiry.inquiry_id!r})"
-            )
-        now = _utc_now()
-        order_id = str(uuid.uuid4())
-        order = Order(
-            order_id=order_id,
-            source_inquiry_id=inquiry.inquiry_id,
-            created_at=now,
-            updated_at=now,
-        )
-        version = OrderVersion(
-            order_version_id=str(uuid.uuid4()),
-            order_id=order_id,
-            version_number=1,
-            created_at=now,
-            event_date=inquiry.event_date,
-            time_window_text=inquiry.time_window_text,
-            location_text=inquiry.location_text,
-            guest_count_estimate=inquiry.guest_count_estimate,
-            planning_mode=inquiry.planning_mode,
-        )
-        self._order_repository.save_order_with_initial_version(order, version)
-        _log.info(
-            "convert_inquiry_to_order inquiry_id=%s order_id=%s version=%s",
-            inquiry.inquiry_id,
-            order_id,
-            version.version_number,
-        )
-        return order, version
+        raise ValueError(f"accepted offer required (inquiry_id={inquiry.inquiry_id!r})")
 
     def orders_for_inquiry(self, inquiry_id: str) -> list[Order]:
         return [

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -72,14 +72,14 @@ class TaskProjectionService:
                         inquiry.event_date,
                     )
                 )
-            elif state.next_action == "convert":
+            elif state.next_action == "prepare-offer":
                 tasks.append(
                     (
                         _inquiry_task(
                             inquiry,
-                            task_id=f"inquiry:{inquiry.inquiry_id}:convert",
-                            category="convert",
-                            title="Anfrage in Auftrag umwandeln",
+                            task_id=f"inquiry:{inquiry.inquiry_id}:prepare-offer",
+                            category="prepare_offer",
+                            title="Angebot vorbereiten",
                             subtitle=subtitle,
                         ),
                         inquiry.event_date,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -36,7 +36,6 @@ from catering_system.domain.inquiry import (
 )
 from catering_system.domain.inquiry_contact_completeness import (
     derive_inquiry_contact_completeness,
-    inquiry_contact_complete,
     missing_contact_fields,
 )
 from catering_system.domain.offer import (
@@ -44,7 +43,6 @@ from catering_system.domain.offer import (
     SENT_CHANNELS,
     AcceptanceChannel,
     SentChannel,
-    offer_blocks_direct_inquiry_conversion,
 )
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_payment_reminder import (
@@ -1012,6 +1010,10 @@ class OfficeApi:
     def cmd_convert(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
     ) -> tuple[int, dict[str, object]]:
+        """Compatibility endpoint: return existing Order or refuse create.
+
+        Order creation is only allowed via convert-accepted (Accepted Offer).
+        """
         inquiry = self._require_inquiry(path_ids["id"])
         linked_orders = [
             order
@@ -1024,53 +1026,7 @@ class OfficeApi:
                 "order_id": order.order_id,
                 "order_version_id": version.order_version_id,
             }
-        offer = self.offers.get_by_source_inquiry_id(inquiry.inquiry_id)
-        state = views.inquiry_office_state(
-            inquiry,
-            linked_orders,
-            offer=offer,
-            today=views.berlin_today(),
-        )
-        if inquiry.crm_stage == "Abgelehnt / verloren":
-            raise ApiError(422, "inquiry_rejected")
-        if offer is not None and offer_blocks_direct_inquiry_conversion(
-            offer, today=views.berlin_today()
-        ):
-            raise ApiError(422, "offer_blocks_conversion")
-        if not inquiry_contact_complete(inquiry):
-            raise ApiError(422, "contact_information_incomplete")
-        if state.next_action != "convert":
-            raise ApiError(422, "verification_gate_blocked")
-        try:
-            order, version = self.order_service.convert_inquiry_to_order(inquiry)
-        except sqlite3.IntegrityError:
-            # Race: another writer created the order — return it idempotently.
-            if self.order_service.orders_for_inquiry(inquiry.inquiry_id):
-                order, version = self.order_service.convert_inquiry_to_order(inquiry)
-                return 200, {
-                    "order_id": order.order_id,
-                    "order_version_id": version.order_version_id,
-                }
-            raise
-        except ValueError as exc:
-            message = str(exc)
-            if "contact information incomplete" in message:
-                raise ApiError(422, "contact_information_incomplete") from exc
-            if "already has a linked order" in message:
-                order, version = self.order_service.convert_inquiry_to_order(inquiry)
-                return 200, {
-                    "order_id": order.order_id,
-                    "order_version_id": version.order_version_id,
-                }
-            raise ApiError(422, "verification_gate_blocked") from exc
-        self.inquiry_service.update_inquiry(
-            inquiry.inquiry_id,
-            crm_stage="Bestätigt / Auftrag",
-        )
-        return 201, {
-            "order_id": order.order_id,
-            "order_version_id": version.order_version_id,
-        }
+        raise ApiError(422, "accepted_offer_required")
 
     def cmd_prepare_offer(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -337,7 +337,7 @@ def inquiry_detail(
     detail["intake_summary"] = inquiry.intake_summary
     detail["intake_external_ref"] = inquiry.intake_external_ref
     state = inquiry_office_state(inquiry, orders, offer=offer, today=today)
-    detail["allows_conversion"] = state.next_action == "convert"
+    detail["allows_conversion"] = False
     detail["next_action"] = state.next_action
     if state.offer is not None:
         detail["offer"] = inquiry_offer_projection_shape(state.offer)

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -39,7 +39,6 @@ from catering_system.domain.offer import (
     SENT_CHANNELS,
     AcceptanceChannel,
     SentChannel,
-    offer_blocks_direct_inquiry_conversion,
 )
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_payment_reminder import (
@@ -1358,12 +1357,8 @@ class OfficePanel:
                 f"{_csrf_input(context)}{self._command_fields()}"
                 "<button>Telefonisch verifiziert</button></form>"
             )
-        if state.next_action == "convert":
-            return (
-                f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
-                f"{_csrf_input(context)}{self._command_fields()}"
-                "<button>Auftrag erstellen</button></form>"
-            )
+        if state.next_action == "prepare-offer":
+            return '<span class="muted">Angebot vorbereiten</span>'
         if state.next_action == "offer-pending":
             return '<span class="muted">Angebot ausstehend</span>'
         if state.next_action == "convert-accepted":
@@ -1693,12 +1688,8 @@ class OfficePanel:
                     f"{_csrf_input(context)}{self._command_fields()}"
                     "<button>Telefonisch verifiziert</button></form>"
                 )
-            elif action_name == "convert":
-                action = (
-                    f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
-                    f"{_csrf_input(context)}{self._command_fields()}"
-                    "<button>Auftrag erstellen</button></form>"
-                )
+            elif action_name == "prepare-offer":
+                action = '<span class="muted">Angebot vorbereiten</span>'
             elif action_name == "offer-pending":
                 action = '<span class="muted">Angebot ausstehend</span>'
             elif action_name == "convert-accepted":
@@ -2242,7 +2233,7 @@ class OfficePanel:
                     csrf_input=_csrf_input(context),
                     primary_command_fields=(
                         self._command_fields()
-                        if state.next_action in ("verify", "convert")
+                        if state.next_action == "verify"
                         or inquiry_shows_convert_accepted_button(state)
                         else ""
                     ),
@@ -2272,7 +2263,7 @@ class OfficePanel:
             )
             prog = f'<p class="blocked">Konvertierung blockiert:</p><ul>{reasons}</ul>'
         else:
-            prog = '<p class="ok">Konvertierung möglich.</p>'
+            prog = '<p class="ok">Angebot kann vorbereitet werden.</p>'
         verify_btn = ""
         if state.next_action == "verify":
             verify_btn = (
@@ -2291,12 +2282,8 @@ class OfficePanel:
                 f"<p>Auftrag vorhanden: {links} — "
                 f'<a href="/order/{_e(existing[0].order_id)}">Auftrag öffnen</a></p>'
             )
-        if state.next_action == "convert":
-            convert += (
-                f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/convert">'
-                f"{_csrf_input(context)}{self._command_fields()}"
-                "<button>Auftrag erstellen</button></form>"
-            )
+        if state.next_action == "prepare-offer":
+            convert += '<p class="muted">Auftrag nur aus angenommenem Angebot.</p>'
         elif state.next_action == "offer-pending":
             convert += '<p class="muted">Angebot ausstehend</p>'
         elif state.next_action == "convert-accepted":
@@ -2427,44 +2414,16 @@ class OfficePanel:
         )
 
     def convert_inquiry_to_order(self, inquiry_id: str) -> tuple[Order, OrderVersion]:
-        """Run the truthful gate and stage transition as one direct command.
+        """Compatibility lookup: return linked Order or refuse create.
 
-        Idempotent: an existing linked Order is returned instead of creating
-        another. Remote mode delegates the same atomic command to Core Office API.
+        Remote mode delegates to Core Office API (same hard-block contract).
         """
 
         def work() -> tuple[Order, OrderVersion]:
             inquiry = self._inquiries.get_by_id(inquiry_id)
             if inquiry is None:
                 raise KeyError(inquiry_id)
-            linked_orders = [
-                order
-                for order in self._orders.list_orders()
-                if order.source_inquiry_id == inquiry_id
-            ]
-            if linked_orders:
-                return self.order_service.convert_inquiry_to_order(inquiry)
-            state = self._inquiry_office_state(
-                inquiry,
-                linked_orders,
-                inquiry_id=inquiry_id,
-            )
-            if inquiry.crm_stage == "Abgelehnt / verloren":
-                raise ValueError("rejected inquiry cannot be converted")
-            offer = self._offers.get_by_source_inquiry_id(inquiry_id)
-            if offer is not None and offer_blocks_direct_inquiry_conversion(
-                offer, today=api_views.berlin_today()
-            ):
-                raise ValueError("offer blocks conversion")
-            if state.next_action != "convert":
-                raise ValueError("inquiry conversion gate is not satisfied")
-            order, version = self.order_service.convert_inquiry_to_order(inquiry)
-            if self._remote is None:
-                self.inquiry_service.update_inquiry(
-                    inquiry_id,
-                    crm_stage="Bestätigt / Auftrag",
-                )
-            return order, version
+            return self.order_service.convert_inquiry_to_order(inquiry)
 
         if self._remote is not None:
             inquiry = self._inquiries.get_by_id(inquiry_id)

--- a/src/catering_system/ui/office_panel_dashboard.py
+++ b/src/catering_system/ui/office_panel_dashboard.py
@@ -40,7 +40,7 @@ _WEEKDAYS = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
 # Task-category → monochrome sprite icon (office_panel_shell.py sprite).
 _TASK_ICONS = {
     "verify": "phone",
-    "convert": "doc",
+    "prepare_offer": "doc",
     "convert_accepted": "doc",
     "order_print": "printer",
     "order_effective": "check",

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -79,6 +79,10 @@ _INQUIRY_COMMAND_ERROR_LABELS: dict[str, str] = {
         "Das angenommene Angebot kann derzeit nicht in einen Auftrag umgewandelt werden."
     ),
     "already_converted": "Für diese Anfrage existiert bereits ein Auftrag.",
+    "accepted_offer_required": (
+        "Auftrag nur aus angenommenem Angebot — "
+        "direkte Umwandlung aus der Anfrage ist nicht möglich."
+    ),
     "verification_gate_blocked": (
         "Die Rückrufprüfung ist noch nicht erfüllt — "
         "eine Umwandlung ist noch nicht möglich."
@@ -138,6 +142,8 @@ def office_command_error_message(code_or_text: str) -> str:
         return _OFFER_COMMAND_ERROR_LABELS["conversion_already_exists"]
     if "accepted offer conversion gate" in lowered or "conversion blocked" in lowered:
         return _OFFER_COMMAND_ERROR_LABELS["conversion_blocked"]
+    if "accepted offer required" in lowered:
+        return _INQUIRY_COMMAND_ERROR_LABELS["accepted_offer_required"]
     if "offer blocks conversion" in lowered:
         return _INQUIRY_COMMAND_ERROR_LABELS["offer_blocks_conversion"]
     if "contact information incomplete" in lowered:

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -106,16 +106,15 @@ def _state_copy(
             "Rückruf erforderlich",
             "Die Angaben müssen vor dem nächsten Schritt telefonisch bestätigt werden.",
         )
-    if state.next_action == "convert":
+    if state.next_action == "prepare-offer":
         return (
-            "Bereit für Auftrag",
-            "Die vorhandenen Angaben erlauben die Umwandlung in einen Auftrag.",
+            "Angebot vorbereiten",
+            "Ein Auftrag entsteht nur aus einem angenommenen Angebot.",
         )
     if state.next_action == "offer-pending":
         return (
             "Angebot ausstehend",
-            "Für diese Anfrage läuft der Angebotsprozess. "
-            "Ein direkter Legacy-Auftrag ist derzeit nicht vorgesehen.",
+            "Für diese Anfrage läuft der Angebotsprozess.",
         )
     if state.next_action == "convert-accepted":
         if state.offer is not None and state.offer.commercial_state == "Converted":
@@ -157,14 +156,15 @@ def _primary_action(
         )
         path = "verify"
         label = "Telefonisch verifiziert"
-    elif state.next_action == "convert":
-        heading = "Anfrage in einen Auftrag übernehmen"
-        explanation = (
-            "Die Prüfung ist erfüllt. Mit diesem Schritt wird der bestehende "
-            "Auftragsprozess gestartet."
+    elif state.next_action == "prepare-offer":
+        return (
+            '<section class="inquiry-next-step">'
+            '<div class="inquiry-eyebrow">Nächster Schritt</div>'
+            "<h2>Angebot vorbereiten</h2>"
+            "<p>Ein Auftrag wird nur aus einem angenommenen Angebot erstellt. "
+            "Bereiten Sie zuerst ein Angebot vor.</p>"
+            "</section>"
         )
-        path = "convert"
-        label = "Auftrag erstellen"
     elif inquiry_shows_convert_accepted_button(state):
         return (
             '<section class="inquiry-next-step">'
@@ -194,8 +194,7 @@ def _primary_action(
             '<section class="inquiry-next-step">'
             '<div class="inquiry-eyebrow">Nächster Schritt</div>'
             "<h2>Angebot ausstehend</h2>"
-            "<p>Der Angebotsprozess ist noch offen. "
-            "Es gibt derzeit keine direkte Legacy-Umwandlung in einen Auftrag.</p>"
+            "<p>Der Angebotsprozess ist noch offen.</p>"
             "</section>"
         )
     else:

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -118,7 +118,7 @@ _CONTACT_FIELD_VALUES = frozenset({"email", "phone"})
 _INQUIRY_OFFER_KEYS = frozenset({"offer_id", "offer_version_id", "commercial_state"})
 _INQUIRY_OFFER_OPTIONAL_KEYS = frozenset({"accepted_variant_id", "acceptance_id"})
 _INQUIRY_NEXT_ACTIONS = frozenset(
-    {"verify", "convert", "convert-accepted", "offer-pending"}
+    {"verify", "prepare-offer", "convert-accepted", "offer-pending"}
 )
 _OFFER_COMMERCIAL_STATES = frozenset(
     {
@@ -223,6 +223,7 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "version_not_owned",
             "invalid_payment_reminder",
             "conversion_blocked",
+            "accepted_offer_required",
             "offer_blocks_conversion",
             "sent_recording_blocked",
             "invalid_sent_evidence",
@@ -1721,7 +1722,7 @@ class RemoteCoreClient:
         _exact(body, {"tasks"})
         allowed_categories = {
             "verify",
-            "convert",
+            "prepare_offer",
             "convert_accepted",
             "order_print",
             "order_effective",

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers."""

--- a/tests/helpers/order_seed.py
+++ b/tests/helpers/order_seed.py
@@ -1,0 +1,42 @@
+"""Test-only Order seeding — does not use production Inquiry→Order create."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.repositories.order_repository import OrderRepository
+
+
+def seed_order(
+    order_repository: OrderRepository,
+    inquiry: Inquiry,
+    *,
+    order_id: str | None = None,
+    order_version_id: str | None = None,
+    created_at: datetime | None = None,
+) -> tuple[Order, OrderVersion]:
+    """Persist Order + v1 from Inquiry facts via the repository (fixture only)."""
+    now = created_at or datetime.now(timezone.utc)
+    oid = order_id or str(uuid.uuid4())
+    order = Order(
+        order_id=oid,
+        source_inquiry_id=inquiry.inquiry_id,
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id=order_version_id or str(uuid.uuid4()),
+        order_id=oid,
+        version_number=1,
+        created_at=now,
+        event_date=inquiry.event_date,
+        time_window_text=inquiry.time_window_text,
+        location_text=inquiry.location_text,
+        guest_count_estimate=inquiry.guest_count_estimate,
+        planning_mode=inquiry.planning_mode,
+    )
+    order_repository.save_order_with_initial_version(order, version)
+    return order, version

--- a/tests/unit/test_buffet_cards.py
+++ b/tests/unit/test_buffet_cards.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import UTC, date, datetime
 
 from catering_system.domain.offer_snapshot import compute_snapshot_hash
@@ -352,10 +354,10 @@ def test_buffet_cards_three_positions_from_offer_snapshot() -> None:
 
 def test_buffet_cards_without_offer_integration() -> None:
     inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
-    order_service = OrderService(orders)
+    OrderService(orders)
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
-    order, version = order_service.convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
 
     view = _buffet_service(offers, orders).resolve(
         order.order_id,

--- a/tests/unit/test_calendar_projection.py
+++ b/tests/unit/test_calendar_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import UTC, date, datetime, timedelta
 
 from catering_system.domain.offer import (
@@ -27,7 +29,6 @@ from catering_system.services.calendar_projection_service import (
 )
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
 from catering_system.services.work_center_service import WorkCenterService
 
 _TODAY = date(2026, 7, 15)
@@ -229,7 +230,7 @@ def test_active_order_replaces_offer() -> None:
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
     _save_offer(offers, inquiry.inquiry_id, sent=True)
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     rows = _service(inquiries=inquiries, offers=offers, orders=orders).list_entries(
         date(2026, 8, 1), date(2026, 8, 31)
     )
@@ -242,7 +243,7 @@ def test_effective_order_is_confirmed() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     core = OperationalCoreService(orders)
     core.confirm_kitchen_print(order.order_id, version.order_version_id)
     core.make_order_version_effective(order.order_id, version.order_version_id)
@@ -257,7 +258,7 @@ def test_candidate_only_order_is_planned() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     rows = _service(inquiries=inquiries, orders=orders).list_entries(
         date(2026, 8, 1), date(2026, 8, 31)
     )
@@ -270,7 +271,7 @@ def test_cancelled_order_excluded() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     OperationalCoreService(orders).cancel_order(order.order_id)
     rows = _service(inquiries=inquiries, orders=orders).list_entries(
         date(2026, 8, 1), date(2026, 8, 31)
@@ -284,7 +285,7 @@ def test_cancelled_order_suppresses_inquiry_and_offer() -> None:
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries, intake_subject="War Auftrag")
     _save_offer(offers, inquiry.inquiry_id, sent=True)
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     OperationalCoreService(orders).cancel_order(order.order_id)
     rows = _service(inquiries=inquiries, offers=offers, orders=orders).list_entries(
         date(2026, 1, 1), date(2026, 12, 31)
@@ -311,7 +312,7 @@ def test_no_duplicate_per_source_inquiry_id() -> None:
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
     _save_offer(offers, inquiry.inquiry_id, sent=True, accepted=True)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     core = OperationalCoreService(orders)
     core.confirm_kitchen_print(order.order_id, version.order_version_id)
     core.make_order_version_effective(order.order_id, version.order_version_id)

--- a/tests/unit/test_contact_projection.py
+++ b/tests/unit/test_contact_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import UTC, date, datetime
 
 from catering_system.domain.contact_projection import derive_contact_identity
@@ -131,8 +133,8 @@ def test_open_inquiry_and_active_order_counts() -> None:
         intake_subject="Offene Anfrage",
     )
     orders = InMemoryOrderRepository()
-    order_service = OrderService(orders)
-    order, _version = order_service.convert_inquiry_to_order(inquiry)
+    OrderService(orders)
+    order, _version = seed_order(orders, inquiry)
     assert order.cancelled_at is None
     rows = _service(inquiries=inquiries, orders=orders).list_contacts()
     assert rows[0].open_inquiries == 0
@@ -197,7 +199,7 @@ def test_offer_and_order_linkage_in_detail() -> None:
         )
     )
     orders = InMemoryOrderRepository()
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     detail = _service(
         inquiries=inquiries,
         offers=offers,

--- a/tests/unit/test_contact_status_filter.py
+++ b/tests/unit/test_contact_status_filter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import threading
 import urllib.request
 from datetime import date
@@ -27,7 +29,6 @@ from catering_system.repositories.in_memory_order_repository import (
 )
 from catering_system.services.contact_projection_service import ContactProjectionService
 from catering_system.services.inquiry_service import InquiryService
-from catering_system.services.order_service import OrderService
 from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
 
 _PASSWORD = "test-secret"
@@ -132,7 +133,7 @@ def test_contact_with_one_order_is_kunde() -> None:
     inquiries = InMemoryInquiryRepository()
     inquiry = _inquiry(inquiries, company="Buyer", email="buyer@example.invalid")
     orders = InMemoryOrderRepository()
-    OrderService(orders).convert_inquiry_to_order(inquiry)
+    seed_order(orders, inquiry)
     rows = ContactProjectionService(
         inquiries,
         InMemoryOfferRepository(),
@@ -159,7 +160,7 @@ def test_several_inquiries_and_one_order_is_kunde() -> None:
         customer_linkage={"customer_id": "cust-multi"},
     )
     orders = InMemoryOrderRepository()
-    OrderService(orders).convert_inquiry_to_order(first)
+    seed_order(orders, first)
     rows = ContactProjectionService(
         inquiries,
         InMemoryOfferRepository(),
@@ -185,7 +186,7 @@ def test_filter_interessenten_kunden_and_alle() -> None:
         email="buy@example.invalid",
         phone="+49305555555",
     )
-    OrderService(orders).convert_inquiry_to_order(buyer)
+    seed_order(orders, buyer)
 
     alle = panel.render_kontakte("", "all")
     assert "LeadCo" in alle and "BuyCo" in alle
@@ -224,7 +225,7 @@ def test_search_and_status_filter_together() -> None:
         email="other@example.invalid",
         phone="+49303333333",
     )
-    OrderService(orders).convert_inquiry_to_order(buyer)
+    seed_order(orders, buyer)
 
     page = panel.render_kontakte("jk", "kunde")
     assert "JK Buyer" in page
@@ -251,7 +252,7 @@ def test_invalid_status_falls_back_to_all() -> None:
     buyer = _inquiry(
         inquiries, company="Buyer", email="b@example.invalid", phone="+49307777777"
     )
-    OrderService(orders).convert_inquiry_to_order(buyer)
+    seed_order(orders, buyer)
     page = panel.render_kontakte("", "gesperrt")
     assert "Lead" in page and "Buyer" in page
     assert "<strong>Alle (2)</strong>" in page
@@ -271,7 +272,7 @@ def test_detail_shows_derived_status() -> None:
         email="dbuy@example.invalid",
         phone="+49309999999",
     )
-    OrderService(orders).convert_inquiry_to_order(buyer)
+    seed_order(orders, buyer)
 
     lead_key = "intake:email:dlead@example.invalid"
     buy_key = "intake:email:dbuy@example.invalid"
@@ -297,7 +298,7 @@ def test_http_status_filter_preserves_search() -> None:
         email="httpbuy@example.invalid",
         phone="+49301222222",
     )
-    OrderService(orders).convert_inquiry_to_order(buyer)
+    seed_order(orders, buyer)
     server = create_office_panel_server(
         panel._inquiries,
         panel._orders,

--- a/tests/unit/test_core_transaction.py
+++ b/tests/unit/test_core_transaction.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import json
 import sqlite3
 from dataclasses import replace
@@ -98,9 +100,7 @@ def test_business_write_and_ledger_row_commit_atomically(shared) -> None:
 
     def work() -> str:
         inquiries.save(inquiries_service_input)
-        order, _v1 = OrderService(orders).convert_inquiry_to_order(
-            inquiries_service_input
-        )
+        order, _v1 = seed_order(orders, inquiries_service_input)
         ledger.record("cmd-1", "fp-1", 201, '{"order_id": "x"}')
         return order.order_id
 
@@ -116,7 +116,7 @@ def test_failure_rolls_back_business_write_and_ledger_together(shared) -> None:
 
     def work() -> None:
         inquiries.save(saved)
-        OrderService(orders).convert_inquiry_to_order(saved)
+        seed_order(orders, saved)
         ledger.record("cmd-2", "fp", 201, "{}")
         raise RuntimeError("crash between service write and response")
 
@@ -137,7 +137,7 @@ def test_events_flush_only_after_commit_and_never_on_rollback(shared) -> None:
 
     def create() -> str:
         inquiries.save(inq)
-        order, v1 = OrderService(orders).convert_inquiry_to_order(inq)
+        order, v1 = seed_order(orders, inq)
         core.confirm_kitchen_print(order.order_id, v1.order_version_id)
         assert delivered == []  # nothing may leave before COMMIT
         return order.order_id
@@ -250,12 +250,12 @@ def test_fingerprint_distinguishes_every_command_dimension() -> None:
 # --- orders migration 6: partial unique active-order index (pack §6.2) ---
 
 
-def test_second_convert_is_idempotent_for_same_inquiry(shared) -> None:
+def test_second_convert_lookup_is_idempotent_for_same_inquiry(shared) -> None:
     connection, inquiries, orders, _ledger = shared
     executor = CoreCommandExecutor(connection)
     inq = _inquiry()
     executor.run(lambda: inquiries.save(inq))
-    first = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
+    first = executor.run(lambda: seed_order(orders, inq))
     second = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
     assert second[0].order_id == first[0].order_id
     assert len([o for o in orders.list_orders() if o.cancelled_at is None]) == 1
@@ -267,7 +267,7 @@ def test_convert_after_storno_returns_existing_order(shared) -> None:
     core = OperationalCoreService(orders)
     inq = _inquiry()
     executor.run(lambda: inquiries.save(inq))
-    first = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
+    first = executor.run(lambda: seed_order(orders, inq))
     executor.run(lambda: core.cancel_order(first[0].order_id))
     second = executor.run(lambda: OrderService(orders).convert_inquiry_to_order(inq))
     assert second[0].order_id == first[0].order_id

--- a/tests/unit/test_effective_order_version_change_gate.py
+++ b/tests/unit/test_effective_order_version_change_gate.py
@@ -52,11 +52,13 @@ def _inquiry() -> Inquiry:
 
 
 def _effective_v1():  # noqa: ANN202
+    from tests.helpers.order_seed import seed_order
+
     repository = InMemoryOrderRepository()
     events: list[object] = []
     orders = OrderService(repository, event_sink=events.append)
     core = OperationalCoreService(repository)
-    order, version = orders.convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(repository, _inquiry())
     core.confirm_kitchen_print(order.order_id, version.order_version_id)
     core.make_order_version_effective(order.order_id, version.order_version_id)
     return repository, orders, core, events, order, version

--- a/tests/unit/test_email_intake_projection.py
+++ b/tests/unit/test_email_intake_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import threading
 import urllib.error
 import urllib.request
@@ -31,7 +33,6 @@ from catering_system.services.email_intake_projection_service import (
     EmailIntakeProjectionService,
 )
 from catering_system.services.inquiry_service import InquiryService
-from catering_system.services.order_service import OrderService
 from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
 from catering_system.ui.office_panel_email_detail import render_email_detail
 from catering_system.ui.office_panel_emails_list import render_email_list
@@ -251,7 +252,7 @@ def test_offer_and_order_linkage() -> None:
         )
     )
     orders = InMemoryOrderRepository()
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     row = _service(inquiries=inquiries, offers=offers, orders=orders).email_detail(
         inquiry.inquiry_id
     )

--- a/tests/unit/test_inquiry_contact_completeness.py
+++ b/tests/unit/test_inquiry_contact_completeness.py
@@ -555,14 +555,14 @@ def test_existing_conversion_replay_not_blocked_retroactively() -> None:
 def test_incomplete_inquiry_cannot_direct_convert() -> None:
     inquiry = _inquiry(customer_snapshot=InquiryCustomerSnapshot(email="a@b.de"))
     svc = OrderService(InMemoryOrderRepository())
-    with pytest.raises(ValueError, match="contact information incomplete"):
+    with pytest.raises(ValueError, match="accepted offer required"):
         svc.convert_inquiry_to_order(inquiry)
 
 
-def test_complete_inquiry_converts_as_before() -> None:
+def test_complete_inquiry_still_requires_accepted_offer() -> None:
     svc = OrderService(InMemoryOrderRepository())
-    order, version = svc.convert_inquiry_to_order(_inquiry())
-    assert order.order_id and version.version_number == 1
+    with pytest.raises(ValueError, match="accepted offer required"):
+        svc.convert_inquiry_to_order(_inquiry())
 
 
 def test_office_state_hides_convert_for_incomplete_inquiry() -> None:
@@ -574,7 +574,7 @@ def test_office_state_hides_convert_for_incomplete_inquiry() -> None:
     complete_state = derive_inquiry_office_state(
         _inquiry(), has_order=False, has_active_order=False, today=_TODAY
     )
-    assert complete_state.next_action == "convert"
+    assert complete_state.next_action == "prepare-offer"
 
 
 def test_progression_reasons_include_contact_blockers() -> None:
@@ -594,16 +594,17 @@ def test_existing_verification_gate_still_applies() -> None:
         call_verification_status="pending",
     )
     svc = OrderService(InMemoryOrderRepository())
-    with pytest.raises(ValueError, match="conversion blocked"):
+    with pytest.raises(ValueError, match="accepted offer required"):
         svc.convert_inquiry_to_order(inquiry)
     evaluation = evaluate_inquiry_to_order_progression(inquiry)
     assert "inquiry_call_verification_unsatisfied" in evaluation.reasons
 
 
 def test_existing_order_unaffected_by_incomplete_source_inquiry() -> None:
+    from tests.helpers.order_seed import seed_order
+
     orders = InMemoryOrderRepository()
-    svc = OrderService(orders)
-    order, _version = svc.convert_inquiry_to_order(_inquiry())
+    order, _version = seed_order(orders, _inquiry())
     # The stored Order keeps working even when the source inquiry is later
     # seen without contacts — no Order/OrderVersion schema fields involved.
     loaded = orders.get_order(order.order_id)

--- a/tests/unit/test_inquiry_customer_reference.py
+++ b/tests/unit/test_inquiry_customer_reference.py
@@ -48,7 +48,6 @@ from catering_system.repositories.sqlite_inquiry_repository import (
 )
 from catering_system.repositories.sqlite_migrations import apply_migrations
 from catering_system.services.inquiry_service import InquiryService
-from catering_system.services.order_service import OrderService
 from catering_system.ui import office_api_views as views
 
 UTC = timezone.utc
@@ -369,10 +368,11 @@ def test_no_customer_identity_records_created_on_inquiry_create() -> None:
 
 
 def test_inquiry_to_order_behavior_unchanged() -> None:
+    from tests.helpers.order_seed import seed_order
+
     inquiry_repo = InMemoryInquiryRepository()
     order_repo = InMemoryOrderRepository()
     inquiry_svc = InquiryService(inquiry_repo)
-    order_svc = OrderService(order_repo)
     kwargs = _base_kwargs()
     kwargs["customer_linkage"] = {"placeholder": True}
     inquiry = inquiry_svc.create_inquiry(
@@ -385,7 +385,7 @@ def test_inquiry_to_order_behavior_unchanged() -> None:
         customer_id="cust-1",
         snapshot=inquiry.customer_snapshot or _snapshot(contact_name="Alex"),
     )
-    order, _version = order_svc.convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(order_repo, inquiry)
     assert order.source_inquiry_id == inquiry.inquiry_id
     assert not hasattr(order, "customer_id")
 

--- a/tests/unit/test_inquiry_office_state.py
+++ b/tests/unit/test_inquiry_office_state.py
@@ -173,7 +173,7 @@ def test_open_inquiry_derives_convert_action() -> None:
         today=_TODAY,
     )
     assert state.is_open is True
-    assert state.next_action == "convert"
+    assert state.next_action == "prepare-offer"
     assert state.offer is None
 
 

--- a/tests/unit/test_inquiry_to_order_conversion_gate.py
+++ b/tests/unit/test_inquiry_to_order_conversion_gate.py
@@ -1,4 +1,4 @@
-"""Unit tests — INQUIRY_TO_ORDER_CONVERSION_GATE_V1."""
+"""Unit tests — REMOVE_LEGACY_ORDER_CREATION_V1 / conversion lookup gate."""
 
 from __future__ import annotations
 
@@ -6,13 +6,12 @@ from datetime import date
 
 import pytest
 
+from tests.helpers.order_seed import seed_order
+
 from catering_system.domain.contact_projection import derive_contact_status
 from catering_system.domain.inquiry import derive_inquiry_office_state
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
-)
-from catering_system.repositories.in_memory_offer_repository import (
-    InMemoryOfferRepository,
 )
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
@@ -20,7 +19,6 @@ from catering_system.repositories.in_memory_order_repository import (
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
-from catering_system.ui.office_panel import OfficePanel
 
 _TODAY = date(2026, 7, 15)
 
@@ -51,150 +49,85 @@ def _inquiry(
     )
 
 
-def test_valid_inquiry_creates_exactly_one_order() -> None:
+def test_convert_without_order_requires_accepted_offer() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _inquiry(inquiries)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
-    assert version.version_number == 1
-    assert order.source_inquiry_id == inquiry.inquiry_id
-    assert len(orders.list_orders()) == 1
-    assert len(orders.list_order_versions(order.order_id)) == 1
+    with pytest.raises(ValueError, match="accepted offer required"):
+        OrderService(orders).convert_inquiry_to_order(inquiry)
+    assert orders.list_orders() == []
 
 
-def test_repeated_conversion_returns_same_order_without_new_version() -> None:
+def test_convert_returns_existing_seeded_order() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _inquiry(inquiries)
-    service = OrderService(orders)
-    first_order, first_version = service.convert_inquiry_to_order(inquiry)
-    second_order, second_version = service.convert_inquiry_to_order(inquiry)
+    first_order, first_version = seed_order(orders, inquiry)
+    second_order, second_version = OrderService(orders).convert_inquiry_to_order(
+        inquiry
+    )
     assert second_order.order_id == first_order.order_id
     assert second_version.order_version_id == first_version.order_version_id
     assert len(orders.list_orders()) == 1
     assert len(orders.list_order_versions(first_order.order_id)) == 1
 
 
-def test_cancelled_order_blocks_second_order_and_returns_existing() -> None:
+def test_cancelled_order_lookup_returns_existing_without_second_create() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _inquiry(inquiries)
-    service = OrderService(orders)
-    first_order, first_version = service.convert_inquiry_to_order(inquiry)
+    first_order, first_version = seed_order(orders, inquiry)
     OperationalCoreService(orders).cancel_order(first_order.order_id)
-    second_order, second_version = service.convert_inquiry_to_order(inquiry)
+    second_order, second_version = OrderService(orders).convert_inquiry_to_order(
+        inquiry
+    )
     assert second_order.order_id == first_order.order_id
     assert second_version.order_version_id == first_version.order_version_id
     assert len(orders.list_orders()) == 1
 
 
-def test_rejected_inquiry_is_blocked() -> None:
+def test_ready_inquiry_projects_prepare_offer_not_convert() -> None:
     inquiries = InMemoryInquiryRepository()
-    orders = InMemoryOrderRepository()
-    inquiry = _inquiry(inquiries, crm_stage="Abgelehnt / verloren")
-    with pytest.raises(ValueError, match="conversion blocked"):
-        OrderService(orders).convert_inquiry_to_order(inquiry)
-    assert orders.list_orders() == []
-
-
-def test_incomplete_inquiry_is_blocked() -> None:
-    inquiries = InMemoryInquiryRepository()
-    orders = InMemoryOrderRepository()
-    inquiry = InquiryService(inquiries).create_inquiry(
-        event_date=date(2026, 8, 1),
-        inquiry_source="manual",
-        crm_stage="Neue Anfrage",
-        customer_linkage={},
-        time_window_text="mittags",
-        location_text="Hamburg",
-        guest_count_estimate=12,
-        planning_mode="caterer_suggestion",
-        call_verification_required=False,
-        call_verification_status="not_required",
-    )
-    with pytest.raises(ValueError, match="contact information incomplete"):
-        OrderService(orders).convert_inquiry_to_order(inquiry)
-
-
-def test_verification_required_but_pending_is_blocked() -> None:
-    inquiries = InMemoryInquiryRepository()
-    orders = InMemoryOrderRepository()
-    inquiry = _inquiry(
-        inquiries,
-        call_verification_required=True,
-        call_verification_status="pending",
-    )
-    with pytest.raises(ValueError, match="conversion blocked"):
-        OrderService(orders).convert_inquiry_to_order(inquiry)
-
-
-def test_order_existence_closes_open_queue() -> None:
+    inquiry = _inquiry(inquiries)
     state = derive_inquiry_office_state(
-        _inquiry(InMemoryInquiryRepository()),
-        has_order=True,
+        inquiry,
+        has_order=False,
         has_active_order=False,
+        today=_TODAY,
+    )
+    assert state.next_action == "prepare-offer"
+    assert state.is_open is True
+
+
+def test_seeded_order_leaves_open_queue_but_stays_in_history() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    inquiry = _inquiry(inquiries)
+    seed_order(orders, inquiry)
+    state = derive_inquiry_office_state(
+        inquiry,
+        has_order=True,
+        has_active_order=True,
         today=_TODAY,
     )
     assert state.is_open is False
     assert state.next_action is None
+    assert any(row.inquiry_id == inquiry.inquiry_id for row in inquiries.list_all())
 
 
-def test_converted_inquiry_leaves_open_queue_but_stays_in_history() -> None:
-    inquiries = InMemoryInquiryRepository()
-    orders = InMemoryOrderRepository()
-    inquiry = _inquiry(inquiries)
-    OrderService(orders).convert_inquiry_to_order(inquiry)
-    InquiryService(inquiries).update_inquiry(
-        inquiry.inquiry_id, crm_stage="Bestätigt / Auftrag"
-    )
-    panel = OfficePanel(inquiries, orders, offer_repo=InMemoryOfferRepository())
-    queue = panel.render_queue(None)
-    assert inquiry.inquiry_id not in queue or "Offene Anfragen" in queue
-    # open-inquiry counter excludes converted
-    assert panel._open_inquiries_count() == 0  # noqa: SLF001
-    detail = panel.render_inquiry(inquiry.inquiry_id) or ""
-    assert inquiry.inquiry_id[:8] in detail or "Auftrag" in detail
-    assert "Auftrag öffnen" in detail or "Auftrag vorhanden" in detail
-
-
-def test_contact_status_becomes_kunde_after_conversion() -> None:
+def test_contact_status_becomes_kunde_when_order_exists() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _inquiry(inquiries)
     assert derive_contact_status(linked_order_count=0) == "interessent"
-    OrderService(orders).convert_inquiry_to_order(inquiry)
+    seed_order(orders, inquiry)
     assert derive_contact_status(linked_order_count=1) == "kunde"
 
 
-def test_in_memory_repository_rejects_duplicate_linked_order() -> None:
-    from datetime import UTC, datetime
-    import uuid
-
-    from catering_system.domain.order import Order, OrderVersion
-
+def test_repository_rejects_second_order_for_same_inquiry() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _inquiry(inquiries)
-    OrderService(orders).convert_inquiry_to_order(inquiry)
-    now = datetime.now(UTC)
-    order_id = str(uuid.uuid4())
-    with pytest.raises(ValueError, match="already has a linked order"):
-        orders.save_order_with_initial_version(
-            Order(
-                order_id=order_id,
-                source_inquiry_id=inquiry.inquiry_id,
-                created_at=now,
-                updated_at=now,
-            ),
-            OrderVersion(
-                order_version_id=str(uuid.uuid4()),
-                order_id=order_id,
-                version_number=1,
-                created_at=now,
-                event_date=inquiry.event_date,
-                time_window_text=inquiry.time_window_text,
-                location_text=inquiry.location_text,
-                guest_count_estimate=inquiry.guest_count_estimate,
-                planning_mode=inquiry.planning_mode,
-            ),
-        )
+    seed_order(orders, inquiry)
+    with pytest.raises(ValueError, match="inquiry already has a linked order"):
+        seed_order(orders, inquiry)

--- a/tests/unit/test_kiosk_server.py
+++ b/tests/unit/test_kiosk_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import json
 import threading
 import urllib.error
@@ -67,11 +69,9 @@ def _repo_with_effective_order(
     location: str = "Hamburg", guest_count: int | None = 25
 ) -> InMemoryOrderRepository:
     repo = InMemoryOrderRepository()
-    osvc = OrderService(repo)
+    OrderService(repo)
     core = OperationalCoreService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(
-        _inquiry(date(2026, 10, 1), location, guest_count)
-    )
+    order, v1 = seed_order(repo, _inquiry(date(2026, 10, 1), location, guest_count))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     return repo
@@ -210,9 +210,9 @@ def test_kiosk_serves_sqlite_like_on_lenovo(tmp_path) -> None:
 
     db = tmp_path / "core.db"
     seed = SQLiteOrderRepository(db)
-    osvc = OrderService(seed)
+    OrderService(seed)
     core = OperationalCoreService(seed)
-    order, v1 = osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))
+    order, v1 = seed_order(seed, _inquiry(date(2026, 10, 1)))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     seed.close()

--- a/tests/unit/test_kitchen_print_error_paths.py
+++ b/tests/unit/test_kitchen_print_error_paths.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date, datetime, timedelta, timezone
 from dataclasses import replace
 
@@ -21,7 +23,6 @@ from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
 from catering_system.services.kitchen_print_service import KitchenPrintService
-from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -58,7 +59,7 @@ def _inquiry() -> Inquiry:
 
 def _service() -> tuple[InMemoryOrderRepository, KitchenPrintService, str, str]:
     orders = InMemoryOrderRepository()
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = InMemoryKitchenPrintJobRepository(orders)
     service = KitchenPrintService(orders, jobs, clock=lambda: _NOW)
     return orders, service, order.order_id, version.order_version_id
@@ -79,8 +80,8 @@ def test_request_print_rejects_foreign_version() -> None:
 def test_request_print_rejects_conflicting_existing_job_id() -> None:
     orders, service, order_id, version_id = _service()
     service.request_print(order_id, version_id, print_job_id=JOB_1)
-    other_order, other_version = OrderService(orders).convert_inquiry_to_order(
-        replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
+    other_order, other_version = seed_order(
+        orders, replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
     )
     with pytest.raises(
         ValueError, match="print_job_id already exists with different facts"
@@ -103,7 +104,7 @@ def test_accept_print_job_rejects_after_deadline() -> None:
         return clock[0]
 
     orders = InMemoryOrderRepository()
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = InMemoryKitchenPrintJobRepository(orders)
     service = KitchenPrintService(orders, jobs, clock=tick)
     service.request_print(order.order_id, version.order_version_id, print_job_id=JOB_1)

--- a/tests/unit/test_kitchen_print_repository_errors.py
+++ b/tests/unit/test_kitchen_print_repository_errors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from dataclasses import replace
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -25,7 +27,6 @@ from catering_system.repositories.sqlite_kitchen_print_job_repository import (
     SQLiteKitchenPrintJobRepository,
 )
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
-from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -64,7 +65,7 @@ def _memory_world() -> tuple[
     InMemoryOrderRepository, InMemoryKitchenPrintJobRepository, str, str
 ]:
     orders = InMemoryOrderRepository()
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = InMemoryKitchenPrintJobRepository(orders)
     return orders, jobs, order.order_id, version.order_version_id
 
@@ -74,7 +75,7 @@ def _sqlite_world(
 ) -> tuple[SQLiteOrderRepository, SQLiteKitchenPrintJobRepository, str, str]:
     db = tmp_path / "core.db"
     orders = SQLiteOrderRepository(db)
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = SQLiteKitchenPrintJobRepository(db)
     return orders, jobs, order.order_id, version.order_version_id
 

--- a/tests/unit/test_kitchen_print_service.py
+++ b/tests/unit/test_kitchen_print_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from dataclasses import fields
 from datetime import date, datetime, timedelta, timezone
 
@@ -27,7 +29,6 @@ from catering_system.repositories.in_memory_order_repository import (
 )
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -83,7 +84,7 @@ def _setup() -> tuple[
     list[object],
 ]:
     orders = InMemoryOrderRepository()
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = InMemoryKitchenPrintJobRepository(orders)
     clock = MutableClock(datetime(2026, 7, 14, 9, 0, tzinfo=timezone.utc))
     events: list[object] = []

--- a/tests/unit/test_kitchen_print_sqlite.py
+++ b/tests/unit/test_kitchen_print_sqlite.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import sqlite3
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -21,7 +23,6 @@ from catering_system.repositories.sqlite_kitchen_print_job_repository import (
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -73,7 +74,7 @@ def _sqlite_world(
     str,
 ]:
     orders = SQLiteOrderRepository(db)
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     jobs = SQLiteKitchenPrintJobRepository(db)
     clock = MutableClock()
     service = KitchenPrintService(
@@ -93,7 +94,7 @@ def test_migration_is_additive_and_does_not_backfill_manual_confirmation(
 ) -> None:
     db = tmp_path / "core.db"
     orders = SQLiteOrderRepository(db)
-    order, version = OrderService(orders).convert_inquiry_to_order(_inquiry())
+    order, version = seed_order(orders, _inquiry())
     manually_confirmed = OperationalCoreService(orders).confirm_kitchen_print(
         order.order_id, version.order_version_id
     )

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
@@ -38,7 +40,6 @@ from catering_system.repositories.in_memory_order_repository import (
 )
 from catering_system.services.offer_service import OfferService
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -1048,7 +1049,7 @@ def test_convert_accepted_offer_rejects_active_order_without_link() -> None:
     ) = _accepted_offer_state()
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
-    OrderService(orders).convert_inquiry_to_order(inquiry)
+    seed_order(orders, inquiry)
     with pytest.raises(ValueError, match="active order blocks conversion"):
         service.convert_accepted_offer(
             offer.offer_id, version_id, variant_id, acceptance_id

--- a/tests/unit/test_offer_service_guardrails.py
+++ b/tests/unit/test_offer_service_guardrails.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import UTC, datetime
 
 import pytest
@@ -16,7 +18,6 @@ from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
 from catering_system.services.offer_service import OfferService
-from catering_system.services.order_service import OrderService
 from tests.unit.test_offer_service import (
     _INQUIRY_ID,
     _acceptance_args,
@@ -61,7 +62,7 @@ def test_prepare_offer_rejects_when_active_order_exists() -> None:
     orders = InMemoryOrderRepository()
     inquiry = _sample_inquiry()
     inquiries.save(inquiry)
-    OrderService(orders).convert_inquiry_to_order(inquiry)
+    seed_order(orders, inquiry)
     service = OfferService(offers, inquiries, orders)
     with pytest.raises(ValueError, match="active order blocks offer preparation"):
         service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import json
 import queue
 import sqlite3
@@ -47,7 +49,7 @@ def _seed(db_path: Path) -> dict[str, str]:
     inquiries = SQLiteInquiryRepository(db_path)
     orders = SQLiteOrderRepository(db_path)
     inquiry_service = InquiryService(inquiries)
-    order_service = OrderService(orders)
+    OrderService(orders)
     core = OperationalCoreService(orders)
 
     def make_inquiry(**overrides):  # noqa: ANN202
@@ -79,7 +81,7 @@ def _seed(db_path: Path) -> dict[str, str]:
     ids["inquiry_convertible"] = convertible.inquiry_id
 
     printed_src = make_inquiry(location_text="Bremen")
-    order_printed, v1 = order_service.convert_inquiry_to_order(printed_src)
+    order_printed, v1 = seed_order(orders, printed_src)
     core.confirm_kitchen_print(order_printed.order_id, v1.order_version_id)
     core.make_order_version_effective(order_printed.order_id, v1.order_version_id)
     ids["inquiry_printed"] = printed_src.inquiry_id
@@ -87,13 +89,13 @@ def _seed(db_path: Path) -> dict[str, str]:
     ids["version_ready"] = v1.order_version_id
 
     unprinted_src = make_inquiry(location_text="Lübeck")
-    order_unprinted, v1u = order_service.convert_inquiry_to_order(unprinted_src)
+    order_unprinted, v1u = seed_order(orders, unprinted_src)
     ids["order_unprinted"] = order_unprinted.order_id
     ids["version_unprinted"] = v1u.order_version_id
     ids["inquiry_unprinted"] = unprinted_src.inquiry_id
 
     cancelled_src = make_inquiry(location_text="Flensburg")
-    order_cancelled, v1c = order_service.convert_inquiry_to_order(cancelled_src)
+    order_cancelled, v1c = seed_order(orders, cancelled_src)
     core.cancel_order(order_cancelled.order_id)
     ids["order_cancelled"] = order_cancelled.order_id
     ids["version_cancelled"] = v1c.order_version_id
@@ -299,8 +301,8 @@ def test_queue_view_attention_counts_and_tops(api) -> None:
         row["inquiry_id"]: row["next_action"] for row in body["neue_anfragen_top"]
     }
     assert top_actions[ids["inquiry_verify"]] == "verify"
-    assert top_actions[ids["inquiry_convertible"]] == "convert"
-    assert top_actions[ids["inquiry_offer_ready"]] == "convert"
+    assert top_actions[ids["inquiry_convertible"]] == "prepare-offer"
+    assert top_actions[ids["inquiry_offer_ready"]] == "prepare-offer"
     assert top_actions[ids["inquiry_website"]] == "verify"
     assert ids["inquiry_rejected"] not in top_actions
     (blocked_row,) = body["auftraege_top"]
@@ -1023,46 +1025,19 @@ def test_update_requires_matching_updated_at(api) -> None:
     assert body["updated_at"] != detail["updated_at"]
 
 
-def test_verify_then_convert_flow_with_gates(api) -> None:
+def test_verify_then_convert_hard_blocks_without_accepted_offer(api) -> None:
     base, ids, _db = api
     inquiry_id = ids["inquiry_verify"]
-    # convert before verification: B5 gate
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert (status, body["error"]) == (422, "verification_gate_blocked")
+    assert (status, body["error"]) == (422, "accepted_offer_required")
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/verify")
     assert status == 200
-    # repeated verify stays success (current behavior)
-    status, _body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/verify")
-    assert status == 200
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert status == 201
-    assert set(body) == {"command_id", "order_id", "order_version_id"}
+    assert (status, body["error"]) == (422, "accepted_offer_required")
     status, detail, _h = _get(f"{base}/office/v1/inquiries/{inquiry_id}")
     assert status == 200
-    assert detail["crm_stage"] == "Bestätigt / Auftrag"
     assert detail["allows_conversion"] is False
-    status, body, _h = _post(
-        f"{base}/office/v1/inquiries/{inquiry_id}/update",
-        args={
-            "event_date": detail["event_date"],
-            "crm_stage": "Abgelehnt / verloren",
-            "time_window_text": detail["time_window_text"],
-            "location_text": detail["location_text"],
-            "guest_count_estimate": detail["guest_count_estimate"],
-            "planning_mode": detail["planning_mode"],
-        },
-        expect={"updated_at": detail["updated_at"]},
-    )
-    assert (status, body["error"]) == (422, "active_order_crm_stage_conflict")
-    status, detail_after_rejection, _h = _get(
-        f"{base}/office/v1/inquiries/{inquiry_id}"
-    )
-    assert status == 200
-    assert detail_after_rejection["crm_stage"] == "Bestätigt / Auftrag"
-    # second convert while active: idempotent success (same order)
-    status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert status == 200
-    assert set(body) >= {"order_id", "order_version_id"}
+    assert detail["orders_total_count"] == 0
 
 
 def test_rejected_inquiry_cannot_convert(api) -> None:
@@ -1070,7 +1045,7 @@ def test_rejected_inquiry_cannot_convert(api) -> None:
     status, body, _h = _post(
         f"{base}/office/v1/inquiries/{ids['inquiry_rejected']}/convert"
     )
-    assert (status, body["error"]) == (422, "inquiry_rejected")
+    assert (status, body["error"]) == (422, "accepted_offer_required")
 
 
 def test_convert_after_storno_returns_existing_order_via_api(api) -> None:
@@ -1084,17 +1059,24 @@ def test_convert_after_storno_returns_existing_order_via_api(api) -> None:
     assert body["order_id"] == existing_order_id
 
 
-def test_legacy_convert_blocked_with_prepared_offer(api) -> None:
+def test_legacy_convert_without_order_requires_accepted_offer(api) -> None:
+    base, ids, _db = api
+    inquiry_id = ids["inquiry_convertible"]
+    status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
+    assert (status, body["error"]) == (422, "accepted_offer_required")
+
+
+def test_legacy_convert_with_prepared_offer_still_requires_accepted_offer(api) -> None:
     base, ids, db = api
     offer_id, _version_id = _prepare_offer(api)
     inquiry_id = ids["inquiry_offer_ready"]
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert (status, body["error"]) == (422, "offer_blocks_conversion")
+    assert (status, body["error"]) == (422, "accepted_offer_required")
     conn = sqlite3.connect(db)
     order_count = conn.execute(
         """
         SELECT COUNT(*) FROM orders
-        WHERE source_inquiry_id = ? AND cancelled_at IS NULL
+        WHERE source_inquiry_id = ?
         """,
         (inquiry_id,),
     ).fetchone()[0]
@@ -1107,38 +1089,7 @@ def test_legacy_convert_blocked_with_prepared_offer(api) -> None:
     offers.close()
 
 
-def test_legacy_convert_blocked_with_accepted_offer(api) -> None:
-    base, ids, db = api
-    offer_id, _version_id, _acceptance_id, _variant_id = _prepare_send_accept(api)
-    inquiry_id = ids["inquiry_offer_ready"]
-    status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert (status, body["error"]) == (422, "offer_blocks_conversion")
-    conn = sqlite3.connect(db)
-    order_count = conn.execute(
-        """
-        SELECT COUNT(*) FROM orders
-        WHERE source_inquiry_id = ? AND cancelled_at IS NULL
-        """,
-        (inquiry_id,),
-    ).fetchone()[0]
-    conn.close()
-    assert order_count == 0
-    offers = SQLiteOfferRepository(db)
-    stored = offers.get(offer_id)
-    assert stored is not None
-    assert stored.conversion_link is None
-    offers.close()
-
-
-def test_legacy_convert_without_offer_still_works(api) -> None:
-    base, ids, _db = api
-    inquiry_id = ids["inquiry_convertible"]
-    status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert status == 201
-    assert set(body) == {"command_id", "order_id", "order_version_id"}
-
-
-def test_legacy_convert_allowed_with_expired_offer(api) -> None:
+def test_legacy_convert_with_expired_offer_still_requires_accepted_offer(api) -> None:
     base, ids, db = api
     inquiry_id = ids["inquiry_offer_ready"]
     snapshot = _valid_offer_snapshot(inquiry_id=inquiry_id)
@@ -1159,18 +1110,17 @@ def test_legacy_convert_allowed_with_expired_offer(api) -> None:
         == 200
     )
     status, body, _h = _post(f"{base}/office/v1/inquiries/{inquiry_id}/convert")
-    assert status == 201
-    assert set(body) == {"command_id", "order_id", "order_version_id"}
+    assert (status, body["error"]) == (422, "accepted_offer_required")
     conn = sqlite3.connect(db)
     order_count = conn.execute(
         """
         SELECT COUNT(*) FROM orders
-        WHERE source_inquiry_id = ? AND cancelled_at IS NULL
+        WHERE source_inquiry_id = ?
         """,
         (inquiry_id,),
     ).fetchone()[0]
     conn.close()
-    assert order_count == 1
+    assert order_count == 0
 
 
 def test_versions_expect_and_cancelled_gate(api) -> None:
@@ -1652,13 +1602,15 @@ def test_external_ref_conflict_is_recognized_typed(api) -> None:
 def test_command_replay_returns_recorded_result_without_double_effect(api) -> None:
     base, ids, _db = api
     command_id = str(uuid.uuid4())
-    url = f"{base}/office/v1/inquiries/{ids['inquiry_convertible']}/convert"
+    # Compatibility convert on an inquiry that already has an Order.
+    url = f"{base}/office/v1/inquiries/{ids['inquiry_cancelled_order']}/convert"
     status1, body1, _h = _post(url, command_id=command_id)
-    assert status1 == 201
+    assert status1 == 200
     status2, body2, _h = _post(url, command_id=command_id)
     assert (status2, body2) == (status1, body1)  # verbatim replay
-    # only one active order exists
-    _s, detail, _h = _get(f"{base}/office/v1/inquiries/{ids['inquiry_convertible']}")
+    _s, detail, _h = _get(
+        f"{base}/office/v1/inquiries/{ids['inquiry_cancelled_order']}"
+    )
     assert detail["orders_total_count"] == 1
 
 
@@ -1684,7 +1636,7 @@ def test_same_command_id_different_fingerprint_conflicts(api) -> None:
 def test_lock_contention_503_then_safe_retry_same_command_id(api) -> None:
     base, ids, db = api
     command_id = str(uuid.uuid4())
-    url = f"{base}/office/v1/inquiries/{ids['inquiry_convertible']}/convert"
+    url = f"{base}/office/v1/inquiries/{ids['inquiry_cancelled_order']}/convert"
 
     holder = sqlite3.connect(db)
     holder.execute("PRAGMA busy_timeout = 0")
@@ -1698,8 +1650,10 @@ def test_lock_contention_503_then_safe_retry_same_command_id(api) -> None:
         holder.close()
 
     status, body, _h = _post(url, command_id=command_id)
-    assert status == 201  # retry with the same command_id succeeds exactly once
-    _s, detail, _h = _get(f"{base}/office/v1/inquiries/{ids['inquiry_convertible']}")
+    assert status == 200  # retry with the same command_id succeeds exactly once
+    _s, detail, _h = _get(
+        f"{base}/office/v1/inquiries/{ids['inquiry_cancelled_order']}"
+    )
     assert detail["orders_total_count"] == 1
 
 

--- a/tests/unit/test_office_api_views.py
+++ b/tests/unit/test_office_api_views.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import re
 from datetime import date, datetime, timezone
 
@@ -75,7 +77,7 @@ def _order_states() -> list[tuple[InMemoryOrderRepository, Order]]:
         repo = InMemoryOrderRepository()
         osvc = OrderService(repo)
         core = OperationalCoreService(repo)
-        order, v1 = osvc.convert_inquiry_to_order(_inquiry())
+        order, v1 = seed_order(repo, _inquiry())
         configure(repo, osvc, core, order, v1)
         refreshed = repo.get_order(order.order_id)
         assert refreshed is not None
@@ -152,8 +154,8 @@ def test_week_uses_berlin_calendar() -> None:
 
 def test_detail_caps_and_truncation_flags() -> None:
     repo = InMemoryOrderRepository()
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _inquiry())
     fresh = repo.get_order(order.order_id)
     assert fresh is not None
     many_orders = [

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import base64
 import html
 import json
@@ -37,6 +39,7 @@ from catering_system.ui.office_panel_views import _page
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
 _CSRF_TOKEN = csrf_token_for_password(_PASSWORD)
+_PANEL_REPOS: dict[str, tuple[InMemoryInquiryRepository, InMemoryOrderRepository]] = {}
 
 
 @pytest.fixture()
@@ -49,7 +52,10 @@ def panel():
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
-    yield f"http://{host}:{port}"
+    base = f"http://{host}:{port}"
+    _PANEL_REPOS[base] = (inquiry_repo, order_repo)
+    yield base
+    _PANEL_REPOS.pop(base, None)
     server.shutdown()
     server.server_close()
 
@@ -69,7 +75,10 @@ def premium_panel():
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
-    yield f"http://{host}:{port}"
+    base = f"http://{host}:{port}"
+    _PANEL_REPOS[base] = (inquiry_repo, order_repo)
+    yield base
+    _PANEL_REPOS.pop(base, None)
     server.shutdown()
     server.server_close()
 
@@ -121,8 +130,17 @@ def _create_inquiry(base: str, **overrides: str) -> str:
 
 
 def _convert(base: str, inquiry_id: str) -> str:
-    _status, url, _body = _post(f"{base}/inquiry/{inquiry_id}/convert", {})
-    return url.rsplit("/", 1)[-1]  # order id
+    """Seed an Order for panel tests (no production Inquiry→Order create)."""
+    from dataclasses import replace
+
+    inquiries, orders = _PANEL_REPOS[base]
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    order, _version = seed_order(orders, inquiry)
+    inquiries.update(
+        replace(inquiry, crm_stage="Bestätigt / Auftrag")  # type: ignore[arg-type]
+    )
+    return order.order_id
 
 
 def test_page_context_badge_does_not_leak_between_renders() -> None:
@@ -396,16 +414,20 @@ def test_unverified_inquiry_shows_progression_block_and_convert_fails(
     assert exc.value.code == 400
 
 
-def test_verify_then_convert(panel: str) -> None:
+def test_verify_then_prepare_offer_path(panel: str) -> None:
     iid = _create_inquiry(panel, call_verification_required="1")
     _status, _url, body = _post(f"{panel}/inquiry/{iid}/verify", {})
     assert "verifiziert" in body
-    oid = _convert(panel, iid)
-    status, body = _get(f"{panel}/order/{oid}")
-    assert status == 200
-    assert "v1" in body
     _status, inquiry_body = _get(f"{panel}/inquiry/{iid}")
-    assert "Bestätigt / Auftrag" in inquiry_body
+    assert (
+        "Angebot vorbereiten" in inquiry_body
+        or "Auftrag nur aus angenommenem Angebot" in inquiry_body
+        or "Angebot kann vorbereitet werden" in inquiry_body
+    )
+    assert "Auftrag erstellen" not in inquiry_body
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(f"{panel}/inquiry/{iid}/convert", {})
+    assert exc.value.code == 400
 
 
 def test_order_payment_reminder_is_separate_and_truthful(panel: str) -> None:
@@ -526,9 +548,9 @@ def test_v2_inquiry_detail_ready_to_convert_and_verification_required(
 
     assert "inquiry-hero" in ready
     assert "<h1>Sommerfest HafenCity</h1>" in ready
-    assert "Bereit für Auftrag" in ready
-    assert f'action="/inquiry/{ready_id}/convert"' in ready
-    assert "Auftrag erstellen" in ready
+    assert "Angebot vorbereiten" in ready
+    assert f'action="/inquiry/{ready_id}/convert"' not in ready
+    assert "Auftrag erstellen" not in ready
     assert "Telefonisch verifiziert" not in ready
     assert "Rückruf erforderlich" in verify
     assert "Rückrufprüfung noch nicht erfüllt" in verify
@@ -642,7 +664,8 @@ def test_open_queue_shows_actual_crm_stage(panel: str) -> None:
 
     _status, dashboard = _get(f"{panel}/")
     assert "Angebot gesendet / Rückmeldung offen" in dashboard
-    assert f'action="/inquiry/{iid}/convert"' in dashboard
+    assert "Angebot vorbereiten" in dashboard
+    assert f'action="/inquiry/{iid}/convert"' not in dashboard
 
 
 # -- intake context (INQUIRY_INTAKE_CONTEXT_FIELDS_IMPLEMENTATION_PACK_V1) --
@@ -1160,8 +1183,9 @@ def test_convert_after_storno_returns_existing_order(panel: str) -> None:
     assert "(storniert)" in body
     assert "Auftrag erstellen" not in body
     assert "Auftrag öffnen" in body
-    oid2 = _convert(panel, iid)
-    assert oid2 == oid
+    # Compatibility POST convert returns the existing Order (no second create).
+    _status, url, _body = _post(f"{panel}/inquiry/{iid}/convert", {})
+    assert url.rsplit("/", 1)[-1] == oid
     _status, body = _get(f"{panel}/inquiry/{iid}")
     assert "Auftrag erstellen" not in body
 
@@ -1205,7 +1229,14 @@ def test_panel_serves_sqlite_like_on_lenovo(tmp_path) -> None:
     base = f"http://{host}:{port}"
     try:
         iid = _create_inquiry(base)  # POST → sqlite write over HTTP
-        oid = _convert(base, iid)
+        inquiries = SQLiteInquiryRepository(db)
+        orders = SQLiteOrderRepository(db)
+        inquiry = inquiries.get_by_id(iid)
+        assert inquiry is not None
+        order, _version = seed_order(orders, inquiry)
+        oid = order.order_id
+        inquiries.close()
+        orders.close()
         status, body = _get(f"{base}/order/{oid}")
         assert status == 200 and "v1" in body
     finally:
@@ -1791,7 +1822,8 @@ def test_dashboard_queues_capped_at_five_with_alle_anzeigen_link(panel: str) -> 
         _create_inquiry(panel)
     _status, body = _get(f"{panel}/")
     assert _attention_counts(body)["Offene Anfragen prüfen"] == 7
-    assert body.count("<button>Auftrag erstellen</button>") == 5
+    assert "<button>Auftrag erstellen</button>" not in body
+    assert "Angebot vorbereiten" in body
     assert '<a href="/anfragen">Alle anzeigen</a>' in body
     _status, full_body = _get(f"{panel}/anfragen")
     assert full_body.count("<tr>") == 8  # header row + all 7, not just top 5
@@ -1823,7 +1855,7 @@ def _panel_with_order():
         contact_email="kunde@example.com",
         contact_phone="+49301234567",
     )
-    order, v1 = panel.order_service.convert_inquiry_to_order(inquiry)
+    order, v1 = seed_order(order_repo, inquiry)
     return panel, order, v1
 
 
@@ -2459,7 +2491,7 @@ def test_website_intake_to_office_verification_and_conversion_workflow() -> None
         verified
     ).blocked
 
-    order, version = office.order_service.convert_inquiry_to_order(verified)
+    order, version = seed_order(order_repo, verified)
     assert order.source_inquiry_id == inquiry.inquiry_id
     assert version.version_number == 1
     assert [saved.order_id for saved in order_repo.list_orders()] == [order.order_id]

--- a/tests/unit/test_office_panel_convert_accepted.py
+++ b/tests/unit/test_office_panel_convert_accepted.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import base64
 import json
 import queue
@@ -71,7 +73,7 @@ def _seed(db_path: Path) -> dict[str, str]:
     inquiries = SQLiteInquiryRepository(db_path)
     orders = SQLiteOrderRepository(db_path)
     inquiry_service = InquiryService(inquiries)
-    order_service = OrderService(orders)
+    OrderService(orders)
     core = OperationalCoreService(orders)
     inquiry = inquiry_service.create_inquiry(
         event_date=date(2026, 10, 1),
@@ -102,7 +104,7 @@ def _seed(db_path: Path) -> dict[str, str]:
         contact_email="kunde@example.com",
         contact_phone="+49301234567",
     )
-    cancelled_order, _version = order_service.convert_inquiry_to_order(cancelled_src)
+    cancelled_order, _version = seed_order(orders, cancelled_src)
     core.cancel_order(cancelled_order.order_id)
     offer_ready = inquiry_service.create_inquiry(
         event_date=date(2026, 10, 3),

--- a/tests/unit/test_office_panel_dashboard.py
+++ b/tests/unit/test_office_panel_dashboard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date, timedelta
 
 from catering_system.ui.office_api_views import berlin_today
@@ -396,7 +398,7 @@ def _panel_with_order(event_date: date) -> OfficePanel:
         contact_email="kunde@example.com",
         contact_phone="030 1234567",
     )
-    panel.order_service.convert_inquiry_to_order(inquiry)
+    seed_order(orders, inquiry)
     return panel
 
 

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -8,6 +8,8 @@ never opening core.db in remote mode, and half-config startup rejection.
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import base64
 import json
 import os
@@ -75,7 +77,7 @@ def _seed(db_path: Path) -> dict[str, str]:
     inquiries = SQLiteInquiryRepository(db_path)
     orders = SQLiteOrderRepository(db_path)
     inquiry_service = InquiryService(inquiries)
-    order_service = OrderService(orders)
+    OrderService(orders)
     core = OperationalCoreService(orders)
 
     def make_inquiry(**overrides):  # noqa: ANN202
@@ -108,19 +110,19 @@ def _seed(db_path: Path) -> dict[str, str]:
     ids["inquiry_convertible"] = convertible.inquiry_id
 
     printed_src = make_inquiry(location_text="Bremen")
-    order_printed, v1 = order_service.convert_inquiry_to_order(printed_src)
+    order_printed, v1 = seed_order(orders, printed_src)
     core.confirm_kitchen_print(order_printed.order_id, v1.order_version_id)
     core.make_order_version_effective(order_printed.order_id, v1.order_version_id)
     ids["order_ready"] = order_printed.order_id
     ids["version_ready"] = v1.order_version_id
 
     unprinted_src = make_inquiry(location_text="Lübeck")
-    order_unprinted, v1u = order_service.convert_inquiry_to_order(unprinted_src)
+    order_unprinted, v1u = seed_order(orders, unprinted_src)
     ids["order_unprinted"] = order_unprinted.order_id
     ids["version_unprinted"] = v1u.order_version_id
 
     cancelled_src = make_inquiry(location_text="Flensburg")
-    order_cancelled, _v1c = order_service.convert_inquiry_to_order(cancelled_src)
+    order_cancelled, _v1c = seed_order(orders, cancelled_src)
     core.cancel_order(order_cancelled.order_id)
     ids["order_cancelled"] = order_cancelled.order_id
     ids["inquiry_cancelled_order"] = cancelled_src.inquiry_id
@@ -247,6 +249,18 @@ def _post_form(url: str, fields: dict[str, str]) -> tuple[int, str]:
 
 _VARIANT_ID = "44444444-4444-4444-8444-444444444441"
 _POSITION_ID = "88888888-8888-4888-8888-888888888881"
+_MARK_SENT_ARGS = {
+    "sent_at": "2026-07-15T10:00:00+00:00",
+    "channel": "email",
+    "recipient_reference": "customer@example.invalid",
+    "evidence_reference": "mail-123",
+}
+_RECORD_ACCEPTANCE_ARGS = {
+    "accepted_variant_id": _VARIANT_ID,
+    "accepted_at": "2026-07-15T11:00:00+00:00",
+    "channel": "email",
+    "evidence_reference": "reply-1",
+}
 
 
 def _api_get(url: str) -> tuple[int, dict]:
@@ -397,6 +411,30 @@ def _active_orders_for_inquiry(db: Path, inquiry_id: str) -> int:
         orders.close()
 
 
+def _accept_offer_via_api(api_url: str, inquiry_id: str) -> None:
+    status, body = _api_post(
+        f"{api_url}/office/v1/inquiries/{inquiry_id}/prepare-offer",
+        args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
+    )
+    assert status == 201
+    offer_id = body["offer_id"]
+    version_id = body["offer_version_id"]
+    assert (
+        _api_post(
+            f"{api_url}/office/v1/offers/{offer_id}/versions/{version_id}/mark-sent",
+            args=_MARK_SENT_ARGS,
+        )[0]
+        == 200
+    )
+    assert (
+        _api_post(
+            f"{api_url}/office/v1/offers/{offer_id}/versions/{version_id}/record-acceptance",
+            args=_RECORD_ACCEPTANCE_ARGS,
+        )[0]
+        == 200
+    )
+
+
 def test_legacy_convert_offer_gate_parity_direct_vs_remote(tmp_path: Path) -> None:
     """Direct panel work() and remote panel → Core API must both refuse legacy
     convert while a Prepared Offer blocks the inquiry path."""
@@ -424,9 +462,11 @@ def test_legacy_convert_offer_gate_parity_direct_vs_remote(tmp_path: Path) -> No
             )
 
             assert direct_status == 400
-            assert "Angebotsprozess blockiert" in direct_body
+            assert "angenommenem Angebot" in direct_body
             assert remote_status == 422
-            assert "Angebotsprozess blockiert" in remote_body
+            assert "accepted_offer_required" in remote_body or (
+                "angenommenem Angebot" in remote_body
+            )
             assert _active_orders_for_inquiry(db, inquiry_id) == 0
         finally:
             for server in (direct_server, remote_server):
@@ -821,7 +861,7 @@ def test_truncated_order_detail_warns_and_uses_true_latest_version(
         contact_phone="030 1234567",
     )
     service = OrderService(orders)
-    order, _version = service.convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     for number in range(2, 202):
         service.create_relevant_order_change_version(
             order,
@@ -875,9 +915,9 @@ def test_v2_remote_inquiry_detail_preserves_linked_order_truncation_warning(
         contact_email="kunde@example.com",
         contact_phone="030 1234567",
     )
-    order_service = OrderService(orders)
+    OrderService(orders)
     core = OperationalCoreService(orders)
-    first, version = order_service.convert_inquiry_to_order(inquiry)
+    first, version = seed_order(orders, inquiry)
     core.cancel_order(first.order_id)
     from datetime import UTC, datetime
     import uuid
@@ -994,7 +1034,7 @@ def remote_world(tmp_path: Path):
     api_url, api_server = _start_api_server(db)
     remote = RemoteCoreClient(api_url, _API_TOKEN)
     panel_url, panel_server = _start_remote_panel(remote)
-    yield panel_url
+    yield panel_url, api_url
     panel_server.shutdown()
     panel_server.server_close()
     api_server.shutdown()
@@ -1002,7 +1042,7 @@ def remote_world(tmp_path: Path):
 
 
 def test_full_write_flow_through_remote_panel(remote_world) -> None:
-    base = remote_world
+    base, api_url = remote_world
     status, form_html = _get(f"{base}/inquiry/new")
     assert status == 200
     command_id = _extract_hidden(form_html, "_command_id")
@@ -1059,13 +1099,34 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
     status, detail_html = _get(f"{base}/inquiry/{inquiry_id}")
     assert status == 200
     assert "Rostock-Ost" in detail_html
-    convert_command_id = _extract_hidden(
-        re.search(r"(<form[^>]*convert[^\"]*\"[^>]*>.*?</form>)", detail_html).group(0),
-        "_command_id",
-    )
-    status, _body = _post_form(
+    assert f'action="/inquiry/{inquiry_id}/convert"' not in detail_html
+    assert "Auftrag erstellen" not in detail_html
+    status, error_html = _post_form(
         f"{base}/inquiry/{inquiry_id}/convert",
-        {"_csrf_token": _CSRF_TOKEN, "_command_id": convert_command_id},
+        {"_csrf_token": _CSRF_TOKEN, "_command_id": str(uuid.uuid4())},
+    )
+    assert status == 422
+    assert (
+        "angenommenem Angebot" in error_html or "accepted_offer_required" in error_html
+    )
+
+    _accept_offer_via_api(api_url, inquiry_id)
+    status, detail_html = _get(f"{base}/inquiry/{inquiry_id}")
+    assert status == 200
+    convert_accepted_form = re.search(
+        r"(<form[^>]*convert-accepted[^>]*>.*?</form>)",
+        detail_html,
+        re.DOTALL,
+    )
+    assert convert_accepted_form is not None
+    status, _body = _post_form(
+        f"{base}/inquiry/{inquiry_id}/convert-accepted",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(
+                convert_accepted_form.group(0), "_command_id"
+            ),
+        },
     )
     assert status == 200
 
@@ -1079,7 +1140,7 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
         in converted_inquiry_html
     )
     locked_update_form = re.search(
-        r'(<form method="post" action="/inquiry/[^\"]*/update".*</form>)',
+        r'(<form method="post" action="/inquiry/[^"]*/update".*</form>)',
         converted_inquiry_html,
         re.DOTALL,
     ).group(0)
@@ -1193,7 +1254,7 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
 def test_verify_flow_through_remote_panel(remote_world) -> None:
     """The main flow above never sets call_verification_required, so it never
     exercises verify_customer_by_call — cover it here."""
-    base = remote_world
+    base, _api_url = remote_world
     _status, form_html = _get(f"{base}/inquiry/new")
     command_id = _extract_hidden(form_html, "_command_id")
     _status, _body = _post_form(
@@ -1229,14 +1290,19 @@ def test_verify_flow_through_remote_panel(remote_world) -> None:
 
     _status, detail_html = _get(f"{base}/inquiry/{inquiry_id}")
     assert "Telefonisch verifiziert" not in detail_html  # button gone once verified
-    assert "Auftrag erstellen" in detail_html  # convert now offered
+    assert "Auftrag erstellen" not in detail_html
+    assert (
+        "Angebot vorbereiten" in detail_html
+        or "Auftrag nur aus angenommenem Angebot" in detail_html
+        or "Angebot kann vorbereitet werden" in detail_html
+    )
 
 
 def test_idempotent_retry_same_command_id_and_preconditions(remote_world) -> None:
-    """§6.1/§6.3: after an indeterminate failure, retrying with the identical
-    envelope must not double the effect — convert twice with the same
-    command_id must produce exactly one order."""
-    base = remote_world
+    """§6.1/§6.3: identical command_id retries must not double create.
+    Inquiry create stays idempotent; legacy /convert hard-blocks without Order;
+    after Order exists via convert-accepted, /convert lookup is idempotent."""
+    base, api_url = remote_world
     _status, form_html = _get(f"{base}/inquiry/new")
     command_id = _extract_hidden(form_html, "_command_id")
     fields = {
@@ -1261,15 +1327,39 @@ def test_idempotent_retry_same_command_id_and_preconditions(remote_world) -> Non
     assert list_html.count("<td>Idempotenz-Stadt</td>") == 1
 
     inquiry_id = re.search(r'/inquiry/([0-9a-f-]{36})"', list_html).group(1)
+    convert_fields = {
+        "_csrf_token": _CSRF_TOKEN,
+        "_command_id": str(uuid.uuid4()),
+    }
+    status1, body1 = _post_form(f"{base}/inquiry/{inquiry_id}/convert", convert_fields)
+    status2, body2 = _post_form(f"{base}/inquiry/{inquiry_id}/convert", convert_fields)
+    assert status1 == status2 == 422
+    assert "angenommenem Angebot" in body1 or "accepted_offer_required" in body1
+    assert "angenommenem Angebot" in body2 or "accepted_offer_required" in body2
+
+    _accept_offer_via_api(api_url, inquiry_id)
     _status, detail_html = _get(f"{base}/inquiry/{inquiry_id}")
-    convert_form = re.search(
-        r'(<form[^>]*action="/inquiry/[^"]*/convert"[^>]*>.*?</form>)', detail_html
+    convert_accepted_form = re.search(
+        r"(<form[^>]*convert-accepted[^>]*>.*?</form>)",
+        detail_html,
+        re.DOTALL,
     ).group(0)
-    convert_command_id = _extract_hidden(convert_form, "_command_id")
-    convert_fields = {"_csrf_token": _CSRF_TOKEN, "_command_id": convert_command_id}
-    status1, _ = _post_form(f"{base}/inquiry/{inquiry_id}/convert", convert_fields)
-    status2, _ = _post_form(f"{base}/inquiry/{inquiry_id}/convert", convert_fields)
-    assert status1 == status2 == 200  # replay returns the recorded result
+    status, _ = _post_form(
+        f"{base}/inquiry/{inquiry_id}/convert-accepted",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(convert_accepted_form, "_command_id"),
+        },
+    )
+    assert status == 200
+
+    lookup_fields = {
+        "_csrf_token": _CSRF_TOKEN,
+        "_command_id": str(uuid.uuid4()),
+    }
+    status1, _ = _post_form(f"{base}/inquiry/{inquiry_id}/convert", lookup_fields)
+    status2, _ = _post_form(f"{base}/inquiry/{inquiry_id}/convert", lookup_fields)
+    assert status1 == status2 == 200  # replay / lookup of existing Order
 
     _status, orders_html = _get(f"{base}/auftraege?q={inquiry_id[:8]}")
     # exactly one order row for this inquiry, not two — one header <tr> plus

--- a/tests/unit/test_operational_core_service.py
+++ b/tests/unit/test_operational_core_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from dataclasses import FrozenInstanceError, replace
 from datetime import date, datetime, timezone
 
@@ -74,7 +76,7 @@ def _setup() -> tuple[
 
 def test_confirm_kitchen_print_sets_timestamp_and_emits() -> None:
     repo, osvc, core, events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     confirmed = core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     assert confirmed.kitchen_print_confirmed_at is not None
     stored = repo.get_order_version(v1.order_version_id)
@@ -88,7 +90,7 @@ def test_confirm_kitchen_print_sets_timestamp_and_emits() -> None:
 
 def test_confirm_kitchen_print_is_idempotent() -> None:
     _repo, osvc, core, events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     first = core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     second = core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     assert second == first  # same timestamp, no re-stamp
@@ -97,12 +99,13 @@ def test_confirm_kitchen_print_is_idempotent() -> None:
 
 def test_confirm_kitchen_print_rejects_foreign_or_unknown_version() -> None:
     _repo, osvc, core, _events = _setup()
-    order_a, _va = osvc.convert_inquiry_to_order(_sample_inquiry())
-    order_b, vb = osvc.convert_inquiry_to_order(
+    order_a, _va = seed_order(_repo, _sample_inquiry())
+    order_b, vb = seed_order(
+        _repo,
         replace(
             _sample_inquiry(),
             inquiry_id="22222222-2222-4222-8222-222222222222",
-        )
+        ),
     )
     with pytest.raises(ValueError):
         core.confirm_kitchen_print(order_a.order_id, vb.order_version_id)
@@ -114,7 +117,7 @@ def test_confirm_kitchen_print_rejects_foreign_or_unknown_version() -> None:
 
 def test_make_effective_blocked_without_kitchen_print() -> None:
     repo, osvc, core, events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     with pytest.raises(ValueError, match="kitchen print not confirmed"):
         core.make_order_version_effective(order.order_id, v1.order_version_id)
     stored = repo.get_order(order.order_id)
@@ -124,7 +127,7 @@ def test_make_effective_blocked_without_kitchen_print() -> None:
 
 def test_make_effective_succeeds_after_confirmation() -> None:
     repo, osvc, core, events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     updated = core.make_order_version_effective(order.order_id, v1.order_version_id)
     assert updated.effective_order_version_id == v1.order_version_id
@@ -139,7 +142,7 @@ def test_make_effective_succeeds_after_confirmation() -> None:
 
 def test_make_effective_clears_current_candidate() -> None:
     repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     v2 = osvc.propose_order_version_change(
@@ -162,7 +165,7 @@ def test_make_effective_clears_current_candidate() -> None:
 
 def test_make_effective_rejects_non_candidate_version() -> None:
     _repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 10, 2),
@@ -179,7 +182,7 @@ def test_make_effective_rejects_non_candidate_version() -> None:
 
 def test_history_immutable_after_switch() -> None:
     repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 10, 2),
@@ -200,7 +203,7 @@ def test_history_immutable_after_switch() -> None:
 
 def test_confirming_old_version_does_not_affect_current_effective() -> None:
     repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 10, 2),
@@ -228,7 +231,7 @@ def test_ready_to_send_unknown_order_blocked() -> None:
 
 def test_ready_to_send_blocked_without_effective_version() -> None:
     _repo, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     ev = core.evaluate_ready_to_send(order.order_id)
     assert ev.ready is False
     assert ev.reasons == (READY_REASON_NO_EFFECTIVE_VERSION,)
@@ -236,7 +239,7 @@ def test_ready_to_send_blocked_without_effective_version() -> None:
 
 def test_ready_to_send_ready_after_confirm_and_switch() -> None:
     _repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     ev = core.evaluate_ready_to_send(order.order_id)
@@ -246,7 +249,7 @@ def test_ready_to_send_ready_after_confirm_and_switch() -> None:
 
 def test_evaluate_ready_to_send_is_pure() -> None:
     repo, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     before_order = repo.get_order(order.order_id)
     core.evaluate_ready_to_send(order.order_id)
     assert repo.get_order(order.order_id) == before_order
@@ -255,7 +258,7 @@ def test_evaluate_ready_to_send_is_pure() -> None:
 
 def test_request_ready_to_send_emits_blocked_and_changes_nothing() -> None:
     repo, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     before_order = repo.get_order(order.order_id)
     ev = core.request_ready_to_send(order.order_id)
     assert ev.ready is False
@@ -269,7 +272,7 @@ def test_request_ready_to_send_emits_blocked_and_changes_nothing() -> None:
 
 def test_request_ready_to_send_emits_success() -> None:
     _repo, osvc, core, events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     ev = core.request_ready_to_send(order.order_id)
@@ -285,7 +288,7 @@ def test_ready_reason_when_effective_set_but_print_missing_is_unreachable_via_se
     from catering_system.domain.ready_to_send import evaluate_ready_to_send_from_facts
 
     _repo, osvc, _core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     from dataclasses import replace
 
     tampered = replace(order, effective_order_version_id=v1.order_version_id)
@@ -296,7 +299,7 @@ def test_ready_reason_when_effective_set_but_print_missing_is_unreachable_via_se
 
 def test_order_and_version_are_frozen() -> None:
     _repo, osvc, _core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     with pytest.raises(FrozenInstanceError):
         order.effective_order_version_id = v1.order_version_id  # type: ignore[misc]
     with pytest.raises(FrozenInstanceError):

--- a/tests/unit/test_operational_pause_enforcement.py
+++ b/tests/unit/test_operational_pause_enforcement.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import sqlite3
 import re
 from pathlib import Path
@@ -231,7 +233,7 @@ def test_fake_send_during_pause_returns_blocked_with_zero_rows(tmp_path: Path) -
 
 def test_effective_switch_during_pause_does_not_clear_pause() -> None:
     repo, _pauses, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     v2 = osvc.propose_order_version_change(
@@ -270,7 +272,7 @@ def test_effective_switch_during_pause_does_not_clear_pause() -> None:
 
 def test_storno_blocks_pause_and_preserves_history() -> None:
     _repo, pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     _pause(
         core,
         order.order_id,

--- a/tests/unit/test_order_operational_pause.py
+++ b/tests/unit/test_order_operational_pause.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import sqlite3
 from datetime import date, datetime, timezone
 from uuid import uuid4
@@ -190,7 +192,7 @@ def test_reason_code_validation() -> None:
 
 def test_pause_active_order_success() -> None:
     repo, _pauses, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     event = _pause(
         core,
         order.order_id,
@@ -210,7 +212,7 @@ def test_pause_active_order_success() -> None:
 
 def test_pause_without_effective_version_succeeds() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     assert core.get_active_operational_pause(order.order_id) is None
     _pause(
         core,
@@ -225,7 +227,7 @@ def test_pause_without_effective_version_succeeds() -> None:
 
 def test_repeat_pause_with_new_command_rejected() -> None:
     _repo, _pauses, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     _pause(
         core,
         order.order_id,
@@ -248,7 +250,7 @@ def test_repeat_pause_with_new_command_rejected() -> None:
 
 def test_resume_active_pause_and_history_preserved() -> None:
     repo, pauses, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     paused = _pause(
         core,
         order.order_id,
@@ -277,7 +279,7 @@ def test_resume_active_pause_and_history_preserved() -> None:
 
 def test_resume_not_paused_order_rejected() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     with pytest.raises(ValueError, match="not paused"):
         core.resume_order(
             order.order_id,
@@ -292,7 +294,7 @@ def test_resume_not_paused_order_rejected() -> None:
 
 def test_pause_resume_do_not_change_order_version_or_effective() -> None:
     repo, _pauses, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     before = repo.get_order(order.order_id)
@@ -336,7 +338,7 @@ def test_pause_unknown_order_not_found() -> None:
 
 def test_pause_missing_reason_or_actor_validation() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     with pytest.raises(ValueError, match="invalid pause reason_code"):
         _pause(
             core,
@@ -410,7 +412,7 @@ def test_in_memory_duplicate_event_or_command_id_rejected() -> None:
 def test_sqlite_pause_events_round_trip_and_migration(tmp_path) -> None:
     db = tmp_path / "core.db"
     orders = SQLiteOrderRepository(db)
-    order, _v1 = OrderService(orders).convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(orders, _sample_inquiry())
     orders.close()
     pauses = SQLiteOrderOperationalPauseRepository(db)
     event = _paused_event(order_id=order.order_id)
@@ -450,10 +452,9 @@ def test_sqlite_pause_migration_on_existing_database(tmp_path) -> None:
 def test_paused_effective_order_still_in_wochenuebersicht_and_kiosk_feed() -> None:
     orders = InMemoryOrderRepository()
     pauses = InMemoryOrderOperationalPauseRepository()
-    osvc = OrderService(orders)
     core = OperationalCoreService(orders, pause_repository=pauses)
     week = WochenuebersichtService(orders, pause_repository=pauses)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(orders, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     _pause(
@@ -480,7 +481,7 @@ def test_paused_effective_order_still_in_wochenuebersicht_and_kiosk_feed() -> No
 
 def test_pause_blocks_ready_to_send_and_resume_clears_only_pause_blocker() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     assert core.evaluate_ready_to_send(order.order_id).ready is True
@@ -508,7 +509,7 @@ def test_pause_blocks_ready_to_send_and_resume_clears_only_pause_blocker() -> No
 
 def test_pause_with_pending_candidate_reports_both_blockers() -> None:
     repo, _pauses, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     _pause(
@@ -538,7 +539,7 @@ def test_pause_with_pending_candidate_reports_both_blockers() -> None:
 
 def test_storniert_order_cannot_be_paused_or_resumed() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     core.cancel_order(order.order_id)
     with pytest.raises(ValueError, match="cancelled"):
         _pause(
@@ -577,7 +578,7 @@ def test_derive_operational_pause_projection_inactive_and_active() -> None:
 
 def test_stale_pause_after_resume_cycle_rejected() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     _pause(
         core,
         order.order_id,
@@ -607,7 +608,7 @@ def test_stale_pause_after_resume_cycle_rejected() -> None:
 
 def test_stale_resume_for_previous_pause_event_rejected() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     pause_a = _pause(
         core,
         order.order_id,
@@ -653,7 +654,7 @@ def test_sqlite_pause_update_and_delete_triggers_reject(tmp_path) -> None:
     conn = open_core_connection(db)
     orders = SQLiteOrderRepository.from_connection(conn)
     pauses = SQLiteOrderOperationalPauseRepository.from_connection(conn)
-    order, _v1 = OrderService(orders).convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(orders, _sample_inquiry())
     event = _paused_event(order_id=order.order_id)
     pauses.append_event(event)
     with pytest.raises(sqlite3.IntegrityError):
@@ -673,7 +674,7 @@ def test_sqlite_pause_update_and_delete_triggers_reject(tmp_path) -> None:
 
 def test_resume_on_other_order_with_foreign_pause_id_rejected() -> None:
     _repo, _pauses, osvc, core, _events = _setup()
-    order_a, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order_a, _v1 = seed_order(_repo, _sample_inquiry())
     inquiry_b = Inquiry(
         inquiry_id="33333333-3333-4333-8333-333333333333",
         event_date=date(2026, 10, 2),
@@ -690,7 +691,7 @@ def test_resume_on_other_order_with_foreign_pause_id_rejected() -> None:
         call_verification_status=CALL_VERIFICATION_STATUSES[0],
         customer_snapshot=_CONTACT_COMPLETE_SNAPSHOT,
     )
-    order_b, _v2 = osvc.convert_inquiry_to_order(inquiry_b)
+    order_b, _v2 = seed_order(_repo, inquiry_b)
     paused = _pause(
         core,
         order_a.order_id,
@@ -787,7 +788,7 @@ def test_projection_tolerates_duplicate_resume_fact_and_keeps_latest_id() -> Non
 
 def test_pause_history_and_remaining_stale_service_branches() -> None:
     _repo, pauses, osvc, core, _events = _setup()
-    order, _version = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _version = seed_order(_repo, _sample_inquiry())
     paused = _pause(
         core,
         order.order_id,
@@ -823,7 +824,7 @@ def test_pause_history_and_remaining_stale_service_branches() -> None:
 def test_sqlite_owner_trigger_malformed_row_and_idempotent_migration(tmp_path) -> None:
     db = tmp_path / "pause-integrity.db"
     orders = SQLiteOrderRepository(db)
-    order, _version = OrderService(orders).convert_inquiry_to_order(_sample_inquiry())
+    order, _version = seed_order(orders, _sample_inquiry())
     orders.close()
     pauses = SQLiteOrderOperationalPauseRepository(db)
     with pytest.raises(sqlite3.IntegrityError, match="owner does not exist"):
@@ -858,7 +859,7 @@ def test_sqlite_pause_append_rolls_back_with_failed_command_bundle(tmp_path) -> 
     connection = open_core_connection(tmp_path / "pause-rollback.db")
     orders = SQLiteOrderRepository.from_connection(connection)
     pauses = SQLiteOrderOperationalPauseRepository.from_connection(connection)
-    order, _version = OrderService(orders).convert_inquiry_to_order(_sample_inquiry())
+    order, _version = seed_order(orders, _sample_inquiry())
     event = _paused_event(order_id=order.order_id)
 
     def fail_after_append() -> None:

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date
 
 import pytest
@@ -64,10 +66,10 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
 
 def test_order_without_offer_has_empty_menu() -> None:
     inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
-    order_service = OrderService(orders)
+    OrderService(orders)
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
-    order, version = order_service.convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
 
     projection = _projection_service(offers, orders).resolve(
         order.order_id,
@@ -437,7 +439,7 @@ def test_commercial_block_is_none_without_conversion_link() -> None:
 
     inquiries = InMemoryInquiryRepository()
     inquiries.save(inquiry)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     projection = _projection_service(offers, orders).resolve(
         order.order_id, version.order_version_id
     )
@@ -502,7 +504,7 @@ def test_preview_entwurf_when_effective_version_record_is_missing() -> None:
     inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     broken = replace(
         order,
         effective_order_version_id="00000000-0000-4000-8000-000000000077",

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -13,6 +13,8 @@ _SRC = Path(__file__).resolve().parents[2] / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+from tests.helpers.order_seed import seed_order
+
 from catering_system.domain.inquiry import (
     CALL_VERIFICATION_STATUSES,
     CRM_PIPELINE,
@@ -70,83 +72,25 @@ def _sample_inquiry() -> Inquiry:
     )
 
 
-def test_convert_inquiry_to_order_blocked_when_verification_required_not_verified() -> (
-    None
-):
+def test_convert_inquiry_to_order_requires_accepted_offer_when_missing() -> None:
     svc = OrderService(InMemoryOrderRepository())
-    for status in ("pending", "failed", "blocked"):
-        inquiry = replace(
-            _sample_inquiry(),
-            call_verification_required=True,
-            call_verification_status=status,  # type: ignore[arg-type]
-        )
-        with pytest.raises(ValueError, match="inquiry_to_order conversion blocked"):
-            svc.convert_inquiry_to_order(inquiry)
+    with pytest.raises(ValueError, match="accepted offer required"):
+        svc.convert_inquiry_to_order(_sample_inquiry())
 
 
-def test_convert_inquiry_to_order_blocked_when_required_but_not_verified_status() -> (
-    None
-):
-    """required=True with not_required status is inconsistent — still blocked (not verified)."""
-    svc = OrderService(InMemoryOrderRepository())
-    inquiry = replace(
-        _sample_inquiry(),
-        call_verification_required=True,
-        call_verification_status="not_required",
-    )
-    with pytest.raises(ValueError, match="inquiry_to_order conversion blocked"):
-        svc.convert_inquiry_to_order(inquiry)
-
-
-def test_convert_inquiry_to_order_blocked_when_rejected() -> None:
+def test_convert_inquiry_to_order_returns_existing_order() -> None:
     repo = InMemoryOrderRepository()
-    inquiry = replace(_sample_inquiry(), crm_stage="Abgelehnt / verloren")
-
-    with pytest.raises(ValueError, match="inquiry_to_order conversion blocked"):
-        OrderService(repo).convert_inquiry_to_order(inquiry)
-
-    assert repo.list_orders() == []
-
-
-def test_convert_inquiry_to_order_allowed_when_verification_required_and_verified() -> (
-    None
-):
-    svc = OrderService(InMemoryOrderRepository())
-    inquiry = replace(
-        _sample_inquiry(),
-        call_verification_required=True,
-        call_verification_status="verified",
-    )
-    order, ver = svc.convert_inquiry_to_order(inquiry)
-    assert order.source_inquiry_id == inquiry.inquiry_id
-    assert ver.version_number == 1
-
-
-def test_convert_inquiry_to_order_creates_order_and_initial_version() -> None:
-    repo = InMemoryOrderRepository()
-    svc = OrderService(repo)
     inquiry = _sample_inquiry()
-    order, ver = svc.convert_inquiry_to_order(inquiry)
-    assert order.source_inquiry_id == inquiry.inquiry_id
-    assert ver.order_id == order.order_id
-    assert ver.version_number == 1
-    assert ver.event_date == inquiry.event_date
-    assert ver.time_window_text == inquiry.time_window_text
-    assert ver.location_text == inquiry.location_text
-    assert ver.guest_count_estimate == inquiry.guest_count_estimate
-    assert ver.planning_mode == inquiry.planning_mode
-    loaded = repo.get_order(order.order_id)
-    assert loaded is not None
-    assert loaded.order_id == order.order_id
-    stored = repo.get_order_version(ver.order_version_id)
-    assert stored is not None
-    assert stored.version_number == 1
+    seeded, ver = seed_order(repo, inquiry)
+    order, got = OrderService(repo).convert_inquiry_to_order(inquiry)
+    assert order.order_id == seeded.order_id
+    assert got.order_version_id == ver.order_version_id
 
 
 def test_create_relevant_order_change_version_second_preserves_first() -> None:
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = svc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -173,7 +117,7 @@ def test_create_relevant_order_change_version_second_preserves_first() -> None:
 
 def test_in_memory_repository_rejects_operational_version_update() -> None:
     repo = InMemoryOrderRepository()
-    order, v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     with pytest.raises(ValueError, match="snapshot is immutable"):
         repo.update_order_version(replace(v1, location_text="Andere Adresse"))
     assert repo.get_order(order.order_id) is not None
@@ -184,7 +128,7 @@ def test_list_order_versions_and_get_latest_match_history_not_activation() -> No
     """Full history via service; latest is max(version_number); history not collapsed to one active row."""
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = svc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 12, 3),
@@ -219,7 +163,7 @@ def test_get_latest_order_version_returns_none_when_no_versions() -> None:
 def test_set_and_get_candidate_order_version_office_side_only() -> None:
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     assert repo.get_order(order.order_id) is not None
     assert repo.get_order(order.order_id).candidate_order_version_id is None
     assert svc.get_candidate_order_version(order.order_id) is None
@@ -231,8 +175,9 @@ def test_set_and_get_candidate_order_version_office_side_only() -> None:
 
 
 def test_changing_candidate_preserves_full_version_history() -> None:
-    svc = OrderService(InMemoryOrderRepository())
-    order, v1 = svc.convert_inquiry_to_order(_sample_inquiry())
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = svc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -257,8 +202,9 @@ def test_changing_candidate_preserves_full_version_history() -> None:
 
 def test_candidate_can_differ_from_latest_historical_version() -> None:
     """B6: candidate is not latest-in-history; not effective operational selection."""
-    svc = OrderService(InMemoryOrderRepository())
-    order, v1 = svc.convert_inquiry_to_order(_sample_inquiry())
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = svc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -277,8 +223,9 @@ def test_candidate_can_differ_from_latest_historical_version() -> None:
 
 
 def test_set_candidate_rejects_foreign_version_id() -> None:
-    svc = OrderService(InMemoryOrderRepository())
-    order, _ = svc.convert_inquiry_to_order(_sample_inquiry())
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, _ = seed_order(repo, _sample_inquiry())
     with pytest.raises(ValueError, match="not a version of order"):
         svc.set_candidate_order_version(
             order.order_id, "00000000-0000-0000-0000-000000000001"

--- a/tests/unit/test_progression_service.py
+++ b/tests/unit/test_progression_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import sys
 from dataclasses import replace
 from datetime import date, datetime, timezone
@@ -139,8 +141,8 @@ def test_inquiry_to_order_not_blocked_when_gate_satisfied() -> None:
 def test_candidate_progression_blocked_when_candidate_missing() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     ev = prog.evaluate_candidate_version_progression(order.order_id)
     assert ev.blocked is True
     assert REASON_CANDIDATE_ORDER_VERSION_MISSING in ev.reasons
@@ -150,7 +152,7 @@ def test_candidate_progression_not_blocked_when_candidate_set() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     ev = prog.evaluate_candidate_version_progression(order.order_id)
     assert ev.blocked is False
@@ -169,7 +171,7 @@ def test_candidate_progression_blocked_when_candidate_id_not_resolvable() -> Non
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     del repo._versions[v1.order_version_id]
     ev = prog.evaluate_candidate_version_progression(order.order_id)
@@ -181,7 +183,7 @@ def test_order_progression_view_composes_latest_candidate_and_blocked() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -208,8 +210,8 @@ def test_order_progression_view_composes_latest_candidate_and_blocked() -> None:
 def test_order_progression_view_when_candidate_absent() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
     view = prog.get_order_progression_view(order.order_id)
     assert view is not None
     assert view.latest_order_version is not None
@@ -232,7 +234,7 @@ def test_progression_decision_eligible_when_candidate_ok_and_not_blocked() -> No
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     d = prog.evaluate_order_progression_decision(order.order_id)
     assert isinstance(d, OrderProgressionDecision)
@@ -244,8 +246,8 @@ def test_progression_decision_eligible_when_candidate_ok_and_not_blocked() -> No
 def test_progression_decision_not_eligible_when_candidate_missing() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     d = prog.evaluate_order_progression_decision(order.order_id)
     assert d.eligible_for_progression_review is False
     assert REASON_CANDIDATE_ORDER_VERSION_MISSING in d.reasons
@@ -256,7 +258,7 @@ def test_progression_decision_not_eligible_when_candidate_not_resolvable() -> No
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     del repo._versions[v1.order_version_id]
     d = prog.evaluate_order_progression_decision(order.order_id)
@@ -279,7 +281,7 @@ def test_checkpoint_composes_view_and_decision() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -305,8 +307,8 @@ def test_checkpoint_composes_view_and_decision() -> None:
 def test_checkpoint_when_candidate_absent() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
     cp = prog.get_order_progression_checkpoint(order.order_id)
     assert cp is not None
     assert cp.latest_order_version_id == v1.order_version_id
@@ -329,7 +331,7 @@ def test_review_summary_matches_checkpoint_and_reason_count() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -361,8 +363,8 @@ def test_review_summary_matches_checkpoint_and_reason_count() -> None:
 def test_review_summary_when_candidate_absent() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
     sm = prog.get_order_progression_review_summary(order.order_id)
     assert sm is not None
     assert sm.latest_order_version_id == v1.order_version_id
@@ -386,7 +388,7 @@ def test_consistency_check_consistent_when_layers_align() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     cc = prog.get_order_progression_consistency_check(order.order_id)
     assert cc is not None
@@ -420,7 +422,7 @@ def test_bundle_matches_individual_derived_getters() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -468,7 +470,7 @@ def test_export_flattened_from_bundle_checkpoint_and_consistency() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 11, 2),
@@ -514,7 +516,7 @@ def test_text_summary_deterministic_from_export() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -562,7 +564,7 @@ def test_reason_codes_matches_export_order_and_count() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -588,7 +590,7 @@ def test_status_label_eligible_when_export_eligible_and_consistent() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -603,8 +605,8 @@ def test_status_label_eligible_when_export_eligible_and_consistent() -> None:
 def test_status_label_blocked_when_candidate_missing() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     sl = prog.get_order_progression_status_label(order.order_id)
     assert sl is not None
     assert sl.status_label == "blocked"
@@ -623,7 +625,7 @@ def test_badges_matches_export_derived_tuple() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -638,8 +640,8 @@ def test_badges_matches_export_derived_tuple() -> None:
 def test_badges_blocked_candidate_missing_has_reasons_present() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     bg = prog.get_order_progression_badges(order.order_id)
     assert bg is not None
     assert bg.badges == (
@@ -680,7 +682,7 @@ def test_severity_matches_export_derived_string() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -696,8 +698,8 @@ def test_severity_matches_export_derived_string() -> None:
 def test_severity_blocked_candidate_missing_is_high() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     sv = prog.get_order_progression_severity(order.order_id)
     assert sv is not None
     assert sv.severity == "high"
@@ -794,7 +796,7 @@ def test_state_signature_matches_export_derived_string() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -810,14 +812,15 @@ def test_state_signature_eligible_and_blocked_missing_shapes() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     sig_ok = prog.get_order_progression_state_signature(order.order_id)
-    order2, _v1b = osvc.convert_inquiry_to_order(
+    order2, _v1b = seed_order(
+        repo,
         replace(
             _sample_inquiry(),
             inquiry_id="22222222-2222-4222-8222-222222222222",
-        )
+        ),
     )
     sig_blocked = prog.get_order_progression_state_signature(order2.order_id)
     assert sig_ok is not None and sig_blocked is not None
@@ -861,7 +864,7 @@ def test_facts_matches_from_export_eligible() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -883,8 +886,8 @@ def test_facts_matches_from_export_eligible() -> None:
 def test_facts_blocked_candidate_missing() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     facts = prog.get_order_progression_facts(order.order_id)
     assert facts is not None
     assert facts.has_reasons is True
@@ -927,7 +930,7 @@ def test_reason_fingerprint_eligible_no_reasons_is_none() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -943,8 +946,8 @@ def test_reason_fingerprint_eligible_no_reasons_is_none() -> None:
 def test_reason_fingerprint_blocked_candidate_missing_joins_pipe() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
     fp = prog.get_order_progression_reason_fingerprint(oid)
@@ -984,7 +987,7 @@ def test_readiness_flags_eligible_with_candidate_expected_booleans() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -1004,8 +1007,8 @@ def test_readiness_flags_eligible_with_candidate_expected_booleans() -> None:
 def test_readiness_flags_blocked_candidate_missing_expected_booleans() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     ex = prog.get_order_progression_export(order.order_id)
     rf = prog.get_order_progression_readiness_flags(order.order_id)
     assert ex is not None and rf is not None
@@ -1051,7 +1054,7 @@ def test_reason_presence_eligible_with_candidate_has_reasons_false() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     ex = prog.get_order_progression_export(oid)
@@ -1066,8 +1069,8 @@ def test_reason_presence_eligible_with_candidate_has_reasons_false() -> None:
 def test_reason_presence_blocked_candidate_missing_has_reasons_true() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     ex = prog.get_order_progression_export(order.order_id)
     rp = prog.get_order_progression_reason_presence(order.order_id)
     assert ex is not None and rp is not None

--- a/tests/unit/test_progression_service_review_summary.py
+++ b/tests/unit/test_progression_service_review_summary.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date, datetime, timezone
 
 from catering_system.domain.inquiry import (
@@ -62,7 +64,7 @@ def test_composed_derived_review_eligible_matches_checkpoint_and_derived_getters
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     cp = prog.get_order_progression_checkpoint(oid)
@@ -101,8 +103,8 @@ def test_composed_derived_review_eligible_matches_checkpoint_and_derived_getters
 def test_composed_derived_review_blocked_candidate_missing_matches_parts() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     oid = order.order_id
     cp = prog.get_order_progression_checkpoint(oid)
     sv = prog.get_order_progression_severity(oid)
@@ -133,8 +135,8 @@ def test_composed_derived_review_blocked_candidate_missing_matches_parts() -> No
 def test_composed_derived_review_facts_count_matches_b23_flags_only() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     oid = order.order_id
     facts = prog.get_order_progression_facts(oid)
     comp = prog.get_order_progression_composed_derived_review_summary(oid)
@@ -156,7 +158,7 @@ def test_composed_derived_review_no_mutations_on_repo() -> None:
     repo = InMemoryOrderRepository()
     prog = ProgressionService(repo)
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     oid = order.order_id
     before = len(repo._orders)

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -9,6 +9,8 @@ in test_office_panel_remote.py.
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import json
 import queue
 import socket
@@ -27,7 +29,6 @@ from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
 from catering_system.services.inquiry_service import InquiryService
-from catering_system.services.order_service import OrderService
 from catering_system.ui import remote_core_client as rcc
 from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
 
@@ -517,7 +518,7 @@ def test_confirm_kitchen_print_returns_the_version_not_bad_response(
         contact_email="kunde@example.com",
         contact_phone="+49301234567",
     )
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     inquiries.close()
     orders.close()
 
@@ -555,7 +556,7 @@ def test_create_relevant_order_change_version_returns_the_version_not_bad_respon
         contact_email="kunde@example.com",
         contact_phone="+49301234567",
     )
-    order, _v1 = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _v1 = seed_order(orders, inquiry)
     inquiries.close()
     orders.close()
 

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 import sqlite3
 from dataclasses import replace
 from datetime import date, datetime, timedelta, timezone
@@ -238,7 +240,7 @@ def test_inquiry_save_does_not_overwrite_existing_id(tmp_path: Path) -> None:
 def test_order_roundtrip_and_version_ordering(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
     osvc = OrderService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     v2 = osvc.create_relevant_order_change_version(
         order,
         event_date=date(2026, 10, 2),
@@ -260,9 +262,7 @@ def test_order_roundtrip_and_version_ordering(tmp_path: Path) -> None:
 def test_initial_order_and_version_creation_rolls_back_together(tmp_path: Path) -> None:
     """A failed v1 insert must not leave an order without its initial version."""
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    existing_order, existing_v1 = OrderService(repo).convert_inquiry_to_order(
-        _sample_inquiry()
-    )
+    existing_order, existing_v1 = seed_order(repo, _sample_inquiry())
     new_order = replace(
         existing_order,
         order_id="new-order",
@@ -280,7 +280,7 @@ def test_initial_order_and_version_creation_rolls_back_together(tmp_path: Path) 
 
 def test_initial_version_must_belong_to_order_and_be_v1(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    order, v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     invalid_order = replace(order, order_id="new-order")
 
     with pytest.raises(ValueError, match="must be v1 of the supplied order"):
@@ -292,7 +292,7 @@ def test_initial_version_must_belong_to_order_and_be_v1(tmp_path: Path) -> None:
 def test_append_version_conflict_rolls_back_order_update(tmp_path: Path) -> None:
     """A duplicate version number must not leave updated aggregate metadata."""
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    order, v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     updated_order = replace(order, updated_at=order.updated_at + timedelta(minutes=1))
     duplicate_number = replace(v1, order_version_id="different-version-id")
 
@@ -305,7 +305,7 @@ def test_append_version_conflict_rolls_back_order_update(tmp_path: Path) -> None
 
 def test_update_unknown_order_version_does_not_insert(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    _order, v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    _order, v1 = seed_order(repo, _sample_inquiry())
     missing = replace(v1, order_version_id="missing-version")
 
     with pytest.raises(KeyError):
@@ -316,7 +316,7 @@ def test_update_unknown_order_version_does_not_insert(tmp_path: Path) -> None:
 
 def test_order_version_snapshot_fields_cannot_be_updated(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    order, v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
 
     with pytest.raises(ValueError, match="snapshot is immutable"):
         repo.update_order_version(replace(v1, location_text="Andere Adresse"))
@@ -333,8 +333,8 @@ def test_order_version_snapshot_fields_cannot_be_updated(tmp_path: Path) -> None
 
 def test_order_update_missing_raises(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
-    osvc = OrderService(repo)
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    OrderService(repo)
+    order, _v1 = seed_order(repo, _sample_inquiry())
     ghost = order.__class__(
         order_id="missing",
         source_inquiry_id=order.source_inquiry_id,
@@ -349,9 +349,9 @@ def test_operational_core_flow_survives_reconnect(tmp_path: Path) -> None:
     """Kitchen print confirmation and effective switch persist across process restarts."""
     db = tmp_path / "test.db"
     repo = SQLiteOrderRepository(db)
-    osvc = OrderService(repo)
+    OrderService(repo)
     core = OperationalCoreService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     repo.close()
@@ -372,7 +372,7 @@ def test_progression_chain_works_over_sqlite(tmp_path: Path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "test.db")
     osvc = OrderService(repo)
     prog = ProgressionService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     cp = prog.get_order_progression_checkpoint(order.order_id)
     assert cp is not None
@@ -410,7 +410,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
 def test_sqlite_rejects_orphan_order_version(tmp_path: Path) -> None:
     db = tmp_path / "test.db"
     repo = SQLiteOrderRepository(db)
-    OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    seed_order(repo, _sample_inquiry())
     repo.close()
     connection = sqlite3.connect(db)
 
@@ -430,7 +430,7 @@ def test_sqlite_rejects_orphan_order_version(tmp_path: Path) -> None:
 def test_sqlite_rejects_unowned_order_reference(tmp_path: Path) -> None:
     db = tmp_path / "test.db"
     repo = SQLiteOrderRepository(db)
-    order, _v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     repo.close()
     connection = sqlite3.connect(db)
 
@@ -445,7 +445,7 @@ def test_sqlite_rejects_unowned_order_reference(tmp_path: Path) -> None:
 def test_sqlite_rejects_deleting_order_that_owns_versions(tmp_path: Path) -> None:
     db = tmp_path / "test.db"
     repo = SQLiteOrderRepository(db)
-    order, _v1 = OrderService(repo).convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     repo.close()
     connection = sqlite3.connect(db)
 
@@ -458,10 +458,10 @@ def test_sqlite_rejects_moving_referenced_version(tmp_path: Path) -> None:
     db = tmp_path / "test.db"
     repo = SQLiteOrderRepository(db)
     service = OrderService(repo)
-    order, version = service.convert_inquiry_to_order(_sample_inquiry())
+    order, version = seed_order(repo, _sample_inquiry())
     service.set_candidate_order_version(order.order_id, version.order_version_id)
-    other_order, _other_version = service.convert_inquiry_to_order(
-        replace(_sample_inquiry(), inquiry_id="other-inquiry")
+    other_order, _other_version = seed_order(
+        repo, replace(_sample_inquiry(), inquiry_id="other-inquiry")
     )
     repo.close()
     connection = sqlite3.connect(db)

--- a/tests/unit/test_storno.py
+++ b/tests/unit/test_storno.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date, datetime, timezone
 from pathlib import Path
 
@@ -67,7 +69,7 @@ def _setup() -> tuple[
 
 def test_cancel_sets_fact_and_emits() -> None:
     repo, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(repo, _sample_inquiry())
     cancelled = core.cancel_order(order.order_id)
     assert cancelled.cancelled_at is not None
     stored = repo.get_order(order.order_id)
@@ -77,7 +79,7 @@ def test_cancel_sets_fact_and_emits() -> None:
 
 def test_cancel_is_idempotent() -> None:
     _repo, osvc, core, events = _setup()
-    order, _v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, _v1 = seed_order(_repo, _sample_inquiry())
     first = core.cancel_order(order.order_id)
     second = core.cancel_order(order.order_id)
     assert second == first
@@ -93,7 +95,7 @@ def test_cancel_unknown_order_raises() -> None:
 def test_cancel_preserves_history_candidate_effective() -> None:
     """§1: nothing deleted, nothing reverted — references stay as historical truth."""
     repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     osvc.set_candidate_order_version(order.order_id, v1.order_version_id)
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
@@ -109,7 +111,7 @@ def test_cancel_preserves_history_candidate_effective() -> None:
 
 def test_operational_commands_refused_after_cancel() -> None:
     _repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.cancel_order(order.order_id)
     with pytest.raises(ValueError, match="cancelled"):
         core.confirm_kitchen_print(order.order_id, v1.order_version_id)
@@ -119,7 +121,7 @@ def test_operational_commands_refused_after_cancel() -> None:
 
 def test_order_side_mutations_refused_after_cancel() -> None:
     _repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.cancel_order(order.order_id)
     with pytest.raises(ValueError, match="Storno"):
         osvc.create_relevant_order_change_version(
@@ -137,7 +139,7 @@ def test_order_side_mutations_refused_after_cancel() -> None:
 def test_ready_to_send_blocked_with_cancelled_reason() -> None:
     """§3: cancelled beats everything, even a previously fully-released order."""
     _repo, osvc, core, _events = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(_repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     assert core.evaluate_ready_to_send(order.order_id).ready is True
@@ -150,7 +152,7 @@ def test_ready_to_send_blocked_with_cancelled_reason() -> None:
 def test_cancelled_order_disappears_from_wochenuebersicht() -> None:
     repo, osvc, core, _events = _setup()
     week = WochenuebersichtService(repo)
-    order, v1 = osvc.convert_inquiry_to_order(_sample_inquiry())
+    order, v1 = seed_order(repo, _sample_inquiry())
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     assert len(week.get_week_overview(2026, 40).entries) == 1

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import UTC, date, datetime, timedelta
 
 from catering_system.domain.offer import (
@@ -27,7 +29,6 @@ from catering_system.repositories.in_memory_payment_reminder_repository import (
 )
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
 from catering_system.services.payment_reminder_service import PaymentReminderService
 from catering_system.services.task_projection_service import TaskProjectionService
 from catering_system.services.work_center_service import WorkCenterService
@@ -196,13 +197,13 @@ def test_verify_task_emitted() -> None:
     assert row.action_href == f"/inquiry/{inquiry.inquiry_id}"
 
 
-def test_convert_task_emitted() -> None:
+def test_prepare_offer_task_emitted() -> None:
     inquiries = InMemoryInquiryRepository()
     inquiry = _save_inquiry(inquiries, intake_subject="Bereit")
     rows = _service(inquiries=inquiries).list_tasks()
     assert len(rows) == 1
-    assert rows[0].task_id == f"inquiry:{inquiry.inquiry_id}:convert"
-    assert rows[0].category == "convert"
+    assert rows[0].task_id == f"inquiry:{inquiry.inquiry_id}:prepare-offer"
+    assert rows[0].category == "prepare_offer"
 
 
 def test_convert_accepted_task_emitted() -> None:
@@ -229,7 +230,7 @@ def test_print_confirm_task_emitted() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     rows = _service(inquiries=inquiries, orders=orders).list_tasks()
     task_ids = {row.task_id for row in rows}
     assert (
@@ -243,7 +244,7 @@ def test_effective_task_emitted() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
-    order, version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     OperationalCoreService(orders).confirm_kitchen_print(
         order.order_id, version.order_version_id
     )
@@ -260,7 +261,7 @@ def test_payment_task_emitted_with_overdue_urgency() -> None:
     orders = InMemoryOrderRepository()
     reminders = InMemoryPaymentReminderRepository()
     inquiry = _save_inquiry(inquiries, event_date=date(2026, 8, 1))
-    order, _version = OrderService(orders).convert_inquiry_to_order(inquiry)
+    order, _version = seed_order(orders, inquiry)
     reminders.save(
         OrderPaymentReminder(
             order_id=order.order_id,
@@ -292,8 +293,8 @@ def test_sort_overdue_payment_before_verify() -> None:
         call_verification_required=True,
         call_verification_status="pending",
     )
-    order, _version = OrderService(orders).convert_inquiry_to_order(
-        _save_inquiry(inquiries, location_text="Second")
+    order, _version = seed_order(
+        orders, _save_inquiry(inquiries, location_text="Second")
     )
     reminders.save(
         OrderPaymentReminder(

--- a/tests/unit/test_wochenuebersicht_service.py
+++ b/tests/unit/test_wochenuebersicht_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from datetime import date, datetime, timezone
 from uuid import uuid4
 
@@ -37,7 +39,7 @@ _WEEK = 40
 def _inquiry(event_date: date) -> Inquiry:
     now = datetime.now(timezone.utc)
     return Inquiry(
-        inquiry_id="11111111-1111-1111-1111-111111111111",
+        inquiry_id=str(uuid4()),
         event_date=event_date,
         created_at=now,
         updated_at=now,
@@ -73,7 +75,7 @@ def _setup() -> tuple[
 def _make_effective_order(
     osvc: OrderService, core: OperationalCoreService, event_date: date
 ) -> str:
-    order, v1 = osvc.convert_inquiry_to_order(_inquiry(event_date))
+    order, v1 = seed_order(osvc._order_repository, _inquiry(event_date))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     return order.order_id
@@ -88,7 +90,7 @@ def test_empty_week_returns_empty_overview() -> None:
 
 def test_order_without_effective_version_never_appears() -> None:
     _repo, osvc, _core, week = _setup()
-    osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))  # no confirm, no switch
+    seed_order(_repo, _inquiry(date(2026, 10, 1)))  # no confirm, no switch
     assert week.get_week_overview(_WEEK_YEAR, _WEEK).entries == ()
 
 
@@ -114,7 +116,7 @@ def test_effective_order_outside_week_excluded() -> None:
 def test_overview_shows_effective_not_latest_version() -> None:
     """A newer historical version must not leak in — effective is the only kitchen truth."""
     repo, osvc, core, week = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))
+    order, v1 = seed_order(repo, _inquiry(date(2026, 10, 1)))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     osvc.create_relevant_order_change_version(
@@ -135,7 +137,7 @@ def test_overview_shows_effective_not_latest_version() -> None:
 
 def test_candidate_change_reaches_week_and_day_only_after_effective_switch() -> None:
     _repo, osvc, core, week = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))
+    order, v1 = seed_order(_repo, _inquiry(date(2026, 10, 1)))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     v2 = osvc.propose_order_version_change(
@@ -188,7 +190,7 @@ def test_overview_read_is_pure() -> None:
 
 def test_pause_projection_follows_effective_v2_and_disappears_after_resume() -> None:
     _repo, osvc, core, week = _setup()
-    order, v1 = osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))
+    order, v1 = seed_order(_repo, _inquiry(date(2026, 10, 1)))
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
     v2 = osvc.propose_order_version_change(
@@ -256,7 +258,7 @@ def test_day_overview_excludes_cancelled_and_unreleased_orders() -> None:
     _repo, osvc, core, week = _setup()
     cancelled = _make_effective_order(osvc, core, date(2026, 10, 1))
     core.cancel_order(cancelled)
-    osvc.convert_inquiry_to_order(_inquiry(date(2026, 10, 1)))  # no effective version
+    seed_order(_repo, _inquiry(date(2026, 10, 1)))  # no effective version
     assert week.get_day_overview(date(2026, 10, 1)) == ()
 
 

--- a/tests/unit/test_work_center_service.py
+++ b/tests/unit/test_work_center_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from tests.helpers.order_seed import seed_order
+
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from unittest.mock import patch
@@ -183,9 +185,9 @@ def _save_upcoming_order(
     cancelled: bool = False,
 ) -> Order:
     inquiry = _save_inquiry(inquiries, event_date=event_date)
-    order_service = OrderService(orders)
+    OrderService(orders)
     core = OperationalCoreService(orders)
-    order, version = order_service.convert_inquiry_to_order(inquiry)
+    order, version = seed_order(orders, inquiry)
     updated_version = replace(version, event_date=event_date)
     orders.update_order_version(updated_version)
     if effective:


### PR DESCRIPTION
## Summary
- Убран production create-path Inquiry→Order: `OrderService.convert_inquiry_to_order` только lookup; создание только через Accepted Offer (`create_order_from_offer_version` / convert-accepted).
- Compatibility `POST /office/v1/inquiries/{id}/convert`: linked Order → `200`; иначе `422 accepted_offer_required` (без create).
- UI/next_action: убран «Auftrag erstellen»; путь через prepare-offer; fixtures через `seed_order()` для Order-only тестов.

## Out of scope
- Reject / Withdraw
- Offer Versioning N>1
- Email / PDF

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src/catering_system`
- [x] `coverage run -m pytest -q` → 1533 passed, TOTAL **90.5%**
- [x] `grep -R "convert_inquiry_to_order" src/` — метод остаётся как compatibility lookup, не create-path


Made with [Cursor](https://cursor.com)