### PR TITLE
ORDER_COMMERCIAL_SNAPSHOT_BOUNDARY_V1-A: freeze commercial facts at conversion

### DIFF
--- a/src/catering_system/domain/order_commercial_snapshot.py
+++ b/src/catering_system/domain/order_commercial_snapshot.py
@@ -1,0 +1,244 @@
+"""Append-only commercial snapshot frozen at Accepted Offer → Order conversion.
+
+Operational consumers (print/confirmation/PDF) must read this aggregate, not
+live Offer data. Event facts stay on OrderVersion; Offer lifecycle stays on Offer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
+from catering_system.domain.offer import (
+    POSITION_KINDS,
+    POSITION_QUANTITY_MODES,
+    VAT_RATES,
+    AcceptanceEvidence,
+    Offer,
+    OfferPosition,
+    OfferVariant,
+    OfferVersion,
+    PositionKind,
+    PositionQuantityMode,
+    VatRatePercent,
+)
+from catering_system.domain.order_payment_reminder import (
+    PaymentMethod,
+    validate_payment_method,
+)
+
+_MAX_TEXT = 20_000
+_MAX_LABEL = 500
+
+
+def _require_text(value: str, field: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field} is required")
+
+
+def _require_aware(value: datetime, field: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+
+
+def _require_non_negative_cents(value: int, field: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field} must be non-negative")
+
+
+def _optional_bounded_text(value: str | None, field: str, *, max_len: int) -> None:
+    if value is None:
+        return
+    _require_text(value, field)
+    if len(value) > max_len:
+        raise ValueError(f"{field} exceeds length limit")
+
+
+def _validate_optional_quantity(value: Decimal | None) -> None:
+    if value is None:
+        return
+    if value < 0:
+        raise ValueError("quantity must be non-negative")
+    exponent = value.as_tuple().exponent
+    if isinstance(exponent, int) and exponent < -3:
+        raise ValueError("quantity exceeds fractional precision")
+
+
+@dataclass(frozen=True)
+class OrderCommercialPosition:
+    """Frozen menu/money line from the accepted OfferVariant."""
+
+    position_id: str
+    kind: PositionKind
+    name: str
+    unit_net_cents: int
+    net_total_cents: int
+    vat_rate_percent: VatRatePercent
+    vat_amount_cents: int
+    gross_total_cents: int
+    related_position_id: str | None = None
+    description: str | None = None
+    composition: str | None = None
+    notes: str | None = None
+    quantity: Decimal | None = None
+    quantity_mode: PositionQuantityMode | None = None
+    unit_label: str | None = None
+    catalog_item_id: str | None = None
+    allergens: tuple[AllergenCode, ...] | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.position_id, "position_id")
+        _require_text(self.name, "name")
+        if self.kind not in POSITION_KINDS:
+            raise ValueError("invalid position kind")
+        if self.vat_rate_percent not in VAT_RATES:
+            raise ValueError("vat_rate_percent must be 7 or 19")
+        for field, value in (
+            ("unit_net_cents", self.unit_net_cents),
+            ("net_total_cents", self.net_total_cents),
+            ("vat_amount_cents", self.vat_amount_cents),
+            ("gross_total_cents", self.gross_total_cents),
+        ):
+            _require_non_negative_cents(value, field)
+        _optional_bounded_text(self.description, "description", max_len=_MAX_TEXT)
+        _optional_bounded_text(self.composition, "composition", max_len=_MAX_TEXT)
+        _optional_bounded_text(self.notes, "notes", max_len=_MAX_TEXT)
+        _optional_bounded_text(self.unit_label, "unit_label", max_len=_MAX_LABEL)
+        _validate_optional_quantity(self.quantity)
+        if (
+            self.quantity_mode is not None
+            and self.quantity_mode not in POSITION_QUANTITY_MODES
+        ):
+            raise ValueError("invalid quantity_mode")
+        if self.kind == "surcharge":
+            if self.related_position_id is None:
+                raise ValueError("surcharge requires related_position_id")
+        elif self.related_position_id is not None:
+            raise ValueError("related_position_id is only valid for surcharges")
+        if self.catalog_item_id is not None:
+            _require_text(self.catalog_item_id, "catalog_item_id")
+        if self.allergens is not None:
+            object.__setattr__(
+                self, "allergens", validate_allergen_codes(self.allergens)
+            )
+
+
+@dataclass(frozen=True)
+class OrderCommercialSnapshot:
+    """One immutable commercial decision bound to one Order at conversion."""
+
+    snapshot_id: str
+    order_id: str
+    source_offer_id: str
+    source_offer_version_id: str
+    source_variant_id: str
+    acceptance_id: str
+    accepted_at: datetime
+    recorded_by: str
+    variant_label: str
+    payment_method: PaymentMethod
+    payment_customer_visible_text: str
+    created_at: datetime
+    positions: tuple[OrderCommercialPosition, ...]
+    variant_description: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.snapshot_id, "snapshot_id")
+        _require_text(self.order_id, "order_id")
+        _require_text(self.source_offer_id, "source_offer_id")
+        _require_text(self.source_offer_version_id, "source_offer_version_id")
+        _require_text(self.source_variant_id, "source_variant_id")
+        _require_text(self.acceptance_id, "acceptance_id")
+        _require_aware(self.accepted_at, "accepted_at")
+        _require_text(self.recorded_by, "recorded_by")
+        _require_text(self.variant_label, "variant_label")
+        validate_payment_method(self.payment_method)
+        _require_text(
+            self.payment_customer_visible_text, "payment_customer_visible_text"
+        )
+        if len(self.payment_customer_visible_text) > _MAX_TEXT:
+            raise ValueError("payment_customer_visible_text exceeds length limit")
+        _require_aware(self.created_at, "created_at")
+        _optional_bounded_text(
+            self.variant_description, "variant_description", max_len=_MAX_TEXT
+        )
+        if not self.positions:
+            raise ValueError(
+                "an OrderCommercialSnapshot requires at least one position"
+            )
+        position_ids: set[str] = set()
+        for position in self.positions:
+            if position.position_id in position_ids:
+                raise ValueError("position_id must be unique within a snapshot")
+            position_ids.add(position.position_id)
+        for position in self.positions:
+            if position.kind == "surcharge":
+                if position.related_position_id not in position_ids:
+                    raise ValueError(
+                        "surcharge must reference a position in the snapshot"
+                    )
+
+
+def map_offer_position(position: OfferPosition) -> OrderCommercialPosition:
+    """Copy frozen OfferPosition fields into a commercial snapshot line."""
+    return OrderCommercialPosition(
+        position_id=position.position_id,
+        kind=position.kind,
+        name=position.name,
+        unit_net_cents=position.unit_net_cents,
+        net_total_cents=position.net_total_cents,
+        vat_rate_percent=position.vat_rate_percent,
+        vat_amount_cents=position.vat_amount_cents,
+        gross_total_cents=position.gross_total_cents,
+        related_position_id=position.related_position_id,
+        description=position.description,
+        composition=position.composition,
+        notes=position.notes,
+        quantity=position.quantity,
+        quantity_mode=position.quantity_mode,
+        unit_label=position.unit_label,
+        catalog_item_id=position.catalog_item_id,
+        allergens=position.allergens,
+    )
+
+
+def build_order_commercial_snapshot(
+    *,
+    order_id: str,
+    offer: Offer,
+    offer_version: OfferVersion,
+    variant: OfferVariant,
+    acceptance: AcceptanceEvidence,
+    created_at: datetime,
+    snapshot_id: str | None = None,
+) -> OrderCommercialSnapshot:
+    """Pure factory: Accepted commercial facts → OrderCommercialSnapshot."""
+    if offer.offer_id != acceptance.offer_id:
+        raise ValueError("acceptance does not belong to offer")
+    if offer_version.offer_id != offer.offer_id:
+        raise ValueError("offer_version does not belong to offer")
+    if variant.offer_version_id != offer_version.offer_version_id:
+        raise ValueError("variant does not belong to offer_version")
+    if acceptance.accepted_offer_version_id != offer_version.offer_version_id:
+        raise ValueError("acceptance version mismatch")
+    if acceptance.accepted_variant_id != variant.variant_id:
+        raise ValueError("acceptance variant mismatch")
+    return OrderCommercialSnapshot(
+        snapshot_id=snapshot_id or str(uuid.uuid4()),
+        order_id=order_id,
+        source_offer_id=offer.offer_id,
+        source_offer_version_id=offer_version.offer_version_id,
+        source_variant_id=variant.variant_id,
+        acceptance_id=acceptance.acceptance_id,
+        accepted_at=acceptance.accepted_at,
+        recorded_by=acceptance.recorded_by,
+        variant_label=variant.label,
+        variant_description=variant.description,
+        payment_method=offer_version.payment_method,
+        payment_customer_visible_text=offer_version.payment_customer_visible_text,
+        created_at=created_at,
+        positions=tuple(map_offer_position(item) for item in variant.positions),
+    )

--- a/src/catering_system/repositories/in_memory_order_commercial_snapshot_repository.py
+++ b/src/catering_system/repositories/in_memory_order_commercial_snapshot_repository.py
@@ -1,0 +1,31 @@
+"""In-memory OrderCommercialSnapshot repository."""
+
+from __future__ import annotations
+
+from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+
+
+class InMemoryOrderCommercialSnapshotRepository:
+    def __init__(self) -> None:
+        self._by_id: dict[str, OrderCommercialSnapshot] = {}
+        self._by_order_id: dict[str, str] = {}
+
+    def create(self, snapshot: OrderCommercialSnapshot) -> None:
+        if snapshot.snapshot_id in self._by_id:
+            raise KeyError(snapshot.snapshot_id)
+        if snapshot.order_id in self._by_order_id:
+            raise ValueError(
+                "order commercial snapshot already exists "
+                f"(order_id={snapshot.order_id!r})"
+            )
+        self._by_id[snapshot.snapshot_id] = snapshot
+        self._by_order_id[snapshot.order_id] = snapshot.snapshot_id
+
+    def get_by_order_id(self, order_id: str) -> OrderCommercialSnapshot | None:
+        snapshot_id = self._by_order_id.get(order_id)
+        if snapshot_id is None:
+            return None
+        return self._by_id.get(snapshot_id)
+
+    def get_by_id(self, snapshot_id: str) -> OrderCommercialSnapshot | None:
+        return self._by_id.get(snapshot_id)

--- a/src/catering_system/repositories/order_commercial_snapshot_repository.py
+++ b/src/catering_system/repositories/order_commercial_snapshot_repository.py
@@ -1,0 +1,16 @@
+"""Order commercial snapshot persistence protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+
+
+class OrderCommercialSnapshotRepository(Protocol):
+    def create(self, snapshot: OrderCommercialSnapshot) -> None:
+        """Insert-only. Duplicate order_id must fail."""
+
+    def get_by_order_id(self, order_id: str) -> OrderCommercialSnapshot | None: ...
+
+    def get_by_id(self, snapshot_id: str) -> OrderCommercialSnapshot | None: ...

--- a/src/catering_system/repositories/sqlite_order_commercial_snapshot_repository.py
+++ b/src/catering_system/repositories/sqlite_order_commercial_snapshot_repository.py
@@ -1,0 +1,329 @@
+"""SQLite persistence for OrderCommercialSnapshot (append-only)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
+from catering_system.domain.offer import (
+    POSITION_KINDS,
+    POSITION_QUANTITY_MODES,
+    VAT_RATES,
+    PositionKind,
+    PositionQuantityMode,
+    VatRatePercent,
+)
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.domain.order_payment_reminder import validate_payment_method
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE order_commercial_snapshots (
+            snapshot_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL UNIQUE,
+            source_offer_id TEXT NOT NULL,
+            source_offer_version_id TEXT NOT NULL,
+            source_variant_id TEXT NOT NULL,
+            acceptance_id TEXT NOT NULL,
+            accepted_at TEXT NOT NULL,
+            recorded_by TEXT NOT NULL,
+            variant_label TEXT NOT NULL,
+            variant_description TEXT,
+            payment_method TEXT NOT NULL,
+            payment_customer_visible_text TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE order_commercial_positions (
+            snapshot_id TEXT NOT NULL,
+            position_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            name TEXT NOT NULL,
+            unit_net_cents INTEGER NOT NULL,
+            net_total_cents INTEGER NOT NULL,
+            vat_rate_percent INTEGER NOT NULL,
+            vat_amount_cents INTEGER NOT NULL,
+            gross_total_cents INTEGER NOT NULL,
+            related_position_id TEXT,
+            description TEXT,
+            composition TEXT,
+            notes TEXT,
+            quantity TEXT,
+            quantity_mode TEXT,
+            unit_label TEXT,
+            catalog_item_id TEXT,
+            allergens_json TEXT,
+            PRIMARY KEY (snapshot_id, position_id),
+            FOREIGN KEY (snapshot_id) REFERENCES order_commercial_snapshots(snapshot_id)
+        );
+        CREATE INDEX idx_order_commercial_snapshots_order_id
+            ON order_commercial_snapshots (order_id);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_order_commercial_snapshot_owner_insert
+        BEFORE INSERT ON order_commercial_snapshots
+        WHEN NOT EXISTS (
+            SELECT 1 FROM orders WHERE order_id = NEW.order_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'order commercial snapshot owner is invalid');
+        END;
+        CREATE TRIGGER trg_order_commercial_snapshot_immutable_update
+        BEFORE UPDATE ON order_commercial_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order commercial snapshot is immutable');
+        END;
+        CREATE TRIGGER trg_order_commercial_snapshot_immutable_delete
+        BEFORE DELETE ON order_commercial_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order commercial snapshot is immutable');
+        END;
+        CREATE TRIGGER trg_order_commercial_position_immutable_update
+        BEFORE UPDATE ON order_commercial_positions
+        BEGIN
+            SELECT RAISE(ABORT, 'order commercial position is immutable');
+        END;
+        CREATE TRIGGER trg_order_commercial_position_immutable_delete
+        BEFORE DELETE ON order_commercial_positions
+        BEGIN
+            SELECT RAISE(ABORT, 'order commercial position is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = ((1, "create_order_commercial_snapshots", _migration_1_create_tables),)
+
+
+def _allergens_storage(value: tuple[str, ...] | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(list(value), ensure_ascii=False)
+
+
+def _optional_allergens(value: str | None) -> tuple[AllergenCode, ...] | None:
+    if value is None:
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, list):
+        raise ValueError("allergens_json must decode to a list")
+    return validate_allergen_codes([str(item) for item in parsed])
+
+
+def _quantity_storage(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return format(value, "f")
+
+
+def _optional_quantity(value: str | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(value)
+
+
+def _position_kind(value: str) -> PositionKind:
+    if value not in POSITION_KINDS:
+        raise ValueError("invalid position kind")
+    return value
+
+
+def _vat_rate(value: int) -> VatRatePercent:
+    if value not in VAT_RATES:
+        raise ValueError("vat_rate_percent must be 7 or 19")
+    return value
+
+
+def _position_quantity_mode(value: str | None) -> PositionQuantityMode | None:
+    if value is None:
+        return None
+    if value not in POSITION_QUANTITY_MODES:
+        raise ValueError("invalid stored quantity_mode")
+    return value
+
+
+class SQLiteOrderCommercialSnapshotRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "order_commercial_snapshots", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteOrderCommercialSnapshotRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "order_commercial_snapshots", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def create(self, snapshot: OrderCommercialSnapshot) -> None:
+        with self._write_scope():
+            try:
+                self._conn.execute(
+                    """
+                    INSERT INTO order_commercial_snapshots (
+                        snapshot_id, order_id, source_offer_id, source_offer_version_id,
+                        source_variant_id, acceptance_id, accepted_at, recorded_by,
+                        variant_label, variant_description, payment_method,
+                        payment_customer_visible_text, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        snapshot.snapshot_id,
+                        snapshot.order_id,
+                        snapshot.source_offer_id,
+                        snapshot.source_offer_version_id,
+                        snapshot.source_variant_id,
+                        snapshot.acceptance_id,
+                        snapshot.accepted_at.isoformat(),
+                        snapshot.recorded_by,
+                        snapshot.variant_label,
+                        snapshot.variant_description,
+                        snapshot.payment_method,
+                        snapshot.payment_customer_visible_text,
+                        snapshot.created_at.isoformat(),
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                text = str(exc).lower()
+                if "unique" in text or "order_id" in text:
+                    raise ValueError(
+                        "order commercial snapshot already exists "
+                        f"(order_id={snapshot.order_id!r})"
+                    ) from exc
+                raise
+            for position in snapshot.positions:
+                self._conn.execute(
+                    """
+                    INSERT INTO order_commercial_positions (
+                        snapshot_id, position_id, kind, name,
+                        unit_net_cents, net_total_cents, vat_rate_percent,
+                        vat_amount_cents, gross_total_cents, related_position_id,
+                        description, composition, notes, quantity, quantity_mode,
+                        unit_label, catalog_item_id, allergens_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        snapshot.snapshot_id,
+                        position.position_id,
+                        position.kind,
+                        position.name,
+                        position.unit_net_cents,
+                        position.net_total_cents,
+                        position.vat_rate_percent,
+                        position.vat_amount_cents,
+                        position.gross_total_cents,
+                        position.related_position_id,
+                        position.description,
+                        position.composition,
+                        position.notes,
+                        _quantity_storage(position.quantity),
+                        position.quantity_mode,
+                        position.unit_label,
+                        position.catalog_item_id,
+                        _allergens_storage(position.allergens),
+                    ),
+                )
+
+    def get_by_order_id(self, order_id: str) -> OrderCommercialSnapshot | None:
+        row = self._conn.execute(
+            """
+            SELECT snapshot_id FROM order_commercial_snapshots WHERE order_id = ?
+            """,
+            (order_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self.get_by_id(row[0])
+
+    def get_by_id(self, snapshot_id: str) -> OrderCommercialSnapshot | None:
+        row = self._conn.execute(
+            """
+            SELECT snapshot_id, order_id, source_offer_id, source_offer_version_id,
+                   source_variant_id, acceptance_id, accepted_at, recorded_by,
+                   variant_label, variant_description, payment_method,
+                   payment_customer_visible_text, created_at
+            FROM order_commercial_snapshots WHERE snapshot_id = ?
+            """,
+            (snapshot_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        positions = self._load_positions(snapshot_id)
+        return OrderCommercialSnapshot(
+            snapshot_id=row[0],
+            order_id=row[1],
+            source_offer_id=row[2],
+            source_offer_version_id=row[3],
+            source_variant_id=row[4],
+            acceptance_id=row[5],
+            accepted_at=datetime.fromisoformat(row[6]),
+            recorded_by=row[7],
+            variant_label=row[8],
+            variant_description=row[9],
+            payment_method=validate_payment_method(row[10]),
+            payment_customer_visible_text=row[11],
+            created_at=datetime.fromisoformat(row[12]),
+            positions=positions,
+        )
+
+    def _load_positions(self, snapshot_id: str) -> tuple[OrderCommercialPosition, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT position_id, kind, name, unit_net_cents, net_total_cents,
+                   vat_rate_percent, vat_amount_cents, gross_total_cents,
+                   related_position_id, description, composition, notes,
+                   quantity, quantity_mode, unit_label, catalog_item_id,
+                   allergens_json
+            FROM order_commercial_positions
+            WHERE snapshot_id = ?
+            ORDER BY rowid
+            """,
+            (snapshot_id,),
+        ).fetchall()
+        return tuple(
+            OrderCommercialPosition(
+                position_id=row[0],
+                kind=_position_kind(row[1]),
+                name=row[2],
+                unit_net_cents=row[3],
+                net_total_cents=row[4],
+                vat_rate_percent=_vat_rate(row[5]),
+                vat_amount_cents=row[6],
+                gross_total_cents=row[7],
+                related_position_id=row[8],
+                description=row[9],
+                composition=row[10],
+                notes=row[11],
+                quantity=_optional_quantity(row[12]),
+                quantity_mode=_position_quantity_mode(row[13]),
+                unit_label=row[14],
+                catalog_item_id=row[15],
+                allergens=_optional_allergens(row[16]),
+            )
+            for row in rows
+        )

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -42,10 +42,19 @@ from catering_system.domain.offer_snapshot import (
     OfferSnapshotVariant,
 )
 from catering_system.repositories.inquiry_repository import InquiryRepository
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.offer_repository import OfferRepository
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.order_repository import OrderRepository
 from catering_system.services.order_service import OrderService
 from catering_system.services.offer_snapshot_validation import validate_offer_snapshot
+from catering_system.domain.order_commercial_snapshot import (
+    build_order_commercial_snapshot,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -58,6 +67,7 @@ class OfferService:
         offer_repository: OfferRepository,
         inquiry_repository: InquiryRepository,
         order_repository: OrderRepository,
+        commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
         *,
         now: Callable[[], datetime] | None = None,
         today: Callable[[], date] | None = None,
@@ -65,6 +75,10 @@ class OfferService:
         self._offer_repository = offer_repository
         self._inquiry_repository = inquiry_repository
         self._order_repository = order_repository
+        self._commercial_snapshots = (
+            commercial_snapshot_repository
+            or InMemoryOrderCommercialSnapshotRepository()
+        )
         self._order_service = OrderService(order_repository)
         self._now = now or (lambda: datetime.now(UTC))
         self._today = today or date.today
@@ -538,20 +552,40 @@ class OfferService:
             offer.source_inquiry_id,
             version,
         )
+        acceptance = offer.acceptance_evidence
+        if acceptance is None or acceptance.acceptance_id != acceptance_id:
+            raise ValueError(
+                f"acceptance_id {acceptance_id!r} does not match offer acceptance"
+            )
+        variant = next(
+            item for item in version.variants if item.variant_id == accepted_variant_id
+        )
+        created_at = self._now()
+        snapshot = build_order_commercial_snapshot(
+            order_id=order.order_id,
+            offer=offer,
+            offer_version=version,
+            variant=variant,
+            acceptance=acceptance,
+            created_at=created_at,
+        )
+        self._commercial_snapshots.create(snapshot)
         conversion_link = ConversionLink(
             offer_id=offer_id,
             offer_version_id=offer_version_id,
             variant_id=accepted_variant_id,
             acceptance_id=acceptance_id,
             order_id=order.order_id,
-            created_at=self._now(),
+            created_at=created_at,
         )
         updated = self._offer_repository.append_conversion_link(conversion_link)
         _log.info(
-            "convert_accepted_offer offer_id=%s offer_version_id=%s order_id=%s",
+            "convert_accepted_offer offer_id=%s offer_version_id=%s order_id=%s "
+            "commercial_snapshot_id=%s",
             offer_id,
             offer_version_id,
             order.order_id,
+            snapshot.snapshot_id,
         )
         return updated, order, order_version
 

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -86,6 +86,9 @@ from catering_system.repositories.sqlite_payment_reminder_repository import (
 from catering_system.repositories.sqlite_order_confirmation_document_repository import (
     SQLiteOrderConfirmationDocumentRepository,
 )
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.sqlite_order_confirmation_outbound_repository import (
     SQLiteOrderConfirmationOutboundRepository,
 )
@@ -386,6 +389,9 @@ class OfficeApi:
         self.confirmation_documents = (
             SQLiteOrderConfirmationDocumentRepository.from_connection(connection)
         )
+        self.commercial_snapshots = (
+            SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
+        )
         self.confirmation_outbound = (
             SQLiteOrderConfirmationOutboundRepository.from_connection(connection)
         )
@@ -402,6 +408,7 @@ class OfficeApi:
             self.offers,
             self.inquiries,
             self.orders,
+            self.commercial_snapshots,
             today=views.berlin_today,
         )
         self.payment_reminder_service = PaymentReminderService(

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -50,6 +50,9 @@ from catering_system.domain.order_payment_reminder import (
 from catering_system.repositories.in_memory_offer_repository import (
     InMemoryOfferRepository,
 )
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.in_memory_catalog_repository import (
     InMemoryCatalogRepository,
 )
@@ -83,6 +86,9 @@ from catering_system.repositories.order_confirmation_outbound_repository import 
 from catering_system.repositories.catalog_repository import CatalogRepository
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.offer_repository import OfferRepository
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
 from uuid import uuid4
 
 from catering_system.repositories.in_memory_order_operational_pause_repository import (
@@ -319,6 +325,7 @@ class OfficePanel:
         contact_profile_repo: ContactProfileRepository | None = None,
         offer_repo: OfferRepository | None = None,
         catalog_repo: CatalogRepository | None = None,
+        commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
         ui_version: str = "legacy",
     ) -> None:
         if ui_version not in {"legacy", "v2"}:
@@ -326,6 +333,9 @@ class OfficePanel:
         self._inquiries = inquiry_repo
         self._orders = order_repo
         self._offers = offer_repo or InMemoryOfferRepository()
+        self._commercial_snapshots = (
+            commercial_snapshot_repo or InMemoryOrderCommercialSnapshotRepository()
+        )
         self._catalog = catalog_repo or InMemoryCatalogRepository()
         self._pause_repository: OrderOperationalPauseRepository | None
         self.catalog_dish_write_service = CatalogDishWriteService(self._catalog)
@@ -733,6 +743,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             offer_service.record_sent_evidence(
@@ -783,6 +794,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             offer_service.record_acceptance_evidence(
@@ -828,6 +840,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             offer_service.record_rejection_evidence(
@@ -866,6 +879,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             offer_service.record_withdrawal_evidence(
@@ -904,6 +918,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             converted, order, order_version = offer_service.convert_accepted_offer(
@@ -2579,6 +2594,7 @@ class OfficePanel:
                 self._offers,
                 self._inquiries,
                 self._orders,
+                self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
             converted, order, order_version = offer_service.convert_accepted_offer(
@@ -3240,6 +3256,7 @@ def make_office_panel_handler(
     contact_profile_repo: ContactProfileRepository | None = None,
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
+    commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
     ui_version: str = "legacy",
 ) -> type[BaseHTTPRequestHandler]:
     """Compatibility wrapper; HTTP routing lives in office_panel_http."""
@@ -3266,6 +3283,7 @@ def make_office_panel_handler(
         contact_profile_repo=contact_profile_repo,
         offer_repo=offer_repo,
         catalog_repo=catalog_repo,
+        commercial_snapshot_repo=commercial_snapshot_repo,
         ui_version=ui_version,
     )
 
@@ -3292,6 +3310,7 @@ def create_office_panel_server(
     contact_profile_repo: ContactProfileRepository | None = None,
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
+    commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
     ui_version: str = "legacy",
 ) -> HTTPServer:
     """Compatibility wrapper; server construction lives in office_panel_http."""
@@ -3320,6 +3339,7 @@ def create_office_panel_server(
         contact_profile_repo=contact_profile_repo,
         offer_repo=offer_repo,
         catalog_repo=catalog_repo,
+        commercial_snapshot_repo=commercial_snapshot_repo,
         ui_version=ui_version,
     )
 
@@ -3467,6 +3487,9 @@ def main() -> None:
         from catering_system.repositories.sqlite_catalog_repository import (
             SQLiteCatalogRepository,
         )
+        from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+            SQLiteOrderCommercialSnapshotRepository,
+        )
         from catering_system.repositories.bootstrap_customer_identity_schema import (
             bootstrap_customer_identity_schema,
         )
@@ -3477,6 +3500,9 @@ def main() -> None:
         order_repo = SQLiteOrderRepository.from_connection(connection)
         offer_repo = SQLiteOfferRepository.from_connection(connection)
         catalog_repo = SQLiteCatalogRepository.from_connection(connection)
+        commercial_snapshot_repo = (
+            SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
+        )
         payment_reminder_repo = SQLitePaymentReminderRepository.from_connection(
             connection
         )
@@ -3516,6 +3542,7 @@ def main() -> None:
             contact_profile_repo=contact_profile_repo,
             offer_repo=offer_repo,
             catalog_repo=catalog_repo,
+            commercial_snapshot_repo=commercial_snapshot_repo,
             ui_version=args.ui_version,
         )
         print(f"Office panel on http://{args.host}:{args.port}/ (user: office)")

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -32,6 +32,9 @@ from catering_system.repositories.order_confirmation_document_repository import 
 from catering_system.repositories.order_confirmation_outbound_repository import (
     OrderConfirmationOutboundRepository,
 )
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.order_operational_pause_repository import (
     OrderOperationalPauseRepository,
 )
@@ -226,6 +229,7 @@ def make_office_panel_handler(
     contact_profile_repo: ContactProfileRepository | None = None,
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
+    commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
     ui_version: str = "legacy",
 ) -> type[BaseHTTPRequestHandler]:
     panel = OfficePanel(
@@ -243,6 +247,7 @@ def make_office_panel_handler(
         contact_profile_repo=contact_profile_repo,
         offer_repo=offer_repo,
         catalog_repo=catalog_repo,
+        commercial_snapshot_repo=commercial_snapshot_repo,
         ui_version=ui_version,
     )
     expected = "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
@@ -769,6 +774,7 @@ def create_office_panel_server(
     contact_profile_repo: ContactProfileRepository | None = None,
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
+    commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
     ui_version: str = "legacy",
 ) -> HTTPServer:
     """Create the intentionally single-threaded office HTTP server."""
@@ -793,6 +799,7 @@ def create_office_panel_server(
             contact_profile_repo=contact_profile_repo,
             offer_repo=offer_repo,
             catalog_repo=catalog_repo,
+            commercial_snapshot_repo=commercial_snapshot_repo,
             ui_version=ui_version,
         ),
     )

--- a/tests/unit/test_core_transaction.py
+++ b/tests/unit/test_core_transaction.py
@@ -36,6 +36,9 @@ from catering_system.repositories.sqlite_inquiry_repository import (
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
 )
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
@@ -622,11 +625,12 @@ def test_record_acceptance_evidence_append_failure_leaves_no_ledger(shared) -> N
 def test_convert_accepted_offer_and_ledger_commit_atomically(shared) -> None:
     connection, inquiries, orders, ledger = shared
     offers = SQLiteOfferRepository.from_connection(connection)
+    snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
     reminders = SQLitePaymentReminderRepository.from_connection(connection)
     executor = CoreCommandExecutor(connection)
     inquiry = replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
     executor.run(lambda: inquiries.save(inquiry))
-    service = OfferService(offers, inquiries, orders)
+    service = OfferService(offers, inquiries, orders, snapshots)
     offer = executor.run(
         lambda: service.prepare_offer_version(
             inquiry.inquiry_id,
@@ -695,15 +699,20 @@ def test_convert_accepted_offer_and_ledger_commit_atomically(shared) -> None:
     assert ledger.get(convert_cmd) is not None
     assert reminders.get(stored.conversion_link.order_id) is not None
     assert inquiries.get_by_id(inquiry.inquiry_id).crm_stage == ACTIVE_ORDER_CRM_STAGE
+    snapshot = snapshots.get_by_order_id(stored.conversion_link.order_id)
+    assert snapshot is not None
+    assert snapshot.source_offer_version_id == version_id
+    assert snapshot.positions[0].name == "Fingerfood Paket"
 
 
 def test_convert_accepted_offer_append_failure_leaves_no_ledger(shared) -> None:
     connection, inquiries, orders, ledger = shared
     offers = SQLiteOfferRepository.from_connection(connection)
+    snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
     executor = CoreCommandExecutor(connection)
     inquiry = replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
     executor.run(lambda: inquiries.save(inquiry))
-    service = OfferService(offers, inquiries, orders)
+    service = OfferService(offers, inquiries, orders, snapshots)
     offer = executor.run(
         lambda: service.prepare_offer_version(
             inquiry.inquiry_id,
@@ -759,15 +768,21 @@ def test_convert_accepted_offer_append_failure_leaves_no_ledger(shared) -> None:
     assert stored is not None
     assert stored.conversion_link is None
     assert len(orders.list_orders()) == 0
+    assert snapshots.get_by_order_id("any") is None
+    rows = connection.execute(
+        "SELECT COUNT(*) FROM order_commercial_snapshots"
+    ).fetchone()
+    assert rows is not None and rows[0] == 0
 
 
 def test_convert_accepted_offer_crm_failure_rolls_back(shared) -> None:
     connection, inquiries, orders, ledger = shared
     offers = SQLiteOfferRepository.from_connection(connection)
+    snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
     executor = CoreCommandExecutor(connection)
     inquiry = replace(_inquiry(), inquiry_id="22222222-2222-4222-8222-222222222222")
     executor.run(lambda: inquiries.save(inquiry))
-    service = OfferService(offers, inquiries, orders)
+    service = OfferService(offers, inquiries, orders, snapshots)
     offer = executor.run(
         lambda: service.prepare_offer_version(
             inquiry.inquiry_id,
@@ -836,3 +851,7 @@ def test_convert_accepted_offer_crm_failure_rolls_back(shared) -> None:
     assert stored is not None
     assert stored.conversion_link is None
     assert len(orders.list_orders()) == 0
+    rows = connection.execute(
+        "SELECT COUNT(*) FROM order_commercial_snapshots"
+    ).fetchone()
+    assert rows is not None and rows[0] == 0

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -1079,6 +1079,107 @@ def test_convert_accepted_offer_happy_path() -> None:
         derive_offer_state(updated, version_id, today=date(2026, 7, 15)) == "Converted"
     )
     assert len(orders.list_orders()) == 1
+    snapshot = service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert snapshot is not None
+    assert snapshot.source_offer_id == offer.offer_id
+    assert snapshot.source_offer_version_id == version_id
+    assert snapshot.source_variant_id == variant_id
+    assert snapshot.acceptance_id == acceptance_id
+    assert snapshot.variant_label == "Variante A"
+    assert snapshot.positions[0].name == "Fingerfood Paket"
+    assert snapshot.positions[0].unit_net_cents == 290
+    assert snapshot.positions[0].description == "Frozen description"
+    assert snapshot.positions[0].composition == "Frozen composition"
+
+
+def test_convert_accepted_offer_snapshot_immune_to_later_offer_mutation() -> None:
+    offer, version_id, variant_id, acceptance_id, offers, _orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _updated, order, _ov = service.convert_accepted_offer(
+        offer.offer_id, version_id, variant_id, acceptance_id
+    )
+    frozen = service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert frozen is not None
+    original_name = frozen.positions[0].name
+
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    version = stored.versions[0]
+    variant = version.variants[0]
+    mutated_position = replace(variant.positions[0], name="MUTATED LIVE OFFER")
+    mutated_variant = replace(variant, positions=(mutated_position,))
+    mutated_version = replace(version, variants=(mutated_variant,))
+    # Offer versions are append-only in production; force a live mutation to prove
+    # the commercial snapshot is decoupled from later Offer storage changes.
+    offers._offers[stored.offer_id] = replace(stored, versions=(mutated_version,))
+
+    reloaded = service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert reloaded is not None
+    assert reloaded.positions[0].name == original_name
+    assert reloaded.positions[0].name == "Fingerfood Paket"
+
+
+def test_convert_accepted_offer_replay_does_not_create_second_snapshot() -> None:
+    offer, version_id, variant_id, acceptance_id, offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    first = service.convert_accepted_offer(
+        offer.offer_id, version_id, variant_id, acceptance_id
+    )
+    first_snapshot = service._commercial_snapshots.get_by_order_id(first[1].order_id)
+    assert first_snapshot is not None
+    second = service.convert_accepted_offer(
+        offer.offer_id, version_id, variant_id, acceptance_id
+    )
+    assert second[1].order_id == first[1].order_id
+    assert len(orders.list_orders()) == 1
+    assert offers.get(offer.offer_id) == second[0]
+    again = service._commercial_snapshots.get_by_order_id(first[1].order_id)
+    assert again is not None
+    assert again.snapshot_id == first_snapshot.snapshot_id
+
+
+def test_order_and_snapshot_remain_when_offer_repo_later_unavailable() -> None:
+    """Boundary prep for PR B/C: Order + Snapshot stay readable without Offer."""
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        inquiries,
+        service,
+    ) = _accepted_offer_state()
+    _updated, order, _ov = service.convert_accepted_offer(
+        offer.offer_id, version_id, variant_id, acceptance_id
+    )
+    snapshot = service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert snapshot is not None
+
+    class _UnavailableOfferRepository:
+        def get(self, offer_id: str) -> Offer | None:
+            raise RuntimeError("offer repository unavailable")
+
+        def save(self, offer: Offer) -> None:
+            raise RuntimeError("offer repository unavailable")
+
+        def append_conversion_link(self, link: ConversionLink) -> Offer:
+            raise RuntimeError("offer repository unavailable")
+
+    broken = OfferService(
+        _UnavailableOfferRepository(),  # type: ignore[arg-type]
+        inquiries,
+        orders,
+        service._commercial_snapshots,
+    )
+    with pytest.raises(RuntimeError, match="unavailable"):
+        broken.convert_accepted_offer(
+            offer.offer_id, version_id, variant_id, acceptance_id
+        )
+    assert orders.get_order(order.order_id) is not None
+    assert service._commercial_snapshots.get_by_order_id(order.order_id) == snapshot
 
 
 def test_convert_accepted_offer_order_version_from_offer_not_inquiry() -> None:

--- a/tests/unit/test_order_commercial_snapshot.py
+++ b/tests/unit/test_order_commercial_snapshot.py
@@ -1,0 +1,222 @@
+"""Unit tests — OrderCommercialSnapshot domain factory (PR A)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from catering_system.domain.offer import (
+    AcceptanceEvidence,
+    Offer,
+    OfferPosition,
+    OfferVariant,
+    OfferVersion,
+    SentEvidence,
+)
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+    build_order_commercial_snapshot,
+    map_offer_position,
+)
+
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_ORDER_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_VARIANT_ID = "44444444-4444-4444-8444-444444444441"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+_ACCEPTANCE_ID = "66666666-6666-4666-8666-666666666661"
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _position(**overrides: object) -> OfferPosition:
+    payload: dict[str, object] = {
+        "position_id": _POSITION_ID,
+        "kind": "catalog",
+        "name": "Fingerfood Paket",
+        "unit_net_cents": 290,
+        "net_total_cents": 23200,
+        "vat_rate_percent": 7,
+        "vat_amount_cents": 1624,
+        "gross_total_cents": 24824,
+        "description": "Frozen description",
+        "composition": "Frozen composition",
+        "notes": "Frozen notes",
+        "quantity": Decimal("80"),
+        "quantity_mode": "total",
+        "unit_label": "Stück",
+        "catalog_item_id": "catalog-1",
+        "allergens": ("A", "C"),
+    }
+    payload.update(overrides)
+    return OfferPosition(**payload)  # type: ignore[arg-type]
+
+
+def _variant(*, positions: tuple[OfferPosition, ...] | None = None) -> OfferVariant:
+    return OfferVariant(
+        variant_id=_VARIANT_ID,
+        offer_version_id=_VERSION_ID,
+        label="Variante A",
+        description="Customer-visible alternative",
+        positions=positions or (_position(),),
+    )
+
+
+def _version(*, variant: OfferVariant | None = None) -> OfferVersion:
+    chosen = variant or _variant()
+    return OfferVersion(
+        offer_version_id=_VERSION_ID,
+        offer_id=_OFFER_ID,
+        version_number=1,
+        created_at=_NOW,
+        valid_until=date(2026, 7, 29),
+        snapshot_id="77777777-7777-4777-8777-777777777771",
+        snapshot_hash="sha256:" + ("a" * 64),
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count=80,
+        planning_mode="caterer_suggestion",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        variants=(chosen,),
+    )
+
+
+def _acceptance() -> AcceptanceEvidence:
+    return AcceptanceEvidence(
+        acceptance_id=_ACCEPTANCE_ID,
+        offer_id=_OFFER_ID,
+        accepted_offer_version_id=_VERSION_ID,
+        accepted_variant_id=_VARIANT_ID,
+        accepted_at=_NOW + timedelta(hours=1),
+        recorded_at=_NOW + timedelta(hours=1, minutes=5),
+        channel="email",
+        evidence_reference="reply-1",
+        recorded_by="office-panel",
+    )
+
+
+def _offer(*, version: OfferVersion | None = None) -> Offer:
+    chosen = version or _version()
+    sent = SentEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=chosen.offer_version_id,
+        sent_at=_NOW,
+        recorded_at=_NOW + timedelta(minutes=1),
+        channel="email",
+        recipient_reference="kunde@example.invalid",
+        evidence_reference="mail-1",
+        recorded_by="office-panel",
+    )
+    return Offer(
+        offer_id=_OFFER_ID,
+        source_inquiry_id="88888888-8888-4888-8888-888888888881",
+        created_at=_NOW,
+        versions=(chosen,),
+        sent_evidence=(sent,),
+        acceptance_evidence=_acceptance(),
+    )
+
+
+def test_map_offer_position_copies_frozen_commercial_fields() -> None:
+    mapped = map_offer_position(_position())
+    assert mapped == OrderCommercialPosition(
+        position_id=_POSITION_ID,
+        kind="catalog",
+        name="Fingerfood Paket",
+        unit_net_cents=290,
+        net_total_cents=23200,
+        vat_rate_percent=7,
+        vat_amount_cents=1624,
+        gross_total_cents=24824,
+        description="Frozen description",
+        composition="Frozen composition",
+        notes="Frozen notes",
+        quantity=Decimal("80"),
+        quantity_mode="total",
+        unit_label="Stück",
+        catalog_item_id="catalog-1",
+        allergens=("A", "C"),
+    )
+
+
+def test_build_order_commercial_snapshot_from_accepted_variant() -> None:
+    offer = _offer()
+    version = offer.versions[0]
+    variant = version.variants[0]
+    acceptance = offer.acceptance_evidence
+    assert acceptance is not None
+
+    snapshot = build_order_commercial_snapshot(
+        order_id=_ORDER_ID,
+        offer=offer,
+        offer_version=version,
+        variant=variant,
+        acceptance=acceptance,
+        created_at=_NOW + timedelta(hours=2),
+        snapshot_id="99999999-9999-4999-8999-999999999991",
+    )
+
+    assert snapshot.order_id == _ORDER_ID
+    assert snapshot.source_offer_id == _OFFER_ID
+    assert snapshot.source_offer_version_id == _VERSION_ID
+    assert snapshot.source_variant_id == _VARIANT_ID
+    assert snapshot.acceptance_id == _ACCEPTANCE_ID
+    assert snapshot.accepted_at == acceptance.accepted_at
+    assert snapshot.recorded_by == "office-panel"
+    assert snapshot.variant_label == "Variante A"
+    assert snapshot.variant_description == "Customer-visible alternative"
+    assert snapshot.payment_method == "RECHNUNG"
+    assert snapshot.payment_customer_visible_text == "Zahlung per Rechnung"
+    assert len(snapshot.positions) == 1
+    assert snapshot.positions[0].name == "Fingerfood Paket"
+    assert snapshot.positions[0].unit_net_cents == 290
+
+
+def test_build_rejects_acceptance_variant_mismatch() -> None:
+    offer = _offer()
+    version = offer.versions[0]
+    variant = version.variants[0]
+    acceptance = _acceptance()
+    bad = AcceptanceEvidence(
+        acceptance_id=_ACCEPTANCE_ID,
+        offer_id=_OFFER_ID,
+        accepted_offer_version_id=_VERSION_ID,
+        accepted_variant_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        accepted_at=acceptance.accepted_at,
+        recorded_at=acceptance.recorded_at,
+        channel="email",
+        evidence_reference="reply-1",
+        recorded_by="office-panel",
+    )
+    with pytest.raises(ValueError, match="acceptance variant mismatch"):
+        build_order_commercial_snapshot(
+            order_id=_ORDER_ID,
+            offer=offer,
+            offer_version=version,
+            variant=variant,
+            acceptance=bad,
+            created_at=_NOW,
+        )
+
+
+def test_snapshot_requires_at_least_one_position() -> None:
+    with pytest.raises(ValueError, match="at least one position"):
+        OrderCommercialSnapshot(
+            snapshot_id="99999999-9999-4999-8999-999999999991",
+            order_id=_ORDER_ID,
+            source_offer_id=_OFFER_ID,
+            source_offer_version_id=_VERSION_ID,
+            source_variant_id=_VARIANT_ID,
+            acceptance_id=_ACCEPTANCE_ID,
+            accepted_at=_NOW,
+            recorded_by="office-panel",
+            variant_label="Variante A",
+            payment_method="RECHNUNG",
+            payment_customer_visible_text="Zahlung per Rechnung",
+            created_at=_NOW,
+            positions=(),
+        )

--- a/tests/unit/test_order_commercial_snapshot_repository.py
+++ b/tests/unit/test_order_commercial_snapshot_repository.py
@@ -1,0 +1,222 @@
+"""Persistence tests — OrderCommercialSnapshot repositories (PR A)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.offer import (
+    AcceptanceEvidence,
+    Offer,
+    OfferPosition,
+    OfferVariant,
+    OfferVersion,
+    SentEvidence,
+)
+from catering_system.domain.order_commercial_snapshot import (
+    build_order_commercial_snapshot,
+)
+from catering_system.repositories.core_transaction import open_core_connection
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from tests.helpers.order_seed import seed_order
+
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_INQUIRY_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_VARIANT_ID = "44444444-4444-4444-8444-444444444441"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+_ACCEPTANCE_ID = "66666666-6666-4666-8666-666666666661"
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _inquiry() -> Inquiry:
+    return Inquiry(
+        inquiry_id=_INQUIRY_ID,
+        event_date=date(2026, 8, 20),
+        created_at=_NOW,
+        updated_at=_NOW,
+        inquiry_source="manual",
+        crm_stage="Angebot gesendet / Rückmeldung offen",
+        customer_linkage={},
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+    )
+
+
+def _snapshot(
+    *,
+    order_id: str,
+    snapshot_id: str = "99999999-9999-4999-8999-999999999991",
+    name: str = "Fingerfood Paket",
+):
+    position = OfferPosition(
+        position_id=_POSITION_ID,
+        kind="catalog",
+        name=name,
+        unit_net_cents=290,
+        net_total_cents=23200,
+        vat_rate_percent=7,
+        vat_amount_cents=1624,
+        gross_total_cents=24824,
+        description="Frozen description",
+        composition="Frozen composition",
+        notes="Frozen notes",
+        quantity=Decimal("80"),
+        quantity_mode="total",
+        unit_label="Stück",
+        catalog_item_id="catalog-1",
+        allergens=("A", "C"),
+    )
+    variant = OfferVariant(
+        variant_id=_VARIANT_ID,
+        offer_version_id=_VERSION_ID,
+        label="Variante A",
+        description="Customer-visible alternative",
+        positions=(position,),
+    )
+    version = OfferVersion(
+        offer_version_id=_VERSION_ID,
+        offer_id=_OFFER_ID,
+        version_number=1,
+        created_at=_NOW,
+        valid_until=date(2026, 7, 29),
+        snapshot_id="77777777-7777-4777-8777-777777777771",
+        snapshot_hash="sha256:" + ("a" * 64),
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count=80,
+        planning_mode="caterer_suggestion",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        variants=(variant,),
+    )
+    acceptance = AcceptanceEvidence(
+        acceptance_id=_ACCEPTANCE_ID,
+        offer_id=_OFFER_ID,
+        accepted_offer_version_id=_VERSION_ID,
+        accepted_variant_id=_VARIANT_ID,
+        accepted_at=_NOW,
+        recorded_at=_NOW,
+        channel="email",
+        evidence_reference="reply-1",
+        recorded_by="office-panel",
+    )
+    sent = SentEvidence(
+        offer_id=_OFFER_ID,
+        offer_version_id=_VERSION_ID,
+        sent_at=_NOW,
+        recorded_at=_NOW,
+        channel="email",
+        recipient_reference="kunde@example.invalid",
+        evidence_reference="mail-1",
+        recorded_by="office-panel",
+    )
+    offer = Offer(
+        offer_id=_OFFER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        versions=(version,),
+        sent_evidence=(sent,),
+        acceptance_evidence=acceptance,
+    )
+    return build_order_commercial_snapshot(
+        order_id=order_id,
+        offer=offer,
+        offer_version=version,
+        variant=variant,
+        acceptance=acceptance,
+        created_at=_NOW,
+        snapshot_id=snapshot_id,
+    )
+
+
+def test_in_memory_create_and_get_by_order_id() -> None:
+    repo = InMemoryOrderCommercialSnapshotRepository()
+    snapshot = _snapshot(order_id="order-1")
+    repo.create(snapshot)
+    loaded = repo.get_by_order_id("order-1")
+    assert loaded == snapshot
+    assert repo.get_by_id(snapshot.snapshot_id) == snapshot
+
+
+def test_in_memory_rejects_duplicate_order_id() -> None:
+    repo = InMemoryOrderCommercialSnapshotRepository()
+    repo.create(_snapshot(order_id="order-1"))
+    with pytest.raises(ValueError, match="already exists"):
+        repo.create(
+            _snapshot(
+                order_id="order-1",
+                snapshot_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            )
+        )
+
+
+def test_sqlite_roundtrip_and_immutable(tmp_path: Path) -> None:
+    connection = open_core_connection(tmp_path / "core.db")
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    orders = SQLiteOrderRepository.from_connection(connection)
+    snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
+    inquiry = _inquiry()
+    inquiries.save(inquiry)
+    order, _version = seed_order(orders, inquiry)
+    connection.commit()
+
+    snapshot = _snapshot(order_id=order.order_id)
+    snapshots.create(snapshot)
+    connection.commit()
+
+    loaded = snapshots.get_by_order_id(order.order_id)
+    assert loaded is not None
+    assert loaded.positions[0].name == "Fingerfood Paket"
+    assert loaded.positions[0].allergens == ("A", "C")
+    assert loaded.positions[0].quantity == Decimal("80")
+    assert loaded.payment_method == "RECHNUNG"
+
+    with pytest.raises(sqlite3.Error, match="immutable"):
+        connection.execute(
+            "UPDATE order_commercial_snapshots SET variant_label = ? "
+            "WHERE snapshot_id = ?",
+            ("mutated", snapshot.snapshot_id),
+        )
+    with pytest.raises(sqlite3.Error, match="immutable"):
+        connection.execute(
+            "DELETE FROM order_commercial_snapshots WHERE snapshot_id = ?",
+            (snapshot.snapshot_id,),
+        )
+    with pytest.raises(ValueError, match="already exists"):
+        snapshots.create(
+            _snapshot(
+                order_id=order.order_id,
+                snapshot_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                name="Other",
+            )
+        )
+    connection.close()
+
+
+def test_sqlite_owner_trigger_rejects_orphan_order_id(tmp_path: Path) -> None:
+    connection = open_core_connection(tmp_path / "core.db")
+    SQLiteOrderRepository.from_connection(connection)
+    snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
+    with pytest.raises(sqlite3.Error, match="owner is invalid"):
+        snapshots.create(_snapshot(order_id="missing-order"))
+    connection.close()


### PR DESCRIPTION
## Summary
- Persist append-only `OrderCommercialSnapshot` (+ positions) atomically during `convert_accepted_offer` (Order+v1 → Snapshot → ConversionLink).
- Separate SQLite repository with UNIQUE(order_id), owner + immutable triggers; pure factory for domain mapping.
- Print/confirmation/PDF unchanged (PR B/C); no legacy Order backfill.

## Test plan
- [x] Domain factory + repository roundtrip / duplicate / owner / immutable tests
- [x] Convert creates frozen snapshot; Offer mutation after convert does not change it
- [x] Replay does not create a second snapshot
- [x] SQLite transaction: append/CRM failure rolls back Order + Snapshot + Link
- [x] Boundary prep: Order + Snapshot remain when Offer repo becomes unavailable
- [x] CI: ruff, mypy, coverage ≥90% (1620 passed / 90.2%)

## Auditor pre-merge greps
- `OrderCommercialSnapshot` only in factory / repos / convert / bootstrap (not print/confirmation/PDF)
- `conversion_link` in services: offer_service + legacy print/confirmation (removed in B/C)


Made with [Cursor](https://cursor.com)