### PR TITLE
CUSTOMER_DOCUMENT_PROJECTION_FOUNDATION_V1: types + pure builder

### DIFF
--- a/src/catering_system/domain/customer_document_projection.py
+++ b/src/catering_system/domain/customer_document_projection.py
@@ -1,0 +1,226 @@
+"""Customer-facing document fact projection — CUSTOMER_DOCUMENT_PROJECTION_V1 PR-A.
+
+Frozen read-model separating document facts from persistence, eligibility,
+and rendering. Commercial money/menu come from OrderCommercialSnapshot;
+customer/address facts come from Inquiry customer data — never from Offer
+or intake_message re-parse in builders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal
+
+from catering_system.domain.inquiry import PlanningMode
+from catering_system.domain.order_payment_reminder import (
+    PaymentMethod,
+    validate_payment_method,
+)
+
+DocumentType = Literal["ORDER_CONFIRMATION"]
+DOCUMENT_TYPES: tuple[DocumentType, ...] = ("ORDER_CONFIRMATION",)
+
+CustomerDocumentWarning = Literal["DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE"]
+WARNING_DELIVERY_ADDRESS_DIFFERS: CustomerDocumentWarning = (
+    "DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE"
+)
+
+_MAX_TEXT = 20_000
+_MAX_LABEL = 500
+
+
+def _require_text(value: str, field: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field} is required")
+
+
+def _require_aware(value: datetime, field: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+
+
+def _require_non_negative_cents(value: int, field: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field} must be non-negative")
+
+
+def _optional_bounded_text(value: str | None, field: str, *, max_len: int) -> None:
+    if value is None:
+        return
+    _require_text(value, field)
+    if len(value) > max_len:
+        raise ValueError(f"{field} exceeds length limit")
+
+
+@dataclass(frozen=True)
+class CustomerAddress:
+    """Postal address fact for invoice or delivery on a customer document."""
+
+    street: str | None = None
+    postal_code: str | None = None
+    city: str | None = None
+    country: str | None = None
+
+    def __post_init__(self) -> None:
+        for field, value in (
+            ("street", self.street),
+            ("postal_code", self.postal_code),
+            ("city", self.city),
+            ("country", self.country),
+        ):
+            _optional_bounded_text(value, field, max_len=_MAX_LABEL)
+
+
+@dataclass(frozen=True)
+class CustomerDocumentRecipient:
+    """Customer/contact block for a document — includes dual address slots."""
+
+    name: str
+    email: str | None = None
+    invoice_address: CustomerAddress | None = None
+    delivery_address: CustomerAddress | None = None
+    delivery_address_differs: bool = False
+    warnings: tuple[CustomerDocumentWarning, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_text(self.name, "name")
+        _optional_bounded_text(self.email, "email", max_len=_MAX_LABEL)
+        expected_differs = (
+            self.invoice_address is not None
+            and self.delivery_address is not None
+            and self.invoice_address != self.delivery_address
+        )
+        if self.delivery_address_differs != expected_differs:
+            raise ValueError("delivery_address_differs does not match addresses")
+        if expected_differs:
+            if WARNING_DELIVERY_ADDRESS_DIFFERS not in self.warnings:
+                raise ValueError(
+                    "delivery address differs requires "
+                    f"{WARNING_DELIVERY_ADDRESS_DIFFERS}"
+                )
+        elif WARNING_DELIVERY_ADDRESS_DIFFERS in self.warnings:
+            raise ValueError(
+                f"{WARNING_DELIVERY_ADDRESS_DIFFERS} requires differing addresses"
+            )
+
+
+@dataclass(frozen=True)
+class CustomerDocumentCommercialReference:
+    """Provenance of the commercial state used for the document."""
+
+    snapshot_id: str
+    source_offer_id: str
+    source_offer_version_id: str
+    variant_label: str
+
+    def __post_init__(self) -> None:
+        _require_text(self.snapshot_id, "snapshot_id")
+        _require_text(self.source_offer_id, "source_offer_id")
+        _require_text(self.source_offer_version_id, "source_offer_version_id")
+        _require_text(self.variant_label, "variant_label")
+
+
+@dataclass(frozen=True)
+class CustomerDocumentEvent:
+    """Event facts from OrderVersion for the customer document."""
+
+    order_id: str
+    order_version_id: str
+    version_number: int
+    event_date: date
+    time_window_text: str
+    location_text: str
+    guest_count_estimate: int | None
+    planning_mode: PlanningMode
+
+    def __post_init__(self) -> None:
+        _require_text(self.order_id, "order_id")
+        _require_text(self.order_version_id, "order_version_id")
+        if self.version_number < 1:
+            raise ValueError("version_number must be >= 1")
+        _require_text(self.time_window_text, "time_window_text")
+        _require_text(self.location_text, "location_text")
+        if self.guest_count_estimate is not None and self.guest_count_estimate < 0:
+            raise ValueError("guest_count_estimate must be non-negative")
+
+
+@dataclass(frozen=True)
+class CustomerDocumentPosition:
+    """Customer-visible commercial line derived from OrderCommercialPosition."""
+
+    position_id: str
+    name: str
+    unit_net_cents: int
+    net_total_cents: int
+    vat_rate_percent: int
+    vat_amount_cents: int
+    gross_total_cents: int
+    description: str | None = None
+    composition: str | None = None
+    quantity: str | None = None
+    unit_label: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.position_id, "position_id")
+        _require_text(self.name, "name")
+        if self.vat_rate_percent not in (7, 19):
+            raise ValueError("vat_rate_percent must be 7 or 19")
+        for field, value in (
+            ("unit_net_cents", self.unit_net_cents),
+            ("net_total_cents", self.net_total_cents),
+            ("vat_amount_cents", self.vat_amount_cents),
+            ("gross_total_cents", self.gross_total_cents),
+        ):
+            _require_non_negative_cents(value, field)
+        _optional_bounded_text(self.description, "description", max_len=_MAX_TEXT)
+        _optional_bounded_text(self.composition, "composition", max_len=_MAX_TEXT)
+        _optional_bounded_text(self.quantity, "quantity", max_len=_MAX_LABEL)
+        _optional_bounded_text(self.unit_label, "unit_label", max_len=_MAX_LABEL)
+
+
+@dataclass(frozen=True)
+class CustomerDocumentProjection:
+    """Immutable customer-document fact bundle for later render/delivery."""
+
+    document_type: DocumentType
+    document_id: str
+    created_at: datetime
+    recipient: CustomerDocumentRecipient
+    commercial_reference: CustomerDocumentCommercialReference
+    event: CustomerDocumentEvent
+    positions: tuple[CustomerDocumentPosition, ...]
+    payment_method: PaymentMethod
+    payment_customer_visible_text: str
+    net_total_cents: int
+    vat_total_cents: int
+    gross_total_cents: int
+
+    def __post_init__(self) -> None:
+        if self.document_type not in DOCUMENT_TYPES:
+            raise ValueError("unsupported document_type")
+        _require_text(self.document_id, "document_id")
+        _require_aware(self.created_at, "created_at")
+        if not self.positions:
+            raise ValueError("positions must not be empty")
+        validate_payment_method(self.payment_method)
+        _require_text(
+            self.payment_customer_visible_text, "payment_customer_visible_text"
+        )
+        if len(self.payment_customer_visible_text) > _MAX_TEXT:
+            raise ValueError("payment_customer_visible_text exceeds length limit")
+        for field, value in (
+            ("net_total_cents", self.net_total_cents),
+            ("vat_total_cents", self.vat_total_cents),
+            ("gross_total_cents", self.gross_total_cents),
+        ):
+            _require_non_negative_cents(value, field)
+        expected_net = sum(p.net_total_cents for p in self.positions)
+        expected_vat = sum(p.vat_amount_cents for p in self.positions)
+        expected_gross = sum(p.gross_total_cents for p in self.positions)
+        if (
+            self.net_total_cents != expected_net
+            or self.vat_total_cents != expected_vat
+            or self.gross_total_cents != expected_gross
+        ):
+            raise ValueError("totals must equal sum of position money fields")

--- a/src/catering_system/services/customer_document_projection.py
+++ b/src/catering_system/services/customer_document_projection.py
@@ -1,0 +1,141 @@
+"""Pure builders for CustomerDocumentProjection — FOUNDATION_V1.
+
+No repositories. No Offer. No intake_message parsing. No HTML.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+    CustomerDocumentCommercialReference,
+    CustomerDocumentEvent,
+    CustomerDocumentPosition,
+    CustomerDocumentProjection,
+    CustomerDocumentRecipient,
+    CustomerDocumentWarning,
+    DocumentType,
+)
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.order import OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.services.order_print_projection_service import (
+    format_quantity_display,
+)
+
+
+def build_customer_document_recipient(
+    inquiry: Inquiry | None,
+    *,
+    invoice_address: CustomerAddress | None = None,
+    delivery_address: CustomerAddress | None = None,
+) -> CustomerDocumentRecipient:
+    """Map Inquiry.customer_snapshot (+ optional address facts) to recipient.
+
+    Address kwargs exist so tests and future Inquiry address slots can supply
+    invoice/delivery without reading Offer or commercial snapshot. V1 runtime
+    from Inquiry alone leaves both addresses as None.
+    """
+    snapshot = inquiry.customer_snapshot if inquiry is not None else None
+    name, email = _name_and_email(snapshot)
+    differs = (
+        invoice_address is not None
+        and delivery_address is not None
+        and invoice_address != delivery_address
+    )
+    warnings: tuple[CustomerDocumentWarning, ...] = (
+        (WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else ()
+    )
+    return CustomerDocumentRecipient(
+        name=name,
+        email=email,
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+        delivery_address_differs=differs,
+        warnings=warnings,
+    )
+
+
+def build_customer_document_projection(
+    *,
+    document_type: DocumentType,
+    document_id: str,
+    created_at: datetime,
+    order_version: OrderVersion,
+    commercial_snapshot: OrderCommercialSnapshot,
+    recipient: CustomerDocumentRecipient,
+) -> CustomerDocumentProjection:
+    """Assemble a frozen customer-document projection from value objects."""
+    if commercial_snapshot.order_id != order_version.order_id:
+        raise ValueError(
+            "commercial snapshot order_id does not match order version "
+            f"({commercial_snapshot.order_id!r} != {order_version.order_id!r})"
+        )
+    positions = tuple(
+        _map_position(position, order_version.guest_count_estimate)
+        for position in commercial_snapshot.positions
+    )
+    return CustomerDocumentProjection(
+        document_type=document_type,
+        document_id=document_id,
+        created_at=created_at,
+        recipient=recipient,
+        commercial_reference=CustomerDocumentCommercialReference(
+            snapshot_id=commercial_snapshot.snapshot_id,
+            source_offer_id=commercial_snapshot.source_offer_id,
+            source_offer_version_id=commercial_snapshot.source_offer_version_id,
+            variant_label=commercial_snapshot.variant_label,
+        ),
+        event=CustomerDocumentEvent(
+            order_id=order_version.order_id,
+            order_version_id=order_version.order_version_id,
+            version_number=order_version.version_number,
+            event_date=order_version.event_date,
+            time_window_text=order_version.time_window_text,
+            location_text=order_version.location_text,
+            guest_count_estimate=order_version.guest_count_estimate,
+            planning_mode=order_version.planning_mode,
+        ),
+        positions=positions,
+        payment_method=commercial_snapshot.payment_method,
+        payment_customer_visible_text=commercial_snapshot.payment_customer_visible_text,
+        net_total_cents=sum(p.net_total_cents for p in positions),
+        vat_total_cents=sum(p.vat_amount_cents for p in positions),
+        gross_total_cents=sum(p.gross_total_cents for p in positions),
+    )
+
+
+def _name_and_email(
+    snapshot: InquiryCustomerSnapshot | None,
+) -> tuple[str, str | None]:
+    if snapshot is None or snapshot.is_empty():
+        return "Kunde", None
+    name = (snapshot.contact_name or snapshot.company_name or "Kunde").strip()
+    if not name:
+        name = "Kunde"
+    return name, snapshot.email
+
+
+def _map_position(
+    position: OrderCommercialPosition,
+    guest_count_estimate: int | None,
+) -> CustomerDocumentPosition:
+    return CustomerDocumentPosition(
+        position_id=position.position_id,
+        name=position.name,
+        description=position.description,
+        composition=position.composition,
+        quantity=format_quantity_display(position, guest_count_estimate),
+        unit_label=position.unit_label,
+        unit_net_cents=position.unit_net_cents,
+        net_total_cents=position.net_total_cents,
+        vat_rate_percent=position.vat_rate_percent,
+        vat_amount_cents=position.vat_amount_cents,
+        gross_total_cents=position.gross_total_cents,
+    )

--- a/tests/unit/test_customer_document_projection.py
+++ b/tests/unit/test_customer_document_projection.py
@@ -1,0 +1,272 @@
+"""CUSTOMER_DOCUMENT_PROJECTION_FOUNDATION_V1 — pure projection builders."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+    CustomerDocumentRecipient,
+)
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.order import OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.services.customer_document_projection import (
+    build_customer_document_projection,
+    build_customer_document_recipient,
+)
+
+_ORDER_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_SNAPSHOT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_OFFER_VERSION_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _inquiry(*, snapshot: InquiryCustomerSnapshot | None) -> Inquiry:
+    return Inquiry(
+        inquiry_id="99999999-9999-4999-8999-999999999999",
+        event_date=date(2026, 8, 20),
+        inquiry_source="manual",
+        crm_stage="Bestätigt / Auftrag",
+        customer_linkage={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        customer_snapshot=snapshot,
+        intake_message="Firma: SHOULD-NOT-USE\nE-Mail: intake@example.invalid\n",
+    )
+
+
+def _order_version() -> OrderVersion:
+    return OrderVersion(
+        order_version_id=_VERSION_ID,
+        order_id=_ORDER_ID,
+        version_number=1,
+        created_at=_NOW,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+    )
+
+
+def _commercial_position() -> OrderCommercialPosition:
+    return OrderCommercialPosition(
+        position_id=_POSITION_ID,
+        kind="catalog",
+        name="Fingerfood Paket",
+        unit_net_cents=290,
+        net_total_cents=23200,
+        vat_rate_percent=7,
+        vat_amount_cents=1624,
+        gross_total_cents=24824,
+        description="Frozen description",
+        composition="Frozen composition",
+        quantity=Decimal("80"),
+        quantity_mode="total",
+        unit_label="Stück",
+    )
+
+
+def _commercial_snapshot() -> OrderCommercialSnapshot:
+    return OrderCommercialSnapshot(
+        snapshot_id=_SNAPSHOT_ID,
+        order_id=_ORDER_ID,
+        source_offer_id=_OFFER_ID,
+        source_offer_version_id=_OFFER_VERSION_ID,
+        source_variant_id="44444444-4444-4444-8444-444444444441",
+        acceptance_id="66666666-6666-4666-8666-666666666661",
+        accepted_at=_NOW,
+        recorded_by="office-panel",
+        variant_label="Variante A",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        created_at=_NOW,
+        positions=(_commercial_position(),),
+    )
+
+
+def _projection(
+    *,
+    recipient: CustomerDocumentRecipient | None = None,
+    commercial: OrderCommercialSnapshot | None = None,
+    version: OrderVersion | None = None,
+):
+    return build_customer_document_projection(
+        document_type="ORDER_CONFIRMATION",
+        document_id="doc-1",
+        created_at=_NOW,
+        order_version=version or _order_version(),
+        commercial_snapshot=commercial or _commercial_snapshot(),
+        recipient=recipient
+        or build_customer_document_recipient(
+            _inquiry(
+                snapshot=InquiryCustomerSnapshot(
+                    contact_name="Anna",
+                    email="anna@example.invalid",
+                )
+            )
+        ),
+    )
+
+
+def test_same_invoice_and_delivery_address_has_no_warning() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna")),
+        invoice_address=_INVOICE,
+        delivery_address=_INVOICE,
+    )
+    assert recipient.delivery_address_differs is False
+    assert recipient.warnings == ()
+    projection = _projection(recipient=recipient)
+    assert projection.recipient.warnings == ()
+
+
+def test_different_invoice_and_delivery_address_emits_warning() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna")),
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+    )
+    assert recipient.delivery_address_differs is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in recipient.warnings
+    projection = _projection(recipient=recipient)
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in projection.recipient.warnings
+
+
+def test_delivery_missing_has_no_warning() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna")),
+        invoice_address=_INVOICE,
+        delivery_address=None,
+    )
+    assert recipient.delivery_address_differs is False
+    assert recipient.warnings == ()
+
+
+def test_both_addresses_missing_still_builds_projection() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna")),
+    )
+    assert recipient.invoice_address is None
+    assert recipient.delivery_address is None
+    assert recipient.delivery_address_differs is False
+    assert recipient.warnings == ()
+    projection = _projection(recipient=recipient)
+    assert projection.document_type == "ORDER_CONFIRMATION"
+    assert projection.recipient.email is None or projection.recipient.name == "Anna"
+
+
+def test_commercial_reference_copied_from_snapshot() -> None:
+    snapshot = _commercial_snapshot()
+    projection = _projection(commercial=snapshot)
+    assert projection.commercial_reference.snapshot_id == snapshot.snapshot_id
+    assert projection.commercial_reference.source_offer_id == snapshot.source_offer_id
+    assert (
+        projection.commercial_reference.source_offer_version_id
+        == snapshot.source_offer_version_id
+    )
+    assert projection.commercial_reference.variant_label == "Variante A"
+    assert projection.payment_method == "RECHNUNG"
+    assert projection.net_total_cents == 23200
+    assert projection.vat_total_cents == 1624
+    assert projection.gross_total_cents == 24824
+    assert projection.positions[0].name == "Fingerfood Paket"
+    assert projection.positions[0].quantity == "80 Stück"
+
+
+def test_event_copied_from_order_version() -> None:
+    version = _order_version()
+    projection = _projection(version=version)
+    assert projection.event.order_id == version.order_id
+    assert projection.event.order_version_id == version.order_version_id
+    assert projection.event.event_date == version.event_date
+    assert projection.event.location_text == "Hamburg"
+    assert projection.event.guest_count_estimate == 80
+    assert projection.event.planning_mode == "caterer_suggestion"
+
+
+def test_recipient_uses_customer_snapshot_not_intake_message() -> None:
+    inquiry = _inquiry(
+        snapshot=InquiryCustomerSnapshot(
+            contact_name="Snapshot Name",
+            email="snapshot@example.invalid",
+        )
+    )
+    recipient = build_customer_document_recipient(inquiry)
+    assert recipient.name == "Snapshot Name"
+    assert recipient.email == "snapshot@example.invalid"
+    assert "SHOULD-NOT-USE" not in recipient.name
+    assert recipient.email != "intake@example.invalid"
+
+
+def test_recipient_without_customer_snapshot_still_builds() -> None:
+    recipient = build_customer_document_recipient(_inquiry(snapshot=None))
+    assert recipient.name == "Kunde"
+    assert recipient.email is None
+    projection = _projection(recipient=recipient)
+    assert projection.recipient.name == "Kunde"
+
+
+def test_order_id_mismatch_raises() -> None:
+    version = _order_version()
+    commercial = _commercial_snapshot()
+    from dataclasses import replace
+
+    bad = replace(commercial, order_id="00000000-0000-4000-8000-000000000099")
+    with pytest.raises(ValueError, match="order_id"):
+        build_customer_document_projection(
+            document_type="ORDER_CONFIRMATION",
+            document_id="doc-1",
+            created_at=_NOW,
+            order_version=version,
+            commercial_snapshot=bad,
+            recipient=build_customer_document_recipient(
+                _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna"))
+            ),
+        )
+
+
+def test_foundation_modules_must_not_depend_on_offer_repository() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
+    for relative in (
+        "domain/customer_document_projection.py",
+        "services/customer_document_projection.py",
+    ):
+        text = (root / relative).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, relative
+        assert "offer_repository" not in text, relative
+        assert "conversion_link" not in text, relative
+        assert "parse_intake_contact" not in text, relative
+        assert "labelled_intake_context" not in text, relative

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -875,7 +875,7 @@ def test_payment_reminder_read_write_replay_and_stale_gate(api) -> None:
         "invoice_created": True,
         "invoice_number": "RE-2026-0048",
         "sent_on": "2026-07-15",
-        "due_on": "2026-07-22",
+        "due_on": (date.today() + timedelta(days=7)).isoformat(),
         "paid_on": None,
         "cash_received": False,
     }

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -12,7 +12,7 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import date
+from datetime import date, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -449,7 +449,7 @@ def test_order_payment_reminder_is_separate_and_truthful(panel: str) -> None:
             "invoice_created": "1",
             "invoice_number": "RE-2026-0048",
             "sent_on": "2026-07-15",
-            "due_on": "2026-07-22",
+            "due_on": (office_api_views.berlin_today() + timedelta(days=7)).isoformat(),
         },
     )
     assert status == 200


### PR DESCRIPTION
## Summary
- Add `CustomerDocumentProjection` domain types including `CustomerAddress`, dual invoice/delivery slots, and `DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE` warning.
- Pure builders map `Inquiry.customer_snapshot` + `OrderVersion` + `OrderCommercialSnapshot` — no Offer, no intake re-parse, no confirmation changes.
- Address fields are None from current Inquiry data; synthetic `CustomerAddress` covers warning invariants in tests.

## Test plan
- [x] same invoice/delivery → no warning
- [x] different addresses → warning present
- [x] delivery missing → no warning
- [x] both missing → valid projection
- [x] commercial_reference copied from Snapshot
- [x] no OfferRepository / conversion_link / intake parsers in new modules
- [x] ruff + mypy + unit tests


Made with [Cursor](https://cursor.com)