### PR TITLE
Add live confirmation preview (CUSTOMER_DOCUMENT_PROJECTION_V1-D)

### DIFF
--- a/src/catering_system/domain/customer_document_preview.py
+++ b/src/catering_system/domain/customer_document_preview.py
@@ -1,0 +1,61 @@
+"""Live customer-document preview — CUSTOMER_DOCUMENT_PROJECTION_V1-D.
+
+Read model for operators before create. Not a persisted document identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.domain.customer_document_eligibility import DocumentBlocker
+from catering_system.domain.customer_document_projection import (
+    CustomerDocumentCommercialReference,
+    CustomerDocumentEvent,
+    CustomerDocumentPosition,
+    CustomerDocumentRecipient,
+    CustomerDocumentWarning,
+    DocumentType,
+    DOCUMENT_TYPES,
+)
+from catering_system.domain.order_payment_reminder import (
+    PaymentMethod,
+    validate_payment_method,
+)
+
+
+@dataclass(frozen=True)
+class CustomerDocumentPreview:
+    """Facts + warnings + eligibility for a document that does not yet exist."""
+
+    document_type: DocumentType
+    eligible: bool
+    warnings: tuple[CustomerDocumentWarning, ...]
+    blockers: tuple[DocumentBlocker, ...]
+    recipient: CustomerDocumentRecipient
+    event: CustomerDocumentEvent | None = None
+    commercial_reference: CustomerDocumentCommercialReference | None = None
+    positions: tuple[CustomerDocumentPosition, ...] = ()
+    payment_method: PaymentMethod | None = None
+    payment_customer_visible_text: str | None = None
+    net_total_cents: int | None = None
+    vat_total_cents: int | None = None
+    gross_total_cents: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.document_type not in DOCUMENT_TYPES:
+            raise ValueError("unsupported document_type")
+        if self.eligible != (self.blockers == ()):
+            raise ValueError("eligible must equal (blockers == ())")
+        if self.payment_method is not None:
+            validate_payment_method(self.payment_method)
+        money = (
+            self.net_total_cents,
+            self.vat_total_cents,
+            self.gross_total_cents,
+        )
+        if any(value is None for value in money) and any(
+            value is not None for value in money
+        ):
+            raise ValueError("money totals must be all set or all unset")
+        if self.commercial_reference is None and self.positions:
+            raise ValueError("positions require commercial_reference")

--- a/src/catering_system/services/customer_document_preview.py
+++ b/src/catering_system/services/customer_document_preview.py
@@ -1,0 +1,160 @@
+"""Live customer-document preview — CUSTOMER_DOCUMENT_PROJECTION_V1-D.
+
+Assembles CustomerDocumentPreview from Projection builders + Eligibility.
+No persistence. No Offer. No intake parsing. No PDF/HTML/email.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Callable
+
+from catering_system.domain.customer_document_preview import CustomerDocumentPreview
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    CustomerDocumentEvent,
+)
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+from catering_system.repositories.inquiry_repository import InquiryRepository
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.customer_document_eligibility import (
+    evaluate_customer_document_eligibility,
+)
+from catering_system.services.customer_document_projection import (
+    build_customer_document_projection,
+    build_customer_document_recipient,
+)
+
+_PREVIEW_DOCUMENT_ID = "preview"
+
+
+class CustomerDocumentPreviewNotFoundError(LookupError):
+    """Raised when the order for a live preview does not exist."""
+
+
+def build_customer_document_preview(
+    *,
+    order: Order,
+    order_version: OrderVersion | None,
+    commercial_snapshot: OrderCommercialSnapshot | None,
+    recipient_inquiry: Inquiry | None,
+    invoice_address: CustomerAddress | None = None,
+    delivery_address: CustomerAddress | None = None,
+    now: datetime | None = None,
+) -> CustomerDocumentPreview:
+    """Pure assemble of live preview facts + eligibility (no repos)."""
+    recipient = build_customer_document_recipient(
+        recipient_inquiry,
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+    )
+    eligibility = evaluate_customer_document_eligibility(
+        order=order,
+        order_version=order_version,
+        commercial_snapshot=commercial_snapshot,
+        recipient=recipient,
+    )
+    event = _event_from_version(order_version)
+    if commercial_snapshot is not None and order_version is not None:
+        projection = build_customer_document_projection(
+            document_type="ORDER_CONFIRMATION",
+            document_id=_PREVIEW_DOCUMENT_ID,
+            created_at=now or datetime.now(UTC),
+            order_version=order_version,
+            commercial_snapshot=commercial_snapshot,
+            recipient=recipient,
+        )
+        return CustomerDocumentPreview(
+            document_type="ORDER_CONFIRMATION",
+            eligible=eligibility.allowed,
+            warnings=projection.recipient.warnings,
+            blockers=eligibility.blockers,
+            recipient=projection.recipient,
+            event=projection.event,
+            commercial_reference=projection.commercial_reference,
+            positions=projection.positions,
+            payment_method=projection.payment_method,
+            payment_customer_visible_text=projection.payment_customer_visible_text,
+            net_total_cents=projection.net_total_cents,
+            vat_total_cents=projection.vat_total_cents,
+            gross_total_cents=projection.gross_total_cents,
+        )
+    return CustomerDocumentPreview(
+        document_type="ORDER_CONFIRMATION",
+        eligible=eligibility.allowed,
+        warnings=recipient.warnings,
+        blockers=eligibility.blockers,
+        recipient=recipient,
+        event=event,
+        commercial_reference=None,
+        positions=(),
+        payment_method=None,
+        payment_customer_visible_text=None,
+        net_total_cents=None,
+        vat_total_cents=None,
+        gross_total_cents=None,
+    )
+
+
+def _event_from_version(
+    order_version: OrderVersion | None,
+) -> CustomerDocumentEvent | None:
+    if order_version is None:
+        return None
+    return CustomerDocumentEvent(
+        order_id=order_version.order_id,
+        order_version_id=order_version.order_version_id,
+        version_number=order_version.version_number,
+        event_date=order_version.event_date,
+        time_window_text=order_version.time_window_text,
+        location_text=order_version.location_text,
+        guest_count_estimate=order_version.guest_count_estimate,
+        planning_mode=order_version.planning_mode,
+    )
+
+
+class CustomerDocumentPreviewService:
+    """Load order truth and build a live confirmation preview."""
+
+    def __init__(
+        self,
+        order_repository: OrderRepository,
+        inquiry_repository: InquiryRepository,
+        commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+        *,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._orders = order_repository
+        self._inquiries = inquiry_repository
+        self._commercial_snapshots = commercial_snapshot_repository
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def preview_order_confirmation(
+        self,
+        order_id: str,
+        *,
+        invoice_address: CustomerAddress | None = None,
+        delivery_address: CustomerAddress | None = None,
+    ) -> CustomerDocumentPreview:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise CustomerDocumentPreviewNotFoundError(order_id)
+        version: OrderVersion | None = None
+        if order.effective_order_version_id is not None:
+            version = self._orders.get_order_version(order.effective_order_version_id)
+        commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
+        inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+        return build_customer_document_preview(
+            order=order,
+            order_version=version,
+            commercial_snapshot=commercial,
+            recipient_inquiry=inquiry,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+            now=self._now(),
+        )

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -103,14 +103,18 @@ from catering_system.services.offer_service import OfferService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
 from catering_system.services.payment_reminder_service import PaymentReminderService
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentCreationBlocked,
+)
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewNotFoundError,
+    CustomerDocumentPreviewService,
+)
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentBlockedError,
     OrderConfirmationDocumentNotFoundError,
     OrderConfirmationDocumentService,
     OrderConfirmationDocumentStaleVersionError,
-)
-from catering_system.domain.customer_document_eligibility import (
-    CustomerDocumentCreationBlocked,
 )
 from catering_system.services.order_confirmation_outbound_service import (
     OrderConfirmationOutboundAlreadySentError,
@@ -426,6 +430,11 @@ class OfficeApi:
             self.orders,
             self.inquiries,
             self.confirmation_documents,
+            self.commercial_snapshots,
+        )
+        self.customer_document_preview_service = CustomerDocumentPreviewService(
+            self.orders,
+            self.inquiries,
             self.commercial_snapshots,
         )
         self.core = OperationalCoreService(
@@ -820,6 +829,16 @@ class OfficeApi:
             "snapshot": views.confirmation_document_summary_shape(summary),
             "document_snapshot_id": snapshot.document_snapshot_id,
         }
+
+    def confirmation_preview(self, order_id: str) -> dict[str, object]:
+        """Live CDP preview before document create — V1-D (no persistence)."""
+        try:
+            preview = self.customer_document_preview_service.preview_order_confirmation(
+                order_id
+            )
+        except CustomerDocumentPreviewNotFoundError as exc:
+            raise ApiError(404, "not_found") from exc
+        return views.customer_document_preview_shape(preview)
 
     def confirmation_document_preview(
         self,
@@ -2267,6 +2286,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         {"POST": "confirmation-document-send"},
     ),
     (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/confirmation-preview$"),
+        "/office/v1/orders/{id}/confirmation-preview",
+        {"GET": "confirmation_preview"},
+    ),
+    (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/confirmation-document/preview$"),
         "/office/v1/orders/{id}/confirmation-document/preview",
         {"GET": "confirmation_document_preview"},
@@ -2623,6 +2647,9 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
                 self._respond(
                     200, api.confirmation_document(path_ids["id"], snapshot_id)
                 )
+            elif kind == "confirmation_preview":
+                self._query(set())
+                self._respond(200, api.confirmation_preview(path_ids["id"]))
             elif kind == "confirmation_document_preview":
                 params = self._query({"document_snapshot_id", "format"})
                 snapshot_id = (

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -676,6 +676,93 @@ def confirmation_document_preview_shape(
     return preview_to_json(preview)
 
 
+def customer_document_preview_shape(preview: object) -> dict[str, object]:
+    """JSON shape for live CustomerDocumentPreview (V1-D)."""
+    from catering_system.domain.customer_document_preview import CustomerDocumentPreview
+    from catering_system.domain.customer_document_projection import CustomerAddress
+
+    assert isinstance(preview, CustomerDocumentPreview)
+
+    def address(value: CustomerAddress | None) -> dict[str, object] | None:
+        if value is None:
+            return None
+        return {
+            "street": value.street,
+            "postal_code": value.postal_code,
+            "city": value.city,
+            "country": value.country,
+        }
+
+    recipient = preview.recipient
+    event = preview.event
+    commercial = preview.commercial_reference
+    return {
+        "document_type": preview.document_type,
+        "eligible": preview.eligible,
+        "warnings": list(preview.warnings),
+        "blockers": [
+            {"code": blocker.code, "detail": blocker.detail}
+            for blocker in preview.blockers
+        ],
+        "recipient": {
+            "name": recipient.name,
+            "email": recipient.email,
+            "company_name": recipient.company_name,
+            "phone": recipient.phone,
+            "invoice_address": address(recipient.invoice_address),
+            "delivery_address": address(recipient.delivery_address),
+            "delivery_address_differs": recipient.delivery_address_differs,
+        },
+        "commercial": (
+            None
+            if commercial is None
+            else {
+                "snapshot_id": commercial.snapshot_id,
+                "source_offer_id": commercial.source_offer_id,
+                "source_offer_version_id": commercial.source_offer_version_id,
+                "variant_label": commercial.variant_label,
+            }
+        ),
+        "event": (
+            None
+            if event is None
+            else {
+                "order_id": event.order_id,
+                "order_version_id": event.order_version_id,
+                "version_number": event.version_number,
+                "event_date": event.event_date.isoformat(),
+                "time_window_text": event.time_window_text,
+                "location_text": event.location_text,
+                "guest_count_estimate": event.guest_count_estimate,
+                "planning_mode": event.planning_mode,
+            }
+        ),
+        "positions": [
+            {
+                "position_id": position.position_id,
+                "kind": position.kind,
+                "name": position.name,
+                "description": position.description,
+                "composition": position.composition,
+                "quantity": position.quantity,
+                "unit_label": position.unit_label,
+                "unit_net_cents": position.unit_net_cents,
+                "net_total_cents": position.net_total_cents,
+                "vat_rate_percent": position.vat_rate_percent,
+                "vat_amount_cents": position.vat_amount_cents,
+                "gross_total_cents": position.gross_total_cents,
+                "related_position_id": position.related_position_id,
+            }
+            for position in preview.positions
+        ],
+        "payment_method": preview.payment_method,
+        "payment_customer_visible_text": preview.payment_customer_visible_text,
+        "net_total_cents": preview.net_total_cents,
+        "vat_total_cents": preview.vat_total_cents,
+        "gross_total_cents": preview.gross_total_cents,
+    }
+
+
 def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
     return {
         "order_id": view.order_id,

--- a/tests/unit/test_customer_document_preview.py
+++ b/tests/unit/test_customer_document_preview.py
@@ -1,0 +1,305 @@
+"""CUSTOMER_DOCUMENT_PROJECTION_V1-D — live confirmation preview."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+)
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    OrderCommercialPosition,
+    OrderCommercialSnapshot,
+)
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_confirmation_document_repository import (
+    InMemoryOrderConfirmationDocumentRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewNotFoundError,
+    CustomerDocumentPreviewService,
+    build_customer_document_preview,
+)
+from catering_system.services.order_confirmation_document_service import (
+    OrderConfirmationDocumentService,
+)
+
+_ORDER_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_INQUIRY_ID = "99999999-9999-4999-8999-999999999999"
+_SNAPSHOT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_OFFER_VERSION_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+_PRINT_AT = datetime(2026, 7, 15, 13, 0, tzinfo=UTC)
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _inquiry(
+    *,
+    snapshot: InquiryCustomerSnapshot | None = None,
+) -> Inquiry:
+    return Inquiry(
+        inquiry_id=_INQUIRY_ID,
+        event_date=date(2026, 8, 20),
+        inquiry_source="manual",
+        crm_stage="Bestätigt / Auftrag",
+        customer_linkage={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        customer_snapshot=snapshot
+        or InquiryCustomerSnapshot(
+            company_name="ACME GmbH",
+            contact_name="Anna",
+            email="anna@example.invalid",
+            phone="+49301234567",
+        ),
+        intake_message="Firma: SHOULD-NOT-USE\nE-Mail: intake@example.invalid\n",
+    )
+
+
+def _order() -> Order:
+    return Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+        effective_order_version_id=_VERSION_ID,
+    )
+
+
+def _version() -> OrderVersion:
+    return OrderVersion(
+        order_version_id=_VERSION_ID,
+        order_id=_ORDER_ID,
+        version_number=1,
+        created_at=_NOW,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        kitchen_print_confirmed_at=_PRINT_AT,
+    )
+
+
+def _commercial() -> OrderCommercialSnapshot:
+    return OrderCommercialSnapshot(
+        snapshot_id=_SNAPSHOT_ID,
+        order_id=_ORDER_ID,
+        source_offer_id=_OFFER_ID,
+        source_offer_version_id=_OFFER_VERSION_ID,
+        source_variant_id="44444444-4444-4444-8444-444444444441",
+        acceptance_id="66666666-6666-4666-8666-666666666661",
+        accepted_at=_NOW,
+        recorded_by="office-panel",
+        variant_label="Variante A",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        created_at=_NOW,
+        positions=(
+            OrderCommercialPosition(
+                position_id=_POSITION_ID,
+                kind="catalog",
+                name="Fingerfood Paket",
+                unit_net_cents=290,
+                net_total_cents=23200,
+                vat_rate_percent=7,
+                vat_amount_cents=1624,
+                gross_total_cents=24824,
+                quantity=Decimal("80"),
+                quantity_mode="total",
+                unit_label="Stück",
+            ),
+        ),
+    )
+
+
+def _codes(preview) -> tuple[str, ...]:
+    return tuple(blocker.code for blocker in preview.blockers)
+
+
+def test_valid_preview_is_eligible() -> None:
+    preview = build_customer_document_preview(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient_inquiry=_inquiry(),
+        now=_NOW,
+    )
+    assert preview.eligible is True
+    assert preview.blockers == ()
+    assert preview.recipient.name == "Anna"
+    assert preview.recipient.company_name == "ACME GmbH"
+    assert preview.commercial_reference is not None
+    assert preview.commercial_reference.variant_label == "Variante A"
+    assert preview.positions[0].name == "Fingerfood Paket"
+    assert preview.gross_total_cents == 24824
+    assert preview.event is not None
+    assert preview.event.location_text == "Hamburg"
+
+
+def test_missing_contact_preview_returns_blocker_not_exception() -> None:
+    preview = build_customer_document_preview(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient_inquiry=_inquiry(
+            snapshot=InquiryCustomerSnapshot(
+                company_name="ACME GmbH",
+                contact_name="Anna",
+                email=None,
+                phone=None,
+            )
+        ),
+        now=_NOW,
+    )
+    assert preview.eligible is False
+    assert "MISSING_CUSTOMER_CONTACT" in _codes(preview)
+    assert preview.positions[0].name == "Fingerfood Paket"
+
+
+def test_address_warning_keeps_preview_eligible() -> None:
+    preview = build_customer_document_preview(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient_inquiry=_inquiry(),
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        now=_NOW,
+    )
+    assert preview.eligible is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in preview.warnings
+    assert preview.blockers == ()
+
+
+def test_missing_commercial_preview_is_partial_and_ineligible() -> None:
+    preview = build_customer_document_preview(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=None,
+        recipient_inquiry=_inquiry(),
+        now=_NOW,
+    )
+    assert preview.eligible is False
+    assert _codes(preview) == ("MISSING_COMMERCIAL_SNAPSHOT",)
+    assert preview.commercial_reference is None
+    assert preview.positions == ()
+    assert preview.net_total_cents is None
+    assert preview.event is not None
+    assert preview.recipient.name == "Anna"
+
+
+def test_preview_service_does_not_persist_confirmation_document() -> None:
+    from tests.helpers.order_seed import seed_order
+
+    orders = InMemoryOrderRepository()
+    inquiries = InMemoryInquiryRepository()
+    commercials = InMemoryOrderCommercialSnapshotRepository()
+    documents = InMemoryOrderConfirmationDocumentRepository()
+    inquiry = _inquiry()
+    inquiries.save(inquiry)
+    order, version = seed_order(
+        orders,
+        inquiry,
+        order_id=_ORDER_ID,
+        order_version_id=_VERSION_ID,
+        created_at=_NOW,
+    )
+    orders.update_order_version(
+        OrderVersion(
+            order_version_id=version.order_version_id,
+            order_id=order.order_id,
+            version_number=1,
+            created_at=_NOW,
+            event_date=date(2026, 8, 20),
+            time_window_text="18:00–22:00",
+            location_text="Hamburg",
+            guest_count_estimate=80,
+            planning_mode="caterer_suggestion",
+            kitchen_print_confirmed_at=_PRINT_AT,
+        )
+    )
+    orders.update_order(
+        Order(
+            order_id=order.order_id,
+            source_inquiry_id=inquiry.inquiry_id,
+            created_at=_NOW,
+            updated_at=_NOW,
+            effective_order_version_id=version.order_version_id,
+        )
+    )
+    commercials.create(_commercial())
+
+    preview_service = CustomerDocumentPreviewService(
+        orders, inquiries, commercials, now=lambda: _NOW
+    )
+    preview = preview_service.preview_order_confirmation(_ORDER_ID)
+    assert preview.eligible is True
+    assert documents.get_latest_for_order(_ORDER_ID) is None
+
+    confirmation = OrderConfirmationDocumentService(
+        orders, inquiries, documents, commercials, now=lambda: _NOW
+    )
+    confirmation.prepare_snapshot(_ORDER_ID, _VERSION_ID, "office-panel")
+    assert documents.get_latest_for_order(_ORDER_ID) is not None
+
+
+def test_preview_service_unknown_order_raises() -> None:
+    service = CustomerDocumentPreviewService(
+        InMemoryOrderRepository(),
+        InMemoryInquiryRepository(),
+        InMemoryOrderCommercialSnapshotRepository(),
+    )
+    with pytest.raises(CustomerDocumentPreviewNotFoundError):
+        service.preview_order_confirmation(_ORDER_ID)
+
+
+def test_preview_modules_boundary() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
+    for relative in (
+        "domain/customer_document_preview.py",
+        "services/customer_document_preview.py",
+    ):
+        text = (root / relative).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, relative
+        assert "conversion_link" not in text, relative
+        assert "parse_intake_contact" not in text, relative
+        assert "labelled_intake_context" not in text, relative
+        assert "OrderConfirmationDocumentSnapshot" not in text, relative

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3204,6 +3204,11 @@ def _confirmation_document_url(base: str, order_id: str) -> str:
     return f"{base}/office/v1/orders/{order_id}/confirmation-document"
 
 
+def _live_confirmation_preview_url(base: str, order_id: str) -> str:
+    """Live CDP preview before create (V1-D) — not the persisted-document renderer."""
+    return f"{base}/office/v1/orders/{order_id}/confirmation-preview"
+
+
 def _confirmation_preview_url(
     base: str,
     order_id: str,
@@ -3741,6 +3746,7 @@ def test_confirmation_document_routes_require_bearer_auth(api) -> None:
     for url in (
         _confirmation_document_url(base, order_id),
         _confirmation_preview_url(base, order_id, format="json"),
+        _live_confirmation_preview_url(base, order_id),
     ):
         status, body, _h = _get(url, headers=no_auth)
         assert (status, body["error"]) == (401, "unauthorized")
@@ -3751,6 +3757,104 @@ def test_confirmation_document_routes_require_bearer_auth(api) -> None:
         headers=no_auth,
     )
     assert (status, body["error"]) == (401, "unauthorized")
+
+
+# --- live confirmation preview (CUSTOMER_DOCUMENT_PROJECTION_V1-D) ------------
+
+
+def test_live_confirmation_preview_eligible_does_not_persist(api) -> None:
+    base, _ids, db = api
+    order_id, _version_id = _make_effective_offer_order(api)
+    count_before = _confirmation_snapshot_count(db)
+
+    status, body, _h = _get(_live_confirmation_preview_url(base, order_id))
+    assert status == 200
+    assert body["document_type"] == "ORDER_CONFIRMATION"
+    assert body["eligible"] is True
+    assert body["blockers"] == []
+    assert body["commercial"] is not None
+    assert body["positions"]
+    assert body["recipient"]["email"] == "kunde@example.com"
+    assert body["recipient"]["name"] == "Example Contact"
+    assert "document_id" not in body
+    assert "document_snapshot_id" not in body
+    assert _confirmation_snapshot_count(db) == count_before
+
+
+def test_live_confirmation_preview_missing_commercial_returns_200_with_blocker(
+    api,
+) -> None:
+    base, ids, db = api
+    inquiries = SQLiteInquiryRepository(db)
+    orders = SQLiteOrderRepository(db)
+    inquiry = inquiries.get_by_id(ids["inquiry_convertible"])
+    assert inquiry is not None
+    order, version = seed_order(orders, inquiry)
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, version.order_version_id)
+    core.make_order_version_effective(order.order_id, version.order_version_id)
+    inquiries.close()
+    orders.close()
+
+    status, body, _h = _get(_live_confirmation_preview_url(base, order.order_id))
+    assert status == 200
+    assert body["eligible"] is False
+    assert [row["code"] for row in body["blockers"]] == ["MISSING_COMMERCIAL_SNAPSHOT"]
+    assert body["commercial"] is None
+    assert body["positions"] == []
+    assert body["event"] is not None
+    assert body["recipient"]["name"] == "Example Contact"
+    assert "document_id" not in body
+    assert _confirmation_snapshot_count(db) == 0
+
+
+def test_live_confirmation_preview_shows_blockers_while_prepare_still_enforces(
+    api,
+) -> None:
+    base, ids, db = api
+    inquiry_id = ids["inquiry_offer_ready"]
+    order_id, order_version_id = _make_effective_offer_order(
+        api, inquiry_id=inquiry_id, ensure_recipient_email=False
+    )
+    _clear_inquiry_recipient_email(db, inquiry_id)
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    contact = inquiry.customer_snapshot
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=contact.company_name if contact else None,
+                contact_name=contact.contact_name if contact else None,
+                phone=None,
+                email=None,
+            ),
+        )
+    )
+    inquiries.close()
+
+    status, preview, _h = _get(_live_confirmation_preview_url(base, order_id))
+    assert status == 200
+    assert preview["eligible"] is False
+    assert "MISSING_CUSTOMER_CONTACT" in [row["code"] for row in preview["blockers"]]
+    assert _confirmation_snapshot_count(db) == 0
+
+    status, created, _h = _post(
+        _confirmation_document_url(base, order_id),
+        args={"created_by": "office-api-test"},
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert status == 422
+    assert created["error"] == "confirmation_document_blocked"
+    assert "MISSING_CUSTOMER_CONTACT" in created.get("reasons", [])
+    assert _confirmation_snapshot_count(db) == 0
+
+
+def test_live_confirmation_preview_unknown_order_is_404(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _get(_live_confirmation_preview_url(base, str(uuid.uuid4())))
+    assert (status, body["error"]) == (404, "not_found")
 
 
 # --- confirmation outbound fake outbox (EMAIL_MVP_2 / outbound pack B2) ------


### PR DESCRIPTION
## Summary
- Introduces `CustomerDocumentPreview` + `CustomerDocumentPreviewService` (Projection + Eligibility, no persistence).
- Adds `GET /office/v1/orders/{order_id}/confirmation-preview` for live CDP state: always **200** with `eligible` / `blockers` (including partial facts when commercial is missing).
- Leaves `GET .../confirmation-document/preview` unchanged (persisted snapshot → rendering). No panel wiring, no `document_id` on preview.

## Test plan
- [x] Unit: eligible / missing contact / address warning / missing commercial (200 + blocker) / no persist / boundary greps
- [x] API: eligible preview side-effect free; missing commercial diagnostic; Preview 200 vs Prepare 422; 404; auth
- [x] `ruff` / `mypy` / `coverage run -m pytest` (≥90%)

Made with [Cursor](https://cursor.com)