### PR TITLE
OFFER_VERSIONING_V1-B: version visibility

### DIFF
--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -228,25 +228,72 @@ def _acceptance_shape(acceptance: object | None) -> dict[str, object] | None:
     }
 
 
+def _version_number_by_id(offer: Offer) -> dict[str, int]:
+    return {
+        version.offer_version_id: version.version_number for version in offer.versions
+    }
+
+
+def _version_history_label(prefix: str, version_number: int) -> str:
+    return f"Version {version_number} {prefix}"
+
+
 def _offer_history(offer: Offer) -> list[dict[str, object]]:
+    """Commercial history projection only — not an audit log."""
+    numbers = _version_number_by_id(offer)
     entries: list[tuple[datetime, str]] = []
     for version in sorted(offer.versions, key=lambda item: item.version_number):
-        label = (
-            "Angebot erstellt" if version.version_number == 1 else "Angebot vorbereitet"
+        entries.append(
+            (
+                version.created_at,
+                _version_history_label("vorbereitet", version.version_number),
+            )
         )
-        entries.append((version.created_at, label))
     for sent in offer.sent_evidence:
-        entries.append((sent.sent_at, "Angebot gesendet"))
+        number = numbers.get(sent.offer_version_id)
+        if number is not None:
+            entries.append((sent.sent_at, _version_history_label("gesendet", number)))
     for rejection in offer.rejection_evidence:
-        entries.append((rejection.rejected_at, "Angebot abgelehnt"))
+        number = numbers.get(rejection.offer_version_id)
+        if number is not None:
+            entries.append(
+                (rejection.rejected_at, _version_history_label("abgelehnt", number))
+            )
     for withdrawal in offer.withdrawal_evidence:
-        entries.append((withdrawal.withdrawn_at, "Angebot zurückgezogen"))
+        number = numbers.get(withdrawal.offer_version_id)
+        if number is not None:
+            entries.append(
+                (
+                    withdrawal.withdrawn_at,
+                    _version_history_label("zurückgezogen", number),
+                )
+            )
     if offer.acceptance_evidence is not None:
-        entries.append((offer.acceptance_evidence.accepted_at, "Angebot angenommen"))
+        number = numbers.get(offer.acceptance_evidence.accepted_offer_version_id)
+        if number is not None:
+            entries.append(
+                (
+                    offer.acceptance_evidence.accepted_at,
+                    _version_history_label("angenommen", number),
+                )
+            )
     if offer.conversion_link is not None:
-        entries.append((offer.conversion_link.created_at, "In Auftrag umgewandelt"))
+        number = numbers.get(offer.conversion_link.offer_version_id)
+        label = (
+            _version_history_label("in Auftrag umgewandelt", number)
+            if number is not None
+            else "In Auftrag umgewandelt"
+        )
+        entries.append((offer.conversion_link.created_at, label))
     entries.sort(key=lambda item: item[0])
     return [{"at": at.isoformat(), "label": label} for at, label in entries]
+
+
+def _version_sent_at(offer: Offer, offer_version_id: str) -> str | None:
+    for item in offer.sent_evidence:
+        if item.offer_version_id == offer_version_id:
+            return item.sent_at.isoformat()
+    return None
 
 
 def _position_detail(position: OfferPosition) -> dict[str, object]:
@@ -283,10 +330,13 @@ def offer_detail(offer: Offer, *, today: date | None = None) -> dict[str, object
         "acceptance_id": projection.acceptance_id,
         "versions": [
             {
+                "offer_version_id": version.offer_version_id,
                 "version": version.version_number,
                 "state": derive_offer_state(
                     offer, version.offer_version_id, today=operating_today
                 ),
+                "created_at": version.created_at.isoformat(),
+                "sent_at": _version_sent_at(offer, version.offer_version_id),
                 "event_date": version.event_date.isoformat(),
                 "valid_until": version.valid_until.isoformat(),
                 "time_window_text": version.time_window_text,

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -58,16 +58,52 @@ def _history_date(raw: str) -> str:
     except ValueError:
         return raw
     local = value.astimezone(_BERLIN)
-    return f"{local.day:02d}.{local.month:02d}"
+    return f"{local.day:02d}.{local.month:02d}.{local.year}"
 
 
 def _surface_version(detail: dict[str, object]) -> dict[str, object]:
     versions = cast(list[dict[str, object]], detail["versions"])
     commercial = str(detail["commercial_state"])
+    current_id = str(detail["offer_version_id"])
+    for version in reversed(versions):
+        if str(version.get("offer_version_id", "")) == current_id:
+            return version
     for version in reversed(versions):
         if str(version["state"]) == commercial:
             return version
     return versions[-1]
+
+
+def _version_list(detail: dict[str, object]) -> str:
+    versions = cast(list[dict[str, object]], detail["versions"])
+    current_id = str(detail["offer_version_id"])
+    rows: list[str] = []
+    for version in sorted(
+        versions, key=lambda item: int(cast(int, item["version"])), reverse=True
+    ):
+        number = int(cast(int, version["version"]))
+        state = str(version["state"])
+        state_label = offer_state_label(state)  # type: ignore[arg-type]
+        aktuell = ""
+        if str(version.get("offer_version_id", "")) == current_id:
+            aktuell = '<p class="offer-version-current">✓ Aktuell</p>'
+        sent_at = version.get("sent_at")
+        sent_line = ""
+        if isinstance(sent_at, str) and sent_at:
+            sent_line = f"<p><span>Gesendet</span><strong>{_e(_history_date(sent_at))}</strong></p>"
+        rows.append(
+            '<li class="offer-version-item">'
+            f"<h3>Version {number}</h3>"
+            f"<p><span>Status</span><strong>{_e(state_label)}</strong></p>"
+            f"{aktuell}{sent_line}"
+            "</li>"
+        )
+    return (
+        '<section class="offer-detail-section">'
+        "<h2>Angebotsversionen</h2>"
+        f'<ul class="offer-version-list">{"".join(rows)}</ul>'
+        "</section>"
+    )
 
 
 def _allergen_block(labels: object, *, unknown: bool = False) -> str:
@@ -297,7 +333,7 @@ def render_offer_detail(
     history_rows = (
         "".join(
             f"<li><span>{_e(_history_date(str(entry['at'])))}</span> "
-            f"{_e(str(entry['label']))}</li>"
+            f"<strong>{_e(str(entry['label']))}</strong></li>"
             for entry in cast(list[dict[str, object]], detail["history"])
         )
         or "<li>Noch keine Historie</li>"
@@ -342,8 +378,7 @@ def render_offer_detail(
         + '<section class="offer-detail-section">'
         "<h2>Status</h2>"
         f"<p><strong>{_e(offer_state_label(state))}</strong></p>"  # type: ignore[arg-type]
-        "</section>"
-        '<section class="offer-detail-section">'
+        "</section>" + _version_list(detail) + '<section class="offer-detail-section">'
         "<h2>Veranstaltung</h2>"
         f"<p><span>Datum</span><strong>{_e(_long_date(str(surface['event_date'])))}</strong></p>"
         f"<p><span>Ort</span><strong>{_e(str(surface['location_text']))}</strong></p>"
@@ -360,7 +395,7 @@ def render_offer_detail(
         f'<ul class="offer-variant-list">{variant_rows}</ul>'
         "</section>"
         '<section class="offer-detail-section">'
-        "<h2>Historie</h2>"
+        "<h2>Angebotshistorie</h2>"
         f'<ul class="offer-history-list">{history_rows}</ul>'
         "</section>"
         + order_link

--- a/src/catering_system/ui/office_panel_offers_list.py
+++ b/src/catering_system/ui/office_panel_offers_list.py
@@ -36,13 +36,15 @@ def _queue_table(items: list[dict[str, object]]) -> str:
         label = customer
         if subtitle and str(subtitle) != customer:
             label = f"{customer} — {subtitle}"
+        version_number = int(cast(int, item["version_number"]))
         overdue_note = ""
         days_overdue = item.get("days_overdue")
         if days_overdue is not None and int(cast(int, days_overdue)) > 0:
             overdue_note = f" ({int(cast(int, days_overdue))} Tage)"
         rows.append(
             "<tr>"
-            f"<td>{_e(label)}</td>"
+            f"<td>{_e(label)}"
+            f'<br><span class="muted">Angebot v{version_number}</span></td>'
             f"<td>{_e(_short_date(str(item['event_date'])))}</td>"
             f"<td>{_e(str(item['state_label']))}</td>"
             f"<td>{_e(str(item['next_action_label']))}{_e(overdue_note)}</td>"

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1475,20 +1475,20 @@ class RemoteCoreClient:
             "Rejected",
             "Superseded",
         }
-        _exact(
-            body,
-            {
-                "offer_id",
-                "inquiry_id",
-                "offer_version_id",
-                "commercial_state",
-                "acceptance_id",
-                "versions",
-                "sent_evidence",
-                "acceptance",
-                "history",
-            },
-        )
+        required = {
+            "offer_id",
+            "inquiry_id",
+            "offer_version_id",
+            "commercial_state",
+            "acceptance_id",
+            "versions",
+            "sent_evidence",
+            "acceptance",
+            "history",
+        }
+        keys = set(body)
+        if not required <= keys or keys - required - {"order_id"}:
+            _bad_response()
         _uuid4(body["offer_id"])
         _uuid4(body["inquiry_id"])
         _uuid4(body["offer_version_id"])
@@ -1517,8 +1517,11 @@ class RemoteCoreClient:
             _exact(
                 version,
                 {
+                    "offer_version_id",
                     "version",
                     "state",
+                    "created_at",
+                    "sent_at",
                     "event_date",
                     "valid_until",
                     "time_window_text",
@@ -1531,6 +1534,11 @@ class RemoteCoreClient:
             version_state = _str(version["state"])
             if version_state not in allowed_states:
                 _bad_response()
+            _uuid4(version["offer_version_id"])
+            _int(version["version"])
+            _datetime(version["created_at"])
+            if version["sent_at"] is not None:
+                _datetime(version["sent_at"])
             _date(version["event_date"])
             _date(version["valid_until"])
             _str(version["time_window_text"])

--- a/tests/unit/test_offer_detail.py
+++ b/tests/unit/test_offer_detail.py
@@ -220,7 +220,7 @@ def test_sent_offer_detail_includes_evidence_and_history() -> None:
     assert sent is not None
     assert sent["channel"] == "email"
     labels = [entry["label"] for entry in detail["history"]]
-    assert labels == ["Angebot erstellt", "Angebot gesendet"]
+    assert labels == ["Version 1 vorbereitet", "Version 1 gesendet"]
 
 
 def test_accepted_offer_detail() -> None:
@@ -235,7 +235,7 @@ def test_accepted_offer_detail() -> None:
     assert acceptance is not None
     assert acceptance["accepted_variant_id"] == _VARIANT_ID
     labels = [entry["label"] for entry in detail["history"]]
-    assert "Angebot angenommen" in labels
+    assert "Version 1 angenommen" in labels
 
 
 def test_converted_offer_detail_includes_order_link() -> None:
@@ -247,7 +247,7 @@ def test_converted_offer_detail_includes_order_link() -> None:
     assert detail["commercial_state"] == "Converted"
     assert detail["order_id"] == _ORDER_ID
     labels = [entry["label"] for entry in detail["history"]]
-    assert labels[-1] == "In Auftrag umgewandelt"
+    assert labels[-1] == "Version 1 in Auftrag umgewandelt"
 
 
 def test_history_sorted_chronologically() -> None:
@@ -280,5 +280,11 @@ def test_second_version_history_label() -> None:
         withdrawal_evidence=(),
         conversion_link=None,
     )
-    labels = [entry["label"] for entry in offer_detail(offer, today=_TODAY)["history"]]
-    assert labels == ["Angebot erstellt", "Angebot vorbereitet"]
+    detail = offer_detail(offer, today=_TODAY)
+    labels = [entry["label"] for entry in detail["history"]]
+    assert labels == ["Version 1 vorbereitet", "Version 2 vorbereitet"]
+    assert detail["versions"][0]["offer_version_id"] == _V1_ID
+    assert detail["versions"][1]["offer_version_id"] == _V2_ID
+    assert detail["versions"][0]["sent_at"] is None
+    assert detail["offer_version_id"] == _V2_ID
+    assert detail["commercial_state"] == "Prepared"

--- a/tests/unit/test_offer_queue_projection.py
+++ b/tests/unit/test_offer_queue_projection.py
@@ -31,6 +31,7 @@ _NOW = datetime(2026, 7, 15, 8, 0, tzinfo=UTC)
 _OFFER_ID = "11111111-1111-4111-8111-111111111111"
 _OFFER_ID_B = "22222222-2222-4222-8222-222222222222"
 _V1_ID = "33333333-3333-4333-8333-333333333331"
+_V2_ID = "33333333-3333-4333-8333-333333333332"
 _V1_ID_B = "44444444-4444-4444-8444-444444444444"
 _VARIANT_ID = "55555555-5555-5555-8555-555555555555"
 _ACCEPTANCE_ID = "66666666-6666-6666-8666-666666666666"
@@ -75,16 +76,19 @@ def _version(
     *,
     offer_id: str = _OFFER_ID,
     version_id: str = _V1_ID,
+    version_number: int = 1,
     valid_until: date | None = None,
     created_at: datetime | None = None,
+    snapshot_id: str = "88888888-8888-4888-8888-888888888881",
+    position_id: str = "99999999-9999-4999-8999-999999999991",
 ) -> OfferVersion:
     return OfferVersion(
         offer_version_id=version_id,
         offer_id=offer_id,
-        version_number=1,
+        version_number=version_number,
         created_at=created_at or _NOW,
         valid_until=valid_until or date(2026, 7, 31),
-        snapshot_id="88888888-8888-4888-8888-888888888881",
+        snapshot_id=snapshot_id,
         snapshot_hash=_HASH,
         event_date=date(2026, 8, 1),
         time_window_text="18:00–22:00",
@@ -95,12 +99,14 @@ def _version(
         payment_customer_visible_text="Zahlung per Rechnung",
         variants=(
             OfferVariant(
-                variant_id=_VARIANT_ID,
+                variant_id=_VARIANT_ID
+                if version_number == 1
+                else "55555555-5555-5555-8555-555555555556",
                 offer_version_id=version_id,
                 label="Variante A",
                 positions=(
                     OfferPosition(
-                        position_id="99999999-9999-4999-8999-999999999991",
+                        position_id=position_id,
                         kind="catalog",
                         name="Fingerfood Paket",
                         unit_net_cents=290,
@@ -469,3 +475,160 @@ def test_withdrawn_offer_in_history() -> None:
     assert item.queue_subkind == "withdrawn"
     assert item.next_action == "prepare_next_version"
     assert item.next_action_label == "Neue Version vorbereiten"
+
+
+def test_case_a_sent_v1_prepared_v2_surfaces_prepared() -> None:
+    inquiry = _inquiry()
+    offers = InMemoryOfferRepository()
+    v1 = _version(version_id=_V1_ID, version_number=1)
+    v2 = _version(
+        version_id=_V2_ID,
+        version_number=2,
+        created_at=_NOW + timedelta(days=1),
+        snapshot_id="88888888-8888-4888-8888-888888888882",
+        position_id="99999999-9999-4999-8999-999999999992",
+    )
+    offers.save(
+        Offer(
+            offer_id=_OFFER_ID,
+            source_inquiry_id=inquiry.inquiry_id,
+            created_at=_NOW,
+            versions=(v1, v2),
+            sent_evidence=(
+                SentEvidence(
+                    offer_id=_OFFER_ID,
+                    offer_version_id=_V1_ID,
+                    sent_at=_NOW,
+                    recorded_at=_NOW + timedelta(minutes=1),
+                    channel="email",
+                    recipient_reference="kunde@example.invalid",
+                    evidence_reference="mail-1",
+                    recorded_by="office",
+                ),
+            ),
+            acceptance_evidence=None,
+            rejection_evidence=(),
+            withdrawal_evidence=(),
+            conversion_link=None,
+        )
+    )
+    inquiries = InMemoryInquiryRepository()
+    inquiries.save(inquiry)
+    snapshot = _service(offers=offers, inquiries=inquiries).snapshot()
+    assert snapshot.total_count == 1
+    item = _section(snapshot, "action_required").items[0]
+    assert item.state == "Prepared"
+    assert item.version_number == 2
+    assert item.offer_version_id == _V2_ID
+    assert item.next_action == "mark_sent"
+    assert item.next_action_label == "Als gesendet markieren"
+
+
+def test_case_b_sent_v1_sent_v2_surfaces_await_customer() -> None:
+    inquiry = _inquiry()
+    offers = InMemoryOfferRepository()
+    v1 = _version(version_id=_V1_ID, version_number=1)
+    v2 = _version(
+        version_id=_V2_ID,
+        version_number=2,
+        created_at=_NOW + timedelta(days=1),
+        snapshot_id="88888888-8888-4888-8888-888888888882",
+        position_id="99999999-9999-4999-8999-999999999992",
+    )
+    offers.save(
+        Offer(
+            offer_id=_OFFER_ID,
+            source_inquiry_id=inquiry.inquiry_id,
+            created_at=_NOW,
+            versions=(v1, v2),
+            sent_evidence=(
+                SentEvidence(
+                    offer_id=_OFFER_ID,
+                    offer_version_id=_V1_ID,
+                    sent_at=_NOW,
+                    recorded_at=_NOW + timedelta(minutes=1),
+                    channel="email",
+                    recipient_reference="kunde@example.invalid",
+                    evidence_reference="mail-1",
+                    recorded_by="office",
+                ),
+                SentEvidence(
+                    offer_id=_OFFER_ID,
+                    offer_version_id=_V2_ID,
+                    sent_at=_NOW + timedelta(days=1),
+                    recorded_at=_NOW + timedelta(days=1, minutes=1),
+                    channel="email",
+                    recipient_reference="kunde@example.invalid",
+                    evidence_reference="mail-2",
+                    recorded_by="office",
+                ),
+            ),
+            acceptance_evidence=None,
+            rejection_evidence=(),
+            withdrawal_evidence=(),
+            conversion_link=None,
+        )
+    )
+    inquiries = InMemoryInquiryRepository()
+    inquiries.save(inquiry)
+    item = _section(
+        _service(offers=offers, inquiries=inquiries).snapshot(), "action_required"
+    ).items[0]
+    assert item.state == "Sent"
+    assert item.version_number == 2
+    assert item.next_action == "await_customer"
+    assert item.next_action_label == "Kundenantwort ausstehend"
+
+
+def test_case_c_rejected_v1_prepared_v2_surfaces_prepared() -> None:
+    inquiry = _inquiry()
+    offers = InMemoryOfferRepository()
+    v1 = _version(version_id=_V1_ID, version_number=1)
+    v2 = _version(
+        version_id=_V2_ID,
+        version_number=2,
+        created_at=_NOW + timedelta(days=1),
+        snapshot_id="88888888-8888-4888-8888-888888888882",
+        position_id="99999999-9999-4999-8999-999999999992",
+    )
+    offers.save(
+        Offer(
+            offer_id=_OFFER_ID,
+            source_inquiry_id=inquiry.inquiry_id,
+            created_at=_NOW,
+            versions=(v1, v2),
+            sent_evidence=(
+                SentEvidence(
+                    offer_id=_OFFER_ID,
+                    offer_version_id=_V1_ID,
+                    sent_at=_NOW,
+                    recorded_at=_NOW + timedelta(minutes=1),
+                    channel="email",
+                    recipient_reference="kunde@example.invalid",
+                    evidence_reference="mail-1",
+                    recorded_by="office",
+                ),
+            ),
+            acceptance_evidence=None,
+            rejection_evidence=(
+                RejectionEvidence(
+                    offer_id=_OFFER_ID,
+                    offer_version_id=_V1_ID,
+                    rejected_at=_NOW + timedelta(hours=2),
+                    recorded_at=_NOW + timedelta(hours=2, minutes=1),
+                    recorded_by="office",
+                    evidence_reference="reject-1",
+                ),
+            ),
+            withdrawal_evidence=(),
+            conversion_link=None,
+        )
+    )
+    inquiries = InMemoryInquiryRepository()
+    inquiries.save(inquiry)
+    item = _section(
+        _service(offers=offers, inquiries=inquiries).snapshot(), "action_required"
+    ).items[0]
+    assert item.state == "Prepared"
+    assert item.version_number == 2
+    assert item.next_action == "mark_sent"

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -457,8 +457,11 @@ def test_offer_detail_schema_prepared(api) -> None:
     assert body["acceptance"] is None
     version = body["versions"][0]
     assert set(version) == {
+        "offer_version_id",
         "version",
         "state",
+        "created_at",
+        "sent_at",
         "event_date",
         "valid_until",
         "time_window_text",
@@ -467,12 +470,13 @@ def test_offer_detail_schema_prepared(api) -> None:
         "planning_mode",
         "variants",
     }
+    assert version["sent_at"] is None
     assert version["variants"][0]["name"] == "Variante A"
     assert "positions" in version["variants"][0]
     position = version["variants"][0]["positions"][0]
     assert position["allergens_unknown"] is True
     assert position["allergens"] is None
-    assert body["history"][0]["label"] == "Angebot erstellt"
+    assert body["history"][0]["label"] == "Version 1 vorbereitet"
 
 
 def test_offer_detail_schema_sent(api) -> None:
@@ -488,7 +492,7 @@ def test_offer_detail_schema_sent(api) -> None:
     assert body["sent_evidence"] is not None
     assert body["sent_evidence"]["channel"] == "email"
     labels = [entry["label"] for entry in body["history"]]
-    assert "Angebot gesendet" in labels
+    assert "Version 1 gesendet" in labels
 
 
 def test_list_contacts_schema(api) -> None:

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -585,8 +585,11 @@ def test_html_escaping_in_variant_label() -> None:
         "acceptance_id": None,
         "versions": [
             {
+                "offer_version_id": "33333333-3333-4333-8333-333333333331",
                 "version": 1,
                 "state": "Sent",
+                "created_at": "2026-07-15T08:00:00+00:00",
+                "sent_at": "2026-07-15T10:00:00+00:00",
                 "event_date": "2026-08-01",
                 "valid_until": "2026-07-31",
                 "time_window_text": "18:00",
@@ -603,7 +606,9 @@ def test_html_escaping_in_variant_label() -> None:
         ],
         "sent_evidence": {"sent_at": "2026-07-15T10:00:00+00:00", "channel": "email"},
         "acceptance": None,
-        "history": [{"at": "2026-07-15T08:00:00+00:00", "label": "Angebot erstellt"}],
+        "history": [
+            {"at": "2026-07-15T08:00:00+00:00", "label": "Version 1 vorbereitet"}
+        ],
     }
     from catering_system.ui.office_panel_offer_detail import OfferDetailFormFields
 
@@ -626,8 +631,11 @@ def test_expired_offer_detail_shows_prepare_next_without_link() -> None:
         "acceptance_id": None,
         "versions": [
             {
+                "offer_version_id": "33333333-3333-4333-8333-333333333331",
                 "version": 1,
                 "state": "Expired",
+                "created_at": "2026-07-01T08:00:00+00:00",
+                "sent_at": "2026-07-01T10:00:00+00:00",
                 "event_date": "2026-08-01",
                 "valid_until": "2026-07-01",
                 "time_window_text": "18:00",
@@ -639,7 +647,9 @@ def test_expired_offer_detail_shows_prepare_next_without_link() -> None:
         ],
         "sent_evidence": {"sent_at": "2026-07-01T10:00:00+00:00", "channel": "email"},
         "acceptance": None,
-        "history": [{"at": "2026-07-01T08:00:00+00:00", "label": "Angebot erstellt"}],
+        "history": [
+            {"at": "2026-07-01T08:00:00+00:00", "label": "Version 1 vorbereitet"}
+        ],
     }
     from catering_system.ui.office_panel_offer_detail import OfferDetailFormFields
 
@@ -651,6 +661,8 @@ def test_expired_offer_detail_shows_prepare_next_without_link() -> None:
     )
     assert "Neue Version vorbereiten" in html
     assert "offer-revision-link" not in html
+    assert "Angebotsversionen" in html
+    assert "✓ Aktuell" in html
 
 
 def test_expired_offer_detail_shows_prepare_next_with_link() -> None:
@@ -662,8 +674,11 @@ def test_expired_offer_detail_shows_prepare_next_with_link() -> None:
         "acceptance_id": None,
         "versions": [
             {
+                "offer_version_id": "33333333-3333-4333-8333-333333333331",
                 "version": 1,
                 "state": "Expired",
+                "created_at": "2026-07-01T08:00:00+00:00",
+                "sent_at": "2026-07-01T10:00:00+00:00",
                 "event_date": "2026-08-01",
                 "valid_until": "2026-07-01",
                 "time_window_text": "18:00",
@@ -675,7 +690,9 @@ def test_expired_offer_detail_shows_prepare_next_with_link() -> None:
         ],
         "sent_evidence": {"sent_at": "2026-07-01T10:00:00+00:00", "channel": "email"},
         "acceptance": None,
-        "history": [{"at": "2026-07-01T08:00:00+00:00", "label": "Angebot erstellt"}],
+        "history": [
+            {"at": "2026-07-01T08:00:00+00:00", "label": "Version 1 vorbereitet"}
+        ],
     }
     from catering_system.ui.office_panel_offer_detail import OfferDetailFormFields
 

--- a/tests/unit/test_office_panel_offer_queue.py
+++ b/tests/unit/test_office_panel_offer_queue.py
@@ -57,6 +57,7 @@ def test_angebote_queue_renders_sections_and_counters(monkeypatch) -> None:
     assert "Abgeschlossen / Verlauf" in page
     assert "Vorbereitet — versenden" in page
     assert "Als gesendet markieren" in page
+    assert "Angebot v1" in page
     assert f"/offer/{offer.offer_id}" in page
 
 

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -751,7 +751,7 @@ def test_offer_detail_parity_direct_vs_remote(tmp_path: Path) -> None:
             _assert_same_modulo_remote_fields(d_html, r_html)
             assert "Gesendet" in d_html
             assert "Angebotsvarianten" in d_html
-            assert "Angebot gesendet" in d_html
+            assert "Version 1 gesendet" in d_html
             assert f'href="/inquiry/{inquiry_id}"' in d_html
             assert 'name="_command_id"' not in d_html
             assert 'name="_command_id"' in r_html

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -626,11 +626,16 @@ def test_offer_detail_accepts_valid_payload() -> None:
         "acceptance_id": None,
         "sent_evidence": None,
         "acceptance": None,
-        "history": [{"at": "2026-07-14T10:00:00+02:00", "label": "Prepared"}],
+        "history": [
+            {"at": "2026-07-14T10:00:00+02:00", "label": "Version 1 vorbereitet"}
+        ],
         "versions": [
             {
+                "offer_version_id": version_id,
                 "version": 1,
                 "state": "Prepared",
+                "created_at": "2026-07-14T10:00:00+02:00",
+                "sent_at": None,
                 "event_date": "2026-10-01",
                 "valid_until": "2026-10-15",
                 "time_window_text": "mittags",
@@ -666,6 +671,77 @@ def test_offer_detail_accepts_valid_payload() -> None:
         parsed = RemoteCoreClient(url, _TOKEN).offer_detail(offer_id)
         assert parsed is not None
         assert parsed["offer_id"] == offer_id
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_offer_detail_accepts_converted_order_id() -> None:
+    offer_id = str(uuid.uuid4())
+    inquiry_id = str(uuid.uuid4())
+    version_id = str(uuid.uuid4())
+    order_id = str(uuid.uuid4())
+    variant_id = str(uuid.uuid4())
+    position_id = str(uuid.uuid4())
+    payload = {
+        "offer_id": offer_id,
+        "inquiry_id": inquiry_id,
+        "offer_version_id": version_id,
+        "commercial_state": "Converted",
+        "acceptance_id": str(uuid.uuid4()),
+        "order_id": order_id,
+        "sent_evidence": {"sent_at": "2026-07-14T11:00:00+02:00", "channel": "email"},
+        "acceptance": {
+            "accepted_at": "2026-07-14T12:00:00+02:00",
+            "channel": "email",
+            "accepted_variant_id": variant_id,
+        },
+        "history": [
+            {"at": "2026-07-14T10:00:00+02:00", "label": "Version 1 vorbereitet"}
+        ],
+        "versions": [
+            {
+                "offer_version_id": version_id,
+                "version": 1,
+                "state": "Converted",
+                "created_at": "2026-07-14T10:00:00+02:00",
+                "sent_at": "2026-07-14T11:00:00+02:00",
+                "event_date": "2026-10-01",
+                "valid_until": "2026-10-15",
+                "time_window_text": "mittags",
+                "location_text": "Hamburg",
+                "guest_count": 25,
+                "planning_mode": "caterer_suggestion",
+                "variants": [
+                    {
+                        "variant_id": variant_id,
+                        "name": "Variante A",
+                        "positions": [
+                            {
+                                "position_id": position_id,
+                                "kind": "catalog",
+                                "name": "Fingerfood",
+                                "unit_net_cents": 290,
+                                "net_total_cents": 23200,
+                                "catalog_item_id": None,
+                                "description": None,
+                                "composition": None,
+                                "allergens": None,
+                                "allergen_labels": None,
+                                "allergens_unknown": False,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        parsed = RemoteCoreClient(url, _TOKEN).offer_detail(offer_id)
+        assert parsed is not None
+        assert parsed["order_id"] == order_id
+        assert parsed["commercial_state"] == "Converted"
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- Offer Detail shows **Angebotsversionen** with status, ✓ Aktuell, and per-version Gesendet when evidence exists.
- History projection is version-aware (`Version N vorbereitet/gesendet/abgelehnt…`) — commercial projection only.
- Queue keeps **1 Offer = 1 row** and displays `Angebot vN`.
- Remote `offer_detail` accepts optional Converted `order_id` (parity with direct mode).

## Scope (frozen)
Read visibility only — no domain expansion, no new persistence, no new service.

## Test plan
- [x] Cases A/B/C queue projection tests
- [x] Converted remote `order_id` parity test
- [x] `ruff` / `mypy` / coverage **90.3%** — **1609 passed**
- [ ] CI green on PR
- [ ] Manual: Rejected v1 + Prepared v2 → version list + Aktuell on v2
- [ ] Manual: Queue shows Angebot v2 for Prepared surface


Made with [Cursor](https://cursor.com)