### PR TITLE
Confirmation uses CustomerDocumentProjection (CDP PR-B)

### DIFF
--- a/src/catering_system/domain/customer_document_projection.py
+++ b/src/catering_system/domain/customer_document_projection.py
@@ -150,12 +150,14 @@ class CustomerDocumentPosition:
     """Customer-visible commercial line derived from OrderCommercialPosition."""
 
     position_id: str
+    kind: str
     name: str
     unit_net_cents: int
     net_total_cents: int
     vat_rate_percent: int
     vat_amount_cents: int
     gross_total_cents: int
+    related_position_id: str | None = None
     description: str | None = None
     composition: str | None = None
     quantity: str | None = None
@@ -163,6 +165,7 @@ class CustomerDocumentPosition:
 
     def __post_init__(self) -> None:
         _require_text(self.position_id, "position_id")
+        _require_text(self.kind, "kind")
         _require_text(self.name, "name")
         if self.vat_rate_percent not in (7, 19):
             raise ValueError("vat_rate_percent must be 7 or 19")
@@ -173,6 +176,9 @@ class CustomerDocumentPosition:
             ("gross_total_cents", self.gross_total_cents),
         ):
             _require_non_negative_cents(value, field)
+        _optional_bounded_text(
+            self.related_position_id, "related_position_id", max_len=_MAX_LABEL
+        )
         _optional_bounded_text(self.description, "description", max_len=_MAX_TEXT)
         _optional_bounded_text(self.composition, "composition", max_len=_MAX_TEXT)
         _optional_bounded_text(self.quantity, "quantity", max_len=_MAX_LABEL)

--- a/src/catering_system/domain/order_confirmation_document.py
+++ b/src/catering_system/domain/order_confirmation_document.py
@@ -67,6 +67,7 @@ class OrderConfirmationDocumentSnapshot:
     payment_customer_visible_text: str
     document_hash: str
     schema_version: int = SCHEMA_VERSION
+    document_warnings: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.schema_version != SCHEMA_VERSION:

--- a/src/catering_system/services/customer_document_projection.py
+++ b/src/catering_system/services/customer_document_projection.py
@@ -128,6 +128,7 @@ def _map_position(
 ) -> CustomerDocumentPosition:
     return CustomerDocumentPosition(
         position_id=position.position_id,
+        kind=position.kind,
         name=position.name,
         description=position.description,
         composition=position.composition,
@@ -138,4 +139,35 @@ def _map_position(
         vat_rate_percent=position.vat_rate_percent,
         vat_amount_cents=position.vat_amount_cents,
         gross_total_cents=position.gross_total_cents,
+        related_position_id=position.related_position_id,
     )
+
+
+class CustomerDocumentProjectionService:
+    """Factory over pure CDP builders for document consumers (Confirmation, …)."""
+
+    def build(
+        self,
+        *,
+        document_type: DocumentType,
+        document_id: str,
+        created_at: datetime,
+        order_version: OrderVersion,
+        commercial_snapshot: OrderCommercialSnapshot,
+        inquiry: Inquiry | None,
+        invoice_address: CustomerAddress | None = None,
+        delivery_address: CustomerAddress | None = None,
+    ) -> CustomerDocumentProjection:
+        recipient = build_customer_document_recipient(
+            inquiry,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+        )
+        return build_customer_document_projection(
+            document_type=document_type,
+            document_id=document_id,
+            created_at=created_at,
+            order_version=order_version,
+            commercial_snapshot=commercial_snapshot,
+            recipient=recipient,
+        )

--- a/src/catering_system/services/order_confirmation_document_hash.py
+++ b/src/catering_system/services/order_confirmation_document_hash.py
@@ -59,6 +59,7 @@ def snapshot_hash_payload(
         "gross_total_cents": snapshot.gross_total_cents,
         "payment_method": snapshot.payment_method,
         "payment_customer_visible_text": snapshot.payment_customer_visible_text,
+        "document_warnings": list(snapshot.document_warnings),
     }
 
 

--- a/src/catering_system/services/order_confirmation_document_serialization.py
+++ b/src/catering_system/services/order_confirmation_document_serialization.py
@@ -59,6 +59,7 @@ def snapshot_from_canonical_json(raw: str) -> OrderConfirmationDocumentSnapshot:
         payment_customer_visible_text=str(payload["payment_customer_visible_text"]),
         document_hash=str(payload["document_hash"]),
         schema_version=int(payload.get("schema_version", SCHEMA_VERSION)),
+        document_warnings=_document_warnings(payload.get("document_warnings")),
     )
 
 
@@ -115,6 +116,7 @@ def _snapshot_payload(snapshot: OrderConfirmationDocumentSnapshot) -> dict[str, 
         "payment_customer_visible_text": snapshot.payment_customer_visible_text,
         "document_hash": snapshot.document_hash,
         "schema_version": snapshot.schema_version,
+        "document_warnings": list(snapshot.document_warnings),
     }
 
 
@@ -169,3 +171,11 @@ def _recipient_status(value: object) -> RecipientStatus:
     if value == "missing":
         return "missing"
     raise ValueError("invalid recipient_status")
+
+
+def _document_warnings(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("document_warnings must be a list")
+    return tuple(str(item) for item in value)

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -1,23 +1,24 @@
-"""Build and read frozen Auftragsbestätigung document snapshots — EMAIL_MVP_1 B1."""
+"""Build and read frozen Auftragsbestätigung document snapshots — EMAIL_MVP_1 B1.
+
+Facts come from CustomerDocumentProjection (Inquiry + OrderVersion +
+OrderCommercialSnapshot). Persistence remains OrderConfirmationDocumentSnapshot.
+"""
 
 from __future__ import annotations
 
 import uuid
-from typing import Callable, Protocol, cast
+from typing import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import Decimal
 
-from catering_system.domain.inquiry import Inquiry
-from catering_system.domain.offer import (
-    PositionKind,
-    PositionQuantityMode,
-    VatRatePercent,
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    CustomerDocumentProjection,
 )
+from catering_system.domain.inquiry import Inquiry
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
-    OrderCommercialSnapshot,
 )
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentPosition,
@@ -27,12 +28,7 @@ from catering_system.domain.order_confirmation_document import (
 )
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHOD_LABELS,
-    PaymentMethod,
     validate_payment_method,
-)
-from catering_system.intake.intake_contact import (
-    labelled_intake_context,
-    parse_intake_contact,
 )
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
@@ -42,11 +38,11 @@ from catering_system.repositories.order_confirmation_document_repository import 
     OrderConfirmationDocumentRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.customer_document_projection import (
+    CustomerDocumentProjectionService,
+)
 from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
-)
-from catering_system.services.order_print_projection_service import (
-    format_quantity_display,
 )
 
 
@@ -88,59 +84,6 @@ class OrderConfirmationDocumentEligibility:
     snapshot: OrderConfirmationDocumentSummary | None = None
 
 
-@dataclass(frozen=True)
-class _CommercialFacts:
-    offer_id: str
-    offer_version_id: str
-    payment_method: PaymentMethod
-    payment_customer_visible_text: str
-    positions: tuple[_PricedCommercialPosition, ...]
-
-
-class _PricedCommercialPosition(Protocol):
-    @property
-    def position_id(self) -> str: ...
-
-    @property
-    def kind(self) -> PositionKind: ...
-
-    @property
-    def name(self) -> str: ...
-
-    @property
-    def description(self) -> str | None: ...
-
-    @property
-    def composition(self) -> str | None: ...
-
-    @property
-    def quantity(self) -> Decimal | None: ...
-
-    @property
-    def quantity_mode(self) -> PositionQuantityMode | None: ...
-
-    @property
-    def unit_label(self) -> str | None: ...
-
-    @property
-    def unit_net_cents(self) -> int: ...
-
-    @property
-    def net_total_cents(self) -> int: ...
-
-    @property
-    def vat_rate_percent(self) -> VatRatePercent: ...
-
-    @property
-    def vat_amount_cents(self) -> int: ...
-
-    @property
-    def gross_total_cents(self) -> int: ...
-
-    @property
-    def related_position_id(self) -> str | None: ...
-
-
 def document_reference(order_id: str, version_number: int) -> str:
     return f"AB-{order_id.split('-', maxsplit=1)[0].upper()}-V{version_number}"
 
@@ -153,12 +96,14 @@ class OrderConfirmationDocumentService:
         document_repository: OrderConfirmationDocumentRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository,
         *,
+        projection_service: CustomerDocumentProjectionService | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._orders = order_repository
         self._inquiries = inquiry_repository
         self._documents = document_repository
         self._commercial_snapshots = commercial_snapshot_repository
+        self._projection = projection_service or CustomerDocumentProjectionService()
         self._now = now or (lambda: datetime.now(UTC))
 
     def eligibility(self, order_id: str) -> OrderConfirmationDocumentEligibility:
@@ -201,6 +146,9 @@ class OrderConfirmationDocumentService:
         order_id: str,
         expected_effective_order_version_id: str,
         created_by: str,
+        *,
+        invoice_address: CustomerAddress | None = None,
+        delivery_address: CustomerAddress | None = None,
     ) -> OrderConfirmationDocumentSnapshot:
         order = self._orders.get_order(order_id)
         if order is None:
@@ -219,68 +167,32 @@ class OrderConfirmationDocumentService:
             return existing
         assert order.effective_order_version_id is not None
         version = self._require_effective_version(order)
-        commercial = self._resolve_commercial(order)
+        commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
+        if commercial is None:
+            raise MissingCommercialSnapshotError(order.order_id)
         inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
-        recipient = _recipient_snapshot(inquiry)
-        positions, buckets, totals = _commercial_positions(
-            commercial.positions,
-            guest_count_estimate=version.guest_count_estimate,
+        document_id = str(uuid.uuid4())
+        created_at = self._now()
+        projection = self._projection.build(
+            document_type="ORDER_CONFIRMATION",
+            document_id=document_id,
+            created_at=created_at,
+            order_version=version,
+            commercial_snapshot=commercial,
+            inquiry=inquiry,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
         )
-        reference = document_reference(order.order_id, version.version_number)
-        draft = OrderConfirmationDocumentSnapshot(
-            document_snapshot_id=str(uuid.uuid4()),
-            order_id=order.order_id,
-            order_version_id=version.order_version_id,
-            offer_id=commercial.offer_id,
-            offer_version_id=commercial.offer_version_id,
-            document_reference=reference,
-            created_at=self._now(),
+        draft = _persist_snapshot_from_projection(
+            projection,
+            inquiry=inquiry,
             created_by=created_by,
-            recipient_name=recipient["recipient_name"],
-            recipient_email=recipient["recipient_email"],
-            recipient_company=recipient["recipient_company"],
-            recipient_phone=recipient["recipient_phone"],
-            recipient_status=cast(RecipientStatus, recipient["recipient_status"]),
-            event_date=version.event_date,
-            time_window_text=version.time_window_text,
-            location_text=version.location_text,
-            guest_count_estimate=version.guest_count_estimate,
-            planning_mode=version.planning_mode,
-            positions=positions,
-            vat_buckets=buckets,
-            net_total_cents=totals["net_total_cents"],
-            vat_total_cents=totals["vat_total_cents"],
-            gross_total_cents=totals["gross_total_cents"],
-            payment_method=commercial.payment_method,
-            payment_customer_visible_text=commercial.payment_customer_visible_text,
             document_hash="sha256:" + ("0" * 64),
         )
-        snapshot = OrderConfirmationDocumentSnapshot(
-            document_snapshot_id=draft.document_snapshot_id,
-            order_id=draft.order_id,
-            order_version_id=draft.order_version_id,
-            offer_id=draft.offer_id,
-            offer_version_id=draft.offer_version_id,
-            document_reference=draft.document_reference,
-            created_at=draft.created_at,
-            created_by=draft.created_by,
-            recipient_name=draft.recipient_name,
-            recipient_email=draft.recipient_email,
-            recipient_company=draft.recipient_company,
-            recipient_phone=draft.recipient_phone,
-            recipient_status=draft.recipient_status,
-            event_date=draft.event_date,
-            time_window_text=draft.time_window_text,
-            location_text=draft.location_text,
-            guest_count_estimate=draft.guest_count_estimate,
-            planning_mode=draft.planning_mode,
-            positions=draft.positions,
-            vat_buckets=draft.vat_buckets,
-            net_total_cents=draft.net_total_cents,
-            vat_total_cents=draft.vat_total_cents,
-            gross_total_cents=draft.gross_total_cents,
-            payment_method=draft.payment_method,
-            payment_customer_visible_text=draft.payment_customer_visible_text,
+        snapshot = _persist_snapshot_from_projection(
+            projection,
+            inquiry=inquiry,
+            created_by=created_by,
             document_hash=compute_document_hash(draft),
         )
         self._documents.insert(snapshot)
@@ -364,72 +276,69 @@ class OrderConfirmationDocumentService:
             raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
         return version
 
-    def _resolve_commercial(self, order: Order) -> _CommercialFacts:
-        snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
-        if snapshot is None:
-            raise MissingCommercialSnapshotError(order.order_id)
-        return _commercial_from_snapshot(snapshot)
+
+def _recipient_status_from_inquiry(inquiry: Inquiry | None) -> RecipientStatus:
+    if inquiry is None or inquiry.customer_snapshot is None:
+        return "missing"
+    return "ready" if inquiry.customer_snapshot.email else "missing"
 
 
-def _commercial_from_snapshot(snapshot: OrderCommercialSnapshot) -> _CommercialFacts:
-    return _CommercialFacts(
-        offer_id=snapshot.source_offer_id,
-        offer_version_id=snapshot.source_offer_version_id,
-        payment_method=snapshot.payment_method,
-        payment_customer_visible_text=snapshot.payment_customer_visible_text,
-        positions=snapshot.positions,
+def _persist_snapshot_from_projection(
+    projection: CustomerDocumentProjection,
+    *,
+    inquiry: Inquiry | None,
+    created_by: str,
+    document_hash: str,
+) -> OrderConfirmationDocumentSnapshot:
+    positions, buckets = _positions_and_buckets(projection)
+    if (
+        projection.net_total_cents + projection.vat_total_cents
+        != projection.gross_total_cents
+    ):
+        raise OrderConfirmationDocumentBlockedError("commercial_totals_invalid")
+    contact = inquiry.customer_snapshot if inquiry is not None else None
+    return OrderConfirmationDocumentSnapshot(
+        document_snapshot_id=projection.document_id,
+        order_id=projection.event.order_id,
+        order_version_id=projection.event.order_version_id,
+        offer_id=projection.commercial_reference.source_offer_id,
+        offer_version_id=projection.commercial_reference.source_offer_version_id,
+        document_reference=document_reference(
+            projection.event.order_id, projection.event.version_number
+        ),
+        created_at=projection.created_at,
+        created_by=created_by,
+        recipient_name=projection.recipient.name,
+        recipient_email=projection.recipient.email,
+        recipient_company=contact.company_name if contact is not None else None,
+        recipient_phone=contact.phone if contact is not None else None,
+        recipient_status=("ready" if projection.recipient.email else "missing"),
+        event_date=projection.event.event_date,
+        time_window_text=projection.event.time_window_text,
+        location_text=projection.event.location_text,
+        guest_count_estimate=projection.event.guest_count_estimate,
+        planning_mode=projection.event.planning_mode,
+        positions=positions,
+        vat_buckets=buckets,
+        net_total_cents=projection.net_total_cents,
+        vat_total_cents=projection.vat_total_cents,
+        gross_total_cents=projection.gross_total_cents,
+        payment_method=projection.payment_method,
+        payment_customer_visible_text=projection.payment_customer_visible_text,
+        document_hash=document_hash,
+        document_warnings=tuple(projection.recipient.warnings),
     )
 
 
-def _recipient_status_from_inquiry(inquiry: Inquiry | None) -> RecipientStatus:
-    if inquiry is None:
-        return "missing"
-    parsed = parse_intake_contact(inquiry)
-    return "ready" if parsed["email"] else "missing"
-
-
-def _recipient_snapshot(
-    inquiry: Inquiry | None,
-) -> dict[str, RecipientStatus | str | None]:
-    if inquiry is None:
-        return {
-            "recipient_name": None,
-            "recipient_email": None,
-            "recipient_company": None,
-            "recipient_phone": None,
-            "recipient_status": "missing",
-        }
-    labelled, _remaining = labelled_intake_context(inquiry.intake_message)
-    parsed = parse_intake_contact(inquiry)
-    company = labelled.get("Firma", "").strip() or None
-    person = labelled.get("Name", "").strip() or None
-    recipient_name = person or parsed["display_name"]
-    email = parsed["email"]
-    return {
-        "recipient_name": recipient_name,
-        "recipient_email": email,
-        "recipient_company": company,
-        "recipient_phone": parsed["phone"],
-        "recipient_status": "ready" if email else "missing",
-    }
-
-
-def _commercial_positions(
-    positions: tuple[_PricedCommercialPosition, ...],
-    *,
-    guest_count_estimate: int | None,
+def _positions_and_buckets(
+    projection: CustomerDocumentProjection,
 ) -> tuple[
     tuple[OrderConfirmationDocumentPosition, ...],
     tuple[OrderConfirmationVatBucket, ...],
-    dict[str, int],
 ]:
     mapped: list[OrderConfirmationDocumentPosition] = []
     bucket_totals: dict[int, dict[str, int]] = {}
-    net_total = 0
-    vat_total = 0
-    gross_total = 0
-    for position in positions:
-        quantity = format_quantity_display(position, guest_count_estimate)
+    for position in projection.positions:
         mapped.append(
             OrderConfirmationDocumentPosition(
                 position_id=position.position_id,
@@ -437,7 +346,7 @@ def _commercial_positions(
                 name=position.name,
                 description=position.description,
                 composition=position.composition,
-                quantity=quantity,
+                quantity=position.quantity,
                 unit_label=position.unit_label,
                 unit_net_cents=position.unit_net_cents,
                 net_total_cents=position.net_total_cents,
@@ -447,26 +356,12 @@ def _commercial_positions(
                 related_position_id=position.related_position_id,
             )
         )
-        net_total += position.net_total_cents
-        vat_total += position.vat_amount_cents
-        gross_total += position.gross_total_cents
         bucket = bucket_totals.setdefault(
             position.vat_rate_percent,
             {"base_net_cents": 0, "vat_cents": 0},
         )
         bucket["base_net_cents"] += position.net_total_cents
         bucket["vat_cents"] += position.vat_amount_cents
-    if net_total + vat_total != gross_total:
-        raise OrderConfirmationDocumentBlockedError("commercial_totals_invalid")
-    position_net = sum(item.net_total_cents for item in mapped)
-    position_vat = sum(item.vat_cents for item in mapped)
-    position_gross = sum(item.gross_cents for item in mapped)
-    if (position_net, position_vat, position_gross) != (
-        net_total,
-        vat_total,
-        gross_total,
-    ):
-        raise OrderConfirmationDocumentBlockedError("commercial_totals_invalid")
     buckets = tuple(
         OrderConfirmationVatBucket(
             rate_percent=rate,
@@ -475,15 +370,7 @@ def _commercial_positions(
         )
         for rate, values in sorted(bucket_totals.items())
     )
-    return (
-        tuple(mapped),
-        buckets,
-        {
-            "net_total_cents": net_total,
-            "vat_total_cents": vat_total,
-            "gross_total_cents": gross_total,
-        },
-    )
+    return tuple(mapped), buckets
 
 
 def payment_method_label(method: str) -> str:

--- a/tests/unit/test_customer_document_projection.py
+++ b/tests/unit/test_customer_document_projection.py
@@ -21,6 +21,7 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialSnapshot,
 )
 from catering_system.services.customer_document_projection import (
+    CustomerDocumentProjectionService,
     build_customer_document_projection,
     build_customer_document_recipient,
 )
@@ -203,6 +204,7 @@ def test_commercial_reference_copied_from_snapshot() -> None:
     assert projection.vat_total_cents == 1624
     assert projection.gross_total_cents == 24824
     assert projection.positions[0].name == "Fingerfood Paket"
+    assert projection.positions[0].kind == "catalog"
     assert projection.positions[0].quantity == "80 Stück"
 
 
@@ -256,6 +258,28 @@ def test_order_id_mismatch_raises() -> None:
                 _inquiry(snapshot=InquiryCustomerSnapshot(contact_name="Anna"))
             ),
         )
+
+
+def test_customer_document_projection_service_build() -> None:
+    service = CustomerDocumentProjectionService()
+    projection = service.build(
+        document_type="ORDER_CONFIRMATION",
+        document_id="doc-1",
+        created_at=_NOW,
+        order_version=_order_version(),
+        commercial_snapshot=_commercial_snapshot(),
+        inquiry=_inquiry(
+            snapshot=InquiryCustomerSnapshot(
+                contact_name="Anna",
+                email="anna@example.invalid",
+            )
+        ),
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+    )
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in projection.recipient.warnings
+    assert projection.recipient.name == "Anna"
+    assert projection.positions[0].kind == "catalog"
 
 
 def test_foundation_modules_must_not_depend_on_offer_repository() -> None:

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -13,11 +13,13 @@ import threading
 import urllib.error
 import urllib.request
 import uuid
+from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
@@ -3276,6 +3278,37 @@ def _ensure_inquiry_recipient_email(base: str, inquiry_id: str) -> None:
     )
 
 
+def _set_inquiry_customer_snapshot(
+    db: Path,
+    inquiry_id: str,
+    snapshot: InquiryCustomerSnapshot,
+) -> None:
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    inquiries.update(replace(inquiry, customer_snapshot=snapshot))
+    inquiries.close()
+
+
+def _clear_inquiry_recipient_email(db: Path, inquiry_id: str) -> None:
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    contact = inquiry.customer_snapshot
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=contact.company_name if contact else None,
+                contact_name=contact.contact_name if contact else None,
+                phone=contact.phone if contact else None,
+                email=None,
+            ),
+        )
+    )
+    inquiries.close()
+
+
 def _make_effective_offer_order(
     api: tuple[str, dict[str, str], Path],
     *,
@@ -3468,7 +3501,7 @@ def test_confirmation_document_preview_json_and_html(api) -> None:
 def test_confirmation_document_preview_escapes_html_but_preserves_json_text(
     api,
 ) -> None:
-    base, ids, _db = api
+    base, ids, db = api
     malicious = "<script>alert(1)</script>"
     rich = "<b>Test</b>"
     amp = "A&B"
@@ -3499,6 +3532,16 @@ def test_confirmation_document_preview_escapes_html_but_preserves_json_text(
         inquiry_id=inquiry_id,
         snapshot=snapshot_payload,
         ensure_recipient_email=False,
+    )
+    _set_inquiry_customer_snapshot(
+        db,
+        inquiry_id,
+        InquiryCustomerSnapshot(
+            company_name=malicious,
+            contact_name=rich,
+            email="customer@example.invalid",
+            phone="+49301234567",
+        ),
     )
     _post(
         _confirmation_document_url(base, order_id),
@@ -3615,23 +3658,10 @@ def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
 def test_confirmation_document_missing_recipient_is_allowed(api) -> None:
     base, ids, db = api
     inquiry_id = ids["inquiry_offer_ready"]
-    detail = _get(f"{base}/office/v1/inquiries/{inquiry_id}")[1]
-    _post(
-        f"{base}/office/v1/inquiries/{inquiry_id}/update",
-        args={
-            "event_date": detail["event_date"],
-            "crm_stage": detail["crm_stage"],
-            "time_window_text": detail["time_window_text"],
-            "location_text": detail["location_text"],
-            "guest_count_estimate": detail["guest_count_estimate"],
-            "planning_mode": detail["planning_mode"],
-            "intake_message": "Firma: Ohne E-Mail GmbH\nName: Anna\n",
-        },
-        expect={"updated_at": detail["updated_at"]},
-    )
     order_id, order_version_id = _make_effective_offer_order(
         api, inquiry_id=inquiry_id, ensure_recipient_email=False
     )
+    _clear_inquiry_recipient_email(db, inquiry_id)
     status, created, _h = _post(
         _confirmation_document_url(base, order_id),
         args={"created_by": "office-api-test"},
@@ -3981,10 +4011,12 @@ def test_confirmation_send_succeeds_after_pause_is_resumed(api) -> None:
 
 
 def test_confirmation_outbound_missing_recipient_returns_422(api) -> None:
-    base, _ids, _db = api
+    base, ids, db = api
+    inquiry_id = ids["inquiry_offer_ready"]
     order_id, order_version_id = _make_effective_offer_order(
-        api, ensure_recipient_email=False
+        api, inquiry_id=inquiry_id, ensure_recipient_email=False
     )
+    _clear_inquiry_recipient_email(db, inquiry_id)
     status, body, _h = _post(
         _confirmation_document_url(base, order_id),
         args={"created_by": "office-api-test"},

--- a/tests/unit/test_office_panel_confirmation_document.py
+++ b/tests/unit/test_office_panel_confirmation_document.py
@@ -16,6 +16,7 @@ from http.server import HTTPServer
 from pathlib import Path
 from unittest.mock import patch
 
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.repositories.core_transaction import (
     CoreCommandExecutor,
     open_core_connection,
@@ -136,6 +137,8 @@ def _sqlite_world(
     tmp_path: Path,
     *,
     intake_message: str = ("Firma: Example GmbH\nE-Mail: customer@example.invalid\n"),
+    customer_snapshot: object | None = ...,
+    clear_recipient_email_after_convert: bool = False,
 ) -> tuple[
     Path,
     OrderConfirmationDocumentService,
@@ -154,7 +157,19 @@ def _sqlite_world(
         connection
     )
 
-    inquiry = replace(_sample_inquiry(), intake_message=intake_message)
+    if customer_snapshot is ...:
+        snapshot = InquiryCustomerSnapshot(
+            company_name="Example GmbH",
+            email="customer@example.invalid",
+            phone="+49301234567",
+        )
+    else:
+        snapshot = customer_snapshot  # type: ignore[assignment]
+    inquiry = replace(
+        _sample_inquiry(),
+        intake_message=intake_message,
+        customer_snapshot=snapshot,
+    )
     inquiries.save(inquiry)
     offer_service = OfferService(offers, inquiries, orders, commercial_snapshots)
     offer = offer_service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
@@ -174,6 +189,21 @@ def _sqlite_world(
         updated.acceptance_evidence.acceptance_id,
     )
     assert converted.conversion_link is not None
+    if clear_recipient_email_after_convert:
+        current = inquiries.get_by_id(_INQUIRY_ID)
+        assert current is not None
+        contact = current.customer_snapshot
+        inquiries.update(
+            replace(
+                current,
+                customer_snapshot=InquiryCustomerSnapshot(
+                    company_name=contact.company_name if contact else None,
+                    contact_name=contact.contact_name if contact else None,
+                    phone=contact.phone if contact else None,
+                    email=None,
+                ),
+            )
+        )
     core = OperationalCoreService(orders)
     core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
     core.make_order_version_effective(order.order_id, order_version.order_version_id)
@@ -383,7 +413,7 @@ def test_panel_prepare_action_persists_single_snapshot(tmp_path: Path) -> None:
 def test_missing_email_shows_state_and_allows_preview(tmp_path: Path) -> None:
     db, doc_service, _core, _orders, order_id, order_version_id = _sqlite_world(
         tmp_path,
-        intake_message="Firma: Ohne E-Mail GmbH\nName: Anna\n",
+        clear_recipient_email_after_convert=True,
     )
     connection = open_core_connection(db)
     panel = OfficePanel(
@@ -536,6 +566,11 @@ def test_confirmation_card_escapes_hostile_user_data() -> None:
         replace(
             inquiry,
             intake_message='Firma: <script>alert("x")</script>\nE-Mail: safe@example.invalid\n',
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name='<script>alert("x")</script>',
+                email="safe@example.invalid",
+                phone="+49301234567",
+            ),
         )
     )
     updated, order, order_version = offer_service.convert_accepted_offer(

--- a/tests/unit/test_office_panel_confirmation_outbound.py
+++ b/tests/unit/test_office_panel_confirmation_outbound.py
@@ -231,7 +231,7 @@ def test_panel_test_send_persists_evidence_and_shows_protokolliert(
 def test_missing_recipient_blocks_testversand_button(tmp_path: Path) -> None:
     db, doc_service, _core, _orders, order_id, order_version_id = _sqlite_world(
         tmp_path,
-        intake_message="Firma: Ohne E-Mail GmbH\nName: Anna\n",
+        clear_recipient_email_after_convert=True,
     )
     doc_service.prepare_snapshot(order_id, order_version_id, "office-panel")
     panel = _panel_with_outbound(db)

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -11,10 +11,16 @@ from pathlib import Path
 
 import pytest
 
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+)
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
 )
-from catering_system.domain.offer import OfferPosition
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
 )
@@ -30,6 +36,9 @@ from catering_system.repositories.in_memory_order_repository import (
 from catering_system.repositories.sqlite_order_confirmation_document_repository import (
     SQLiteOrderConfirmationDocumentRepository,
 )
+from catering_system.services.customer_document_projection import (
+    CustomerDocumentProjectionService,
+)
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
@@ -38,7 +47,7 @@ from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentBlockedError,
     OrderConfirmationDocumentService,
     OrderConfirmationDocumentStaleVersionError,
-    _commercial_positions,
+    _persist_snapshot_from_projection,
 )
 from catering_system.services.order_service import OrderService
 from catering_system.services.offer_service import OfferService
@@ -287,67 +296,151 @@ def test_totals_and_vat_match_positions() -> None:
 def test_surcharge_linkage_preserved() -> None:
     base_id = "88888888-8888-4888-8888-888888888881"
     surcharge_id = "99999999-9999-4999-8999-999999999991"
-    base = OfferPosition(
-        position_id=base_id,
-        kind="catalog",
-        name="Basis",
-        unit_net_cents=1000,
-        net_total_cents=1000,
-        vat_rate_percent=7,
-        vat_amount_cents=70,
-        gross_total_cents=1070,
+    now = datetime(2026, 7, 18, 10, 0, tzinfo=UTC)
+    commercial = OrderCommercialSnapshot(
+        snapshot_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_offer_id="11111111-1111-4111-8111-111111111111",
+        source_offer_version_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        source_variant_id="44444444-4444-4444-8444-444444444441",
+        acceptance_id="66666666-6666-4666-8666-666666666661",
+        accepted_at=now,
+        recorded_by="office-panel",
+        variant_label="Variante A",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        created_at=now,
+        positions=(
+            OrderCommercialPosition(
+                position_id=base_id,
+                kind="catalog",
+                name="Basis",
+                unit_net_cents=1000,
+                net_total_cents=1000,
+                vat_rate_percent=7,
+                vat_amount_cents=70,
+                gross_total_cents=1070,
+            ),
+            OrderCommercialPosition(
+                position_id=surcharge_id,
+                kind="surcharge",
+                name="Aufschlag",
+                unit_net_cents=200,
+                net_total_cents=200,
+                vat_rate_percent=7,
+                vat_amount_cents=14,
+                gross_total_cents=214,
+                related_position_id=base_id,
+            ),
+        ),
     )
-    surcharge = OfferPosition(
-        position_id=surcharge_id,
-        kind="surcharge",
-        name="Aufschlag",
-        unit_net_cents=200,
-        net_total_cents=200,
-        vat_rate_percent=7,
-        vat_amount_cents=14,
-        gross_total_cents=214,
-        related_position_id=base_id,
+    from catering_system.domain.order import OrderVersion
+
+    version = OrderVersion(
+        order_version_id="33333333-3333-4333-8333-333333333331",
+        order_id=commercial.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
     )
-    positions, _buckets, totals = _commercial_positions(
-        (base, surcharge), guest_count_estimate=10
+    projection = CustomerDocumentProjectionService().build(
+        document_type="ORDER_CONFIRMATION",
+        document_id="doc-1",
+        created_at=now,
+        order_version=version,
+        commercial_snapshot=commercial,
+        inquiry=None,
     )
-    surcharge_position = next(item for item in positions if item.kind == "surcharge")
+    document = _persist_snapshot_from_projection(
+        projection,
+        inquiry=None,
+        created_by="test",
+        document_hash="sha256:" + ("0" * 64),
+    )
+    surcharge_position = next(
+        item for item in document.positions if item.kind == "surcharge"
+    )
     assert surcharge_position.related_position_id == base_id
-    assert totals["gross_total_cents"] == 1284
+    assert document.gross_total_cents == 1284
 
 
 def test_fee_position_preserved() -> None:
-    fee = OfferPosition(
-        position_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        kind="fee",
-        name="Servicepauschale",
-        unit_net_cents=500,
-        net_total_cents=500,
-        vat_rate_percent=19,
-        vat_amount_cents=95,
-        gross_total_cents=595,
+    now = datetime(2026, 7, 18, 10, 0, tzinfo=UTC)
+    commercial = OrderCommercialSnapshot(
+        snapshot_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_offer_id="11111111-1111-4111-8111-111111111111",
+        source_offer_version_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        source_variant_id="44444444-4444-4444-8444-444444444441",
+        acceptance_id="66666666-6666-4666-8666-666666666661",
+        accepted_at=now,
+        recorded_by="office-panel",
+        variant_label="Variante A",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        created_at=now,
+        positions=(
+            OrderCommercialPosition(
+                position_id=_POSITION_ID,
+                kind="catalog",
+                name="Fingerfood Paket",
+                unit_net_cents=290,
+                net_total_cents=23200,
+                vat_rate_percent=7,
+                vat_amount_cents=1624,
+                gross_total_cents=24824,
+                quantity=Decimal("80"),
+                quantity_mode="total",
+                unit_label="Stück",
+            ),
+            OrderCommercialPosition(
+                position_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                kind="fee",
+                name="Servicepauschale",
+                unit_net_cents=500,
+                net_total_cents=500,
+                vat_rate_percent=19,
+                vat_amount_cents=95,
+                gross_total_cents=595,
+            ),
+        ),
     )
-    catalog = OfferPosition(
-        position_id=_POSITION_ID,
-        kind="catalog",
-        name="Fingerfood Paket",
-        unit_net_cents=290,
-        net_total_cents=23200,
-        vat_rate_percent=7,
-        vat_amount_cents=1624,
-        gross_total_cents=24824,
-        quantity=Decimal("80"),
-        quantity_mode="total",
-        unit_label="Stück",
+    from catering_system.domain.order import OrderVersion
+
+    version = OrderVersion(
+        order_version_id="33333333-3333-4333-8333-333333333331",
+        order_id=commercial.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
     )
-    positions, _buckets, totals = _commercial_positions(
-        (catalog, fee), guest_count_estimate=80
+    projection = CustomerDocumentProjectionService().build(
+        document_type="ORDER_CONFIRMATION",
+        document_id="doc-1",
+        created_at=now,
+        order_version=version,
+        commercial_snapshot=commercial,
+        inquiry=None,
     )
-    assert any(position.kind == "fee" for position in positions)
-    assert totals["gross_total_cents"] == 25419
+    document = _persist_snapshot_from_projection(
+        projection,
+        inquiry=None,
+        created_by="test",
+        document_hash="sha256:" + ("0" * 64),
+    )
+    assert any(position.kind == "fee" for position in document.positions)
+    assert document.gross_total_cents == 25419
 
 
-def test_recipient_snapshot_and_missing_email() -> None:
+def test_recipient_from_customer_snapshot_missing_email() -> None:
     (
         offer,
         version_id,
@@ -358,19 +451,25 @@ def test_recipient_snapshot_and_missing_email() -> None:
         inquiries,
         offer_service,
     ) = _accepted_offer_state()
-    inquiry = inquiries.get_by_id(_INQUIRY_ID)
-    assert inquiry is not None
-    inquiries.update(
-        replace(
-            inquiry,
-            intake_message="Firma: ACME GmbH\nName: Anna\nTelefon: +491701234567\n",
-        )
-    )
     _converted, order, order_version = offer_service.convert_accepted_offer(
         offer.offer_id,
         version_id,
         variant_id,
         acceptance_id,
+    )
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="ACME GmbH",
+                contact_name="Anna",
+                phone="+491701234567",
+                email=None,
+            ),
+            intake_message="Firma: SHOULD-NOT-USE\nE-Mail: intake@example.invalid\n",
+        )
     )
     core = OperationalCoreService(orders)
     core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
@@ -391,6 +490,54 @@ def test_recipient_snapshot_and_missing_email() -> None:
     assert snapshot.recipient_company == "ACME GmbH"
     assert snapshot.recipient_name == "Anna"
     assert snapshot.recipient_email is None
+    assert snapshot.recipient_phone == "+491701234567"
+
+
+def test_address_warning_flows_into_confirmation_document() -> None:
+    services = _services()
+    order, version = _effective_order(services)
+    service = services[4]
+    invoice = CustomerAddress(
+        street="Bürostraße 1",
+        postal_code="20095",
+        city="Hamburg",
+        country="DE",
+    )
+    delivery = CustomerAddress(
+        street="Eventplatz 9",
+        postal_code="20457",
+        city="Hamburg",
+        country="DE",
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+        invoice_address=invoice,
+        delivery_address=delivery,
+    )
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in snapshot.document_warnings
+
+
+def test_confirmation_builds_via_customer_document_projection() -> None:
+    services = _services()
+    order, version = _effective_order(services)
+    orders, _offers, inquiries, _documents, service, _core, offer_service = services
+    commercial = offer_service._commercial_snapshots.get_by_order_id(order.order_id)
+    assert commercial is not None
+    inquiry = inquiries.get_by_id(order.source_inquiry_id)
+    assert inquiry is not None
+    assert inquiry.customer_snapshot is not None
+    snapshot = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+    )
+    assert snapshot.offer_id == commercial.source_offer_id
+    assert snapshot.offer_version_id == commercial.source_offer_version_id
+    assert snapshot.recipient_email == inquiry.customer_snapshot.email
+    assert snapshot.gross_total_cents == commercial.positions[0].gross_total_cents
+    assert snapshot.positions[0].kind == commercial.positions[0].kind
 
 
 def test_document_hash_stable() -> None:
@@ -701,6 +848,18 @@ def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
         "office-panel",
     )
     assert snapshot.positions[0].name == "Fingerfood Paket"
+
+
+def test_confirmation_document_service_has_no_offer_repository() -> None:
+    root = Path(__file__).resolve().parents[2]
+    text = (
+        root
+        / "src/catering_system/services/order_confirmation_document_service.py"
+    ).read_text(encoding="utf-8")
+    assert "OfferRepository" not in text
+    assert "conversion_link" not in text
+    assert "parse_intake_contact" not in text
+    assert "labelled_intake_context" not in text
 
 
 def test_confirmation_fails_when_commercial_snapshot_missing() -> None:

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -853,8 +853,7 @@ def test_confirmation_snapshot_immune_to_later_offer_mutation() -> None:
 def test_confirmation_document_service_has_no_offer_repository() -> None:
     root = Path(__file__).resolve().parents[2]
     text = (
-        root
-        / "src/catering_system/services/order_confirmation_document_service.py"
+        root / "src/catering_system/services/order_confirmation_document_service.py"
     ).read_text(encoding="utf-8")
     assert "OfferRepository" not in text
     assert "conversion_link" not in text

--- a/tests/unit/test_order_confirmation_outbound.py
+++ b/tests/unit/test_order_confirmation_outbound.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.order_confirmation_outbound import (
     OUTCOME_ACCEPTED,
     TRANSPORT_KIND,
@@ -80,6 +81,11 @@ def _world() -> tuple[
         replace(
             inquiry,
             intake_message="Firma: Example GmbH\nE-Mail: customer@example.invalid\n",
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="Example GmbH",
+                email="customer@example.invalid",
+                phone="+49301234567",
+            ),
         )
     )
     _converted, order, order_version = offer_service.convert_accepted_offer(
@@ -203,9 +209,6 @@ def test_missing_email_blocks_send() -> None:
         outbound_service,
         core,
     ) = world
-    inquiry = inquiries.get_by_id(_INQUIRY_ID)
-    assert inquiry is not None
-    inquiries.update(replace(inquiry, intake_message="Firma: Example GmbH\n"))
     order, version, snapshot = _prepared_snapshot(
         (
             orders,
@@ -217,6 +220,27 @@ def test_missing_email_blocks_send() -> None:
             outbound_service,
             core,
         )
+    )
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    # Rebuild document after clearing email — outbound reads frozen snapshot email.
+    documents._by_id.clear()
+    documents._by_version.clear()
+    inquiries.update(
+        replace(
+            inquiry,
+            intake_message="Firma: Example GmbH\n",
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="Example GmbH",
+                phone="+49301234567",
+                email=None,
+            ),
+        )
+    )
+    snapshot = doc_service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
     )
     with pytest.raises(OrderConfirmationOutboundRecipientMissingError):
         outbound_service.send_to_fake_outbox(


### PR DESCRIPTION
## Summary
- `OrderConfirmationDocumentService` builds facts via `CustomerDocumentProjectionService` (Inquiry + OrderVersion + OrderCommercialSnapshot).
- Removes intake re-parse / `_recipient_snapshot` / `_commercial_positions` from Confirmation; `OfferRepository` / `conversion_link` remain absent.
- Persist path stays `OrderConfirmationDocumentSnapshot` (adds `document_warnings` for address-diff warning); PDF/email/renderer untouched.

## Test plan
- [x] Inquiry + Snapshot + OrderVersion → CDP → Confirmation document
- [x] OfferRepository unavailable → Confirmation still works
- [x] Differing invoice/delivery addresses → `DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE` on document
- [x] Missing `OrderCommercialSnapshot` → `MissingCommercialSnapshotError`
- [x] `grep OfferRepository|conversion_link` on confirmation service = 0
- [x] ruff / mypy / pytest / coverage ≥ 90%


Made with [Cursor](https://cursor.com)