### PR TITLE
Offer rejection and withdrawal evidence (OFFER_REJECTION_WITHDRAWAL_V1)

### DIFF
--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -580,6 +580,39 @@ def offer_allows_sent_recording(
     return derive_offer_state(offer, offer_version_id, today=today) == "Prepared"
 
 
+def offer_allows_rejection(offer: Offer, offer_version_id: str, *, today: date) -> bool:
+    """True only when one exact sent OfferVersion may receive RejectionEvidence."""
+    if offer.acceptance_evidence is not None or offer.conversion_link is not None:
+        return False
+    try:
+        _version(offer, offer_version_id)
+    except ValueError:
+        return False
+    if any(
+        item.offer_version_id == offer_version_id for item in offer.rejection_evidence
+    ):
+        return False
+    return derive_offer_state(offer, offer_version_id, today=today) == "Sent"
+
+
+def offer_allows_withdrawal(
+    offer: Offer, offer_version_id: str, *, today: date
+) -> bool:
+    """True when one Prepared or Sent version may receive WithdrawalEvidence."""
+    if offer.acceptance_evidence is not None or offer.conversion_link is not None:
+        return False
+    try:
+        _version(offer, offer_version_id)
+    except ValueError:
+        return False
+    if any(
+        item.offer_version_id == offer_version_id for item in offer.withdrawal_evidence
+    ):
+        return False
+    state = derive_offer_state(offer, offer_version_id, today=today)
+    return state in ("Prepared", "Sent")
+
+
 def offer_allows_conversion(
     offer: Offer,
     offer_version_id: str,

--- a/src/catering_system/repositories/in_memory_offer_repository.py
+++ b/src/catering_system/repositories/in_memory_offer_repository.py
@@ -6,7 +6,9 @@ from catering_system.domain.offer import (
     AcceptanceEvidence,
     ConversionLink,
     Offer,
+    RejectionEvidence,
     SentEvidence,
+    WithdrawalEvidence,
 )
 
 
@@ -71,6 +73,42 @@ class InMemoryOfferRepository:
             acceptance_evidence=evidence,
             rejection_evidence=offer.rejection_evidence,
             withdrawal_evidence=offer.withdrawal_evidence,
+            conversion_link=offer.conversion_link,
+        )
+        self._offers[offer.offer_id] = updated
+        return updated
+
+    def append_rejection_evidence(self, evidence: RejectionEvidence) -> Offer:
+        offer = self.get(evidence.offer_id)
+        if offer is None:
+            raise KeyError(evidence.offer_id)
+        updated = Offer(
+            offer_id=offer.offer_id,
+            source_inquiry_id=offer.source_inquiry_id,
+            created_at=offer.created_at,
+            versions=offer.versions,
+            sent_evidence=offer.sent_evidence,
+            acceptance_evidence=offer.acceptance_evidence,
+            rejection_evidence=(*offer.rejection_evidence, evidence),
+            withdrawal_evidence=offer.withdrawal_evidence,
+            conversion_link=offer.conversion_link,
+        )
+        self._offers[offer.offer_id] = updated
+        return updated
+
+    def append_withdrawal_evidence(self, evidence: WithdrawalEvidence) -> Offer:
+        offer = self.get(evidence.offer_id)
+        if offer is None:
+            raise KeyError(evidence.offer_id)
+        updated = Offer(
+            offer_id=offer.offer_id,
+            source_inquiry_id=offer.source_inquiry_id,
+            created_at=offer.created_at,
+            versions=offer.versions,
+            sent_evidence=offer.sent_evidence,
+            acceptance_evidence=offer.acceptance_evidence,
+            rejection_evidence=offer.rejection_evidence,
+            withdrawal_evidence=(*offer.withdrawal_evidence, evidence),
             conversion_link=offer.conversion_link,
         )
         self._offers[offer.offer_id] = updated

--- a/src/catering_system/repositories/offer_repository.py
+++ b/src/catering_system/repositories/offer_repository.py
@@ -8,7 +8,9 @@ from catering_system.domain.offer import (
     AcceptanceEvidence,
     ConversionLink,
     Offer,
+    RejectionEvidence,
     SentEvidence,
+    WithdrawalEvidence,
 )
 
 
@@ -33,6 +35,12 @@ class OfferRepository(Protocol):
 
     def append_acceptance_evidence(self, evidence: AcceptanceEvidence) -> Offer:
         """Append one AcceptanceEvidence row and return the updated Offer aggregate."""
+
+    def append_rejection_evidence(self, evidence: RejectionEvidence) -> Offer:
+        """Append one RejectionEvidence row and return the updated Offer aggregate."""
+
+    def append_withdrawal_evidence(self, evidence: WithdrawalEvidence) -> Offer:
+        """Append one WithdrawalEvidence row and return the updated Offer aggregate."""
 
     def append_conversion_link(self, link: ConversionLink) -> Offer:
         """Append one ConversionLink row and return the updated Offer aggregate."""

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -512,6 +512,44 @@ class SQLiteOfferRepository:
             self._insert_acceptance_evidence(evidence)
             return updated
 
+    def append_rejection_evidence(self, evidence: RejectionEvidence) -> Offer:
+        with self._write_scope():
+            offer = self.get(evidence.offer_id)
+            if offer is None:
+                raise KeyError(evidence.offer_id)
+            updated = Offer(
+                offer_id=offer.offer_id,
+                source_inquiry_id=offer.source_inquiry_id,
+                created_at=offer.created_at,
+                versions=offer.versions,
+                sent_evidence=offer.sent_evidence,
+                acceptance_evidence=offer.acceptance_evidence,
+                rejection_evidence=(*offer.rejection_evidence, evidence),
+                withdrawal_evidence=offer.withdrawal_evidence,
+                conversion_link=offer.conversion_link,
+            )
+            self._insert_rejection_evidence(evidence)
+            return updated
+
+    def append_withdrawal_evidence(self, evidence: WithdrawalEvidence) -> Offer:
+        with self._write_scope():
+            offer = self.get(evidence.offer_id)
+            if offer is None:
+                raise KeyError(evidence.offer_id)
+            updated = Offer(
+                offer_id=offer.offer_id,
+                source_inquiry_id=offer.source_inquiry_id,
+                created_at=offer.created_at,
+                versions=offer.versions,
+                sent_evidence=offer.sent_evidence,
+                acceptance_evidence=offer.acceptance_evidence,
+                rejection_evidence=offer.rejection_evidence,
+                withdrawal_evidence=(*offer.withdrawal_evidence, evidence),
+                conversion_link=offer.conversion_link,
+            )
+            self._insert_withdrawal_evidence(evidence)
+            return updated
+
     def append_conversion_link(self, link: ConversionLink) -> Offer:
         with self._write_scope():
             offer = self.get(link.offer_id)

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -21,12 +21,16 @@ from catering_system.domain.offer import (
     OfferPosition,
     OfferVariant,
     OfferVersion,
+    RejectionEvidence,
     SentChannel,
     SentEvidence,
+    WithdrawalEvidence,
     derive_offer_state,
     offer_allows_acceptance,
     offer_allows_conversion,
+    offer_allows_rejection,
     offer_allows_sent_recording,
+    offer_allows_withdrawal,
 )
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.offer_snapshot import (
@@ -249,6 +253,121 @@ class OfferService:
             offer_id,
             offer_version_id,
             accepted_variant_id,
+        )
+        return updated
+
+    def record_rejection_evidence(
+        self,
+        offer_id: str,
+        offer_version_id: str,
+        *,
+        rejected_at: datetime,
+        recorded_by: str,
+        evidence_reference: str | None = None,
+    ) -> Offer:
+        """Append RejectionEvidence for one eligible sent OfferVersion."""
+        offer = self._offer_repository.get(offer_id)
+        if offer is None:
+            raise KeyError(offer_id)
+
+        if not any(
+            version.offer_version_id == offer_version_id for version in offer.versions
+        ):
+            raise ValueError(
+                f"offer_version_id {offer_version_id!r} is not a version of "
+                f"offer {offer_id!r}"
+            )
+
+        if offer.acceptance_evidence is not None or offer.conversion_link is not None:
+            raise ValueError("acceptance blocks rejection recording")
+
+        self._require_contact_complete_inquiry(offer.source_inquiry_id)
+
+        if any(
+            item.offer_version_id == offer_version_id
+            for item in offer.rejection_evidence
+        ):
+            raise ValueError(
+                f"rejection evidence already exists for offer_version_id={offer_version_id!r}"
+            )
+
+        if not offer_allows_rejection(offer, offer_version_id, today=self._today()):
+            raise ValueError(
+                f"rejection blocked (offer_id={offer_id!r}, "
+                f"offer_version_id={offer_version_id!r}, "
+                f"state={derive_offer_state(offer, offer_version_id, today=self._today())!r})"
+            )
+
+        recorded_at = self._now()
+        evidence = RejectionEvidence(
+            offer_id=offer_id,
+            offer_version_id=offer_version_id,
+            rejected_at=rejected_at,
+            recorded_at=recorded_at,
+            recorded_by=recorded_by,
+            evidence_reference=evidence_reference,
+        )
+        updated = self._offer_repository.append_rejection_evidence(evidence)
+        _log.info(
+            "record_rejection_evidence offer_id=%s offer_version_id=%s",
+            offer_id,
+            offer_version_id,
+        )
+        return updated
+
+    def record_withdrawal_evidence(
+        self,
+        offer_id: str,
+        offer_version_id: str,
+        *,
+        recorded_by: str,
+        reason: str | None = None,
+    ) -> Offer:
+        """Append WithdrawalEvidence for one eligible Prepared or Sent version."""
+        offer = self._offer_repository.get(offer_id)
+        if offer is None:
+            raise KeyError(offer_id)
+
+        if not any(
+            version.offer_version_id == offer_version_id for version in offer.versions
+        ):
+            raise ValueError(
+                f"offer_version_id {offer_version_id!r} is not a version of "
+                f"offer {offer_id!r}"
+            )
+
+        if offer.acceptance_evidence is not None or offer.conversion_link is not None:
+            raise ValueError("acceptance blocks withdrawal recording")
+
+        self._require_contact_complete_inquiry(offer.source_inquiry_id)
+
+        if any(
+            item.offer_version_id == offer_version_id
+            for item in offer.withdrawal_evidence
+        ):
+            raise ValueError(
+                f"withdrawal evidence already exists for offer_version_id={offer_version_id!r}"
+            )
+
+        if not offer_allows_withdrawal(offer, offer_version_id, today=self._today()):
+            raise ValueError(
+                f"withdrawal blocked (offer_id={offer_id!r}, "
+                f"offer_version_id={offer_version_id!r}, "
+                f"state={derive_offer_state(offer, offer_version_id, today=self._today())!r})"
+            )
+
+        evidence = WithdrawalEvidence(
+            offer_id=offer_id,
+            offer_version_id=offer_version_id,
+            withdrawn_at=self._now(),
+            recorded_by=recorded_by,
+            reason=reason,
+        )
+        updated = self._offer_repository.append_withdrawal_evidence(evidence)
+        _log.info(
+            "record_withdrawal_evidence offer_id=%s offer_version_id=%s",
+            offer_id,
+            offer_version_id,
         )
         return updated
 

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -1151,6 +1151,93 @@ class OfficeApi:
             "acceptance_id": acceptance.acceptance_id,
         }
 
+    def cmd_record_rejection(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        offer_id = path_ids["offer_id"]
+        offer_version_id = path_ids["version_id"]
+        try:
+            offer = self.offer_service.record_rejection_evidence(
+                offer_id,
+                offer_version_id,
+                rejected_at=_v_datetime(args["rejected_at"]),
+                recorded_by=CLIENT_ID,
+                evidence_reference=_v_optional_str(
+                    args.get("evidence_reference"), 1000
+                ),
+            )
+        except KeyError as exc:
+            raise ApiError(404, "not_found") from exc
+        except ValueError as exc:
+            message = str(exc)
+            if "rejection evidence already exists" in message:
+                raise ApiError(409, "rejection_evidence_exists") from exc
+            if "not a version of offer" in message:
+                raise ApiError(422, "version_not_owned") from exc
+            if "acceptance blocks rejection" in message:
+                raise ApiError(422, "rejection_blocked") from exc
+            if "rejection blocked" in message:
+                raise ApiError(422, "rejection_blocked") from exc
+            if "contact information incomplete" in message:
+                raise ApiError(422, "contact_information_incomplete") from exc
+            raise ApiError(422, "invalid_rejection_evidence") from exc
+        except sqlite3.IntegrityError:
+            if self.offers.get(offer_id) is None:
+                raise ApiError(404, "not_found") from None
+            raise ApiError(409, "rejection_evidence_exists") from None
+        evidence = next(
+            item
+            for item in offer.rejection_evidence
+            if item.offer_version_id == offer_version_id
+        )
+        return 200, {
+            "offer_id": offer.offer_id,
+            "offer_version_id": offer_version_id,
+            "rejected_at": evidence.rejected_at.isoformat(),
+        }
+
+    def cmd_record_withdrawal(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        offer_id = path_ids["offer_id"]
+        offer_version_id = path_ids["version_id"]
+        try:
+            offer = self.offer_service.record_withdrawal_evidence(
+                offer_id,
+                offer_version_id,
+                recorded_by=CLIENT_ID,
+                reason=_v_optional_str(args.get("reason"), 20000),
+            )
+        except KeyError as exc:
+            raise ApiError(404, "not_found") from exc
+        except ValueError as exc:
+            message = str(exc)
+            if "withdrawal evidence already exists" in message:
+                raise ApiError(409, "withdrawal_evidence_exists") from exc
+            if "not a version of offer" in message:
+                raise ApiError(422, "version_not_owned") from exc
+            if "acceptance blocks withdrawal" in message:
+                raise ApiError(422, "withdrawal_blocked") from exc
+            if "withdrawal blocked" in message:
+                raise ApiError(422, "withdrawal_blocked") from exc
+            if "contact information incomplete" in message:
+                raise ApiError(422, "contact_information_incomplete") from exc
+            raise ApiError(422, "invalid_withdrawal_evidence") from exc
+        except sqlite3.IntegrityError:
+            if self.offers.get(offer_id) is None:
+                raise ApiError(404, "not_found") from None
+            raise ApiError(409, "withdrawal_evidence_exists") from None
+        evidence = next(
+            item
+            for item in offer.withdrawal_evidence
+            if item.offer_version_id == offer_version_id
+        )
+        return 200, {
+            "offer_id": offer.offer_id,
+            "offer_version_id": offer_version_id,
+            "withdrawn_at": evidence.withdrawn_at.isoformat(),
+        }
+
     def cmd_convert_accepted(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
     ) -> tuple[int, dict[str, object]]:
@@ -1737,6 +1824,14 @@ _RECORD_ACCEPTANCE_ARGS = _ArgKeys(
     ),
     optional=frozenset({"note"}),
 )
+_RECORD_REJECTION_ARGS = _ArgKeys(
+    required=frozenset({"rejected_at"}),
+    optional=frozenset({"evidence_reference"}),
+)
+_RECORD_WITHDRAWAL_ARGS = _ArgKeys(
+    required=frozenset(),
+    optional=frozenset({"reason"}),
+)
 _CONVERT_ACCEPTED_ARGS = _ArgKeys(
     required=frozenset({"accepted_variant_id", "acceptance_id"})
 )
@@ -1790,6 +1885,12 @@ _COMMANDS: dict[str, _CommandSpec] = {
     "mark-sent": _CommandSpec("cmd_mark_sent", _MARK_SENT_ARGS, set()),
     "record-acceptance": _CommandSpec(
         "cmd_record_acceptance", _RECORD_ACCEPTANCE_ARGS, set()
+    ),
+    "record-rejection": _CommandSpec(
+        "cmd_record_rejection", _RECORD_REJECTION_ARGS, set()
+    ),
+    "record-withdrawal": _CommandSpec(
+        "cmd_record_withdrawal", _RECORD_WITHDRAWAL_ARGS, set()
     ),
     "convert-accepted": _CommandSpec(
         "cmd_convert_accepted", _CONVERT_ACCEPTED_ARGS, set()
@@ -1964,6 +2065,22 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         ),
         "/office/v1/offers/{offer_id}/versions/{version_id}/record-acceptance",
         {"POST": "record-acceptance"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/offers/(?P<offer_id>[^/]+)/versions/"
+            r"(?P<version_id>[^/]+)/record-rejection$"
+        ),
+        "/office/v1/offers/{offer_id}/versions/{version_id}/record-rejection",
+        {"POST": "record-rejection"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/offers/(?P<offer_id>[^/]+)/versions/"
+            r"(?P<version_id>[^/]+)/record-withdrawal$"
+        ),
+        "/office/v1/offers/{offer_id}/versions/{version_id}/record-withdrawal",
+        {"POST": "record-withdrawal"},
     ),
     (
         re.compile(

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -178,6 +178,10 @@ def _offer_history(offer: Offer) -> list[dict[str, object]]:
         entries.append((version.created_at, label))
     for sent in offer.sent_evidence:
         entries.append((sent.sent_at, "Angebot gesendet"))
+    for rejection in offer.rejection_evidence:
+        entries.append((rejection.rejected_at, "Angebot abgelehnt"))
+    for withdrawal in offer.withdrawal_evidence:
+        entries.append((withdrawal.withdrawn_at, "Angebot zurückgezogen"))
     if offer.acceptance_evidence is not None:
         entries.append((offer.acceptance_evidence.accepted_at, "Angebot angenommen"))
     if offer.conversion_link is not None:

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -791,6 +791,81 @@ class OfficePanel:
             return
         work()
 
+    def record_offer_rejection(self, offer_id: str, form: dict[str, str]) -> None:
+        detail = self._offer_detail_dict(offer_id)
+        if str(detail["commercial_state"]) != "Sent":
+            raise ValueError("rejection blocked")
+        offer_version_id = str(detail["offer_version_id"])
+        rejected_at = parse_datetime_local_berlin(form.get("rejected_at", ""))
+        evidence_raw = form.get("evidence_reference", "").strip()
+        evidence_reference = evidence_raw or None
+        if evidence_reference is not None and len(evidence_reference) > 1000:
+            raise ValueError("evidence_reference exceeds length limit")
+
+        def work() -> None:
+            offer_service = OfferService(
+                self._offers,
+                self._inquiries,
+                self._orders,
+                today=api_views.berlin_today,
+            )
+            offer_service.record_rejection_evidence(
+                offer_id,
+                offer_version_id,
+                rejected_at=rejected_at,
+                recorded_by="office-panel",
+                evidence_reference=evidence_reference,
+            )
+
+        if self._remote is not None:
+            self._remote.record_offer_rejection(
+                offer_id,
+                offer_version_id,
+                rejected_at=format_datetime_utc_iso(rejected_at),
+                evidence_reference=evidence_reference,
+            )
+            return
+        if self._command_executor is not None:
+            self._command_executor.run(work)
+            return
+        work()
+
+    def record_offer_withdrawal(self, offer_id: str, form: dict[str, str]) -> None:
+        detail = self._offer_detail_dict(offer_id)
+        if str(detail["commercial_state"]) != "Sent":
+            raise ValueError("withdrawal blocked")
+        offer_version_id = str(detail["offer_version_id"])
+        reason_raw = form.get("reason", "").strip()
+        reason = reason_raw or None
+        if reason is not None and len(reason) > 20000:
+            raise ValueError("reason exceeds length limit")
+
+        def work() -> None:
+            offer_service = OfferService(
+                self._offers,
+                self._inquiries,
+                self._orders,
+                today=api_views.berlin_today,
+            )
+            offer_service.record_withdrawal_evidence(
+                offer_id,
+                offer_version_id,
+                recorded_by="office-panel",
+                reason=reason,
+            )
+
+        if self._remote is not None:
+            self._remote.record_offer_withdrawal(
+                offer_id,
+                offer_version_id,
+                reason=reason,
+            )
+            return
+        if self._command_executor is not None:
+            self._command_executor.run(work)
+            return
+        work()
+
     def convert_accepted_offer(
         self, offer_id: str, form: dict[str, str]
     ) -> tuple[Order, OrderVersion]:

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -119,6 +119,18 @@ _OFFER_COMMAND_ERROR_LABELS: dict[str, str] = {
     "conversion_blocked": (
         "Das angenommene Angebot kann derzeit nicht in einen Auftrag umgewandelt werden."
     ),
+    "rejection_evidence_exists": (
+        "Für diese Angebotsversion ist bereits eine Ablehnung erfasst."
+    ),
+    "withdrawal_evidence_exists": (
+        "Für diese Angebotsversion ist bereits ein Rückzug erfasst."
+    ),
+    "rejection_blocked": (
+        "Die Ablehnung kann in diesem Angebotsstatus nicht erfasst werden."
+    ),
+    "withdrawal_blocked": (
+        "Der Rückzug kann in diesem Angebotsstatus nicht erfasst werden."
+    ),
 }
 
 
@@ -138,6 +150,17 @@ def office_command_error_message(code_or_text: str) -> str:
         return _OFFER_COMMAND_ERROR_LABELS["acceptance_blocked"]
     if "sent recording blocked" in lowered:
         return _OFFER_COMMAND_ERROR_LABELS["sent_recording_blocked"]
+    if "rejection blocked" in lowered or "rejection evidence already exists" in lowered:
+        if "already exists" in lowered:
+            return _OFFER_COMMAND_ERROR_LABELS["rejection_evidence_exists"]
+        return _OFFER_COMMAND_ERROR_LABELS["rejection_blocked"]
+    if (
+        "withdrawal blocked" in lowered
+        or "withdrawal evidence already exists" in lowered
+    ):
+        if "already exists" in lowered:
+            return _OFFER_COMMAND_ERROR_LABELS["withdrawal_evidence_exists"]
+        return _OFFER_COMMAND_ERROR_LABELS["withdrawal_blocked"]
     if "conversion link already exists" in lowered or "conversion already" in lowered:
         return _OFFER_COMMAND_ERROR_LABELS["conversion_already_exists"]
     if "accepted offer conversion gate" in lowered or "conversion blocked" in lowered:
@@ -675,6 +698,12 @@ def make_office_panel_handler(
                 self._redirect(f"/offer/{offer_id}")
             elif action == "record-acceptance":
                 panel.record_offer_acceptance(offer_id, form)
+                self._redirect(f"/offer/{offer_id}")
+            elif action == "record-rejection":
+                panel.record_offer_rejection(offer_id, form)
+                self._redirect(f"/offer/{offer_id}")
+            elif action == "record-withdrawal":
+                panel.record_offer_withdrawal(offer_id, form)
                 self._redirect(f"/offer/{offer_id}")
             elif action == "convert":
                 order, _version = panel.convert_accepted_offer(offer_id, form)

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -183,6 +183,52 @@ def _record_acceptance_form(
     )
 
 
+def _record_rejection_form(offer_id: str, *, forms: OfferDetailFormFields) -> str:
+    default_at = default_datetime_local_berlin()
+    return (
+        '<section class="offer-detail-section offer-action-section">'
+        "<h2>Kunde lehnt ab</h2>"
+        f'<form method="post" action="/offer/{_e(offer_id)}/record-rejection">'
+        f"{forms.csrf_input}{forms.command_fields}"
+        "<fieldset>"
+        f'<label>Ablehnungszeitpunkt <input type="datetime-local" name="rejected_at" '
+        f'value="{_e(default_at)}" required></label>'
+        '<label>Kommentar / Nachweis (optional) <input name="evidence_reference" '
+        'maxlength="1000" placeholder="Telefonische Absage"></label>'
+        "</fieldset>"
+        '<button type="submit">Kunde lehnt ab</button>'
+        "</form></section>"
+    )
+
+
+def _record_withdrawal_form(offer_id: str, *, forms: OfferDetailFormFields) -> str:
+    return (
+        '<section class="offer-detail-section offer-action-section">'
+        "<h2>Angebot zurückziehen</h2>"
+        f'<form method="post" action="/offer/{_e(offer_id)}/record-withdrawal">'
+        f"{forms.csrf_input}{forms.command_fields}"
+        "<fieldset>"
+        '<label>Grund (optional) <textarea name="reason" rows="3" maxlength="20000">'
+        "</textarea></label>"
+        "</fieldset>"
+        '<button type="submit">Angebot zurückziehen</button>'
+        "</form></section>"
+    )
+
+
+def _sent_offer_actions(
+    offer_id: str,
+    variants: list[dict[str, object]],
+    *,
+    forms: OfferDetailFormFields,
+) -> str:
+    return (
+        _record_acceptance_form(offer_id, variants, forms=forms)
+        + _record_rejection_form(offer_id, forms=forms)
+        + _record_withdrawal_form(offer_id, forms=forms)
+    )
+
+
 def _convert_form(
     offer_id: str,
     *,
@@ -244,7 +290,7 @@ def render_offer_detail(
     if state == "Prepared":
         action_section = _mark_sent_form(offer_id, forms=forms)
     elif state == "Sent":
-        action_section = _record_acceptance_form(offer_id, variants, forms=forms)
+        action_section = _sent_offer_actions(offer_id, variants, forms=forms)
     elif state == "Accepted":
         acceptance_id = detail.get("acceptance_id")
         acceptance = cast(dict[str, object] | None, detail.get("acceptance"))

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -207,6 +207,8 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "conversion_already_exists",
             "sent_evidence_exists",
             "acceptance_already_exists",
+            "rejection_evidence_exists",
+            "withdrawal_evidence_exists",
             "order_already_paused",
             "order_not_paused",
         }
@@ -230,6 +232,10 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "acceptance_blocked",
             "invalid_variant",
             "invalid_acceptance_evidence",
+            "rejection_blocked",
+            "withdrawal_blocked",
+            "invalid_rejection_evidence",
+            "invalid_withdrawal_evidence",
             "order_version_not_current_candidate",
         }
     ),
@@ -1099,6 +1105,45 @@ class RemoteCoreClient:
                 "accepted_variant_id",
                 "acceptance_id",
             },
+        )
+
+    def record_offer_rejection(
+        self,
+        offer_id: str,
+        offer_version_id: str,
+        *,
+        rejected_at: str,
+        evidence_reference: str | None = None,
+    ) -> None:
+        args: dict[str, object] = {"rejected_at": rejected_at}
+        if evidence_reference is not None:
+            args["evidence_reference"] = evidence_reference
+        self.command(
+            f"/office/v1/offers/{quote(offer_id, safe='')}/versions/"
+            f"{quote(offer_version_id, safe='')}/record-rejection",
+            args,
+            {},
+            expected={200},
+            result_keys={"offer_id", "offer_version_id", "rejected_at"},
+        )
+
+    def record_offer_withdrawal(
+        self,
+        offer_id: str,
+        offer_version_id: str,
+        *,
+        reason: str | None = None,
+    ) -> None:
+        args: dict[str, object] = {}
+        if reason is not None:
+            args["reason"] = reason
+        self.command(
+            f"/office/v1/offers/{quote(offer_id, safe='')}/versions/"
+            f"{quote(offer_version_id, safe='')}/record-withdrawal",
+            args,
+            {},
+            expected={200},
+            result_keys={"offer_id", "offer_version_id", "withdrawn_at"},
         )
 
     # -- reads / repository-shaped facade ---------------------------------

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -19,7 +19,9 @@ from catering_system.domain.offer import (
     derive_offer_state,
     offer_allows_acceptance,
     offer_allows_conversion,
+    offer_allows_rejection,
     offer_allows_sent_recording,
+    offer_allows_withdrawal,
     offer_blocks_direct_inquiry_conversion,
 )
 
@@ -293,6 +295,41 @@ def test_expired_or_superseded_version_cannot_be_accepted() -> None:
         dual_sent, _V1_ID, _B_ID, today=date(2026, 7, 20)
     )
     assert offer_allows_acceptance(dual_sent, _V2_ID, _C_ID, today=date(2026, 7, 20))
+
+
+def test_offer_allows_rejection_only_for_sent_versions() -> None:
+    sent_offer = _offer(sent=(_sent(),))
+    assert offer_allows_rejection(sent_offer, _V1_ID, today=date(2026, 7, 20))
+    assert not offer_allows_rejection(_offer(), _V1_ID, today=date(2026, 7, 20))
+    rejected = RejectionEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=_V1_ID,
+        rejected_at=_NOW + timedelta(days=1),
+        recorded_at=_NOW + timedelta(days=1, minutes=1),
+        recorded_by="office",
+    )
+    assert not offer_allows_rejection(
+        _offer(sent=(_sent(),), rejected=(rejected,)),
+        _V1_ID,
+        today=date(2026, 7, 20),
+    )
+
+
+def test_offer_allows_withdrawal_for_prepared_or_sent() -> None:
+    assert offer_allows_withdrawal(_offer(), _V1_ID, today=date(2026, 7, 20))
+    sent_offer = _offer(sent=(_sent(),))
+    assert offer_allows_withdrawal(sent_offer, _V1_ID, today=date(2026, 7, 20))
+    withdrawn = WithdrawalEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=_V1_ID,
+        withdrawn_at=_NOW + timedelta(minutes=1),
+        recorded_by="office",
+    )
+    assert not offer_allows_withdrawal(
+        _offer(withdrawn=(withdrawn,)),
+        _V1_ID,
+        today=date(2026, 7, 20),
+    )
 
 
 def test_offer_allows_sent_recording_only_for_prepared_versions() -> None:

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -158,6 +158,27 @@ def _link() -> ConversionLink:
     )
 
 
+def _rejection() -> RejectionEvidence:
+    return RejectionEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=_V1_ID,
+        rejected_at=_NOW + timedelta(days=1),
+        recorded_at=_NOW + timedelta(days=1, minutes=1),
+        recorded_by="office",
+        evidence_reference="phone-decline",
+    )
+
+
+def _withdrawal() -> WithdrawalEvidence:
+    return WithdrawalEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=_V1_ID,
+        withdrawn_at=_NOW + timedelta(minutes=1),
+        recorded_by="office",
+        reason="Kunde nicht erreichbar",
+    )
+
+
 def _offer(
     *,
     versions: tuple[OfferVersion, ...] | None = None,
@@ -329,6 +350,46 @@ def test_append_acceptance_evidence_rejects_second_acceptance() -> None:
     repo.save(_offer(sent=(_sent(),), acceptance=_acceptance()))
     with pytest.raises(ValueError, match="acceptance already exists"):
         repo.append_acceptance_evidence(_acceptance())
+
+
+def test_append_rejection_evidence_roundtrip_in_memory_and_sqlite(
+    tmp_path: Path,
+) -> None:
+    evidence = _rejection()
+    sent_offer = _offer(sent=(_sent(),))
+    for repo_factory in (
+        lambda: InMemoryOfferRepository(),
+        lambda: SQLiteOfferRepository(tmp_path / "reject.db"),
+    ):
+        repo = repo_factory()
+        repo.save(sent_offer)
+        updated = repo.append_rejection_evidence(evidence)
+        assert len(updated.rejection_evidence) == 1
+        assert (
+            derive_offer_state(updated, _V1_ID, today=date(2026, 7, 20)) == "Rejected"
+        )
+        reloaded = repo.get(_OFFER_ID)
+        assert reloaded == updated
+
+
+def test_append_withdrawal_evidence_roundtrip_in_memory_and_sqlite(
+    tmp_path: Path,
+) -> None:
+    evidence = _withdrawal()
+    sent_offer = _offer(sent=(_sent(),))
+    for repo_factory in (
+        lambda: InMemoryOfferRepository(),
+        lambda: SQLiteOfferRepository(tmp_path / "withdraw.db"),
+    ):
+        repo = repo_factory()
+        repo.save(sent_offer)
+        updated = repo.append_withdrawal_evidence(evidence)
+        assert len(updated.withdrawal_evidence) == 1
+        assert (
+            derive_offer_state(updated, _V1_ID, today=date(2026, 7, 20)) == "Withdrawn"
+        )
+        reloaded = repo.get(_OFFER_ID)
+        assert reloaded == updated
 
 
 def test_append_conversion_link_roundtrip_in_memory_and_sqlite(tmp_path: Path) -> None:

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -23,6 +23,7 @@ from catering_system.domain.offer import (
     OfferPosition,
     OfferVariant,
     OfferVersion,
+    RejectionEvidence,
     SentEvidence,
     WithdrawalEvidence,
     derive_offer_state,
@@ -207,6 +208,14 @@ class _FailingAppendRepository(InMemoryOfferRepository):
         raise self._error
 
     def append_acceptance_evidence(self, evidence: AcceptanceEvidence) -> Offer:
+        self.append_calls += 1
+        raise self._error
+
+    def append_rejection_evidence(self, evidence: RejectionEvidence) -> Offer:
+        self.append_calls += 1
+        raise self._error
+
+    def append_withdrawal_evidence(self, evidence: WithdrawalEvidence) -> Offer:
         self.append_calls += 1
         raise self._error
 
@@ -893,6 +902,117 @@ def test_record_acceptance_evidence_append_failure_leaves_offer_unchanged() -> N
 
     assert offers.append_calls == 1
     assert offers.get(offer.offer_id) == sent
+
+
+_REJECTED_AT = _SENT_AT + timedelta(seconds=1)
+
+
+def _rejection_args() -> dict[str, object]:
+    return {
+        "rejected_at": _REJECTED_AT,
+        "recorded_by": "office-panel",
+        "evidence_reference": "phone-decline",
+    }
+
+
+def test_record_rejection_evidence_sent_to_rejected() -> None:
+    offer, version_id, _offers, service = _sent_offer_state()
+
+    updated = service.record_rejection_evidence(
+        offer.offer_id,
+        version_id,
+        **_rejection_args(),
+    )
+
+    assert len(updated.rejection_evidence) == 1
+    evidence = updated.rejection_evidence[0]
+    assert evidence.rejected_at == _REJECTED_AT
+    assert evidence.recorded_at == _RECORDED_AT
+    assert evidence.evidence_reference == "phone-decline"
+    assert (
+        derive_offer_state(updated, version_id, today=date(2026, 7, 15)) == "Rejected"
+    )
+
+
+def test_record_rejection_evidence_rejects_prepared() -> None:
+    offer = _existing_offer()
+    version_id = offer.versions[0].offer_version_id
+    offers = InMemoryOfferRepository()
+    offers.save(offer)
+    service = _service(offers)
+
+    with pytest.raises(ValueError, match="rejection blocked"):
+        service.record_rejection_evidence(
+            offer.offer_id, version_id, **_rejection_args()
+        )
+
+
+def test_record_rejection_evidence_rejects_second_rejection() -> None:
+    offer, version_id, _offers, service = _sent_offer_state()
+    service.record_rejection_evidence(offer.offer_id, version_id, **_rejection_args())
+
+    with pytest.raises(ValueError, match="rejection evidence already exists"):
+        service.record_rejection_evidence(
+            offer.offer_id, version_id, **_rejection_args()
+        )
+
+
+def test_record_rejection_evidence_blocks_acceptance() -> None:
+    offer, version_id, _offers, service = _sent_offer_state()
+    service.record_rejection_evidence(offer.offer_id, version_id, **_rejection_args())
+
+    with pytest.raises(ValueError, match="acceptance blocked"):
+        service.record_acceptance_evidence(
+            offer.offer_id, version_id, _VARIANT_ID, **_acceptance_args()
+        )
+
+
+def test_record_withdrawal_evidence_sent_to_withdrawn() -> None:
+    offer, version_id, _offers, service = _sent_offer_state()
+
+    updated = service.record_withdrawal_evidence(
+        offer.offer_id,
+        version_id,
+        recorded_by="office-panel",
+        reason="Angebot zurückgezogen",
+    )
+
+    assert len(updated.withdrawal_evidence) == 1
+    evidence = updated.withdrawal_evidence[0]
+    assert evidence.withdrawn_at == _RECORDED_AT
+    assert evidence.reason == "Angebot zurückgezogen"
+    assert (
+        derive_offer_state(updated, version_id, today=date(2026, 7, 15)) == "Withdrawn"
+    )
+
+
+def test_record_withdrawal_evidence_rejects_prepared_in_ui_but_domain_allows() -> None:
+    offer = _existing_offer()
+    version_id = offer.versions[0].offer_version_id
+    offers = InMemoryOfferRepository()
+    offers.save(offer)
+    service = _service(offers)
+
+    updated = service.record_withdrawal_evidence(
+        offer.offer_id,
+        version_id,
+        recorded_by="office-panel",
+    )
+    assert (
+        derive_offer_state(updated, version_id, today=date(2026, 7, 15)) == "Withdrawn"
+    )
+
+
+def test_record_withdrawal_evidence_rejects_second_withdrawal() -> None:
+    offer, version_id, _offers, service = _sent_offer_state()
+    service.record_withdrawal_evidence(
+        offer.offer_id, version_id, recorded_by="office-panel"
+    )
+
+    with pytest.raises(ValueError, match="withdrawal evidence already exists"):
+        service.record_withdrawal_evidence(
+            offer.offer_id, version_id, recorded_by="office-panel"
+        )
 
 
 def _accepted_offer_state() -> tuple[

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -2382,6 +2382,102 @@ def test_record_acceptance_failure_leaves_no_acceptance_or_ledger(api) -> None:
     assert ledger_count == 0
 
 
+_RECORD_REJECTION_ARGS = {
+    "rejected_at": "2026-07-15T12:00:00+00:00",
+    "evidence_reference": "phone-decline",
+}
+
+
+def _record_rejection_url(base: str, offer_id: str, version_id: str) -> str:
+    return f"{base}/office/v1/offers/{offer_id}/versions/{version_id}/record-rejection"
+
+
+def _record_withdrawal_url(base: str, offer_id: str, version_id: str) -> str:
+    return f"{base}/office/v1/offers/{offer_id}/versions/{version_id}/record-withdrawal"
+
+
+def test_record_rejection_sent_to_rejected_and_replay(api) -> None:
+    base, _ids, db = api
+    offer_id, version_id = _prepare_and_send(api)
+    url = _record_rejection_url(base, offer_id, version_id)
+    command_id = str(uuid.uuid4())
+
+    status, body, _h = _post(url, args=_RECORD_REJECTION_ARGS, command_id=command_id)
+    assert status == 200
+    assert set(body) == {
+        "command_id",
+        "offer_id",
+        "offer_version_id",
+        "rejected_at",
+    }
+    assert body["offer_id"] == offer_id
+    assert body["offer_version_id"] == version_id
+
+    status2, body2, _h = _post(url, args=_RECORD_REJECTION_ARGS, command_id=command_id)
+    assert (status2, body2) == (status, body)
+
+    offers = SQLiteOfferRepository(db)
+    stored = offers.get(offer_id)
+    assert stored is not None
+    assert len(stored.rejection_evidence) == 1
+    offers.close()
+
+
+def test_record_rejection_rejects_prepared(api) -> None:
+    base, _ids, _db = api
+    offer_id, version_id = _prepare_offer(api)
+    status, body, _h = _post(
+        _record_rejection_url(base, offer_id, version_id),
+        args=_RECORD_REJECTION_ARGS,
+    )
+    assert (status, body["error"]) == (422, "rejection_blocked")
+
+
+def test_record_rejection_rejects_second_rejection(api) -> None:
+    base, _ids, _db = api
+    offer_id, version_id = _prepare_and_send(api)
+    url = _record_rejection_url(base, offer_id, version_id)
+    assert _post(url, args=_RECORD_REJECTION_ARGS)[0] == 200
+    status, body, _h = _post(url, args=_RECORD_REJECTION_ARGS)
+    assert (status, body["error"]) == (409, "rejection_evidence_exists")
+
+
+def test_record_withdrawal_sent_to_withdrawn_and_replay(api) -> None:
+    base, _ids, db = api
+    offer_id, version_id = _prepare_and_send(api)
+    url = _record_withdrawal_url(base, offer_id, version_id)
+    command_id = str(uuid.uuid4())
+    args = {"reason": "Angebot zurückgezogen"}
+
+    status, body, _h = _post(url, args=args, command_id=command_id)
+    assert status == 200
+    assert set(body) == {
+        "command_id",
+        "offer_id",
+        "offer_version_id",
+        "withdrawn_at",
+    }
+
+    status2, body2, _h = _post(url, args=args, command_id=command_id)
+    assert (status2, body2) == (status, body)
+
+    offers = SQLiteOfferRepository(db)
+    stored = offers.get(offer_id)
+    assert stored is not None
+    assert len(stored.withdrawal_evidence) == 1
+    assert stored.withdrawal_evidence[0].reason == "Angebot zurückgezogen"
+    offers.close()
+
+
+def test_record_withdrawal_rejects_second_withdrawal(api) -> None:
+    base, _ids, _db = api
+    offer_id, version_id = _prepare_and_send(api)
+    url = _record_withdrawal_url(base, offer_id, version_id)
+    assert _post(url, args={})[0] == 200
+    status, body, _h = _post(url, args={})
+    assert (status, body["error"]) == (409, "withdrawal_evidence_exists")
+
+
 def _prepare_send_accept(
     api: tuple[str, dict[str, str], Path],
 ) -> tuple[str, str, str, str]:

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -358,13 +358,17 @@ def test_prepared_shows_mark_sent_form_only(direct_world) -> None:
     assert "In Auftrag umwandeln" not in html
 
 
-def test_sent_shows_acceptance_form_only(direct_world) -> None:
+def test_sent_shows_sent_lifecycle_actions(direct_world) -> None:
     panel_url, api_url, ids, _db = direct_world
     offer_id, version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
     _mark_sent_api(api_url, offer_id, version_id)
     _status, html = _get(f"{panel_url}/offer/{offer_id}")
     assert "Annahme erfassen" in html
     assert "/record-acceptance" in html
+    assert "Kunde lehnt ab" in html
+    assert "/record-rejection" in html
+    assert "Angebot zurückziehen" in html
+    assert "/record-withdrawal" in html
     assert "Als gesendet markieren" not in html
     assert "In Auftrag umwandeln" not in html
 
@@ -656,3 +660,75 @@ def test_remote_offer_mark_sent_parity(tmp_path: Path) -> None:
         panel_server.server_close()
         api_server.shutdown()
         api_server.server_close()
+
+
+def test_sent_offer_shows_rejection_and_withdrawal_actions(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _mark_sent_api(api_url, offer_id, version_id)
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Annahme erfassen" in html
+    assert "Kunde lehnt ab" in html
+    assert "Angebot zurückziehen" in html
+    assert f'action="/offer/{offer_id}/record-rejection"' in html
+    assert f'action="/offer/{offer_id}/record-withdrawal"' in html
+
+
+def test_record_rejection_through_panel(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _mark_sent_api(api_url, offer_id, version_id)
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    fields = _offer_form_fields(html, "/record-rejection")
+    fields.update(
+        {
+            "rejected_at": _past_datetime_local(),
+            "evidence_reference": "Telefonische Absage",
+        }
+    )
+    status, final_url, _body = _post(
+        f"{panel_url}/offer/{offer_id}/record-rejection",
+        fields,
+    )
+    assert status == 200
+    assert final_url.endswith(f"/offer/{offer_id}")
+    _status, detail = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Abgelehnt" in detail
+    assert "Kunde lehnt ab" not in detail
+    assert "Annahme erfassen" not in detail
+
+
+def test_record_withdrawal_through_panel(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _mark_sent_api(api_url, offer_id, version_id)
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    fields = _offer_form_fields(html, "/record-withdrawal")
+    fields["reason"] = "Angebot zurückgezogen"
+    status, final_url, _body = _post(
+        f"{panel_url}/offer/{offer_id}/record-withdrawal",
+        fields,
+    )
+    assert status == 200
+    assert final_url.endswith(f"/offer/{offer_id}")
+    _status, detail = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Zurückgezogen" in detail
+    assert "Angebot zurückziehen" not in detail
+
+
+def test_rejected_offer_has_no_lifecycle_actions(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _mark_sent_api(api_url, offer_id, version_id)
+    assert (
+        _api_post(
+            f"{api_url}/office/v1/offers/{offer_id}/versions/{version_id}/record-rejection",
+            args={"rejected_at": "2026-07-15T12:00:00+00:00"},
+        )[0]
+        == 200
+    )
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Annahme erfassen" not in html
+    assert "Kunde lehnt ab" not in html
+    assert "Angebot zurückziehen" not in html
+    assert "Abgelehnt" in html


### PR DESCRIPTION
## Summary
- Добавлены append-only команды `record_rejection_evidence` / `record_withdrawal_evidence` end-to-end: domain helpers → repository → service → Office API → panel/remote.
- `POST .../record-rejection` и `POST .../record-withdrawal` с command ledger/idempotency по паттерну acceptance.
- UI (Sent): «Annahme erfassen», «Kunde lehnt ab», «Angebot zurückziehen»; Rejected/Withdrawn — только отображение + history.

## Архитектура
- Facts → Derived State (без status columns / `rejected=true`).
- Version-scoped `RejectionEvidence` / `WithdrawalEvidence` без изменения доменной схемы.
- Prepared → Withdrawn разрешён в domain; UI withdraw только для Sent.

## Out of scope
- OfferVersion v2 / neues Angebot
- Email / PDF / CRM automation
- Superseded commands

## Verification
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src/catering_system`
- [x] `coverage run -m pytest -q` → **1553 passed**, TOTAL **90.2%**
- [x] `grep -R "RejectionEvidence\|WithdrawalEvidence" src tests` — только append evidence paths, нет `rejected=true` / `offer.status`

## Test plan
- [x] Service: Sent → Rejected / Withdrawn, duplicate 409, blocked states
- [x] API: replay + 409/422 error codes
- [x] Panel: Sent actions, Rejected/Withdrawn status-only
- [x] Repository roundtrip (SQLite + in-memory)


Made with [Cursor](https://cursor.com)