### PR TITLE
Confirmation uses CustomerDocumentEligibility (V1-C-2)

### DIFF
--- a/src/catering_system/domain/customer_document_eligibility.py
+++ b/src/catering_system/domain/customer_document_eligibility.py
@@ -64,3 +64,29 @@ def sort_document_blockers(
             key=lambda item: (_BLOCKER_SORT_ORDER[item.code], item.detail or ""),
         )
     )
+
+
+class CustomerDocumentCreationBlocked(Exception):
+    """Controlled refusal to create a customer document.
+
+    Carries the full eligibility decision so UI/API can show structured
+    blocker codes without parsing exception text.
+    """
+
+    def __init__(self, eligibility: CustomerDocumentEligibility) -> None:
+        if eligibility.allowed or not eligibility.blockers:
+            raise ValueError(
+                "CustomerDocumentCreationBlocked requires a blocked eligibility"
+            )
+        self.eligibility = eligibility
+        self.blockers = eligibility.blockers
+        codes = ", ".join(blocker.code for blocker in eligibility.blockers)
+        super().__init__(f"customer document creation blocked: {codes}")
+
+    @property
+    def primary_code(self) -> DocumentBlockerCode:
+        return self.blockers[0].code
+
+    @property
+    def codes(self) -> tuple[DocumentBlockerCode, ...]:
+        return tuple(blocker.code for blocker in self.blockers)

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -1,7 +1,7 @@
 """Build and read frozen Auftragsbestätigung document snapshots — EMAIL_MVP_1 B1.
 
-Facts come from CustomerDocumentProjection (Inquiry + OrderVersion +
-OrderCommercialSnapshot). Persistence remains OrderConfirmationDocumentSnapshot.
+Lifecycle: build CustomerDocumentProjection → evaluate eligibility → persist.
+Create policy lives in evaluate_customer_document_eligibility only.
 """
 
 from __future__ import annotations
@@ -11,15 +11,17 @@ from typing import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentCreationBlocked,
+    CustomerDocumentEligibility as DocumentCreateEligibility,
+)
 from catering_system.domain.customer_document_projection import (
     CustomerAddress,
     CustomerDocumentProjection,
+    CustomerDocumentRecipient,
 )
-from catering_system.domain.inquiry import Inquiry
 from catering_system.domain.order import Order, OrderVersion
-from catering_system.domain.order_commercial_snapshot import (
-    MissingCommercialSnapshotError,
-)
+from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentPosition,
     OrderConfirmationDocumentSnapshot,
@@ -38,8 +40,12 @@ from catering_system.repositories.order_confirmation_document_repository import 
     OrderConfirmationDocumentRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.customer_document_eligibility import (
+    evaluate_customer_document_eligibility,
+)
 from catering_system.services.customer_document_projection import (
     CustomerDocumentProjectionService,
+    build_customer_document_recipient,
 )
 from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
@@ -51,7 +57,10 @@ class OrderConfirmationDocumentNotFoundError(LookupError):
 
 
 class OrderConfirmationDocumentBlockedError(ValueError):
-    """Preconditions for snapshot creation are not satisfied."""
+    """Legacy/internal refusal (e.g. invalid commercial totals).
+
+    Create-policy refusals use CustomerDocumentCreationBlocked instead.
+    """
 
 
 class OrderConfirmationDocumentStaleVersionError(ValueError):
@@ -120,24 +129,18 @@ class OrderConfirmationDocumentService:
                 can_prepare=False,
                 snapshot=self._summary(existing, version_number),
             )
-        blocked = self._prepare_blocker(order)
-        if blocked is not None:
+        decision = self._evaluate_create(order)
+        if not decision.allowed:
+            primary = decision.blockers[0].code
             return OrderConfirmationDocumentEligibility(
                 available=False,
-                state=blocked,
-                blocker_code=blocked,
+                state=primary,
+                blocker_code=primary,
                 can_prepare=False,
             )
-        inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
-        recipient_status = _recipient_status_from_inquiry(inquiry)
-        state = (
-            "empfaenger_fehlt"
-            if recipient_status == "missing"
-            else "bereit_zur_vorschau"
-        )
         return OrderConfirmationDocumentEligibility(
             available=True,
-            state=state,
+            state="bereit_zur_vorschau",
             can_prepare=True,
         )
 
@@ -153,24 +156,32 @@ class OrderConfirmationDocumentService:
         order = self._orders.get_order(order_id)
         if order is None:
             raise OrderConfirmationDocumentNotFoundError(order_id)
-        blocker = self._operational_blocker(order)
-        if blocker is not None:
-            raise OrderConfirmationDocumentBlockedError(blocker)
-        if order.effective_order_version_id != expected_effective_order_version_id:
-            raise OrderConfirmationDocumentStaleVersionError(
-                "expected effective order version is stale"
-            )
         existing = self._documents.get_by_order_version_id(
             expected_effective_order_version_id
         )
         if existing is not None:
             return existing
-        assert order.effective_order_version_id is not None
-        version = self._require_effective_version(order)
-        commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
-        if commercial is None:
-            raise MissingCommercialSnapshotError(order.order_id)
-        inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+
+        version, commercial, recipient = self._create_inputs(
+            order,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+        )
+        decision = evaluate_customer_document_eligibility(
+            order=order,
+            order_version=version,
+            commercial_snapshot=commercial,
+            recipient=recipient,
+        )
+        if not decision.allowed:
+            raise CustomerDocumentCreationBlocked(decision)
+        if order.effective_order_version_id != expected_effective_order_version_id:
+            raise OrderConfirmationDocumentStaleVersionError(
+                "expected effective order version is stale"
+            )
+        assert commercial is not None
+        assert version is not None
+
         document_id = str(uuid.uuid4())
         created_at = self._now()
         projection = self._projection.build(
@@ -179,19 +190,17 @@ class OrderConfirmationDocumentService:
             created_at=created_at,
             order_version=version,
             commercial_snapshot=commercial,
-            inquiry=inquiry,
+            inquiry=self._inquiries.get_by_id(order.source_inquiry_id),
             invoice_address=invoice_address,
             delivery_address=delivery_address,
         )
         draft = _persist_snapshot_from_projection(
             projection,
-            inquiry=inquiry,
             created_by=created_by,
             document_hash="sha256:" + ("0" * 64),
         )
         snapshot = _persist_snapshot_from_projection(
             projection,
-            inquiry=inquiry,
             created_by=created_by,
             document_hash=compute_document_hash(draft),
         )
@@ -246,47 +255,52 @@ class OrderConfirmationDocumentService:
             effective_version_number=version_number,
         )
 
-    def _operational_blocker(self, order: Order) -> str | None:
-        if order.cancelled_at is not None:
-            return "nicht_verfuegbar"
-        if order.effective_order_version_id is None:
-            return "nicht_verfuegbar"
-        version = self._orders.get_order_version(order.effective_order_version_id)
-        if version is None:
-            return "nicht_verfuegbar"
-        if order.candidate_order_version_id is not None:
-            return "aenderung_wartet"
-        if version.kitchen_print_confirmed_at is None:
-            return "aenderung_wartet"
-        return None
+    def _evaluate_create(
+        self,
+        order: Order,
+        *,
+        invoice_address: CustomerAddress | None = None,
+        delivery_address: CustomerAddress | None = None,
+    ) -> DocumentCreateEligibility:
+        version, commercial, recipient = self._create_inputs(
+            order,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+        )
+        return evaluate_customer_document_eligibility(
+            order=order,
+            order_version=version,
+            commercial_snapshot=commercial,
+            recipient=recipient,
+        )
 
-    def _prepare_blocker(self, order: Order) -> str | None:
-        blocked = self._operational_blocker(order)
-        if blocked is not None:
-            return blocked
-        if self._commercial_snapshots.get_by_order_id(order.order_id) is None:
-            return "nicht_verfuegbar"
-        return None
-
-    def _require_effective_version(self, order: Order) -> OrderVersion:
-        version_id = order.effective_order_version_id
-        assert version_id is not None
-        version = self._orders.get_order_version(version_id)
-        if version is None:
-            raise OrderConfirmationDocumentBlockedError("nicht_verfuegbar")
-        return version
-
-
-def _recipient_status_from_inquiry(inquiry: Inquiry | None) -> RecipientStatus:
-    if inquiry is None or inquiry.customer_snapshot is None:
-        return "missing"
-    return "ready" if inquiry.customer_snapshot.email else "missing"
+    def _create_inputs(
+        self,
+        order: Order,
+        *,
+        invoice_address: CustomerAddress | None = None,
+        delivery_address: CustomerAddress | None = None,
+    ) -> tuple[
+        OrderVersion | None,
+        OrderCommercialSnapshot | None,
+        CustomerDocumentRecipient,
+    ]:
+        version: OrderVersion | None = None
+        if order.effective_order_version_id is not None:
+            version = self._orders.get_order_version(order.effective_order_version_id)
+        commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
+        inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+        recipient = build_customer_document_recipient(
+            inquiry,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+        )
+        return version, commercial, recipient
 
 
 def _persist_snapshot_from_projection(
     projection: CustomerDocumentProjection,
     *,
-    inquiry: Inquiry | None,
     created_by: str,
     document_hash: str,
 ) -> OrderConfirmationDocumentSnapshot:
@@ -296,7 +310,6 @@ def _persist_snapshot_from_projection(
         != projection.gross_total_cents
     ):
         raise OrderConfirmationDocumentBlockedError("commercial_totals_invalid")
-    contact = inquiry.customer_snapshot if inquiry is not None else None
     return OrderConfirmationDocumentSnapshot(
         document_snapshot_id=projection.document_id,
         order_id=projection.event.order_id,
@@ -310,8 +323,8 @@ def _persist_snapshot_from_projection(
         created_by=created_by,
         recipient_name=projection.recipient.name,
         recipient_email=projection.recipient.email,
-        recipient_company=contact.company_name if contact is not None else None,
-        recipient_phone=contact.phone if contact is not None else None,
+        recipient_company=projection.recipient.company_name,
+        recipient_phone=projection.recipient.phone,
         recipient_status=("ready" if projection.recipient.email else "missing"),
         event_date=projection.event.event_date,
         time_window_text=projection.event.time_window_text,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -109,6 +109,9 @@ from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentService,
     OrderConfirmationDocumentStaleVersionError,
 )
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentCreationBlocked,
+)
 from catering_system.services.order_confirmation_outbound_service import (
     OrderConfirmationOutboundAlreadySentError,
     OrderConfirmationOutboundBlockedError,
@@ -1707,12 +1710,14 @@ class OfficeApi:
             )
         except OrderConfirmationDocumentStaleVersionError as exc:
             raise ApiError(409, "stale_state") from exc
-        except MissingCommercialSnapshotError as exc:
-            raise ApiError(422, "confirmation_document_blocked") from exc
+        except CustomerDocumentCreationBlocked as exc:
+            raise ApiError(
+                422,
+                "confirmation_document_blocked",
+                reasons=exc.codes,
+            ) from exc
         except OrderConfirmationDocumentBlockedError as exc:
             message = str(exc)
-            if message == "aenderung_wartet":
-                raise ApiError(422, "pending_order_version_change") from exc
             if message == "commercial_totals_invalid":
                 raise ApiError(422, "commercial_totals_invalid") from exc
             raise ApiError(422, "confirmation_document_blocked") from exc

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3144,6 +3144,13 @@ class OfficePanel:
     def prepare_confirmation_document(
         self, order_id: str, form: dict[str, str]
     ) -> None:
+        from catering_system.domain.customer_document_eligibility import (
+            CustomerDocumentCreationBlocked,
+        )
+        from catering_system.ui.office_panel_order_detail import (
+            _CONFIRMATION_STATE_LABELS,
+        )
+
         order = self._orders.get_order(order_id)
         if order is None or order.cancelled_at is not None:
             raise ValueError(f"no active order with id {order_id!r}")
@@ -3160,11 +3167,17 @@ class OfficePanel:
         assert effective_version_id is not None
 
         def work() -> None:
-            self.confirmation_document_service.prepare_snapshot(
-                order_id,
-                effective_version_id,
-                "office-panel",
-            )
+            try:
+                self.confirmation_document_service.prepare_snapshot(
+                    order_id,
+                    effective_version_id,
+                    "office-panel",
+                )
+            except CustomerDocumentCreationBlocked as exc:
+                labels = [
+                    _CONFIRMATION_STATE_LABELS.get(code, code) for code in exc.codes
+                ]
+                raise ValueError("; ".join(labels)) from exc
 
         if self._remote is not None:
             work()

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -35,6 +35,10 @@ _CONFIRMATION_STATE_LABELS = {
     "empfaenger_fehlt": "Empfänger-E-Mail fehlt",
     "bereit_zur_vorschau": "Bereit zur Vorschau",
     "dokument_erstellt": "Dokument erstellt",
+    "MISSING_COMMERCIAL_SNAPSHOT": "Kommerzieller Snapshot fehlt",
+    "MISSING_CUSTOMER_NAME": "Kundenname fehlt",
+    "MISSING_CUSTOMER_CONTACT": "Kundenkontakt fehlt",
+    "INVALID_ORDER_STATE": "Auftrag nicht bereit für Kundendokument",
 }
 
 _OUTBOUND_STATE_LABELS = {

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -47,7 +47,9 @@ from catering_system.domain.inquiry_customer_snapshot import (
 )
 
 _CONTACT_COMPLETE_SNAPSHOT = _CCSnapshot(
-    email="kunde@example.com", phone="+49301234567"
+    email="kunde@example.com",
+    phone="+49301234567",
+    company_name="Example GmbH",
 )
 
 _INQUIRY_ID = "22222222-2222-4222-8222-222222222222"

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -72,6 +72,8 @@ def _seed(db_path: Path) -> dict[str, str]:
             call_verification_status="not_required",
             contact_email="kunde@example.com",
             contact_phone="+49301234567",
+            company_name="Example GmbH",
+            contact_name="Example Contact",
         )
         base.update(overrides)
         return inquiry_service.create_inquiry(**base)
@@ -796,8 +798,8 @@ def test_inquiry_detail_shape(api) -> None:
     assert body["customer_linkage"] == {}
     assert body["customer_id"] is None
     assert body["customer_snapshot"] == {
-        "company_name": None,
-        "contact_name": None,
+        "company_name": "Example GmbH",
+        "contact_name": "Example Contact",
         "email": "kunde@example.com",
         "phone": "+49301234567",
     }
@@ -3621,7 +3623,8 @@ def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
         args={"created_by": "office-api-test"},
         expect={"current_effective_order_version_id": order_version_id},
     )
-    assert (status, body["error"]) == (422, "pending_order_version_change")
+    assert (status, body["error"]) == (422, "confirmation_document_blocked")
+    assert "INVALID_ORDER_STATE" in body.get("reasons", [])
 
     # Order without commercial snapshot: confirmation is blocked (invariant).
     inquiries = SQLiteInquiryRepository(db)
@@ -3655,28 +3658,38 @@ def test_confirmation_document_stale_expect_and_blocked_states(api) -> None:
     assert (status, body["error"]) == (422, "confirmation_document_blocked")
 
 
-def test_confirmation_document_missing_recipient_is_allowed(api) -> None:
+def test_confirmation_document_missing_recipient_is_blocked(api) -> None:
     base, ids, db = api
     inquiry_id = ids["inquiry_offer_ready"]
     order_id, order_version_id = _make_effective_offer_order(
         api, inquiry_id=inquiry_id, ensure_recipient_email=False
     )
     _clear_inquiry_recipient_email(db, inquiry_id)
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    contact = inquiry.customer_snapshot
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=contact.company_name if contact else None,
+                contact_name=contact.contact_name if contact else None,
+                phone=None,
+                email=None,
+            ),
+        )
+    )
+    inquiries.close()
     status, created, _h = _post(
         _confirmation_document_url(base, order_id),
         args={"created_by": "office-api-test"},
         expect={"current_effective_order_version_id": order_version_id},
     )
-    assert status == 201
-    assert created["snapshot"]["recipient_status"] == "missing"
-    assert created["snapshot"]["recipient_email_masked"] is None
-
-    preview = _get(_confirmation_preview_url(base, order_id, format="json"))[1][
-        "preview"
-    ]
-    assert preview["recipient_status"] == "missing"
-    assert preview["recipient_email_masked"] is None
-    assert _confirmation_snapshot_count(db) == 1
+    assert status == 422
+    assert created["error"] == "confirmation_document_blocked"
+    assert "MISSING_CUSTOMER_CONTACT" in created.get("reasons", [])
+    assert _confirmation_snapshot_count(db) == 0
 
 
 def test_confirmation_document_preview_rejects_unknown_format(api) -> None:

--- a/tests/unit/test_office_panel_confirmation_document.py
+++ b/tests/unit/test_office_panel_confirmation_document.py
@@ -16,6 +16,8 @@ from http.server import HTTPServer
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.repositories.core_transaction import (
     CoreCommandExecutor,
@@ -290,11 +292,10 @@ def test_legacy_order_detail_before_snapshot_shows_prepare_action(
     page = panel.render_order(order_id)
     assert page is not None
     assert "Auftragsbestätigung" in page
-    assert views.confirmation_document_shape(eligibility)["state"] in {
-        "bereit_zur_vorschau",
-        "empfaenger_fehlt",
-    }
-    assert "Bereit zur Vorschau" in page or "Empfänger-E-Mail fehlt" in page
+    assert (
+        views.confirmation_document_shape(eligibility)["state"] == "bereit_zur_vorschau"
+    )
+    assert "Bereit zur Vorschau" in page
     assert "Vorschau erstellen" in page
     assert "Senden" not in page
 
@@ -410,12 +411,28 @@ def test_panel_prepare_action_persists_single_snapshot(tmp_path: Path) -> None:
         server.server_close()
 
 
-def test_missing_email_shows_state_and_allows_preview(tmp_path: Path) -> None:
+def test_missing_contact_blocks_prepare_action(tmp_path: Path) -> None:
     db, doc_service, _core, _orders, order_id, order_version_id = _sqlite_world(
         tmp_path,
         clear_recipient_email_after_convert=True,
     )
+    # Clear phone too — contact requires email or phone.
     connection = open_core_connection(db)
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    contact = inquiry.customer_snapshot
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=contact.company_name if contact else None,
+                contact_name=contact.contact_name if contact else None,
+                phone=None,
+                email=None,
+            ),
+        )
+    )
     panel = OfficePanel(
         SQLiteInquiryRepository.from_connection(connection),
         SQLiteOrderRepository.from_connection(connection),
@@ -430,27 +447,20 @@ def test_missing_email_shows_state_and_allows_preview(tmp_path: Path) -> None:
     )
     before = panel.render_order(order_id)
     assert before is not None
-    assert "Empfänger-E-Mail fehlt" in before
+    assert "Kundenkontakt fehlt" in before
+    assert "Vorschau erstellen" not in before
 
-    snapshot = doc_service.prepare_snapshot(
-        order_id,
-        order_version_id,
-        "office-panel",
+    from catering_system.domain.customer_document_eligibility import (
+        CustomerDocumentCreationBlocked,
     )
-    assert snapshot.recipient_status == "missing"
-    assert snapshot.recipient_email is None
 
-    panel_url, server = _start_panel_server(db)
-    try:
-        status, preview, _headers = _get(
-            f"{panel_url}/order/{order_id}/confirmation-document/preview"
+    with pytest.raises(CustomerDocumentCreationBlocked):
+        doc_service.prepare_snapshot(
+            order_id,
+            order_version_id,
+            "office-panel",
         )
-        assert status == 200
-        assert "customer@example.invalid" not in preview
-        assert "@example.invalid" not in preview
-    finally:
-        server.shutdown()
-        server.server_close()
+    assert _snapshot_count(db) == 0
 
 
 def test_pending_candidate_shows_blocked_state_without_prepare(tmp_path: Path) -> None:
@@ -486,9 +496,10 @@ def test_pending_candidate_shows_blocked_state_without_prepare(tmp_path: Path) -
     )
     page = panel.render_order(order_id)
     assert page is not None
-    assert "Änderung wartet auf Küchendruck" in page
+    assert "Auftrag nicht bereit für Kundendokument" in page
     assert "Vorschau erstellen" not in page
     assert doc_service.eligibility(order_id).can_prepare is False
+    assert doc_service.eligibility(order_id).state == "INVALID_ORDER_STATE"
 
 
 def test_legacy_and_v2_share_confirmation_projection(tmp_path: Path) -> None:

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -11,13 +11,15 @@ from pathlib import Path
 
 import pytest
 
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentCreationBlocked,
+)
 from catering_system.domain.customer_document_projection import (
     WARNING_DELIVERY_ADDRESS_DIFFERS,
     CustomerAddress,
 )
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.order_commercial_snapshot import (
-    MissingCommercialSnapshotError,
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
@@ -145,8 +147,9 @@ def test_no_effective_version_blocked() -> None:
     orders, _offers, _inquiries, _documents, service, _core, _offer_service = services
     order = orders.list_orders()[0]
     orders.update_order(replace(order, effective_order_version_id=None))
-    with pytest.raises(OrderConfirmationDocumentBlockedError, match="nicht_verfuegbar"):
+    with pytest.raises(CustomerDocumentCreationBlocked) as exc_info:
         service.prepare_snapshot(order.order_id, str(uuid.uuid4()), "office-panel")
+    assert "INVALID_ORDER_STATE" in exc_info.value.codes
 
 
 def test_pending_candidate_blocked() -> None:
@@ -164,12 +167,13 @@ def test_pending_candidate_blocked() -> None:
         actor_reference="office-panel",
         change_reason="Test",
     )
-    with pytest.raises(OrderConfirmationDocumentBlockedError, match="aenderung_wartet"):
+    with pytest.raises(CustomerDocumentCreationBlocked) as exc_info:
         service.prepare_snapshot(
             order.order_id,
             order.effective_order_version_id,
             "office-panel",
         )
+    assert "INVALID_ORDER_STATE" in exc_info.value.codes
 
 
 def test_kitchen_print_not_confirmed_blocked() -> None:
@@ -198,12 +202,13 @@ def test_kitchen_print_not_confirmed_blocked() -> None:
         InMemoryOrderConfirmationDocumentRepository(),
         offer_service._commercial_snapshots,
     )
-    with pytest.raises(OrderConfirmationDocumentBlockedError, match="aenderung_wartet"):
+    with pytest.raises(CustomerDocumentCreationBlocked) as exc_info:
         service.prepare_snapshot(
             order.order_id,
             order_version.order_version_id,
             "office-panel",
         )
+    assert "INVALID_ORDER_STATE" in exc_info.value.codes
 
 
 def test_snapshot_uses_effective_order_version_facts() -> None:
@@ -357,7 +362,6 @@ def test_surcharge_linkage_preserved() -> None:
     )
     document = _persist_snapshot_from_projection(
         projection,
-        inquiry=None,
         created_by="test",
         document_hash="sha256:" + ("0" * 64),
     )
@@ -432,7 +436,6 @@ def test_fee_position_preserved() -> None:
     )
     document = _persist_snapshot_from_projection(
         projection,
-        inquiry=None,
         created_by="test",
         document_hash="sha256:" + ("0" * 64),
     )
@@ -440,7 +443,7 @@ def test_fee_position_preserved() -> None:
     assert document.gross_total_cents == 25419
 
 
-def test_recipient_from_customer_snapshot_missing_email() -> None:
+def test_phone_without_email_still_allows_prepare() -> None:
     (
         offer,
         version_id,
@@ -491,6 +494,56 @@ def test_recipient_from_customer_snapshot_missing_email() -> None:
     assert snapshot.recipient_name == "Anna"
     assert snapshot.recipient_email is None
     assert snapshot.recipient_phone == "+491701234567"
+
+
+def test_missing_customer_contact_blocks_prepare() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        offers,
+        orders,
+        inquiries,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="ACME GmbH",
+                contact_name="Anna",
+                phone=None,
+                email=None,
+            ),
+        )
+    )
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+    service = OrderConfirmationDocumentService(
+        orders,
+        inquiries,
+        InMemoryOrderConfirmationDocumentRepository(),
+        offer_service._commercial_snapshots,
+        now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+    with pytest.raises(CustomerDocumentCreationBlocked) as exc_info:
+        service.prepare_snapshot(
+            order.order_id,
+            order_version.order_version_id,
+            "office-panel",
+        )
+    assert "MISSING_CUSTOMER_CONTACT" in exc_info.value.codes
+    assert order_version.order_version_id not in service._documents._by_version
 
 
 def test_address_warning_flows_into_confirmation_document() -> None:
@@ -698,7 +751,7 @@ def test_office_panel_confirmation_block_renders() -> None:
     order, version = _effective_order(services)
     service = services[4]
     eligibility = service.eligibility(order.order_id)
-    assert eligibility.state in {"bereit_zur_vorschau", "empfaenger_fehlt"}
+    assert eligibility.state == "bereit_zur_vorschau"
     outbound = OutboundSendEligibility(state="dokument_fehlt", can_send=False)
     page = render_order_detail(
         order,
@@ -880,9 +933,11 @@ def test_confirmation_fails_when_commercial_snapshot_missing() -> None:
         snapshots,
         now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    with pytest.raises(MissingCommercialSnapshotError):
+    with pytest.raises(CustomerDocumentCreationBlocked) as exc_info:
         service.prepare_snapshot(
             order.order_id,
             version.order_version_id,
             "office-panel",
         )
+    assert "MISSING_COMMERCIAL_SNAPSHOT" in exc_info.value.codes
+    assert exc_info.value.primary_code == "MISSING_COMMERCIAL_SNAPSHOT"

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -46,7 +46,6 @@ from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
 )
 from catering_system.services.order_confirmation_document_service import (
-    OrderConfirmationDocumentBlockedError,
     OrderConfirmationDocumentService,
     OrderConfirmationDocumentStaleVersionError,
     _persist_snapshot_from_projection,


### PR DESCRIPTION
## Summary
- `OrderConfirmationDocumentService` builds projection facts, evaluates `CustomerDocumentEligibility`, then persists — no private create-policy helpers.
- New controlled error `CustomerDocumentCreationBlocked` carries `blockers[]` / `codes` for UI/API (`reasons` on 422).
- Intentional tighten: missing customer contact/name blocks create; address-diff remains warning-only.
- Persist `company`/`phone` from `projection.recipient` (customer_snapshot), not intake parse.

## Test plan
- [x] Valid order → document persisted
- [x] Missing commercial → `CustomerDocumentCreationBlocked` / `MISSING_COMMERCIAL_SNAPSHOT`
- [x] Missing contact → blocked, nothing persisted
- [x] Address warning → persisted + warning
- [x] Invalid order state (candidate / no kitchen / cancelled) → `INVALID_ORDER_STATE`
- [x] ruff / mypy / pytest / coverage ≥ 90%
- [x] confirmation service: no OfferRepository / conversion_link / intake parsing


Made with [Cursor](https://cursor.com)