### PR TITLE
ORDER_COMMERCIAL_SNAPSHOT_BOUNDARY_V1-B: print from Snapshot

### DIFF
--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -1,15 +1,34 @@
-"""Read-only print projection joining OrderVersion facts with Offer menu data."""
+"""Read-only print projection joining OrderVersion facts with commercial menu data.
+
+Primary commercial source is OrderCommercialSnapshot (frozen at conversion).
+Legacy Offer lookup remains only as a temporary bridge for pre-snapshot Orders.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Literal, Protocol
 
-from catering_system.domain.offer import Offer, OfferPosition, OfferVariant
+from catering_system.domain.offer import (
+    Offer,
+    OfferPosition,
+    OfferVariant,
+    PositionQuantityMode,
+)
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.offer_repository import OfferRepository
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.order_repository import OrderRepository
 
 PrintIntent = Literal["preview", "change_preview", "final"]
@@ -80,8 +99,19 @@ class OrderPrintProjection:
     flags: PrintFlagsBlock
 
 
+class _QuantityDisplaySource(Protocol):
+    @property
+    def quantity(self) -> Decimal | None: ...
+
+    @property
+    def quantity_mode(self) -> PositionQuantityMode | None: ...
+
+    @property
+    def unit_label(self) -> str | None: ...
+
+
 def format_quantity_display(
-    position: OfferPosition, guest_count_estimate: int | None
+    position: _QuantityDisplaySource, guest_count_estimate: int | None
 ) -> str | None:
     if position.quantity is None:
         return None
@@ -114,9 +144,14 @@ class OrderPrintProjectionService:
         self,
         order_repository: OrderRepository,
         offer_repository: OfferRepository,
+        commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
     ) -> None:
         self._orders = order_repository
         self._offers = offer_repository
+        self._commercial_snapshots = (
+            commercial_snapshot_repository
+            or InMemoryOrderCommercialSnapshotRepository()
+        )
 
     def resolve(
         self,
@@ -146,6 +181,15 @@ class OrderPrintProjectionService:
     def _resolve_commercial(
         self, order: Order, version: OrderVersion
     ) -> PrintCommercialBlock:
+        snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
+        if snapshot is not None:
+            return _commercial_from_snapshot(snapshot, version.guest_count_estimate)
+        # TODO: remove legacy fallback after snapshot migration window
+        return self._legacy_offer_commercial(order, version)
+
+    def _legacy_offer_commercial(
+        self, order: Order, version: OrderVersion
+    ) -> PrintCommercialBlock:
         offer = self._offers.get_by_source_inquiry_id(order.source_inquiry_id)
         if offer is None:
             return PrintCommercialBlock(source="none")
@@ -162,7 +206,7 @@ class OrderPrintProjectionService:
             accepted_variant_id=link.variant_id,
             variant_label=variant.label,
             positions=tuple(
-                _position_line(position, version.guest_count_estimate)
+                _position_line_from_offer(position, version.guest_count_estimate)
                 for position in variant.positions
             ),
         )
@@ -244,6 +288,22 @@ def _event_block(order: Order, version: OrderVersion) -> PrintEventBlock:
     )
 
 
+def _commercial_from_snapshot(
+    snapshot: OrderCommercialSnapshot, guest_count_estimate: int | None
+) -> PrintCommercialBlock:
+    return PrintCommercialBlock(
+        source="offer_conversion",
+        offer_id=snapshot.source_offer_id,
+        offer_version_id=snapshot.source_offer_version_id,
+        accepted_variant_id=snapshot.source_variant_id,
+        variant_label=snapshot.variant_label,
+        positions=tuple(
+            _position_line_from_snapshot(position, guest_count_estimate)
+            for position in snapshot.positions
+        ),
+    )
+
+
 def _accepted_variant(
     offer: Offer, offer_version_id: str, variant_id: str
 ) -> OfferVariant | None:
@@ -259,8 +319,23 @@ def _accepted_variant(
     )
 
 
-def _position_line(
+def _position_line_from_offer(
     position: OfferPosition, guest_count_estimate: int | None
+) -> PrintPositionLine:
+    return PrintPositionLine(
+        position_id=position.position_id,
+        kind=position.kind,
+        name=position.name,
+        description=position.description,
+        composition=position.composition,
+        notes=position.notes,
+        quantity_display=format_quantity_display(position, guest_count_estimate),
+        unit_label=position.unit_label,
+    )
+
+
+def _position_line_from_snapshot(
+    position: OrderCommercialPosition, guest_count_estimate: int | None
 ) -> PrintPositionLine:
     return PrintPositionLine(
         position_id=position.position_id,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -474,6 +474,7 @@ class OfficeApi:
         self.print_projection_service = OrderPrintProjectionService(
             self.orders,
             self.offers,
+            self.commercial_snapshots,
         )
         self.buffet_cards_service = BuffetCardsService(
             self.orders,

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -508,6 +508,7 @@ def make_office_panel_handler(
             return OrderPrintProjectionService(
                 order_repo,
                 panel._offers,
+                panel._commercial_snapshots,
             ).resolve(order_id, version_id, intent="preview")
 
         def _resolve_buffet_cards_view(self, order_id: str, version_id: str):
@@ -515,7 +516,11 @@ def make_office_panel_handler(
                 return remote.buffet_cards_data(order_id, version_id)
             return BuffetCardsService(
                 order_repo,
-                OrderPrintProjectionService(order_repo, panel._offers),
+                OrderPrintProjectionService(
+                    order_repo,
+                    panel._offers,
+                    panel._commercial_snapshots,
+                ),
             ).resolve(order_id, version_id)
 
         def _print_sheet(self, order_id: str, query: str) -> None:

--- a/tests/unit/test_buffet_cards.py
+++ b/tests/unit/test_buffet_cards.py
@@ -127,10 +127,14 @@ def _three_position_snapshot() -> dict[str, object]:
     return payload
 
 
-def _buffet_service(offers, orders) -> BuffetCardsService:
+def _buffet_service(
+    offers,
+    orders,
+    snapshots=None,
+) -> BuffetCardsService:
     return BuffetCardsService(
         orders,
-        OrderPrintProjectionService(orders, offers),
+        OrderPrintProjectionService(orders, offers, snapshots),
     )
 
 
@@ -312,7 +316,7 @@ def test_buffet_cards_from_conversion_link() -> None:
         acceptance_id,
     )
 
-    view = _buffet_service(offers, orders).resolve(
+    view = _buffet_service(offers, orders, offer_service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -342,7 +346,7 @@ def test_buffet_cards_three_positions_from_offer_snapshot() -> None:
         updated.acceptance_evidence.acceptance_id,
     )
 
-    view = _buffet_service(offers, orders).resolve(
+    view = _buffet_service(offers, orders, service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -17,6 +17,9 @@ from catering_system.services.operational_core_service import OperationalCoreSer
 from catering_system.repositories.in_memory_offer_repository import (
     InMemoryOfferRepository,
 )
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
@@ -30,8 +33,12 @@ from tests.unit.test_offer_service import (
 )
 
 
-def _projection_service(offers, orders) -> OrderPrintProjectionService:
-    return OrderPrintProjectionService(orders, offers)
+def _projection_service(
+    offers,
+    orders,
+    snapshots: InMemoryOrderCommercialSnapshotRepository | None = None,
+) -> OrderPrintProjectionService:
+    return OrderPrintProjectionService(orders, offers, snapshots)
 
 
 def test_order_with_offer_conversion_has_menu_positions() -> None:
@@ -46,7 +53,9 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
     )
     assert converted.conversion_link is not None
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        offers, orders, service._commercial_snapshots
+    ).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -583,3 +592,123 @@ def test_commercial_none_when_variant_resolution_returns_none(monkeypatch) -> No
         order_version.order_version_id,
     )
     assert projection.commercial.source == "none"
+
+
+def test_print_uses_snapshot_when_offer_repository_unavailable() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = offer_service._commercial_snapshots
+    assert snapshots.get_by_order_id(order.order_id) is not None
+
+    class _UnavailableOfferRepository:
+        def get_by_source_inquiry_id(self, inquiry_id: str):  # noqa: ANN201
+            raise RuntimeError("offer repository unavailable")
+
+    projection = OrderPrintProjectionService(
+        orders,
+        _UnavailableOfferRepository(),  # type: ignore[arg-type]
+        snapshots,
+    ).resolve(order.order_id, order_version.order_version_id)
+
+    assert projection.commercial.source == "offer_conversion"
+    assert projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert projection.commercial.positions[0].description == "Frozen description"
+    assert projection.commercial.positions[0].quantity_display == "80 Stück"
+    sheet = render_print_sheet(projection)
+    assert "Fingerfood Paket" in sheet
+    assert "Menge: 80 Stück" in sheet
+
+
+def test_print_snapshot_immune_to_later_offer_mutation() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = offer_service._commercial_snapshots
+    from dataclasses import replace
+
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    version = stored.versions[0]
+    variant = version.variants[0]
+    mutated = replace(
+        stored,
+        versions=(
+            replace(
+                version,
+                variants=(
+                    replace(
+                        variant,
+                        positions=(
+                            replace(variant.positions[0], name="MUTATED LIVE OFFER"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    offers._offers[stored.offer_id] = mutated
+
+    projection = _projection_service(offers, orders, snapshots).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    assert projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert "MUTATED LIVE OFFER" not in render_print_sheet(projection)
+
+
+def test_print_legacy_offer_fallback_when_snapshot_missing() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = offer_service._commercial_snapshots
+    assert snapshots.get_by_order_id(order.order_id) is not None
+    snapshots._by_id.clear()
+    snapshots._by_order_id.clear()
+
+    projection = _projection_service(offers, orders, snapshots).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    assert projection.commercial.source == "offer_conversion"
+    assert projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert "Fingerfood Paket" in render_print_sheet(projection)


### PR DESCRIPTION
## Summary
- `OrderPrintProjectionService` resolves commercial menu from `OrderCommercialSnapshot` first.
- Temporary legacy Offer/`conversion_link` fallback when no snapshot (pre-PR A Orders); marked `TODO: remove legacy fallback after snapshot migration window`.
- `PrintCommercialBlock` / `PrintPositionLine` unchanged — buffet/remote/HTML keep the same contract.
- Wire snapshot repo through Core API and panel direct mode.

## Test plan
- [x] Snapshot path after convert (shared repo)
- [x] Print works when Offer repository is unavailable
- [x] Offer mutation after convert does not change print output
- [x] Legacy fallback when snapshot missing
- [x] Buffet inherits via projection
- [x] CI: 1623 passed, coverage 90.2%, ruff/mypy green

## Auditor notes
- `conversion_link` still appears in `order_print_projection_service.py` only inside `_legacy_offer_commercial` (migration bridge). Primary path no longer uses Offer.
- Confirmation documents remain Offer-backed → PR C.


Made with [Cursor](https://cursor.com)