### PR TITLE
Customer document eligibility foundation (V1-C-1)

### DIFF
--- a/src/catering_system/domain/customer_document_eligibility.py
+++ b/src/catering_system/domain/customer_document_eligibility.py
@@ -1,0 +1,66 @@
+"""Customer document create eligibility — CUSTOMER_DOCUMENT_PROJECTION_V1-C-1.
+
+Sibling decision object to CustomerDocumentProjection (facts). Never embed
+allowed/blockers on the projection itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+DocumentBlockerCode = Literal[
+    "MISSING_COMMERCIAL_SNAPSHOT",
+    "MISSING_CUSTOMER_NAME",
+    "MISSING_CUSTOMER_CONTACT",
+    "INVALID_ORDER_STATE",
+]
+
+DOCUMENT_BLOCKER_CODES: tuple[DocumentBlockerCode, ...] = (
+    "MISSING_COMMERCIAL_SNAPSHOT",
+    "MISSING_CUSTOMER_NAME",
+    "MISSING_CUSTOMER_CONTACT",
+    "INVALID_ORDER_STATE",
+)
+
+_BLOCKER_SORT_ORDER: dict[DocumentBlockerCode, int] = {
+    code: index for index, code in enumerate(DOCUMENT_BLOCKER_CODES)
+}
+
+
+@dataclass(frozen=True)
+class DocumentBlocker:
+    """One hard reason a customer document must not be created."""
+
+    code: DocumentBlockerCode
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.code not in DOCUMENT_BLOCKER_CODES:
+            raise ValueError(f"unsupported document blocker code: {self.code!r}")
+        if self.detail is not None and not self.detail.strip():
+            raise ValueError("detail must not be blank when provided")
+
+
+@dataclass(frozen=True)
+class CustomerDocumentEligibility:
+    """Pure create decision for a customer-facing document."""
+
+    allowed: bool
+    blockers: tuple[DocumentBlocker, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.allowed != (self.blockers == ()):
+            raise ValueError("allowed must equal (blockers == ())")
+
+
+def sort_document_blockers(
+    blockers: tuple[DocumentBlocker, ...],
+) -> tuple[DocumentBlocker, ...]:
+    """Stable deterministic order for tests and API surfaces."""
+    return tuple(
+        sorted(
+            blockers,
+            key=lambda item: (_BLOCKER_SORT_ORDER[item.code], item.detail or ""),
+        )
+    )

--- a/src/catering_system/domain/customer_document_projection.py
+++ b/src/catering_system/domain/customer_document_projection.py
@@ -78,6 +78,8 @@ class CustomerDocumentRecipient:
 
     name: str
     email: str | None = None
+    company_name: str | None = None
+    phone: str | None = None
     invoice_address: CustomerAddress | None = None
     delivery_address: CustomerAddress | None = None
     delivery_address_differs: bool = False
@@ -86,6 +88,8 @@ class CustomerDocumentRecipient:
     def __post_init__(self) -> None:
         _require_text(self.name, "name")
         _optional_bounded_text(self.email, "email", max_len=_MAX_LABEL)
+        _optional_bounded_text(self.company_name, "company_name", max_len=_MAX_LABEL)
+        _optional_bounded_text(self.phone, "phone", max_len=_MAX_LABEL)
         expected_differs = (
             self.invoice_address is not None
             and self.delivery_address is not None

--- a/src/catering_system/services/customer_document_eligibility.py
+++ b/src/catering_system/services/customer_document_eligibility.py
@@ -1,0 +1,77 @@
+"""Pure customer-document create eligibility — V1-C-1.
+
+No repositories. No Offer. No intake parsing. No HTML/PDF/email/persistence.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentEligibility,
+    DocumentBlocker,
+    sort_document_blockers,
+)
+from catering_system.domain.customer_document_projection import (
+    CustomerDocumentRecipient,
+)
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+
+_PLACEHOLDER_NAME = "Kunde"
+
+
+def evaluate_customer_document_eligibility(
+    *,
+    order: Order,
+    order_version: OrderVersion | None,
+    commercial_snapshot: OrderCommercialSnapshot | None,
+    recipient: CustomerDocumentRecipient,
+) -> CustomerDocumentEligibility:
+    """Decide whether a customer document may be created for this order state."""
+    blockers: list[DocumentBlocker] = []
+
+    if commercial_snapshot is None:
+        blockers.append(DocumentBlocker(code="MISSING_COMMERCIAL_SNAPSHOT"))
+
+    if _invalid_order_state(order, order_version):
+        blockers.append(DocumentBlocker(code="INVALID_ORDER_STATE"))
+
+    if not _has_usable_name(recipient):
+        blockers.append(DocumentBlocker(code="MISSING_CUSTOMER_NAME"))
+
+    if not _has_usable_contact(recipient):
+        blockers.append(DocumentBlocker(code="MISSING_CUSTOMER_CONTACT"))
+
+    ordered = sort_document_blockers(tuple(blockers))
+    return CustomerDocumentEligibility(allowed=not ordered, blockers=ordered)
+
+
+def _invalid_order_state(order: Order, order_version: OrderVersion | None) -> bool:
+    if order.cancelled_at is not None:
+        return True
+    if order.effective_order_version_id is None:
+        return True
+    if order_version is None:
+        return True
+    if order_version.order_id != order.order_id:
+        return True
+    if order_version.order_version_id != order.effective_order_version_id:
+        return True
+    if order.candidate_order_version_id is not None:
+        return True
+    if order_version.kitchen_print_confirmed_at is None:
+        return True
+    return False
+
+
+def _has_usable_name(recipient: CustomerDocumentRecipient) -> bool:
+    name = recipient.name.strip()
+    if name and name != _PLACEHOLDER_NAME:
+        return True
+    company = (recipient.company_name or "").strip()
+    return bool(company)
+
+
+def _has_usable_contact(recipient: CustomerDocumentRecipient) -> bool:
+    email = (recipient.email or "").strip()
+    phone = (recipient.phone or "").strip()
+    return bool(email) or bool(phone)

--- a/src/catering_system/services/customer_document_projection.py
+++ b/src/catering_system/services/customer_document_projection.py
@@ -44,6 +44,7 @@ def build_customer_document_recipient(
     """
     snapshot = inquiry.customer_snapshot if inquiry is not None else None
     name, email = _name_and_email(snapshot)
+    company_name, phone = _company_and_phone(snapshot)
     differs = (
         invoice_address is not None
         and delivery_address is not None
@@ -55,6 +56,8 @@ def build_customer_document_recipient(
     return CustomerDocumentRecipient(
         name=name,
         email=email,
+        company_name=company_name,
+        phone=phone,
         invoice_address=invoice_address,
         delivery_address=delivery_address,
         delivery_address_differs=differs,
@@ -120,6 +123,16 @@ def _name_and_email(
     if not name:
         name = "Kunde"
     return name, snapshot.email
+
+
+def _company_and_phone(
+    snapshot: InquiryCustomerSnapshot | None,
+) -> tuple[str | None, str | None]:
+    if snapshot is None or snapshot.is_empty():
+        return None, None
+    company = (snapshot.company_name or "").strip() or None
+    phone = (snapshot.phone or "").strip() or None
+    return company, phone
 
 
 def _map_position(

--- a/tests/unit/test_customer_document_eligibility.py
+++ b/tests/unit/test_customer_document_eligibility.py
@@ -1,0 +1,288 @@
+"""CUSTOMER_DOCUMENT_PROJECTION_V1-C-1 — pure create eligibility."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentEligibility,
+    DocumentBlocker,
+)
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+    CustomerDocumentRecipient,
+)
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.services.customer_document_eligibility import (
+    evaluate_customer_document_eligibility,
+)
+
+_ORDER_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_INQUIRY_ID = "99999999-9999-4999-8999-999999999999"
+_SNAPSHOT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_OFFER_VERSION_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+_PRINT_AT = datetime(2026, 7, 15, 13, 0, tzinfo=UTC)
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _order(
+    *,
+    cancelled: bool = False,
+    effective: str | None = _VERSION_ID,
+    candidate: str | None = None,
+) -> Order:
+    return Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+        effective_order_version_id=effective,
+        candidate_order_version_id=candidate,
+        cancelled_at=_NOW if cancelled else None,
+    )
+
+
+def _version(*, kitchen_print: bool = True) -> OrderVersion:
+    return OrderVersion(
+        order_version_id=_VERSION_ID,
+        order_id=_ORDER_ID,
+        version_number=1,
+        created_at=_NOW,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        kitchen_print_confirmed_at=_PRINT_AT if kitchen_print else None,
+    )
+
+
+def _commercial() -> OrderCommercialSnapshot:
+    return OrderCommercialSnapshot(
+        snapshot_id=_SNAPSHOT_ID,
+        order_id=_ORDER_ID,
+        source_offer_id=_OFFER_ID,
+        source_offer_version_id=_OFFER_VERSION_ID,
+        source_variant_id="44444444-4444-4444-8444-444444444441",
+        acceptance_id="66666666-6666-4666-8666-666666666661",
+        accepted_at=_NOW,
+        recorded_by="office-panel",
+        variant_label="Variante A",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        created_at=_NOW,
+        positions=(
+            OrderCommercialPosition(
+                position_id=_POSITION_ID,
+                kind="catalog",
+                name="Fingerfood Paket",
+                unit_net_cents=290,
+                net_total_cents=23200,
+                vat_rate_percent=7,
+                vat_amount_cents=1624,
+                gross_total_cents=24824,
+                quantity=Decimal("80"),
+                quantity_mode="total",
+                unit_label="Stück",
+            ),
+        ),
+    )
+
+
+def _recipient(
+    *,
+    name: str = "Anna",
+    email: str | None = "anna@example.invalid",
+    company_name: str | None = "ACME GmbH",
+    phone: str | None = "+49301234567",
+    invoice_address: CustomerAddress | None = None,
+    delivery_address: CustomerAddress | None = None,
+) -> CustomerDocumentRecipient:
+    differs = (
+        invoice_address is not None
+        and delivery_address is not None
+        and invoice_address != delivery_address
+    )
+    return CustomerDocumentRecipient(
+        name=name,
+        email=email,
+        company_name=company_name,
+        phone=phone,
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+        delivery_address_differs=differs,
+        warnings=(WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else (),
+    )
+
+
+def _codes(result: CustomerDocumentEligibility) -> tuple[str, ...]:
+    return tuple(blocker.code for blocker in result.blockers)
+
+
+def test_valid_order_is_allowed() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(),
+    )
+    assert result.allowed is True
+    assert result.blockers == ()
+
+
+def test_missing_commercial_snapshot_blocks() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=None,
+        recipient=_recipient(),
+    )
+    assert result.allowed is False
+    assert _codes(result) == ("MISSING_COMMERCIAL_SNAPSHOT",)
+
+
+def test_cancelled_order_blocks_with_invalid_order_state() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(cancelled=True),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(),
+    )
+    assert result.allowed is False
+    assert _codes(result) == ("INVALID_ORDER_STATE",)
+
+
+def test_candidate_and_missing_kitchen_print_are_invalid_order_state() -> None:
+    candidate = evaluate_customer_document_eligibility(
+        order=_order(candidate="cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(),
+    )
+    assert candidate.allowed is False
+    assert _codes(candidate) == ("INVALID_ORDER_STATE",)
+
+    no_print = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(kitchen_print=False),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(),
+    )
+    assert no_print.allowed is False
+    assert _codes(no_print) == ("INVALID_ORDER_STATE",)
+
+
+def test_missing_customer_name_and_contact_block() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(
+            name="Kunde",
+            email=None,
+            company_name=None,
+            phone=None,
+        ),
+    )
+    assert result.allowed is False
+    assert _codes(result) == (
+        "MISSING_CUSTOMER_NAME",
+        "MISSING_CUSTOMER_CONTACT",
+    )
+
+
+def test_company_name_alone_satisfies_name_requirement() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(
+            name="Kunde",
+            company_name="ACME GmbH",
+            email="anna@example.invalid",
+            phone=None,
+        ),
+    )
+    assert result.allowed is True
+    assert result.blockers == ()
+
+
+def test_phone_alone_satisfies_contact_requirement() -> None:
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=_recipient(
+            name="Anna",
+            email=None,
+            phone="+49301234567",
+        ),
+    )
+    assert result.allowed is True
+    assert result.blockers == ()
+
+
+def test_address_warning_does_not_block_eligibility() -> None:
+    recipient = _recipient(invoice_address=_INVOICE, delivery_address=_DELIVERY)
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in recipient.warnings
+    result = evaluate_customer_document_eligibility(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient=recipient,
+    )
+    assert result.allowed is True
+    assert result.blockers == ()
+
+
+def test_eligibility_invariant_rejects_inconsistent_state() -> None:
+    with pytest.raises(ValueError, match="allowed must equal"):
+        CustomerDocumentEligibility(
+            allowed=True,
+            blockers=(DocumentBlocker(code="INVALID_ORDER_STATE"),),
+        )
+    with pytest.raises(ValueError, match="allowed must equal"):
+        CustomerDocumentEligibility(allowed=False, blockers=())
+
+
+def test_eligibility_modules_must_not_depend_on_offer_or_channels() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
+    for relative in (
+        "domain/customer_document_eligibility.py",
+        "services/customer_document_eligibility.py",
+    ):
+        text = (root / relative).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, relative
+        assert "offer_repository" not in text, relative
+        assert "conversion_link" not in text, relative
+        assert "parse_intake_contact" not in text, relative
+        assert "labelled_intake_context" not in text, relative
+        assert "smtp" not in text.lower(), relative
+        assert "weasyprint" not in text.lower(), relative
+        assert "order_confirmation_document_preview" not in text, relative
+        assert "OrderConfirmationOutbound" not in text, relative

--- a/tests/unit/test_customer_document_projection.py
+++ b/tests/unit/test_customer_document_projection.py
@@ -282,6 +282,23 @@ def test_customer_document_projection_service_build() -> None:
     assert projection.positions[0].kind == "catalog"
 
 
+def test_recipient_maps_company_and_phone_from_customer_snapshot() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(
+            snapshot=InquiryCustomerSnapshot(
+                contact_name="Anna",
+                company_name="ACME GmbH",
+                email="anna@example.invalid",
+                phone="+49301234567",
+            )
+        )
+    )
+    assert recipient.name == "Anna"
+    assert recipient.company_name == "ACME GmbH"
+    assert recipient.phone == "+49301234567"
+    assert recipient.email == "anna@example.invalid"
+
+
 def test_foundation_modules_must_not_depend_on_offer_repository() -> None:
     root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
     for relative in (


### PR DESCRIPTION
## Summary
- Add `CustomerDocumentEligibility` / `DocumentBlocker` with invariant `allowed == (blockers == ())`.
- Add pure `evaluate_customer_document_eligibility(order, order_version, commercial_snapshot, recipient)`.
- Extend `CustomerDocumentRecipient` with `company_name` / `phone` mapped from `Inquiry.customer_snapshot`.
- **No Confirmation wiring** — missing-contact hard policy lives only in the evaluator until V1-C-2.

## Test plan
- [x] Valid order → `allowed=True`
- [x] Missing commercial → `MISSING_COMMERCIAL_SNAPSHOT`
- [x] Cancelled / candidate / no kitchen print → `INVALID_ORDER_STATE`
- [x] Placeholder name + no contact → `MISSING_CUSTOMER_NAME` + `MISSING_CUSTOMER_CONTACT`
- [x] Address-diff warning does not block
- [x] Boundary greps: no OfferRepository / conversion_link / SMTP / outbound in eligibility modules
- [x] ruff / mypy / pytest / coverage ≥ 90%


Made with [Cursor](https://cursor.com)