### PR TITLE
ORDER_COMMERCIAL_SNAPSHOT_CLEANUP_V1: remove Offer fallback

### DIFF
--- a/src/catering_system/domain/order_commercial_snapshot.py
+++ b/src/catering_system/domain/order_commercial_snapshot.py
@@ -34,6 +34,14 @@ _MAX_TEXT = 20_000
 _MAX_LABEL = 500
 
 
+class MissingCommercialSnapshotError(LookupError):
+    """Order has no OrderCommercialSnapshot; operational consumers must not proceed."""
+
+    def __init__(self, order_id: str) -> None:
+        self.order_id = order_id
+        super().__init__(f"order commercial snapshot missing (order_id={order_id!r})")
+
+
 def _require_text(value: str, field: str) -> None:
     if not value.strip():
         raise ValueError(f"{field} is required")

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -205,7 +205,7 @@ class OrderConfirmationDocumentService:
         order = self._orders.get_order(order_id)
         if order is None:
             raise OrderConfirmationDocumentNotFoundError(order_id)
-        blocker = self._prepare_blocker(order)
+        blocker = self._operational_blocker(order)
         if blocker is not None:
             raise OrderConfirmationDocumentBlockedError(blocker)
         if order.effective_order_version_id != expected_effective_order_version_id:
@@ -334,7 +334,7 @@ class OrderConfirmationDocumentService:
             effective_version_number=version_number,
         )
 
-    def _prepare_blocker(self, order: Order) -> str | None:
+    def _operational_blocker(self, order: Order) -> str | None:
         if order.cancelled_at is not None:
             return "nicht_verfuegbar"
         if order.effective_order_version_id is None:
@@ -346,6 +346,12 @@ class OrderConfirmationDocumentService:
             return "aenderung_wartet"
         if version.kitchen_print_confirmed_at is None:
             return "aenderung_wartet"
+        return None
+
+    def _prepare_blocker(self, order: Order) -> str | None:
+        blocked = self._operational_blocker(order)
+        if blocked is not None:
+            return blocked
         if self._commercial_snapshots.get_by_order_id(order.order_id) is None:
             return "nicht_verfuegbar"
         return None

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -10,15 +10,15 @@ from decimal import Decimal
 
 from catering_system.domain.inquiry import Inquiry
 from catering_system.domain.offer import (
-    Offer,
-    OfferVariant,
-    OfferVersion,
     PositionKind,
     PositionQuantityMode,
     VatRatePercent,
 )
 from catering_system.domain.order import Order, OrderVersion
-from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+    OrderCommercialSnapshot,
+)
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentPosition,
     OrderConfirmationDocumentSnapshot,
@@ -34,11 +34,7 @@ from catering_system.intake.intake_contact import (
     labelled_intake_context,
     parse_intake_contact,
 )
-from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
-    InMemoryOrderCommercialSnapshotRepository,
-)
 from catering_system.repositories.inquiry_repository import InquiryRepository
-from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
@@ -153,21 +149,16 @@ class OrderConfirmationDocumentService:
     def __init__(
         self,
         order_repository: OrderRepository,
-        offer_repository: OfferRepository,
         inquiry_repository: InquiryRepository,
         document_repository: OrderConfirmationDocumentRepository,
-        commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
+        commercial_snapshot_repository: OrderCommercialSnapshotRepository,
         *,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._orders = order_repository
-        self._offers = offer_repository
         self._inquiries = inquiry_repository
         self._documents = document_repository
-        self._commercial_snapshots = (
-            commercial_snapshot_repository
-            or InMemoryOrderCommercialSnapshotRepository()
-        )
+        self._commercial_snapshots = commercial_snapshot_repository
         self._now = now or (lambda: datetime.now(UTC))
 
     def eligibility(self, order_id: str) -> OrderConfirmationDocumentEligibility:
@@ -355,13 +346,7 @@ class OrderConfirmationDocumentService:
             return "aenderung_wartet"
         if version.kitchen_print_confirmed_at is None:
             return "aenderung_wartet"
-        if self._commercial_snapshots.get_by_order_id(order.order_id) is not None:
-            return None
-        # TODO: remove legacy fallback after snapshot migration window
-        offer = self._offers.get_by_source_inquiry_id(order.source_inquiry_id)
-        if offer is None or offer.conversion_link is None:
-            return "nicht_verfuegbar"
-        if offer.conversion_link.order_id != order.order_id:
+        if self._commercial_snapshots.get_by_order_id(order.order_id) is None:
             return "nicht_verfuegbar"
         return None
 
@@ -375,51 +360,9 @@ class OrderConfirmationDocumentService:
 
     def _resolve_commercial(self, order: Order) -> _CommercialFacts:
         snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
-        if snapshot is not None:
-            return _commercial_from_snapshot(snapshot)
-        # TODO: remove legacy fallback after snapshot migration window
-        return self._legacy_offer_commercial(order)
-
-    def _legacy_offer_commercial(self, order: Order) -> _CommercialFacts:
-        offer, variant, offer_version = self._legacy_commercial_bundle(order)
-        return _CommercialFacts(
-            offer_id=offer.offer_id,
-            offer_version_id=offer_version.offer_version_id,
-            payment_method=offer_version.payment_method,
-            payment_customer_visible_text=offer_version.payment_customer_visible_text,
-            positions=variant.positions,
-        )
-
-    def _legacy_commercial_bundle(
-        self, order: Order
-    ) -> tuple[Offer, OfferVariant, OfferVersion]:
-        offer = self._offers.get_by_source_inquiry_id(order.source_inquiry_id)
-        if offer is None or offer.conversion_link is None:
-            raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
-        link = offer.conversion_link
-        if link.order_id != order.order_id:
-            raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
-        offer_version = next(
-            (
-                item
-                for item in offer.versions
-                if item.offer_version_id == link.offer_version_id
-            ),
-            None,
-        )
-        if offer_version is None:
-            raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
-        variant = next(
-            (
-                item
-                for item in offer_version.variants
-                if item.variant_id == link.variant_id
-            ),
-            None,
-        )
-        if variant is None:
-            raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
-        return offer, variant, offer_version
+        if snapshot is None:
+            raise MissingCommercialSnapshotError(order.order_id)
+        return _commercial_from_snapshot(snapshot)
 
 
 def _commercial_from_snapshot(snapshot: OrderCommercialSnapshot) -> _CommercialFacts:

--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -1,8 +1,4 @@
-"""Read-only print projection joining OrderVersion facts with commercial menu data.
-
-Primary commercial source is OrderCommercialSnapshot (frozen at conversion).
-Legacy Offer lookup remains only as a temporary bridge for pre-snapshot Orders.
-"""
+"""Read-only print projection joining OrderVersion facts with commercial snapshot."""
 
 from __future__ import annotations
 
@@ -11,21 +7,13 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal, Protocol
 
-from catering_system.domain.offer import (
-    Offer,
-    OfferPosition,
-    OfferVariant,
-    PositionQuantityMode,
-)
+from catering_system.domain.offer import PositionQuantityMode
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
-from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
-    InMemoryOrderCommercialSnapshotRepository,
-)
-from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
@@ -143,15 +131,10 @@ class OrderPrintProjectionService:
     def __init__(
         self,
         order_repository: OrderRepository,
-        offer_repository: OfferRepository,
-        commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
+        commercial_snapshot_repository: OrderCommercialSnapshotRepository,
     ) -> None:
         self._orders = order_repository
-        self._offers = offer_repository
-        self._commercial_snapshots = (
-            commercial_snapshot_repository
-            or InMemoryOrderCommercialSnapshotRepository()
-        )
+        self._commercial_snapshots = commercial_snapshot_repository
 
     def resolve(
         self,
@@ -182,34 +165,9 @@ class OrderPrintProjectionService:
         self, order: Order, version: OrderVersion
     ) -> PrintCommercialBlock:
         snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
-        if snapshot is not None:
-            return _commercial_from_snapshot(snapshot, version.guest_count_estimate)
-        # TODO: remove legacy fallback after snapshot migration window
-        return self._legacy_offer_commercial(order, version)
-
-    def _legacy_offer_commercial(
-        self, order: Order, version: OrderVersion
-    ) -> PrintCommercialBlock:
-        offer = self._offers.get_by_source_inquiry_id(order.source_inquiry_id)
-        if offer is None:
-            return PrintCommercialBlock(source="none")
-        link = offer.conversion_link
-        if link is None or link.order_id != order.order_id:
-            return PrintCommercialBlock(source="none")
-        variant = _accepted_variant(offer, link.offer_version_id, link.variant_id)
-        if variant is None:
-            return PrintCommercialBlock(source="none")
-        return PrintCommercialBlock(
-            source="offer_conversion",
-            offer_id=link.offer_id,
-            offer_version_id=link.offer_version_id,
-            accepted_variant_id=link.variant_id,
-            variant_label=variant.label,
-            positions=tuple(
-                _position_line_from_offer(position, version.guest_count_estimate)
-                for position in variant.positions
-            ),
-        )
+        if snapshot is None:
+            raise MissingCommercialSnapshotError(order.order_id)
+        return _commercial_from_snapshot(snapshot, version.guest_count_estimate)
 
     def _resolve_flags(
         self,
@@ -301,36 +259,6 @@ def _commercial_from_snapshot(
             _position_line_from_snapshot(position, guest_count_estimate)
             for position in snapshot.positions
         ),
-    )
-
-
-def _accepted_variant(
-    offer: Offer, offer_version_id: str, variant_id: str
-) -> OfferVariant | None:
-    version = next(
-        (item for item in offer.versions if item.offer_version_id == offer_version_id),
-        None,
-    )
-    if version is None:
-        return None
-    return next(
-        (item for item in version.variants if item.variant_id == variant_id),
-        None,
-    )
-
-
-def _position_line_from_offer(
-    position: OfferPosition, guest_count_estimate: int | None
-) -> PrintPositionLine:
-    return PrintPositionLine(
-        position_id=position.position_id,
-        kind=position.kind,
-        name=position.name,
-        description=position.description,
-        composition=position.composition,
-        notes=position.notes,
-        quantity_display=format_quantity_display(position, guest_count_estimate),
-        unit_label=position.unit_label,
     )
 
 

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -45,6 +45,9 @@ from catering_system.domain.offer import (
     SentChannel,
 )
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+)
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
     validate_payment_method,
@@ -418,7 +421,6 @@ class OfficeApi:
         )
         self.confirmation_document_service = OrderConfirmationDocumentService(
             self.orders,
-            self.offers,
             self.inquiries,
             self.confirmation_documents,
             self.commercial_snapshots,
@@ -474,7 +476,6 @@ class OfficeApi:
         )
         self.print_projection_service = OrderPrintProjectionService(
             self.orders,
-            self.offers,
             self.commercial_snapshots,
         )
         self.buffet_cards_service = BuffetCardsService(
@@ -868,7 +869,7 @@ class OfficeApi:
             )
         except PrintFinalRequiresEffectiveError:
             raise ApiError(400, "invalid_request") from None
-        except PrintProjectionNotFoundError:
+        except (PrintProjectionNotFoundError, MissingCommercialSnapshotError):
             raise ApiError(404, "not_found") from None
         return {
             "order": views.order_summary(order),
@@ -879,7 +880,7 @@ class OfficeApi:
     def buffet_cards_data(self, order_id: str, version_id: str) -> dict[str, object]:
         try:
             view = self.buffet_cards_service.resolve(order_id, version_id)
-        except PrintProjectionNotFoundError:
+        except (PrintProjectionNotFoundError, MissingCommercialSnapshotError):
             raise ApiError(404, "not_found") from None
         return views.buffet_cards_data_shape(view)
 

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -1707,6 +1707,8 @@ class OfficeApi:
             )
         except OrderConfirmationDocumentStaleVersionError as exc:
             raise ApiError(409, "stale_state") from exc
+        except MissingCommercialSnapshotError as exc:
+            raise ApiError(422, "confirmation_document_blocked") from exc
         except OrderConfirmationDocumentBlockedError as exc:
             message = str(exc)
             if message == "aenderung_wartet":

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -381,7 +381,6 @@ class OfficePanel:
             )
             self.confirmation_document_service = OrderConfirmationDocumentService(
                 order_repo,
-                self._offers,
                 inquiry_repo,
                 document_repo,
                 self._commercial_snapshots,

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -55,6 +55,9 @@ from catering_system.ui.office_panel import (
     render_proposal_preview_form,
     render_rueckruf,
 )
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+)
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjectionService,
     PrintProjectionNotFoundError,
@@ -507,7 +510,6 @@ def make_office_panel_handler(
                 return remote.print_data(order_id, version_id)
             return OrderPrintProjectionService(
                 order_repo,
-                panel._offers,
                 panel._commercial_snapshots,
             ).resolve(order_id, version_id, intent="preview")
 
@@ -518,7 +520,6 @@ def make_office_panel_handler(
                 order_repo,
                 OrderPrintProjectionService(
                     order_repo,
-                    panel._offers,
                     panel._commercial_snapshots,
                 ),
             ).resolve(order_id, version_id)
@@ -530,7 +531,7 @@ def make_office_panel_handler(
                 return
             try:
                 projection = self._resolve_print_projection(order_id, version_id)
-            except PrintProjectionNotFoundError:
+            except (PrintProjectionNotFoundError, MissingCommercialSnapshotError):
                 self.send_error(404)
                 return
             if projection is None:
@@ -545,7 +546,7 @@ def make_office_panel_handler(
                 return
             try:
                 view = self._resolve_buffet_cards_view(order_id, version_id)
-            except PrintProjectionNotFoundError:
+            except (PrintProjectionNotFoundError, MissingCommercialSnapshotError):
                 self.send_error(404)
                 return
             if view is None:

--- a/tests/helpers/commercial_snapshot_seed.py
+++ b/tests/helpers/commercial_snapshot_seed.py
@@ -1,0 +1,57 @@
+"""Test-only commercial snapshot seeding for Orders created outside Offer convert."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
+
+
+def seed_commercial_snapshot(
+    snapshot_repository: OrderCommercialSnapshotRepository,
+    order_id: str,
+    *,
+    created_at: datetime | None = None,
+    position_name: str = "Seeded Menü",
+) -> OrderCommercialSnapshot:
+    """Persist a minimal valid snapshot so print/confirmation can resolve."""
+    now = created_at or datetime.now(UTC)
+    snapshot = OrderCommercialSnapshot(
+        snapshot_id=str(uuid.uuid4()),
+        order_id=order_id,
+        source_offer_id=str(uuid.uuid4()),
+        source_offer_version_id=str(uuid.uuid4()),
+        source_variant_id=str(uuid.uuid4()),
+        acceptance_id=str(uuid.uuid4()),
+        accepted_at=now,
+        recorded_by="test-seed",
+        variant_label="Standard",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Rechnung laut Vereinbarung.",
+        created_at=now,
+        positions=(
+            OrderCommercialPosition(
+                position_id=str(uuid.uuid4()),
+                kind="catalog",
+                name=position_name,
+                unit_net_cents=1000,
+                net_total_cents=1000,
+                vat_rate_percent=7,
+                vat_amount_cents=70,
+                gross_total_cents=1070,
+                description="Seeded description",
+                quantity=None,
+                quantity_mode=None,
+                unit_label=None,
+            ),
+        ),
+    )
+    snapshot_repository.create(snapshot)
+    return snapshot

--- a/tests/unit/test_buffet_cards.py
+++ b/tests/unit/test_buffet_cards.py
@@ -6,6 +6,8 @@ from tests.helpers.order_seed import seed_order
 
 from datetime import UTC, date, datetime
 
+import pytest
+
 from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.services.buffet_cards_service import BuffetCardsService
 from catering_system.services.operational_core_service import OperationalCoreService
@@ -128,13 +130,12 @@ def _three_position_snapshot() -> dict[str, object]:
 
 
 def _buffet_service(
-    offers,
     orders,
-    snapshots=None,
+    snapshots,
 ) -> BuffetCardsService:
     return BuffetCardsService(
         orders,
-        OrderPrintProjectionService(orders, offers, snapshots),
+        OrderPrintProjectionService(orders, snapshots),
     )
 
 
@@ -237,7 +238,7 @@ def test_buffet_cards_effective_is_final() -> None:
     core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
     core.make_order_version_effective(order.order_id, order_version.order_version_id)
 
-    view = _buffet_service(offers, orders).resolve(
+    view = _buffet_service(orders, offer_service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -284,7 +285,9 @@ def test_buffet_cards_old_version_is_veraltet() -> None:
     core.confirm_kitchen_print(order.order_id, v2.order_version_id)
     core.make_order_version_effective(order.order_id, v2.order_version_id)
 
-    view = _buffet_service(offers, orders).resolve(order.order_id, v1.order_version_id)
+    view = _buffet_service(orders, offer_service._commercial_snapshots).resolve(
+        order.order_id, v1.order_version_id
+    )
     html = render_buffet_cards(
         view.projection,
         view.cards,
@@ -316,7 +319,7 @@ def test_buffet_cards_from_conversion_link() -> None:
         acceptance_id,
     )
 
-    view = _buffet_service(offers, orders, offer_service._commercial_snapshots).resolve(
+    view = _buffet_service(orders, offer_service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -346,7 +349,7 @@ def test_buffet_cards_three_positions_from_offer_snapshot() -> None:
         updated.acceptance_evidence.acceptance_id,
     )
 
-    view = _buffet_service(offers, orders, service._commercial_snapshots).resolve(
+    view = _buffet_service(orders, service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -356,20 +359,25 @@ def test_buffet_cards_three_positions_from_offer_snapshot() -> None:
     assert names == {"Fingerfood Paket", "Kartoffelsalat", "Obstsalat"}
 
 
-def test_buffet_cards_without_offer_integration() -> None:
-    inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
+def test_buffet_cards_fail_when_commercial_snapshot_missing() -> None:
+    from catering_system.domain.order_commercial_snapshot import (
+        MissingCommercialSnapshotError,
+    )
+    from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+        InMemoryOrderCommercialSnapshotRepository,
+    )
+
+    inquiries, orders, _offers, _service = _world(inquiry=_sample_inquiry())
     OrderService(orders)
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
     order, version = seed_order(orders, inquiry)
 
-    view = _buffet_service(offers, orders).resolve(
-        order.order_id,
-        version.order_version_id,
-    )
-
-    assert view.cards == ()
-    assert "Kein Menü hinterlegt" in render_buffet_cards(view.projection, view.cards)
+    with pytest.raises(MissingCommercialSnapshotError):
+        _buffet_service(orders, InMemoryOrderCommercialSnapshotRepository()).resolve(
+            order.order_id,
+            version.order_version_id,
+        )
 
 
 def _record_args() -> dict[str, object]:

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.order_seed import seed_order
 
 import json
@@ -22,6 +23,9 @@ from catering_system.repositories.sqlite_inquiry_repository import (
 )
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
+)
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
@@ -82,6 +86,10 @@ def _seed(db_path: Path) -> dict[str, str]:
 
     printed_src = make_inquiry(location_text="Bremen")
     order_printed, v1 = seed_order(orders, printed_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_printed.order_id,
+    )
     core.confirm_kitchen_print(order_printed.order_id, v1.order_version_id)
     core.make_order_version_effective(order_printed.order_id, v1.order_version_id)
     ids["inquiry_printed"] = printed_src.inquiry_id
@@ -90,12 +98,20 @@ def _seed(db_path: Path) -> dict[str, str]:
 
     unprinted_src = make_inquiry(location_text="Lübeck")
     order_unprinted, v1u = seed_order(orders, unprinted_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_unprinted.order_id,
+    )
     ids["order_unprinted"] = order_unprinted.order_id
     ids["version_unprinted"] = v1u.order_version_id
     ids["inquiry_unprinted"] = unprinted_src.inquiry_id
 
     cancelled_src = make_inquiry(location_text="Flensburg")
     order_cancelled, v1c = seed_order(orders, cancelled_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_cancelled.order_id,
+    )
     core.cancel_order(order_cancelled.order_id)
     ids["order_cancelled"] = order_cancelled.order_id
     ids["version_cancelled"] = v1c.order_version_id
@@ -831,7 +847,8 @@ def test_order_detail_and_print_data(api) -> None:
     )
     assert status == 200
     assert set(body) == {"order", "version", "projection"}
-    assert body["projection"]["commercial"]["source"] == "none"
+    assert body["projection"]["commercial"]["source"] == "offer_conversion"
+    assert body["projection"]["commercial"]["positions"]
 
     status, body, _h = _get(
         f"{base}/office/v1/orders/{ids['order_ready']}/buffet-cards-data"
@@ -839,7 +856,7 @@ def test_order_detail_and_print_data(api) -> None:
     )
     assert status == 200
     assert set(body) == {"projection", "cards", "effective_version_number"}
-    assert body["cards"] == []
+    assert len(body["cards"]) == 1
     assert body["effective_version_number"] == 1
 
     # unknown and unowned are the same 404 (no distinction leaked)
@@ -875,7 +892,7 @@ def test_payment_reminder_read_write_replay_and_stale_gate(api) -> None:
         "invoice_created": True,
         "invoice_number": "RE-2026-0048",
         "sent_on": "2026-07-15",
-        "due_on": "2026-07-22",
+        "due_on": (date.today() + timedelta(days=7)).isoformat(),
         "paid_on": None,
         "cash_received": False,
     }
@@ -3530,7 +3547,7 @@ def test_confirmation_document_snapshot_isolated_by_order(api) -> None:
 
 
 def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
-    base, ids, _db = api
+    base, ids, db = api
     order_id, order_version_id = _make_effective_offer_order(api)
 
     status, body, _h = _post(
@@ -3563,10 +3580,34 @@ def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
     )
     assert (status, body["error"]) == (422, "pending_order_version_change")
 
+    # Order without commercial snapshot: confirmation is blocked (invariant).
+    inquiries = SQLiteInquiryRepository(db)
+    orders = SQLiteOrderRepository(db)
+    core = OperationalCoreService(orders)
+    inquiry = InquiryService(inquiries).create_inquiry(
+        event_date=date(2026, 10, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Ohne Snapshot",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="kunde@example.com",
+        contact_phone="+49301234567",
+    )
+    order, version = seed_order(orders, inquiry)
+    core.confirm_kitchen_print(order.order_id, version.order_version_id)
+    core.make_order_version_effective(order.order_id, version.order_version_id)
+    inquiries.close()
+    orders.close()
+
     status, body, _h = _post(
-        _confirmation_document_url(base, ids["order_ready"]),
+        _confirmation_document_url(base, order.order_id),
         args={"created_by": "office-api-test"},
-        expect={"current_effective_order_version_id": ids["version_ready"]},
+        expect={"current_effective_order_version_id": version.order_version_id},
     )
     assert (status, body["error"]) == (422, "confirmation_document_blocked")
 

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.order_seed import seed_order
 
 import base64
@@ -12,7 +13,7 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import date
+from datetime import date, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -20,6 +21,9 @@ import pytest
 from catering_system.intake.website_form_adapter import intake_from_website_form
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
@@ -39,21 +43,34 @@ from catering_system.ui.office_panel_views import _page
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
 _CSRF_TOKEN = csrf_token_for_password(_PASSWORD)
-_PANEL_REPOS: dict[str, tuple[InMemoryInquiryRepository, InMemoryOrderRepository]] = {}
+_PANEL_REPOS: dict[
+    str,
+    tuple[
+        InMemoryInquiryRepository,
+        InMemoryOrderRepository,
+        InMemoryOrderCommercialSnapshotRepository,
+    ],
+] = {}
 
 
 @pytest.fixture()
 def panel():
     inquiry_repo = InMemoryInquiryRepository()
     order_repo = InMemoryOrderRepository()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
     server = create_office_panel_server(
-        inquiry_repo, order_repo, _PASSWORD, host="127.0.0.1", port=0
+        inquiry_repo,
+        order_repo,
+        _PASSWORD,
+        host="127.0.0.1",
+        port=0,
+        commercial_snapshot_repo=snapshots,
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
     base = f"http://{host}:{port}"
-    _PANEL_REPOS[base] = (inquiry_repo, order_repo)
+    _PANEL_REPOS[base] = (inquiry_repo, order_repo, snapshots)
     yield base
     _PANEL_REPOS.pop(base, None)
     server.shutdown()
@@ -64,19 +81,21 @@ def panel():
 def premium_panel():
     inquiry_repo = InMemoryInquiryRepository()
     order_repo = InMemoryOrderRepository()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
     server = create_office_panel_server(
         inquiry_repo,
         order_repo,
         _PASSWORD,
         host="127.0.0.1",
         port=0,
+        commercial_snapshot_repo=snapshots,
         ui_version="v2",
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address[:2]
     base = f"http://{host}:{port}"
-    _PANEL_REPOS[base] = (inquiry_repo, order_repo)
+    _PANEL_REPOS[base] = (inquiry_repo, order_repo, snapshots)
     yield base
     _PANEL_REPOS.pop(base, None)
     server.shutdown()
@@ -133,10 +152,11 @@ def _convert(base: str, inquiry_id: str) -> str:
     """Seed an Order for panel tests (no production Inquiry→Order create)."""
     from dataclasses import replace
 
-    inquiries, orders = _PANEL_REPOS[base]
+    inquiries, orders, snapshots = _PANEL_REPOS[base]
     inquiry = inquiries.get_by_id(inquiry_id)
     assert inquiry is not None
     order, _version = seed_order(orders, inquiry)
+    seed_commercial_snapshot(snapshots, order.order_id)
     inquiries.update(
         replace(inquiry, crm_stage="Bestätigt / Auftrag")  # type: ignore[arg-type]
     )
@@ -449,7 +469,7 @@ def test_order_payment_reminder_is_separate_and_truthful(panel: str) -> None:
             "invoice_created": "1",
             "invoice_number": "RE-2026-0048",
             "sent_on": "2026-07-15",
-            "due_on": "2026-07-22",
+            "due_on": (office_api_views.berlin_today() + timedelta(days=7)).isoformat(),
         },
     )
     assert status == 200

--- a/tests/unit/test_office_panel_confirmation_document.py
+++ b/tests/unit/test_office_panel_confirmation_document.py
@@ -30,6 +30,9 @@ from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
 from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.sqlite_order_confirmation_document_repository import (
     SQLiteOrderConfirmationDocumentRepository,
 )
@@ -115,6 +118,9 @@ def _start_panel_server(
             confirmation_document_repo=confirmation_document_repo,
             offer_repo=offer_repo,
             catalog_repo=catalog_repo,
+            commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+                connection
+            ),
             ui_version=ui_version,
         )
         ready.put(server)
@@ -144,10 +150,13 @@ def _sqlite_world(
     orders = SQLiteOrderRepository.from_connection(connection)
     offers = SQLiteOfferRepository.from_connection(connection)
     documents = SQLiteOrderConfirmationDocumentRepository.from_connection(connection)
+    commercial_snapshots = SQLiteOrderCommercialSnapshotRepository.from_connection(
+        connection
+    )
 
     inquiry = replace(_sample_inquiry(), intake_message=intake_message)
     inquiries.save(inquiry)
-    offer_service = OfferService(offers, inquiries, orders)
+    offer_service = OfferService(offers, inquiries, orders, commercial_snapshots)
     offer = offer_service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
     version_id = offer.versions[0].offer_version_id
     offer_service.record_sent_evidence(offer.offer_id, version_id, **_record_args())
@@ -170,10 +179,9 @@ def _sqlite_world(
     core.make_order_version_effective(order.order_id, order_version.order_version_id)
     doc_service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
-        offer_service._commercial_snapshots,
+        commercial_snapshots,
         now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
     return db, doc_service, core, orders, order.order_id, order_version.order_version_id
@@ -243,6 +251,9 @@ def test_legacy_order_detail_before_snapshot_shows_prepare_action(
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="legacy",
     )
     eligibility = doc_service.eligibility(order_id)
@@ -277,6 +288,9 @@ def test_legacy_order_detail_after_snapshot_shows_created_facts(
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="legacy",
     )
     page = panel.render_order(order_id)
@@ -379,6 +393,9 @@ def test_missing_email_shows_state_and_allows_preview(tmp_path: Path) -> None:
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="legacy",
     )
     before = panel.render_order(order_id)
@@ -432,6 +449,9 @@ def test_pending_candidate_shows_blocked_state_without_prepare(tmp_path: Path) -
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="legacy",
     )
     page = panel.render_order(order_id)
@@ -457,6 +477,9 @@ def test_legacy_and_v2_share_confirmation_projection(tmp_path: Path) -> None:
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="legacy",
     )
     v2 = OfficePanel(
@@ -466,6 +489,9 @@ def test_legacy_and_v2_share_confirmation_projection(tmp_path: Path) -> None:
             connection
         ),
         offer_repo=SQLiteOfferRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
         ui_version="v2",
     )
     legacy_page = legacy.render_order(order_id)
@@ -525,7 +551,6 @@ def test_confirmation_card_escapes_hostile_user_data() -> None:
     documents = InMemoryOrderConfirmationDocumentRepository()
     doc_service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
         offer_service._commercial_snapshots,

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -8,6 +8,7 @@ never opening core.db in remote mode, and half-config startup rejection.
 
 from __future__ import annotations
 
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.order_seed import seed_order
 
 import base64
@@ -39,6 +40,9 @@ from catering_system.repositories.sqlite_catalog_repository import (
 )
 from catering_system.domain.catalog import CatalogDish
 from datetime import UTC, datetime
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
@@ -111,6 +115,10 @@ def _seed(db_path: Path) -> dict[str, str]:
 
     printed_src = make_inquiry(location_text="Bremen")
     order_printed, v1 = seed_order(orders, printed_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_printed.order_id,
+    )
     core.confirm_kitchen_print(order_printed.order_id, v1.order_version_id)
     core.make_order_version_effective(order_printed.order_id, v1.order_version_id)
     ids["order_ready"] = order_printed.order_id
@@ -118,11 +126,19 @@ def _seed(db_path: Path) -> dict[str, str]:
 
     unprinted_src = make_inquiry(location_text="Lübeck")
     order_unprinted, v1u = seed_order(orders, unprinted_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_unprinted.order_id,
+    )
     ids["order_unprinted"] = order_unprinted.order_id
     ids["version_unprinted"] = v1u.order_version_id
 
     cancelled_src = make_inquiry(location_text="Flensburg")
     order_cancelled, _v1c = seed_order(orders, cancelled_src)
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db_path),
+        order_cancelled.order_id,
+    )
     core.cancel_order(order_cancelled.order_id)
     ids["order_cancelled"] = order_cancelled.order_id
     ids["inquiry_cancelled_order"] = cancelled_src.inquiry_id
@@ -195,6 +211,7 @@ def _start_direct_panel(
             port=0,
             offer_repo=SQLiteOfferRepository(db),
             catalog_repo=SQLiteCatalogRepository(db),
+            commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository(db),
             ui_version=ui_version,
         )
     )

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -11,6 +11,9 @@ from pathlib import Path
 
 import pytest
 
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+)
 from catering_system.domain.offer import OfferPosition
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
@@ -703,11 +706,15 @@ def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
 def test_confirmation_fails_when_commercial_snapshot_missing() -> None:
     services = _services()
     order, version = _effective_order(services)
-    orders, _offers, inquiries, documents, _service, _core, offer_service = services
+    orders, offers, inquiries, documents, _service, _core, offer_service = services
     snapshots = offer_service._commercial_snapshots
-    assert snapshots.get_by_order_id(order.order_id) is not None
+    commercial = snapshots.get_by_order_id(order.order_id)
+    assert commercial is not None
+    assert offers.get(commercial.source_offer_id) is not None
     snapshots._by_id.clear()
     snapshots._by_order_id.clear()
+    # Offer remains available — must not hide the invariant violation.
+    assert offers.get(commercial.source_offer_id) is not None
     service = OrderConfirmationDocumentService(
         orders,
         inquiries,
@@ -715,7 +722,7 @@ def test_confirmation_fails_when_commercial_snapshot_missing() -> None:
         snapshots,
         now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    with pytest.raises(OrderConfirmationDocumentBlockedError, match="nicht_verfuegbar"):
+    with pytest.raises(MissingCommercialSnapshotError):
         service.prepare_snapshot(
             order.order_id,
             version.order_version_id,

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -95,7 +95,6 @@ def _services() -> tuple[
     documents = InMemoryOrderConfirmationDocumentRepository()
     service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
         offer_service._commercial_snapshots,
@@ -183,7 +182,6 @@ def test_kitchen_print_not_confirmed_blocked() -> None:
     )
     service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         InMemoryOrderConfirmationDocumentRepository(),
         offer_service._commercial_snapshots,
@@ -376,7 +374,6 @@ def test_recipient_snapshot_and_missing_email() -> None:
     core.make_order_version_effective(order.order_id, order_version.order_version_id)
     service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         InMemoryOrderConfirmationDocumentRepository(),
         offer_service._commercial_snapshots,
@@ -646,20 +643,9 @@ def test_office_panel_confirmation_block_renders() -> None:
 def test_confirmation_uses_snapshot_when_offer_repository_unavailable() -> None:
     services = _services()
     order, version = _effective_order(services)
-    orders, _offers, inquiries, documents, _service, _core, offer_service = services
+    orders, offers, _inquiries, _documents, service, _core, offer_service = services
+    offers._offers.clear()
 
-    class _UnavailableOfferRepository:
-        def get_by_source_inquiry_id(self, inquiry_id: str):  # noqa: ANN201
-            raise RuntimeError("offer repository unavailable")
-
-    service = OrderConfirmationDocumentService(
-        orders,
-        _UnavailableOfferRepository(),  # type: ignore[arg-type]
-        inquiries,
-        documents,
-        offer_service._commercial_snapshots,
-        now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
-    )
     snapshot = service.prepare_snapshot(
         order.order_id,
         version.order_version_id,
@@ -668,12 +654,9 @@ def test_confirmation_uses_snapshot_when_offer_repository_unavailable() -> None:
     assert snapshot.gross_total_cents == 24824
     assert snapshot.payment_method == "RECHNUNG"
     assert snapshot.positions[0].name == "Fingerfood Paket"
-    assert (
-        snapshot.offer_id
-        == offer_service._commercial_snapshots.get_by_order_id(
-            order.order_id
-        ).source_offer_id
-    )  # type: ignore[union-attr]
+    commercial = offer_service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert commercial is not None
+    assert snapshot.offer_id == commercial.source_offer_id
 
 
 def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
@@ -704,7 +687,6 @@ def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
     )
     service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
         offer_service._commercial_snapshots,
@@ -718,26 +700,24 @@ def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
     assert snapshot.positions[0].name == "Fingerfood Paket"
 
 
-def test_confirmation_legacy_offer_fallback_when_commercial_snapshot_missing() -> None:
+def test_confirmation_fails_when_commercial_snapshot_missing() -> None:
     services = _services()
     order, version = _effective_order(services)
-    orders, offers, inquiries, documents, _service, _core, offer_service = services
+    orders, _offers, inquiries, documents, _service, _core, offer_service = services
     snapshots = offer_service._commercial_snapshots
     assert snapshots.get_by_order_id(order.order_id) is not None
     snapshots._by_id.clear()
     snapshots._by_order_id.clear()
     service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
         snapshots,
         now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    snapshot = service.prepare_snapshot(
-        order.order_id,
-        version.order_version_id,
-        "office-panel",
-    )
-    assert snapshot.positions[0].name == "Fingerfood Paket"
-    assert snapshot.gross_total_cents == 24824
+    with pytest.raises(OrderConfirmationDocumentBlockedError, match="nicht_verfuegbar"):
+        service.prepare_snapshot(
+            order.order_id,
+            version.order_version_id,
+            "office-panel",
+        )

--- a/tests/unit/test_order_confirmation_outbound.py
+++ b/tests/unit/test_order_confirmation_outbound.py
@@ -95,7 +95,6 @@ def _world() -> tuple[
     outbound = InMemoryOrderConfirmationOutboundRepository()
     doc_service = OrderConfirmationDocumentService(
         orders,
-        offers,
         inquiries,
         documents,
         offer_service._commercial_snapshots,

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -603,7 +603,7 @@ def test_print_fails_when_commercial_snapshot_missing_after_convert() -> None:
         version_id,
         variant_id,
         acceptance_id,
-        _offers,
+        offers,
         orders,
         _inq,
         offer_service,
@@ -616,8 +616,11 @@ def test_print_fails_when_commercial_snapshot_missing_after_convert() -> None:
     )
     snapshots = offer_service._commercial_snapshots
     assert snapshots.get_by_order_id(order.order_id) is not None
+    assert offers.get(offer.offer_id) is not None
     snapshots._by_id.clear()
     snapshots._by_order_id.clear()
+    # OfferRepository still has the Offer — must not hide missing Snapshot.
+    assert offers.get(offer.offer_id) is not None
 
     with pytest.raises(MissingCommercialSnapshotError):
         _projection_service(orders, snapshots).resolve(
@@ -626,7 +629,9 @@ def test_print_fails_when_commercial_snapshot_missing_after_convert() -> None:
         )
 
 
-def test_print_and_confirmation_services_must_not_depend_on_offer_repository() -> None:
+def test_print_and_confirmation_services_must_not_depend_on_offer_or_conversion_link() -> (
+    None
+):
     from pathlib import Path
 
     root = Path(__file__).resolve().parents[2] / "src" / "catering_system" / "services"
@@ -636,3 +641,4 @@ def test_print_and_confirmation_services_must_not_depend_on_offer_repository() -
     ):
         text = (root / name).read_text(encoding="utf-8")
         assert "OfferRepository" not in text, name
+        assert "conversion_link" not in text, name

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -8,15 +8,15 @@ from datetime import date
 
 import pytest
 
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+)
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjectionService,
     PrintFinalRequiresEffectiveError,
     PrintProjectionNotFoundError,
 )
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.repositories.in_memory_offer_repository import (
-    InMemoryOfferRepository,
-)
 from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
     InMemoryOrderCommercialSnapshotRepository,
 )
@@ -34,11 +34,10 @@ from tests.unit.test_offer_service import (
 
 
 def _projection_service(
-    offers,
     orders,
-    snapshots: InMemoryOrderCommercialSnapshotRepository | None = None,
+    snapshots: InMemoryOrderCommercialSnapshotRepository,
 ) -> OrderPrintProjectionService:
-    return OrderPrintProjectionService(orders, offers, snapshots)
+    return OrderPrintProjectionService(orders, snapshots)
 
 
 def test_order_with_offer_conversion_has_menu_positions() -> None:
@@ -53,9 +52,7 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
     )
     assert converted.conversion_link is not None
 
-    projection = _projection_service(
-        offers, orders, service._commercial_snapshots
-    ).resolve(
+    projection = _projection_service(orders, service._commercial_snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -73,23 +70,19 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
     assert "Menge: 80 Stück" in sheet
 
 
-def test_order_without_offer_has_empty_menu() -> None:
-    inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
+def test_print_fails_when_commercial_snapshot_missing_for_seeded_order() -> None:
+    inquiries, orders, _offers, _service = _world(inquiry=_sample_inquiry())
     OrderService(orders)
     inquiry = inquiries.get_by_id(_INQUIRY_ID)
     assert inquiry is not None
     order, version = seed_order(orders, inquiry)
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
 
-    projection = _projection_service(offers, orders).resolve(
-        order.order_id,
-        version.order_version_id,
-    )
-
-    assert projection.commercial.source == "none"
-    assert projection.commercial.positions == ()
-
-    sheet = render_print_sheet(projection)
-    assert "Kein Menü hinterlegt" in sheet
+    with pytest.raises(MissingCommercialSnapshotError):
+        _projection_service(orders, snapshots).resolve(
+            order.order_id,
+            version.order_version_id,
+        )
 
 
 def test_new_order_version_uses_version_facts_and_accepted_offer_menu() -> None:
@@ -119,7 +112,9 @@ def test_new_order_version_uses_version_facts_and_accepted_offer_menu() -> None:
         planning_mode="caterer_suggestion",
     )
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        orders, offer_service._commercial_snapshots
+    ).resolve(
         order.order_id,
         v2.order_version_id,
     )
@@ -159,7 +154,7 @@ def test_preview_watermark_candidate_entwurf_effective_clear() -> None:
         order.order_id, order_version.order_version_id
     )
 
-    service = _projection_service(offers, orders)
+    service = _projection_service(orders, offer_service._commercial_snapshots)
     candidate_projection = service.resolve(
         order.order_id,
         order_version.order_version_id,
@@ -221,7 +216,7 @@ def test_candidate_change_preview_contains_reason_diff_and_frozen_offer_menu() -
         actor_reference="office-panel",
         change_reason="Beginn verschoben",
     )
-    service = _projection_service(offers, orders)
+    service = _projection_service(orders, offer_service._commercial_snapshots)
     effective = service.resolve(order.order_id, v1.order_version_id)
     candidate = service.resolve(order.order_id, v2.order_version_id)
 
@@ -266,7 +261,9 @@ def test_stale_stand_shows_veraltet_watermark() -> None:
     core.confirm_kitchen_print(order.order_id, v2.order_version_id)
     core.make_order_version_effective(order.order_id, v2.order_version_id)
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        orders, offer_service._commercial_snapshots
+    ).resolve(
         order.order_id,
         v1.order_version_id,
         intent="preview",
@@ -292,7 +289,7 @@ def test_final_intent_requires_effective_version() -> None:
         variant_id,
         acceptance_id,
     )
-    service = _projection_service(offers, orders)
+    service = _projection_service(orders, offer_service._commercial_snapshots)
     with pytest.raises(PrintFinalRequiresEffectiveError):
         service.resolve(
             order.order_id,
@@ -320,7 +317,9 @@ def test_cancelled_order_shows_storniert_banner_but_remains_readable() -> None:
     )
     OperationalCoreService(orders).cancel_order(order.order_id)
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        orders, offer_service._commercial_snapshots
+    ).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -383,9 +382,9 @@ def test_format_quantity_display_per_person_with_guest_count() -> None:
 
 
 def test_resolve_unknown_order_raises_not_found() -> None:
-    offers = InMemoryOfferRepository()
     orders = InMemoryOrderRepository()
-    service = _projection_service(offers, orders)
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
+    service = _projection_service(orders, snapshots)
     with pytest.raises(PrintProjectionNotFoundError):
         service.resolve(
             "00000000-0000-4000-8000-000000000000",
@@ -433,29 +432,12 @@ def test_resolve_foreign_version_raises_not_found() -> None:
         variant_id,
         acceptance_id,
     )
-    service = _projection_service(offers, orders)
+    service = _projection_service(orders, offer_service._commercial_snapshots)
     with pytest.raises(PrintProjectionNotFoundError):
         service.resolve(order.order_id, "00000000-0000-4000-8000-000000000099")
 
 
-def test_commercial_block_is_none_without_conversion_link() -> None:
-    offers = InMemoryOfferRepository()
-    orders = InMemoryOrderRepository()
-    inquiry = _sample_inquiry()
-    from catering_system.repositories.in_memory_inquiry_repository import (
-        InMemoryInquiryRepository,
-    )
-
-    inquiries = InMemoryInquiryRepository()
-    inquiries.save(inquiry)
-    order, version = seed_order(orders, inquiry)
-    projection = _projection_service(offers, orders).resolve(
-        order.order_id, version.order_version_id
-    )
-    assert projection.commercial.source == "none"
-
-
-def test_commercial_none_when_conversion_link_targets_other_order() -> None:
+def test_preview_entwurf_when_effective_version_record_is_missing() -> None:
     from dataclasses import replace
 
     (
@@ -463,57 +445,17 @@ def test_commercial_none_when_conversion_link_targets_other_order() -> None:
         version_id,
         variant_id,
         acceptance_id,
-        offers,
+        _offers,
         orders,
         _inq,
         offer_service,
     ) = _accepted_offer_state()
-    _converted, order, order_version = offer_service.convert_accepted_offer(
+    _converted, order, version = offer_service.convert_accepted_offer(
         offer.offer_id,
         version_id,
         variant_id,
         acceptance_id,
     )
-    stored = offers.get(offer.offer_id)
-    assert stored is not None and stored.conversion_link is not None
-    bad_link = replace(
-        stored.conversion_link,
-        order_id="00000000-0000-4000-8000-000000000099",
-    )
-    offers._offers[offer.offer_id] = replace(stored, conversion_link=bad_link)
-
-    projection = _projection_service(offers, orders).resolve(
-        order.order_id,
-        order_version.order_version_id,
-    )
-    assert projection.commercial.source == "none"
-
-
-def test_commercial_none_when_accepted_variant_lookup_fails() -> None:
-    from catering_system.services.order_print_projection_service import (
-        _accepted_variant,
-    )
-
-    offer, version_id, variant_id, _acceptance_id, _offers, _orders, _inq, _service = (
-        _accepted_offer_state()
-    )
-    assert (
-        _accepted_variant(offer, "00000000-0000-4000-8000-000000000077", variant_id)
-        is None
-    )
-    assert (
-        _accepted_variant(offer, version_id, "00000000-0000-4000-8000-000000000088")
-        is None
-    )
-
-
-def test_preview_entwurf_when_effective_version_record_is_missing() -> None:
-    from dataclasses import replace
-
-    inquiries, orders, offers, _service = _world(inquiry=_sample_inquiry())
-    inquiry = inquiries.get_by_id(_INQUIRY_ID)
-    assert inquiry is not None
-    order, version = seed_order(orders, inquiry)
     broken = replace(
         order,
         effective_order_version_id="00000000-0000-4000-8000-000000000077",
@@ -521,7 +463,9 @@ def test_preview_entwurf_when_effective_version_record_is_missing() -> None:
     )
     orders._orders[order.order_id] = broken
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        orders, offer_service._commercial_snapshots
+    ).resolve(
         order.order_id,
         version.order_version_id,
         intent="preview",
@@ -559,7 +503,9 @@ def test_preview_entwurf_for_non_effective_version_without_candidate_parent() ->
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
 
-    projection = _projection_service(offers, orders).resolve(
+    projection = _projection_service(
+        orders, offer_service._commercial_snapshots
+    ).resolve(
         order.order_id,
         v2.order_version_id,
         intent="preview",
@@ -567,7 +513,7 @@ def test_preview_entwurf_for_non_effective_version_without_candidate_parent() ->
     assert projection.flags.watermark == "ENTWURF"
 
 
-def test_commercial_none_when_variant_resolution_returns_none(monkeypatch) -> None:
+def test_print_uses_snapshot_when_offer_repository_unavailable() -> None:
     (
         offer,
         version_id,
@@ -584,45 +530,13 @@ def test_commercial_none_when_variant_resolution_returns_none(monkeypatch) -> No
         variant_id,
         acceptance_id,
     )
-    import catering_system.services.order_print_projection_service as mod
-
-    monkeypatch.setattr(mod, "_accepted_variant", lambda *_args, **_kwargs: None)
-    projection = _projection_service(offers, orders).resolve(
-        order.order_id,
-        order_version.order_version_id,
-    )
-    assert projection.commercial.source == "none"
-
-
-def test_print_uses_snapshot_when_offer_repository_unavailable() -> None:
-    (
-        offer,
-        version_id,
-        variant_id,
-        acceptance_id,
-        _offers,
-        orders,
-        _inq,
-        offer_service,
-    ) = _accepted_offer_state()
-    _converted, order, order_version = offer_service.convert_accepted_offer(
-        offer.offer_id,
-        version_id,
-        variant_id,
-        acceptance_id,
-    )
     snapshots = offer_service._commercial_snapshots
     assert snapshots.get_by_order_id(order.order_id) is not None
+    offers._offers.clear()
 
-    class _UnavailableOfferRepository:
-        def get_by_source_inquiry_id(self, inquiry_id: str):  # noqa: ANN201
-            raise RuntimeError("offer repository unavailable")
-
-    projection = OrderPrintProjectionService(
-        orders,
-        _UnavailableOfferRepository(),  # type: ignore[arg-type]
-        snapshots,
-    ).resolve(order.order_id, order_version.order_version_id)
+    projection = _projection_service(orders, snapshots).resolve(
+        order.order_id, order_version.order_version_id
+    )
 
     assert projection.commercial.source == "offer_conversion"
     assert projection.commercial.positions[0].name == "Fingerfood Paket"
@@ -675,7 +589,7 @@ def test_print_snapshot_immune_to_later_offer_mutation() -> None:
     )
     offers._offers[stored.offer_id] = mutated
 
-    projection = _projection_service(offers, orders, snapshots).resolve(
+    projection = _projection_service(orders, snapshots).resolve(
         order.order_id,
         order_version.order_version_id,
     )
@@ -683,13 +597,13 @@ def test_print_snapshot_immune_to_later_offer_mutation() -> None:
     assert "MUTATED LIVE OFFER" not in render_print_sheet(projection)
 
 
-def test_print_legacy_offer_fallback_when_snapshot_missing() -> None:
+def test_print_fails_when_commercial_snapshot_missing_after_convert() -> None:
     (
         offer,
         version_id,
         variant_id,
         acceptance_id,
-        offers,
+        _offers,
         orders,
         _inq,
         offer_service,
@@ -705,10 +619,20 @@ def test_print_legacy_offer_fallback_when_snapshot_missing() -> None:
     snapshots._by_id.clear()
     snapshots._by_order_id.clear()
 
-    projection = _projection_service(offers, orders, snapshots).resolve(
-        order.order_id,
-        order_version.order_version_id,
-    )
-    assert projection.commercial.source == "offer_conversion"
-    assert projection.commercial.positions[0].name == "Fingerfood Paket"
-    assert "Fingerfood Paket" in render_print_sheet(projection)
+    with pytest.raises(MissingCommercialSnapshotError):
+        _projection_service(orders, snapshots).resolve(
+            order.order_id,
+            order_version.order_version_id,
+        )
+
+
+def test_print_and_confirmation_services_must_not_depend_on_offer_repository() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system" / "services"
+    for name in (
+        "order_print_projection_service.py",
+        "order_confirmation_document_service.py",
+    ):
+        text = (root / name).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, name


### PR DESCRIPTION
## Summary
- Remove legacy Offer fallback from print and confirmation; both read `OrderCommercialSnapshot` only.
- Missing snapshot is an explicit invariant failure: `MissingCommercialSnapshotError` (not `ValueError`).
- Architecture boundary: `OfferRepository` and `conversion_link` absent from print and confirmation services (grep = 0).
- Depends on #16 (BOUNDARY_V1-C). After merge: `ORDER_COMMERCIAL_SNAPSHOT_BOUNDARY_V1 = COMPLETE`.

## Legacy data check
Query:

```sql
SELECT COUNT(*)
FROM orders o
LEFT JOIN order_commercial_snapshots s
  ON s.order_id = o.order_id
WHERE s.order_id IS NULL;
```

Result in this worktree (fresh migrated schema, no production `core.db` attached): **0** (orders=0, snapshots=0).

Policy if production count &gt; 0:
- do **not** block CLEANUP merge
- do **not** backfill here
- record the count in ops notes
- schedule separate `ORDER_COMMERCIAL_SNAPSHOT_BACKFILL_V1`

## Test plan
- [x] `ruff check` + `ruff format --check`
- [x] `mypy src/catering_system`
- [x] pytest + coverage ≥ 90%
- [x] grep `OfferRepository` in print/confirmation services → 0
- [x] grep `conversion_link` in print/confirmation services → 0
- [x] Snapshot exists + Offer unavailable → Print OK / Confirmation OK
- [x] Snapshot missing + Offer available → `MissingCommercialSnapshotError`