### PR TITLE
Wire Office Panel to live confirmation preview (V1-E)

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -112,6 +112,10 @@ from catering_system.services.payment_reminder_service import PaymentReminderSer
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentService,
 )
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewNotFoundError,
+    CustomerDocumentPreviewService,
+)
 from catering_system.services.order_confirmation_outbound_service import (
     OrderConfirmationOutboundAlreadySentError,
     OrderConfirmationOutboundService,
@@ -163,7 +167,9 @@ from catering_system.ui.office_panel_inquiry_detail import (
     render_inquiry_detail,
 )
 from catering_system.ui.office_panel_order_detail import (
+    ConfirmationLivePreviewView,
     OrderDetailFormFields,
+    _DOCUMENT_BLOCKER_LABELS,
     render_confirmation_card,
     render_confirmation_outbound_card,
     render_operational_pause_card,
@@ -385,6 +391,11 @@ class OfficePanel:
                 document_repo,
                 self._commercial_snapshots,
             )
+            self.customer_document_preview_service = CustomerDocumentPreviewService(
+                order_repo,
+                inquiry_repo,
+                self._commercial_snapshots,
+            )
             self.confirmation_outbound_service = OrderConfirmationOutboundService(
                 order_repo,
                 document_repo,
@@ -405,6 +416,10 @@ class OfficePanel:
             self.core = remote.core  # type: ignore[assignment]
             self.payment_reminder_service = remote.payment_reminder_service  # type: ignore[assignment]
             self.confirmation_document_service = remote.confirmation_document_service  # type: ignore[assignment]
+            self.customer_document_preview_service = cast(
+                CustomerDocumentPreviewService,
+                remote.confirmation_document_service,
+            )
             self.confirmation_outbound_service = remote.confirmation_outbound_service  # type: ignore[assignment]
             self.catalog_dish_write_service = remote.catalog_dish_write_service  # type: ignore[assignment]
             self._pause_repository = None
@@ -2690,6 +2705,7 @@ class OfficePanel:
         ev = self.core.evaluate_ready_to_send(order_id)
         payment = self.payment_reminder_service.view(order_id)
         confirmation = self.confirmation_document_service.eligibility(order_id)
+        live_preview = self._live_confirmation_preview(order_id)
         snapshot_id = (
             confirmation.snapshot.document_snapshot_id
             if confirmation.snapshot is not None
@@ -2833,6 +2849,7 @@ class OfficePanel:
                     version_change_prefill=change_prefill if not cancelled else None,
                 ),
                 confirmation=confirmation,
+                live_preview=live_preview,
                 outbound=outbound,
                 operational_pause=pause_view,
                 versions_total_count=versions_total_count,
@@ -3046,6 +3063,7 @@ class OfficePanel:
             order,
             confirmation,
             detail_forms,
+            live_preview,
         )
         outbound_card = render_confirmation_outbound_card(
             order,
@@ -3141,14 +3159,29 @@ class OfficePanel:
         else:
             work()
 
+    def _live_confirmation_preview(self, order_id: str) -> ConfirmationLivePreviewView:
+        """Load live CDP preview for create-gate diagnostics (V1-E)."""
+        from catering_system.ui.remote_core_client import RemoteCoreError
+
+        try:
+            preview = self.customer_document_preview_service.preview_order_confirmation(
+                order_id
+            )
+        except CustomerDocumentPreviewNotFoundError:
+            return ConfirmationLivePreviewView(state="not_found")
+        except RemoteCoreError as exc:
+            if exc.status == 404:
+                return ConfirmationLivePreviewView(state="not_found")
+            if exc.code == "invalid_response":
+                return ConfirmationLivePreviewView(state="parse_error")
+            return ConfirmationLivePreviewView(state="unavailable")
+        return ConfirmationLivePreviewView(state="ready", preview=preview)
+
     def prepare_confirmation_document(
         self, order_id: str, form: dict[str, str]
     ) -> None:
         from catering_system.domain.customer_document_eligibility import (
             CustomerDocumentCreationBlocked,
-        )
-        from catering_system.ui.office_panel_order_detail import (
-            _CONFIRMATION_STATE_LABELS,
         )
 
         order = self._orders.get_order(order_id)
@@ -3175,7 +3208,7 @@ class OfficePanel:
                 )
             except CustomerDocumentCreationBlocked as exc:
                 labels = [
-                    _CONFIRMATION_STATE_LABELS.get(code, code) for code in exc.codes
+                    _DOCUMENT_BLOCKER_LABELS.get(code, code) for code in exc.codes
                 ]
                 raise ValueError("; ".join(labels)) from exc
 

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import html
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
+from catering_system.domain.customer_document_preview import CustomerDocumentPreview
 from catering_system.domain.inquiry import PLANNING_MODES
 from catering_system.domain.order import (
     Order,
@@ -35,11 +37,21 @@ _CONFIRMATION_STATE_LABELS = {
     "empfaenger_fehlt": "Empfänger-E-Mail fehlt",
     "bereit_zur_vorschau": "Bereit zur Vorschau",
     "dokument_erstellt": "Dokument erstellt",
+}
+
+_DOCUMENT_BLOCKER_LABELS = {
     "MISSING_COMMERCIAL_SNAPSHOT": "Kommerzieller Snapshot fehlt",
     "MISSING_CUSTOMER_NAME": "Kundenname fehlt",
     "MISSING_CUSTOMER_CONTACT": "Kundenkontakt fehlt",
     "INVALID_ORDER_STATE": "Auftrag nicht bereit für Kundendokument",
 }
+
+_DOCUMENT_WARNING_LABELS = {
+    "DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE": (
+        "Lieferadresse weicht von Rechnungsadresse ab"
+    ),
+}
+
 
 _OUTBOUND_STATE_LABELS = {
     "dokument_fehlt": "Dokument fehlt",
@@ -99,6 +111,28 @@ class OrderVersionChangePrefill:
     guest_count_estimate: str
     planning_mode: str
     latest_version_number: int
+
+
+ConfirmationLivePreviewState = Literal[
+    "ready",
+    "unavailable",
+    "parse_error",
+    "not_found",
+]
+
+
+@dataclass(frozen=True)
+class ConfirmationLivePreviewView:
+    """Live CDP preview load result for Order Detail (V1-E)."""
+
+    state: ConfirmationLivePreviewState
+    preview: CustomerDocumentPreview | None = None
+
+    def __post_init__(self) -> None:
+        if self.state == "ready" and self.preview is None:
+            raise ValueError("ready live preview requires preview payload")
+        if self.state != "ready" and self.preview is not None:
+            raise ValueError("non-ready live preview must not carry payload")
 
 
 @dataclass(frozen=True)
@@ -572,12 +606,27 @@ def _payment_card(
     )
 
 
+def _document_blocker_label(code: str) -> str:
+    return _DOCUMENT_BLOCKER_LABELS.get(code, code)
+
+
+def _document_warning_label(code: str) -> str:
+    return _DOCUMENT_WARNING_LABELS.get(code, code)
+
+
+def _confirmation_state_label(state: str) -> str:
+    if state in _CONFIRMATION_STATE_LABELS:
+        return _CONFIRMATION_STATE_LABELS[state]
+    return _document_blocker_label(state)
+
+
 def _confirmation_card(
     order: Order,
     confirmation: OrderConfirmationDocumentEligibility,
     forms: OrderDetailFormFields,
+    live_preview: ConfirmationLivePreviewView,
 ) -> str:
-    state_label = _CONFIRMATION_STATE_LABELS.get(confirmation.state, confirmation.state)
+    state_label = _confirmation_state_label(confirmation.state)
     facts: list[tuple[str, str]] = [("Status", state_label)]
     snapshot = confirmation.snapshot
     if snapshot is not None:
@@ -597,12 +646,19 @@ def _confirmation_card(
                 ("Erstellt", snapshot.created_at.strftime("%d.%m.%Y · %H:%M")),
             ]
         )
+    live_html = _live_preview_diagnostics(live_preview)
     actions: list[str] = []
-    if confirmation.can_prepare:
+    can_create = (
+        snapshot is None
+        and live_preview.state == "ready"
+        and live_preview.preview is not None
+        and live_preview.preview.eligible
+    )
+    if can_create:
         actions.append(
             f'<form method="post" action="/order/{_e(order.order_id)}/confirmation-document">'
             f"{forms.csrf_input}{forms.confirmation_command_fields}"
-            '<button type="submit">Vorschau erstellen</button></form>'
+            '<button type="submit">Auftragsbestätigung erstellen</button></form>'
         )
     if snapshot is not None:
         actions.append(
@@ -620,18 +676,74 @@ def _confirmation_card(
             for label, value in facts
         )
         + "</dl>"
+        + live_html
         + "".join(actions)
         + "</section>"
     )
+
+
+def _live_preview_diagnostics(live_preview: ConfirmationLivePreviewView) -> str:
+    if live_preview.state == "unavailable":
+        return (
+            '<p class="order-context-note blocked">'
+            "Live-Vorschau derzeit nicht verfügbar.</p>"
+        )
+    if live_preview.state == "parse_error":
+        return (
+            '<p class="order-context-note blocked">'
+            "Live-Vorschau konnte nicht gelesen werden.</p>"
+        )
+    if live_preview.state == "not_found":
+        return (
+            '<p class="order-context-note blocked">'
+            "Auftrag für Live-Vorschau nicht gefunden.</p>"
+        )
+    preview = live_preview.preview
+    assert preview is not None
+    parts: list[str] = []
+    if preview.blockers:
+        items = "".join(
+            f"<li>{_e(_document_blocker_label(blocker.code))}</li>"
+            for blocker in preview.blockers
+        )
+        parts.append(
+            '<div class="order-blockers"><strong>Erstellung blockiert</strong>'
+            f"<ul>{items}</ul></div>"
+        )
+    if preview.warnings:
+        items = "".join(
+            f"<li>{_e(_document_warning_label(code))}</li>" for code in preview.warnings
+        )
+        parts.append(
+            '<div class="order-context-note"><strong>Hinweise</strong>'
+            f"<ul>{items}</ul></div>"
+        )
+    if (
+        preview.commercial_reference is not None
+        and preview.gross_total_cents is not None
+    ):
+        parts.append(
+            '<p class="order-context-note">'
+            f"Vorschau brutto: "
+            f"{_e(f'{preview.gross_total_cents / 100:.2f} €'.replace('.', ','))}"
+            f" · {_e(preview.commercial_reference.variant_label)}</p>"
+        )
+    elif preview.recipient.name:
+        parts.append(
+            '<p class="order-context-note">'
+            f"Empfänger (Vorschau): {_e(preview.recipient.name)}</p>"
+        )
+    return "".join(parts)
 
 
 def render_confirmation_card(
     order: Order,
     confirmation: OrderConfirmationDocumentEligibility,
     forms: OrderDetailFormFields,
+    live_preview: ConfirmationLivePreviewView,
 ) -> str:
     """Shared Auftragsbestätigung card for v2 and legacy Order Detail."""
-    return _confirmation_card(order, confirmation, forms)
+    return _confirmation_card(order, confirmation, forms, live_preview)
 
 
 def render_confirmation_outbound_card(
@@ -866,6 +978,7 @@ def render_order_detail(
     confirmation: OrderConfirmationDocumentEligibility,
     outbound: OutboundSendEligibility,
     forms: OrderDetailFormFields,
+    live_preview: ConfirmationLivePreviewView,
     *,
     operational_pause: Mapping[str, object] | None = None,
     versions_total_count: int,
@@ -946,7 +1059,7 @@ def render_order_detail(
         + "</div>"
         '<aside class="order-detail-side">'
         + _primary_action(order, target, next_action, forms)
-        + _confirmation_card(order, confirmation, forms)
+        + _confirmation_card(order, confirmation, forms, live_preview)
         + render_confirmation_outbound_card(
             order, confirmation, outbound, forms, operational_pause=pause_view
         )

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -18,9 +18,27 @@ from datetime import date, datetime
 from typing import Any, NoReturn, cast
 from urllib.parse import quote, urlencode, urlparse
 
+from catering_system.domain.customer_document_eligibility import (
+    DOCUMENT_BLOCKER_CODES,
+    DocumentBlocker,
+    DocumentBlockerCode,
+)
+from catering_system.domain.customer_document_preview import CustomerDocumentPreview
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+    CustomerDocumentCommercialReference,
+    CustomerDocumentEvent,
+    CustomerDocumentPosition,
+    CustomerDocumentRecipient,
+    CustomerDocumentWarning,
+    DocumentType,
+)
 from catering_system.domain.inquiry import (
     Inquiry,
     InquiryOfficeNextAction,
+    PLANNING_MODE_SET,
+    PlanningMode,
     validate_call_verification_status,
     validate_crm_stage,
     validate_customer_linkage,
@@ -35,7 +53,9 @@ from catering_system.domain.inquiry_customer_snapshot import (
     snapshot_from_structured_contact,
 )
 from catering_system.domain.order_payment_reminder import (
+    PAYMENT_METHODS,
     OrderPaymentReminder,
+    PaymentMethod,
     PaymentReminderView,
     validate_payment_method,
 )
@@ -2912,6 +2932,76 @@ _CONFIRMATION_SUMMARY_KEYS = frozenset(
         "effective_version_number",
     }
 )
+_CUSTOMER_DOCUMENT_PREVIEW_KEYS = frozenset(
+    {
+        "document_type",
+        "eligible",
+        "blockers",
+        "warnings",
+        "recipient",
+        "event",
+        "commercial",
+        "positions",
+        "payment_method",
+        "payment_customer_visible_text",
+        "net_total_cents",
+        "vat_total_cents",
+        "gross_total_cents",
+    }
+)
+_PREVIEW_RECIPIENT_KEYS = frozenset(
+    {
+        "name",
+        "email",
+        "company_name",
+        "phone",
+        "invoice_address",
+        "delivery_address",
+        "delivery_address_differs",
+    }
+)
+_PREVIEW_ADDRESS_KEYS = frozenset({"street", "postal_code", "city", "country"})
+_PREVIEW_BLOCKER_KEYS = frozenset({"code", "detail"})
+_PREVIEW_COMMERCIAL_KEYS = frozenset(
+    {
+        "snapshot_id",
+        "source_offer_id",
+        "source_offer_version_id",
+        "variant_label",
+    }
+)
+_PREVIEW_EVENT_KEYS = frozenset(
+    {
+        "order_id",
+        "order_version_id",
+        "version_number",
+        "event_date",
+        "time_window_text",
+        "location_text",
+        "guest_count_estimate",
+        "planning_mode",
+    }
+)
+_PREVIEW_POSITION_KEYS = frozenset(
+    {
+        "position_id",
+        "kind",
+        "name",
+        "description",
+        "composition",
+        "quantity",
+        "unit_label",
+        "unit_net_cents",
+        "net_total_cents",
+        "vat_rate_percent",
+        "vat_amount_cents",
+        "gross_total_cents",
+        "related_position_id",
+    }
+)
+_DOCUMENT_BLOCKER_CODE_SET: frozenset[str] = frozenset(DOCUMENT_BLOCKER_CODES)
+_DOCUMENT_WARNING_SET: frozenset[str] = frozenset({WARNING_DELIVERY_ADDRESS_DIFFERS})
+_PAYMENT_METHOD_SET: frozenset[str] = frozenset(PAYMENT_METHODS)
 
 
 def _confirmation_document_summary(raw: object) -> OrderConfirmationDocumentSummary:
@@ -2957,6 +3047,184 @@ def _confirmation_document_eligibility(
     )
 
 
+def _preview_address(raw: object) -> CustomerAddress | None:
+    if raw is None:
+        return None
+    data = _dict(raw)
+    _exact(data, _PREVIEW_ADDRESS_KEYS)
+    try:
+        return CustomerAddress(
+            street=_optional_str(data["street"]),
+            postal_code=_optional_str(data["postal_code"]),
+            city=_optional_str(data["city"]),
+            country=_optional_str(data["country"]),
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _preview_blocker(raw: object) -> DocumentBlocker:
+    data = _dict(raw)
+    _exact(data, _PREVIEW_BLOCKER_KEYS)
+    code = _str(data["code"])
+    if code not in _DOCUMENT_BLOCKER_CODE_SET:
+        _bad_response()
+    try:
+        return DocumentBlocker(
+            code=cast(DocumentBlockerCode, code),
+            detail=_optional_str(data["detail"]),
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _preview_warnings(raw: object) -> tuple[CustomerDocumentWarning, ...]:
+    items = _list(raw)
+    warnings: list[CustomerDocumentWarning] = []
+    for item in items:
+        code = _str(item)
+        if code not in _DOCUMENT_WARNING_SET:
+            _bad_response()
+        warnings.append(cast(CustomerDocumentWarning, code))
+    return tuple(warnings)
+
+
+def _preview_recipient(raw: object) -> CustomerDocumentRecipient:
+    data = _dict(raw)
+    _exact(data, _PREVIEW_RECIPIENT_KEYS)
+    differs = _bool(data["delivery_address_differs"])
+    invoice = _preview_address(data["invoice_address"])
+    delivery = _preview_address(data["delivery_address"])
+    recipient_warnings: tuple[CustomerDocumentWarning, ...] = (
+        (WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else ()
+    )
+    try:
+        return CustomerDocumentRecipient(
+            name=_str(data["name"]),
+            email=_optional_str(data["email"]),
+            company_name=_optional_str(data["company_name"]),
+            phone=_optional_str(data["phone"]),
+            invoice_address=invoice,
+            delivery_address=delivery,
+            delivery_address_differs=differs,
+            warnings=recipient_warnings,
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _preview_commercial(
+    raw: object,
+) -> CustomerDocumentCommercialReference | None:
+    if raw is None:
+        return None
+    data = _dict(raw)
+    _exact(data, _PREVIEW_COMMERCIAL_KEYS)
+    try:
+        return CustomerDocumentCommercialReference(
+            snapshot_id=_str(data["snapshot_id"]),
+            source_offer_id=_str(data["source_offer_id"]),
+            source_offer_version_id=_str(data["source_offer_version_id"]),
+            variant_label=_str(data["variant_label"]),
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _preview_event(raw: object) -> CustomerDocumentEvent | None:
+    if raw is None:
+        return None
+    data = _dict(raw)
+    _exact(data, _PREVIEW_EVENT_KEYS)
+    planning = _str(data["planning_mode"])
+    if planning not in PLANNING_MODE_SET:
+        _bad_response()
+    try:
+        return CustomerDocumentEvent(
+            order_id=_str(data["order_id"]),
+            order_version_id=_str(data["order_version_id"]),
+            version_number=_nonnegative_int(data["version_number"]),
+            event_date=_date(data["event_date"]),
+            time_window_text=_str(data["time_window_text"]),
+            location_text=_str(data["location_text"]),
+            guest_count_estimate=_optional_int(data["guest_count_estimate"]),
+            planning_mode=cast(PlanningMode, planning),
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _preview_position(raw: object) -> CustomerDocumentPosition:
+    data = _dict(raw)
+    _exact(data, _PREVIEW_POSITION_KEYS)
+    try:
+        return CustomerDocumentPosition(
+            position_id=_str(data["position_id"]),
+            kind=_str(data["kind"]),
+            name=_str(data["name"]),
+            description=_optional_str(data["description"]),
+            composition=_optional_str(data["composition"]),
+            quantity=_optional_str(data["quantity"]),
+            unit_label=_optional_str(data["unit_label"]),
+            unit_net_cents=_nonnegative_int(data["unit_net_cents"]),
+            net_total_cents=_nonnegative_int(data["net_total_cents"]),
+            vat_rate_percent=_int(data["vat_rate_percent"]),
+            vat_amount_cents=_nonnegative_int(data["vat_amount_cents"]),
+            gross_total_cents=_nonnegative_int(data["gross_total_cents"]),
+            related_position_id=_optional_str(data["related_position_id"]),
+        )
+    except ValueError:
+        _bad_response()
+
+
+def _customer_document_preview(raw: object) -> CustomerDocumentPreview:
+    data = _dict(raw)
+    _exact(data, _CUSTOMER_DOCUMENT_PREVIEW_KEYS)
+    document_type_raw = _str(data["document_type"])
+    if document_type_raw != "ORDER_CONFIRMATION":
+        _bad_response()
+    document_type: DocumentType = "ORDER_CONFIRMATION"
+    eligible = _bool(data["eligible"])
+    blockers = tuple(_preview_blocker(item) for item in _list(data["blockers"]))
+    warnings = _preview_warnings(data["warnings"])
+    recipient = _preview_recipient(data["recipient"])
+    if (WARNING_DELIVERY_ADDRESS_DIFFERS in warnings) != (
+        recipient.delivery_address_differs
+    ):
+        _bad_response()
+    payment_raw = data["payment_method"]
+    payment: PaymentMethod | None
+    if payment_raw is None:
+        payment = None
+    else:
+        method = _str(payment_raw)
+        if method not in _PAYMENT_METHOD_SET:
+            _bad_response()
+        payment = cast(PaymentMethod, method)
+    try:
+        return CustomerDocumentPreview(
+            document_type=document_type,
+            eligible=eligible,
+            warnings=warnings,
+            blockers=blockers,
+            recipient=recipient,
+            event=_preview_event(data["event"]),
+            commercial_reference=_preview_commercial(data["commercial"]),
+            positions=tuple(
+                _preview_position(item) for item in _list(data["positions"])
+            ),
+            payment_method=payment,
+            payment_customer_visible_text=_optional_str(
+                data["payment_customer_visible_text"]
+            ),
+            net_total_cents=_optional_int(data["net_total_cents"]),
+            vat_total_cents=_optional_int(data["vat_total_cents"]),
+            gross_total_cents=_optional_int(data["gross_total_cents"]),
+        )
+    except ValueError:
+        _bad_response()
+
+
 class _RemoteConfirmationDocumentService:
     def __init__(self, client: RemoteCoreClient) -> None:
         self._client = client
@@ -3000,6 +3268,13 @@ class _RemoteConfirmationDocumentService:
             f"/office/v1/orders/{quote(order_id, safe='')}/confirmation-document/preview",
             {"format": "html"},
         )
+
+    def preview_order_confirmation(self, order_id: str) -> CustomerDocumentPreview:
+        """Live CDP preview before create — V1-E (exact-key, fail-closed)."""
+        payload = self._client.get(
+            f"/office/v1/orders/{quote(order_id, safe='')}/confirmation-preview"
+        )
+        return _customer_document_preview(payload)
 
 
 class _RemoteConfirmationOutboundService:

--- a/tests/unit/test_customer_document_preview_remote.py
+++ b/tests/unit/test_customer_document_preview_remote.py
@@ -1,0 +1,229 @@
+"""CUSTOMER_DOCUMENT_PROJECTION_V1-E — remote preview exact-key parse."""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
+
+_TOKEN = "test-remote-preview-token"
+_ORDER_ID = "22222222-2222-4222-8222-222222222222"
+_VERSION_ID = "33333333-3333-4333-8333-333333333331"
+_SNAPSHOT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_OFFER_VERSION_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_POSITION_ID = "55555555-5555-4555-8555-555555555551"
+
+
+def _serve(handler_cls: type[BaseHTTPRequestHandler]) -> tuple[str, HTTPServer]:
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return f"http://{host}:{port}", server
+
+
+def _eligible_payload() -> dict[str, Any]:
+    return {
+        "document_type": "ORDER_CONFIRMATION",
+        "eligible": True,
+        "blockers": [],
+        "warnings": [],
+        "recipient": {
+            "name": "Anna",
+            "email": "anna@example.invalid",
+            "company_name": "ACME GmbH",
+            "phone": "+49301234567",
+            "invoice_address": None,
+            "delivery_address": None,
+            "delivery_address_differs": False,
+        },
+        "event": {
+            "order_id": _ORDER_ID,
+            "order_version_id": _VERSION_ID,
+            "version_number": 1,
+            "event_date": "2026-08-20",
+            "time_window_text": "18:00–22:00",
+            "location_text": "Hamburg",
+            "guest_count_estimate": 80,
+            "planning_mode": "caterer_suggestion",
+        },
+        "commercial": {
+            "snapshot_id": _SNAPSHOT_ID,
+            "source_offer_id": _OFFER_ID,
+            "source_offer_version_id": _OFFER_VERSION_ID,
+            "variant_label": "Variante A",
+        },
+        "positions": [
+            {
+                "position_id": _POSITION_ID,
+                "kind": "catalog",
+                "name": "Fingerfood Paket",
+                "description": None,
+                "composition": None,
+                "quantity": "80 Stück",
+                "unit_label": "Stück",
+                "unit_net_cents": 290,
+                "net_total_cents": 23200,
+                "vat_rate_percent": 7,
+                "vat_amount_cents": 1624,
+                "gross_total_cents": 24824,
+                "related_position_id": None,
+            }
+        ],
+        "payment_method": "RECHNUNG",
+        "payment_customer_visible_text": "Zahlung per Rechnung",
+        "net_total_cents": 23200,
+        "vat_total_cents": 1624,
+        "gross_total_cents": 24824,
+    }
+
+
+def _handler_with(body: dict[str, Any] | None, *, status: int = 200):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            return
+
+        def do_GET(self) -> None:  # noqa: N802
+            if status == 404:
+                payload = {"error": "not_found"}
+                raw = json.dumps(payload).encode()
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+                return
+            assert body is not None
+            raw = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+    return Handler
+
+
+def test_preview_order_confirmation_parses_eligible_payload() -> None:
+    base, server = _serve(_handler_with(_eligible_payload()))
+    try:
+        client = RemoteCoreClient(base, _TOKEN)
+        preview = client.confirmation_document_service.preview_order_confirmation(
+            _ORDER_ID
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert preview.eligible is True
+    assert preview.blockers == ()
+    assert preview.warnings == ()
+    assert preview.recipient.name == "Anna"
+    assert preview.commercial_reference is not None
+    assert preview.gross_total_cents == 24824
+
+
+def test_preview_order_confirmation_parses_multi_blockers() -> None:
+    payload = _eligible_payload()
+    payload["eligible"] = False
+    payload["blockers"] = [
+        {"code": "MISSING_CUSTOMER_CONTACT", "detail": None},
+        {"code": "MISSING_COMMERCIAL_SNAPSHOT", "detail": "no row"},
+    ]
+    payload["commercial"] = None
+    payload["positions"] = []
+    payload["payment_method"] = None
+    payload["payment_customer_visible_text"] = None
+    payload["net_total_cents"] = None
+    payload["vat_total_cents"] = None
+    payload["gross_total_cents"] = None
+    base, server = _serve(_handler_with(payload))
+    try:
+        client = RemoteCoreClient(base, _TOKEN)
+        preview = client.confirmation_document_service.preview_order_confirmation(
+            _ORDER_ID
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert preview.eligible is False
+    assert [b.code for b in preview.blockers] == [
+        "MISSING_CUSTOMER_CONTACT",
+        "MISSING_COMMERCIAL_SNAPSHOT",
+    ]
+
+
+def test_preview_order_confirmation_parses_warning() -> None:
+    payload = _eligible_payload()
+    payload["warnings"] = ["DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE"]
+    payload["recipient"]["invoice_address"] = {
+        "street": "Büro 1",
+        "postal_code": "20095",
+        "city": "Hamburg",
+        "country": "DE",
+    }
+    payload["recipient"]["delivery_address"] = {
+        "street": "Event 9",
+        "postal_code": "20457",
+        "city": "Hamburg",
+        "country": "DE",
+    }
+    payload["recipient"]["delivery_address_differs"] = True
+    base, server = _serve(_handler_with(payload))
+    try:
+        client = RemoteCoreClient(base, _TOKEN)
+        preview = client.confirmation_document_service.preview_order_confirmation(
+            _ORDER_ID
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert preview.eligible is True
+    assert preview.warnings == ("DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE",)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda p: p.pop("eligible"),
+        lambda p: p.pop("blockers"),
+        lambda p: p.pop("warnings"),
+        lambda p: p.__setitem__("eligible", "yes"),
+        lambda p: p.__setitem__("blockers", "MISSING_CUSTOMER_NAME"),
+        lambda p: p.__setitem__("extra", 1),
+    ],
+)
+def test_preview_order_confirmation_fail_closed_on_bad_payload(mutate) -> None:
+    payload = _eligible_payload()
+    mutate(payload)
+    base, server = _serve(_handler_with(payload))
+    try:
+        client = RemoteCoreClient(base, _TOKEN)
+        with pytest.raises(RemoteCoreError) as exc:
+            client.confirmation_document_service.preview_order_confirmation(_ORDER_ID)
+        assert exc.value.code == "invalid_response"
+        assert exc.value.unavailable is True
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_preview_order_confirmation_404_maps_not_found() -> None:
+    base, server = _serve(_handler_with(None, status=404))
+    try:
+        client = RemoteCoreClient(base, _TOKEN)
+        with pytest.raises(RemoteCoreError) as exc:
+            client.confirmation_document_service.preview_order_confirmation(
+                str(uuid.uuid4())
+            )
+        assert (exc.value.status, exc.value.code) == (404, "not_found")
+        assert exc.value.unavailable is False
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/unit/test_office_panel_confirmation_document.py
+++ b/tests/unit/test_office_panel_confirmation_document.py
@@ -61,6 +61,7 @@ from tests.unit.test_offer_service import (
     _valid_snapshot,
 )
 from catering_system.ui.office_panel_order_detail import (
+    ConfirmationLivePreviewView,
     OrderDetailFormFields,
     render_confirmation_card,
 )
@@ -296,7 +297,7 @@ def test_legacy_order_detail_before_snapshot_shows_prepare_action(
         views.confirmation_document_shape(eligibility)["state"] == "bereit_zur_vorschau"
     )
     assert "Bereit zur Vorschau" in page
-    assert "Vorschau erstellen" in page
+    assert "Auftragsbestätigung erstellen" in page
     assert "Senden" not in page
 
 
@@ -385,7 +386,7 @@ def test_panel_prepare_action_persists_single_snapshot(tmp_path: Path) -> None:
     try:
         status, detail, _ = _get(f"{panel_url}/order/{order_id}")
         assert status == 200
-        assert "Vorschau erstellen" in detail
+        assert "Auftragsbestätigung erstellen" in detail
         assert _snapshot_count(db) == 0
 
         status, _redirect = _post(
@@ -398,7 +399,7 @@ def test_panel_prepare_action_persists_single_snapshot(tmp_path: Path) -> None:
         status, created, _ = _get(f"{panel_url}/order/{order_id}")
         assert status == 200
         assert "Dokument erstellt" in created
-        assert "Vorschau erstellen" not in created
+        assert "Auftragsbestätigung erstellen" not in created
 
         status, _again = _post(
             f"{panel_url}/order/{order_id}/confirmation-document",
@@ -448,7 +449,7 @@ def test_missing_contact_blocks_prepare_action(tmp_path: Path) -> None:
     before = panel.render_order(order_id)
     assert before is not None
     assert "Kundenkontakt fehlt" in before
-    assert "Vorschau erstellen" not in before
+    assert "Auftragsbestätigung erstellen" not in before
 
     from catering_system.domain.customer_document_eligibility import (
         CustomerDocumentCreationBlocked,
@@ -497,7 +498,7 @@ def test_pending_candidate_shows_blocked_state_without_prepare(tmp_path: Path) -
     page = panel.render_order(order_id)
     assert page is not None
     assert "Auftrag nicht bereit für Kundendokument" in page
-    assert "Vorschau erstellen" not in page
+    assert "Auftragsbestätigung erstellen" not in page
     assert doc_service.eligibility(order_id).can_prepare is False
     assert doc_service.eligibility(order_id).state == "INVALID_ORDER_STATE"
 
@@ -621,7 +622,51 @@ def test_confirmation_card_escapes_hostile_user_data() -> None:
             payment_command_fields="",
             confirmation_command_fields="",
         ),
+        live_preview=ConfirmationLivePreviewView(state="unavailable"),
     )
     assert snapshot.document_reference in card
     assert "<script>" not in card
     assert "alert(" not in card
+    assert "Auftragsbestätigung erstellen" not in card
+    assert "Vorschau öffnen" in card
+
+
+def test_create_cta_fail_closed_when_live_preview_unavailable() -> None:
+    """Create gate must not use embed can_prepare when live preview failed."""
+    from catering_system.domain.order import Order
+    from catering_system.services.order_confirmation_document_service import (
+        OrderConfirmationDocumentEligibility,
+    )
+
+    order = Order(
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_inquiry_id="99999999-9999-4999-8999-999999999999",
+        created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+        effective_order_version_id="33333333-3333-4333-8333-333333333331",
+    )
+    eligibility = OrderConfirmationDocumentEligibility(
+        available=True,
+        state="bereit_zur_vorschau",
+        can_prepare=True,
+        snapshot=None,
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        confirmation_command_fields='<input type="hidden" name="x" value="1">',
+    )
+    for state in ("unavailable", "parse_error", "not_found"):
+        card = render_confirmation_card(
+            order,
+            eligibility,
+            forms,
+            live_preview=ConfirmationLivePreviewView(state=state),  # type: ignore[arg-type]
+        )
+        assert "Auftragsbestätigung erstellen" not in card
+        assert "Live-Vorschau" in card or "nicht gefunden" in card

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -55,7 +55,11 @@ from catering_system.services.offer_service import OfferService
 from catering_system.domain.order_payment_reminder import PaymentReminderView
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
 from catering_system.ui import office_api_views as views
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewService,
+)
 from catering_system.ui.office_panel_order_detail import (
+    ConfirmationLivePreviewView,
     OrderDetailFormFields,
     render_order_detail,
 )
@@ -752,6 +756,14 @@ def test_office_panel_confirmation_block_renders() -> None:
     eligibility = service.eligibility(order.order_id)
     assert eligibility.state == "bereit_zur_vorschau"
     outbound = OutboundSendEligibility(state="dokument_fehlt", can_send=False)
+    live = ConfirmationLivePreviewView(
+        state="ready",
+        preview=CustomerDocumentPreviewService(
+            services[0],
+            services[2],
+            services[6]._commercial_snapshots,
+        ).preview_order_confirmation(order.order_id),
+    )
     page = render_order_detail(
         order,
         services[0].list_order_versions(order.order_id),
@@ -785,11 +797,12 @@ def test_office_panel_confirmation_block_renders() -> None:
             confirmation_command_fields="",
             send_command_fields="",
         ),
+        live_preview=live,
         versions_total_count=1,
         versions_truncated=False,
     )
     assert "Auftragsbestätigung" in page.body
-    assert "Vorschau erstellen" in page.body
+    assert "Auftragsbestätigung erstellen" in page.body
     snapshot = service.prepare_snapshot(
         order.order_id,
         version.order_version_id,
@@ -833,11 +846,13 @@ def test_office_panel_confirmation_block_renders() -> None:
             confirmation_command_fields="",
             send_command_fields="",
         ),
+        live_preview=live,
         versions_total_count=1,
         versions_truncated=False,
     )
     assert snapshot.document_reference in page_created.body
     assert "Vorschau öffnen" in page_created.body
+    assert "Auftragsbestätigung erstellen" not in page_created.body
     assert "Testversand erzeugen" in page_created.body
     assert views.confirmation_document_shape(created)["state"] == "dokument_erstellt"
 


### PR DESCRIPTION
## Summary
- Typed `RemoteCoreClient.preview_order_confirmation` with exact-key, fail-closed parsing of the V1-D live preview contract.
- Office Panel Order Detail loads live CDP preview (local + remote parity) and gates **Auftragsbestätigung erstellen** only when: no persisted snapshot + preview ready + `eligible=true`.
- Multi-blocker and soft warning DE labels; `Vorschau öffnen` for persisted documents unchanged; coarse embed `can_prepare` is not the create gate.

## Test plan
- [x] Remote parser: eligible / multi-blocker / warning / missing keys / wrong types / extra keys / 404
- [x] Panel: eligible CTA rename; blocked labels hide CTA; fail-closed when live preview unavailable despite embed `can_prepare`
- [x] After snapshot: create CTA hidden, `Vorschau öffnen` remains
- [x] `ruff` / `mypy` / `coverage run -m pytest` (1671 passed, ≥90%)

Made with [Cursor](https://cursor.com)