### PR TITLE
CUSTOMER_ADDRESS_SOURCE_V1-A: snapshot modes + CDP wiring

### DIFF
--- a/src/catering_system/domain/customer_document_projection.py
+++ b/src/catering_system/domain/customer_document_projection.py
@@ -8,6 +8,7 @@ or intake_message re-parse in builders.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Literal
@@ -28,6 +29,7 @@ WARNING_DELIVERY_ADDRESS_DIFFERS: CustomerDocumentWarning = (
 
 _MAX_TEXT = 20_000
 _MAX_LABEL = 500
+_WHITESPACE = re.compile(r"\s+")
 
 
 def _require_text(value: str, field: str) -> None:
@@ -72,6 +74,53 @@ class CustomerAddress:
             _optional_bounded_text(value, field, max_len=_MAX_LABEL)
 
 
+def canonicalize_customer_address(
+    address: CustomerAddress | None,
+) -> CustomerAddress | None:
+    """Return None when all fields blank; otherwise the address unchanged."""
+    if address is None:
+        return None
+    if not any(
+        (value or "").strip()
+        for value in (
+            address.street,
+            address.postal_code,
+            address.city,
+            address.country,
+        )
+    ):
+        return None
+    return address
+
+
+def normalize_customer_address_fields(
+    address: CustomerAddress,
+) -> tuple[str, str, str, str]:
+    """Comparable form: trim, collapse whitespace, casefold. No geocoding."""
+
+    def one(value: str | None) -> str:
+        if value is None:
+            return ""
+        return _WHITESPACE.sub(" ", value.strip()).casefold()
+
+    return (
+        one(address.street),
+        one(address.postal_code),
+        one(address.city),
+        one(address.country),
+    )
+
+
+def customer_addresses_equal(
+    left: CustomerAddress | None, right: CustomerAddress | None
+) -> bool:
+    if left is None or right is None:
+        return left is right
+    return normalize_customer_address_fields(left) == normalize_customer_address_fields(
+        right
+    )
+
+
 @dataclass(frozen=True)
 class CustomerDocumentRecipient:
     """Customer/contact block for a document — includes dual address slots."""
@@ -93,7 +142,9 @@ class CustomerDocumentRecipient:
         expected_differs = (
             self.invoice_address is not None
             and self.delivery_address is not None
-            and self.invoice_address != self.delivery_address
+            and not customer_addresses_equal(
+                self.invoice_address, self.delivery_address
+            )
         )
         if self.delivery_address_differs != expected_differs:
             raise ValueError("delivery_address_differs does not match addresses")

--- a/src/catering_system/domain/inquiry_customer_snapshot.py
+++ b/src/catering_system/domain/inquiry_customer_snapshot.py
@@ -1,14 +1,30 @@
-"""Immutable inquiry customer snapshot — historical contact fact at link/create time."""
+"""Immutable inquiry customer snapshot — historical contact fact at link/create time.
+
+CUSTOMER_ADDRESS_SOURCE_V1-A: invoice/delivery addresses + delivery_address_mode.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal, cast
 
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    canonicalize_customer_address,
+)
 from catering_system.intake.intake_contact import (
     labelled_intake_context,
     normalize_email,
 )
 from catering_system.domain.phone_normalization import normalize_phone
+
+DeliveryAddressMode = Literal["UNKNOWN", "SAME_AS_INVOICE", "SEPARATE"]
+DELIVERY_ADDRESS_MODES: tuple[DeliveryAddressMode, ...] = (
+    "UNKNOWN",
+    "SAME_AS_INVOICE",
+    "SEPARATE",
+)
+_DELIVERY_ADDRESS_MODE_SET: frozenset[str] = frozenset(DELIVERY_ADDRESS_MODES)
 
 
 @dataclass(frozen=True)
@@ -19,8 +35,32 @@ class InquiryCustomerSnapshot:
     contact_name: str | None = None
     email: str | None = None
     phone: str | None = None
+    invoice_address: CustomerAddress | None = None
+    delivery_address: CustomerAddress | None = None
+    delivery_address_mode: DeliveryAddressMode = "UNKNOWN"
+
+    def __post_init__(self) -> None:
+        if self.delivery_address_mode not in _DELIVERY_ADDRESS_MODE_SET:
+            raise ValueError(
+                f"unsupported delivery_address_mode: {self.delivery_address_mode!r}"
+            )
+        invoice = canonicalize_customer_address(self.invoice_address)
+        delivery = canonicalize_customer_address(self.delivery_address)
+        if invoice is not self.invoice_address:
+            object.__setattr__(self, "invoice_address", invoice)
+        if delivery is not self.delivery_address:
+            object.__setattr__(self, "delivery_address", delivery)
+        if self.delivery_address_mode in {"UNKNOWN", "SAME_AS_INVOICE"}:
+            if self.delivery_address is not None:
+                raise ValueError(
+                    "delivery_address must be None when mode is "
+                    f"{self.delivery_address_mode}"
+                )
+        elif self.delivery_address is None:
+            raise ValueError("SEPARATE mode requires delivery_address")
 
     def is_empty(self) -> bool:
+        """Contact-only emptiness for completeness gates (addresses ignored)."""
         return not any(
             value
             for value in (
@@ -30,6 +70,20 @@ class InquiryCustomerSnapshot:
                 self.phone,
             )
         )
+
+    def has_persisted_facts(self) -> bool:
+        """True when snapshot should be stored (contact and/or address facts)."""
+        return (
+            not self.is_empty()
+            or self.invoice_address is not None
+            or self.delivery_address_mode != "UNKNOWN"
+        )
+
+
+def validate_delivery_address_mode(value: str) -> DeliveryAddressMode:
+    if value not in _DELIVERY_ADDRESS_MODE_SET:
+        raise ValueError(f"unsupported delivery_address_mode: {value!r}")
+    return cast(DeliveryAddressMode, value)
 
 
 def validate_customer_id_reference(value: str) -> str:
@@ -58,7 +112,7 @@ def snapshot_from_intake_message(
         email=email,
         phone=phone,
     )
-    if snapshot.is_empty():
+    if not snapshot.has_persisted_facts():
         return None
     return snapshot
 
@@ -109,14 +163,49 @@ def snapshot_from_structured_contact(
         email=email,
         phone=phone,
     )
-    if snapshot.is_empty():
+    if not snapshot.has_persisted_facts():
         return None
     return snapshot
 
 
+def customer_address_to_mapping(
+    address: CustomerAddress | None,
+) -> dict[str, str | None] | None:
+    if address is None:
+        return None
+    return {
+        "street": address.street,
+        "postal_code": address.postal_code,
+        "city": address.city,
+        "country": address.country,
+    }
+
+
+def customer_address_from_mapping(
+    data: object | None,
+) -> CustomerAddress | None:
+    if data is None:
+        return None
+    if not isinstance(data, dict) or not all(isinstance(k, str) for k in data):
+        raise TypeError("address must be an object or null")
+    allowed = {"street", "postal_code", "city", "country"}
+    if set(data) != allowed:
+        raise ValueError(
+            "address object keys must be exactly street/postal_code/city/country"
+        )
+    return canonicalize_customer_address(
+        CustomerAddress(
+            street=_optional_str(data.get("street")),
+            postal_code=_optional_str(data.get("postal_code")),
+            city=_optional_str(data.get("city")),
+            country=_optional_str(data.get("country")),
+        )
+    )
+
+
 def customer_snapshot_to_mapping(
     snapshot: InquiryCustomerSnapshot | None,
-) -> dict[str, str | None] | None:
+) -> dict[str, object] | None:
     if snapshot is None:
         return None
     return {
@@ -124,6 +213,9 @@ def customer_snapshot_to_mapping(
         "contact_name": snapshot.contact_name,
         "email": snapshot.email,
         "phone": snapshot.phone,
+        "invoice_address": customer_address_to_mapping(snapshot.invoice_address),
+        "delivery_address": customer_address_to_mapping(snapshot.delivery_address),
+        "delivery_address_mode": snapshot.delivery_address_mode,
     }
 
 
@@ -132,13 +224,23 @@ def customer_snapshot_from_mapping(
 ) -> InquiryCustomerSnapshot | None:
     if data is None:
         return None
+    mode_raw = data.get("delivery_address_mode")
+    if mode_raw is None:
+        mode: DeliveryAddressMode = "UNKNOWN"
+    else:
+        if not isinstance(mode_raw, str):
+            raise TypeError("delivery_address_mode must be a str or null")
+        mode = validate_delivery_address_mode(mode_raw)
     snapshot = InquiryCustomerSnapshot(
         company_name=_optional_str(data.get("company_name")),
         contact_name=_optional_str(data.get("contact_name")),
         email=_optional_str(data.get("email")),
         phone=_optional_str(data.get("phone")),
+        invoice_address=customer_address_from_mapping(data.get("invoice_address")),
+        delivery_address=customer_address_from_mapping(data.get("delivery_address")),
+        delivery_address_mode=mode,
     )
-    if snapshot.is_empty():
+    if not snapshot.has_persisted_facts():
         return None
     return snapshot
 

--- a/src/catering_system/repositories/sqlite_inquiry_repository.py
+++ b/src/catering_system/repositories/sqlite_inquiry_repository.py
@@ -26,6 +26,7 @@ from catering_system.repositories.inquiry_repository import (
 )
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot,
+    customer_address_to_mapping,
     customer_snapshot_from_mapping,
 )
 from catering_system.repositories.sqlite_migrations import apply_migrations
@@ -58,6 +59,12 @@ _CUSTOMER_REFERENCE_COLUMNS = (
     "snapshot_contact_name",
     "snapshot_email",
     "snapshot_phone",
+)
+
+_CUSTOMER_ADDRESS_COLUMNS = (
+    "snapshot_delivery_address_mode",
+    "snapshot_invoice_address_json",
+    "snapshot_delivery_address_json",
 )
 
 _INTAKE_COLUMNS = (
@@ -115,11 +122,21 @@ def _migration_4_add_customer_reference(connection: sqlite3.Connection) -> None:
             connection.execute(f"ALTER TABLE inquiries ADD COLUMN {column} TEXT")
 
 
+def _migration_5_add_customer_addresses(connection: sqlite3.Connection) -> None:
+    columns = {
+        row[1] for row in connection.execute("PRAGMA table_info(inquiries)").fetchall()
+    }
+    for column in _CUSTOMER_ADDRESS_COLUMNS:
+        if column not in columns:
+            connection.execute(f"ALTER TABLE inquiries ADD COLUMN {column} TEXT")
+
+
 _MIGRATIONS = (
     (1, "create_inquiries", _migration_1_create_table),
     (2, "add_intake_context", _migration_2_add_intake_context),
     (3, "unique_website_external_ref", _migration_3_unique_website_external_ref),
     (4, "add_customer_reference", _migration_4_add_customer_reference),
+    (5, "add_customer_addresses", _migration_5_add_customer_addresses),
 )
 
 
@@ -156,8 +173,15 @@ class SQLiteInquiryRepository:
         try:
             with self._write_scope():
                 self._conn.execute(
-                    "INSERT INTO inquiries (inquiry_id, event_date, created_at, updated_at, inquiry_source, crm_stage, customer_linkage, time_window_text, location_text, guest_count_estimate, planning_mode, call_verification_required, call_verification_status, intake_subject, intake_message, intake_summary, intake_external_ref, customer_id, snapshot_company_name, snapshot_contact_name, snapshot_email, snapshot_phone) VALUES "
-                    "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO inquiries (inquiry_id, event_date, created_at, updated_at, "
+                    "inquiry_source, crm_stage, customer_linkage, time_window_text, "
+                    "location_text, guest_count_estimate, planning_mode, "
+                    "call_verification_required, call_verification_status, intake_subject, "
+                    "intake_message, intake_summary, intake_external_ref, customer_id, "
+                    "snapshot_company_name, snapshot_contact_name, snapshot_email, "
+                    "snapshot_phone, snapshot_delivery_address_mode, "
+                    "snapshot_invoice_address_json, snapshot_delivery_address_json) VALUES "
+                    "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     self._values(inquiry),
                 )
         except sqlite3.IntegrityError as exc:
@@ -179,7 +203,7 @@ class SQLiteInquiryRepository:
         return [self._row_to_inquiry(r) for r in rows]
 
     def _row_to_inquiry(self, row: tuple) -> Inquiry:
-        snapshot = self._snapshot_from_row(row[18:22])
+        snapshot = self._snapshot_from_row(row)
         return Inquiry(
             inquiry_id=row[0],
             event_date=date.fromisoformat(row[1]),
@@ -203,15 +227,39 @@ class SQLiteInquiryRepository:
         )
 
     @staticmethod
-    def _snapshot_from_row(values: tuple) -> InquiryCustomerSnapshot | None:
-        if all(value is None for value in values):
+    def _snapshot_from_row(row: tuple) -> InquiryCustomerSnapshot | None:
+        company_name = row[18]
+        contact_name = row[19]
+        email = row[20]
+        phone = row[21]
+        mode = row[22] if len(row) > 22 else None
+        invoice_json = row[23] if len(row) > 23 else None
+        delivery_json = row[24] if len(row) > 24 else None
+        if (
+            company_name is None
+            and contact_name is None
+            and email is None
+            and phone is None
+            and mode is None
+            and invoice_json is None
+            and delivery_json is None
+        ):
             return None
+        invoice_address = None
+        delivery_address = None
+        if invoice_json is not None:
+            invoice_address = json.loads(invoice_json)
+        if delivery_json is not None:
+            delivery_address = json.loads(delivery_json)
         return customer_snapshot_from_mapping(
             {
-                "company_name": values[0],
-                "contact_name": values[1],
-                "email": values[2],
-                "phone": values[3],
+                "company_name": company_name,
+                "contact_name": contact_name,
+                "email": email,
+                "phone": phone,
+                "invoice_address": invoice_address,
+                "delivery_address": delivery_address,
+                "delivery_address_mode": mode,
             }
         )
 
@@ -229,7 +277,10 @@ class SQLiteInquiryRepository:
                         intake_subject = ?, intake_message = ?, intake_summary = ?,
                         intake_external_ref = ?, customer_id = ?,
                         snapshot_company_name = ?, snapshot_contact_name = ?,
-                        snapshot_email = ?, snapshot_phone = ?
+                        snapshot_email = ?, snapshot_phone = ?,
+                        snapshot_delivery_address_mode = ?,
+                        snapshot_invoice_address_json = ?,
+                        snapshot_delivery_address_json = ?
                     WHERE inquiry_id = ?
                     """,
                     self._values(inquiry)[1:] + (inquiry.inquiry_id,),
@@ -256,6 +307,42 @@ class SQLiteInquiryRepository:
     @staticmethod
     def _values(inquiry: Inquiry) -> tuple:
         snapshot = inquiry.customer_snapshot
+        if snapshot is None:
+            return (
+                inquiry.inquiry_id,
+                inquiry.event_date.isoformat(),
+                inquiry.created_at.isoformat(),
+                inquiry.updated_at.isoformat(),
+                inquiry.inquiry_source,
+                inquiry.crm_stage,
+                json.dumps(inquiry.customer_linkage, sort_keys=True),
+                inquiry.time_window_text,
+                inquiry.location_text,
+                inquiry.guest_count_estimate,
+                inquiry.planning_mode,
+                1 if inquiry.call_verification_required else 0,
+                inquiry.call_verification_status,
+                inquiry.intake_subject,
+                inquiry.intake_message,
+                inquiry.intake_summary,
+                inquiry.intake_external_ref,
+                inquiry.customer_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        invoice_json = None
+        delivery_json = None
+        invoice_map = customer_address_to_mapping(snapshot.invoice_address)
+        delivery_map = customer_address_to_mapping(snapshot.delivery_address)
+        if invoice_map is not None:
+            invoice_json = json.dumps(invoice_map, sort_keys=True, ensure_ascii=False)
+        if delivery_map is not None:
+            delivery_json = json.dumps(delivery_map, sort_keys=True, ensure_ascii=False)
         return (
             inquiry.inquiry_id,
             inquiry.event_date.isoformat(),
@@ -275,10 +362,13 @@ class SQLiteInquiryRepository:
             inquiry.intake_summary,
             inquiry.intake_external_ref,
             inquiry.customer_id,
-            None if snapshot is None else snapshot.company_name,
-            None if snapshot is None else snapshot.contact_name,
-            None if snapshot is None else snapshot.email,
-            None if snapshot is None else snapshot.phone,
+            snapshot.company_name,
+            snapshot.contact_name,
+            snapshot.email,
+            snapshot.phone,
+            snapshot.delivery_address_mode,
+            invoice_json,
+            delivery_json,
         )
 
     def find_by_source_and_external_ref(

--- a/src/catering_system/services/customer_document_projection.py
+++ b/src/catering_system/services/customer_document_projection.py
@@ -17,6 +17,7 @@ from catering_system.domain.customer_document_projection import (
     CustomerDocumentRecipient,
     CustomerDocumentWarning,
     DocumentType,
+    customer_addresses_equal,
 )
 from catering_system.domain.inquiry import Inquiry
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
@@ -36,19 +37,19 @@ def build_customer_document_recipient(
     invoice_address: CustomerAddress | None = None,
     delivery_address: CustomerAddress | None = None,
 ) -> CustomerDocumentRecipient:
-    """Map Inquiry.customer_snapshot (+ optional address facts) to recipient.
+    """Map Inquiry.customer_snapshot to recipient (CUSTOMER_ADDRESS_SOURCE_V1-A).
 
-    Address kwargs exist so tests and future Inquiry address slots can supply
-    invoice/delivery without reading Offer or commercial snapshot. V1 runtime
-    from Inquiry alone leaves both addresses as None.
+    Optional address kwargs override snapshot addresses for tests only. When
+    kwargs are omitted, delivery_address_mode on the snapshot controls effective
+    delivery and the soft differ warning.
     """
     snapshot = inquiry.customer_snapshot if inquiry is not None else None
     name, email = _name_and_email(snapshot)
     company_name, phone = _company_and_phone(snapshot)
-    differs = (
-        invoice_address is not None
-        and delivery_address is not None
-        and invoice_address != delivery_address
+    invoice, delivery, differs = _resolve_addresses(
+        snapshot,
+        invoice_override=invoice_address,
+        delivery_override=delivery_address,
     )
     warnings: tuple[CustomerDocumentWarning, ...] = (
         (WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else ()
@@ -58,11 +59,49 @@ def build_customer_document_recipient(
         email=email,
         company_name=company_name,
         phone=phone,
-        invoice_address=invoice_address,
-        delivery_address=delivery_address,
+        invoice_address=invoice,
+        delivery_address=delivery,
         delivery_address_differs=differs,
         warnings=warnings,
     )
+
+
+def _resolve_addresses(
+    snapshot: InquiryCustomerSnapshot | None,
+    *,
+    invoice_override: CustomerAddress | None,
+    delivery_override: CustomerAddress | None,
+) -> tuple[CustomerAddress | None, CustomerAddress | None, bool]:
+    """Resolve invoice/delivery/differs from snapshot mode (or test overrides)."""
+    # Explicit kwargs (both provided as non-default path): legacy test override
+    # when caller passes addresses without putting them on the snapshot.
+    if invoice_override is not None or delivery_override is not None:
+        # If either override is passed, use overrides exclusively for address
+        # slots (tests). Mode is ignored in that case.
+        invoice = invoice_override
+        delivery = delivery_override
+        differs = (
+            invoice is not None
+            and delivery is not None
+            and not customer_addresses_equal(invoice, delivery)
+        )
+        return invoice, delivery, differs
+
+    if snapshot is None:
+        return None, None, False
+    invoice = snapshot.invoice_address
+    mode = snapshot.delivery_address_mode
+    if mode == "UNKNOWN":
+        return invoice, None, False
+    if mode == "SAME_AS_INVOICE":
+        return invoice, invoice, False
+    delivery = snapshot.delivery_address
+    differs = (
+        invoice is not None
+        and delivery is not None
+        and not customer_addresses_equal(invoice, delivery)
+    )
+    return invoice, delivery, differs
 
 
 def build_customer_document_projection(

--- a/tests/unit/test_customer_address_source_v1_a.py
+++ b/tests/unit/test_customer_address_source_v1_a.py
@@ -1,0 +1,271 @@
+"""CUSTOMER_ADDRESS_SOURCE_V1-A — snapshot addresses + CDP mode wiring."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, date, datetime
+
+import pytest
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+    customer_addresses_equal,
+)
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot,
+    customer_snapshot_from_mapping,
+    customer_snapshot_to_mapping,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_migrations import apply_migrations
+from catering_system.services.customer_document_projection import (
+    build_customer_document_recipient,
+)
+
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _inquiry(snapshot: InquiryCustomerSnapshot | None) -> Inquiry:
+    return Inquiry(
+        inquiry_id="99999999-9999-4999-8999-999999999999",
+        event_date=date(2026, 8, 20),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        customer_snapshot=snapshot,
+    )
+
+
+def test_same_as_invoice_rejects_stored_delivery() -> None:
+    with pytest.raises(ValueError, match="delivery_address must be None"):
+        InquiryCustomerSnapshot(
+            contact_name="Anna",
+            invoice_address=_INVOICE,
+            delivery_address=_DELIVERY,
+            delivery_address_mode="SAME_AS_INVOICE",
+        )
+
+
+def test_separate_requires_delivery() -> None:
+    with pytest.raises(ValueError, match="SEPARATE mode requires delivery_address"):
+        InquiryCustomerSnapshot(
+            contact_name="Anna",
+            invoice_address=_INVOICE,
+            delivery_address_mode="SEPARATE",
+        )
+
+
+def test_mapping_round_trip_with_addresses() -> None:
+    snapshot = InquiryCustomerSnapshot(
+        contact_name="Anna",
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    mapped = customer_snapshot_to_mapping(snapshot)
+    assert mapped is not None
+    assert mapped["delivery_address_mode"] == "SEPARATE"
+    assert customer_snapshot_from_mapping(mapped) == snapshot
+
+
+def test_direct_and_remote_mapping_shape_parity() -> None:
+    """Office API mapping and RemoteCoreClient share customer_snapshot_from_mapping."""
+    snapshot = InquiryCustomerSnapshot(
+        company_name="ACME",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    direct = customer_snapshot_to_mapping(snapshot)
+    assert direct is not None
+    assert set(direct) == {
+        "company_name",
+        "contact_name",
+        "email",
+        "phone",
+        "invoice_address",
+        "delivery_address",
+        "delivery_address_mode",
+    }
+    assert direct["delivery_address"] is None
+    assert direct["delivery_address_mode"] == "SAME_AS_INVOICE"
+    remote_parsed = customer_snapshot_from_mapping(direct)
+    assert remote_parsed == snapshot
+    assert customer_snapshot_to_mapping(remote_parsed) == direct
+
+
+def test_recipient_unknown_does_not_copy_invoice() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(
+            InquiryCustomerSnapshot(
+                contact_name="Anna",
+                invoice_address=_INVOICE,
+                delivery_address_mode="UNKNOWN",
+            )
+        )
+    )
+    assert recipient.invoice_address == _INVOICE
+    assert recipient.delivery_address is None
+    assert recipient.warnings == ()
+
+
+def test_recipient_same_as_invoice_uses_effective_delivery() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(
+            InquiryCustomerSnapshot(
+                contact_name="Anna",
+                invoice_address=_INVOICE,
+                delivery_address_mode="SAME_AS_INVOICE",
+            )
+        )
+    )
+    assert recipient.invoice_address == _INVOICE
+    assert recipient.delivery_address == _INVOICE
+    assert recipient.delivery_address_differs is False
+    assert recipient.warnings == ()
+
+
+def test_recipient_separate_equal_normalized_no_warning() -> None:
+    noisy = CustomerAddress(
+        street="  Bürostraße   1 ",
+        postal_code="20095",
+        city="hamburg",
+        country="de",
+    )
+    assert customer_addresses_equal(_INVOICE, noisy)
+    recipient = build_customer_document_recipient(
+        _inquiry(
+            InquiryCustomerSnapshot(
+                contact_name="Anna",
+                invoice_address=_INVOICE,
+                delivery_address=noisy,
+                delivery_address_mode="SEPARATE",
+            )
+        )
+    )
+    assert recipient.delivery_address_differs is False
+    assert recipient.warnings == ()
+
+
+def test_recipient_separate_differing_emits_warning() -> None:
+    recipient = build_customer_document_recipient(
+        _inquiry(
+            InquiryCustomerSnapshot(
+                contact_name="Anna",
+                invoice_address=_INVOICE,
+                delivery_address=_DELIVERY,
+                delivery_address_mode="SEPARATE",
+            )
+        )
+    )
+    assert recipient.delivery_address_differs is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in recipient.warnings
+
+
+def test_sqlite_legacy_row_loads_unknown_mode(tmp_path) -> None:
+    db = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db)
+    # Apply only migrations 1–4, insert contact snapshot, then run migration 5.
+    from catering_system.repositories import sqlite_inquiry_repository as repo_mod
+
+    apply_migrations(conn, "inquiries", repo_mod._MIGRATIONS[:4])
+    conn.execute(
+        "INSERT INTO inquiries ("
+        "inquiry_id, event_date, created_at, updated_at, inquiry_source, crm_stage, "
+        "customer_linkage, time_window_text, location_text, guest_count_estimate, "
+        "planning_mode, call_verification_required, call_verification_status, "
+        "intake_subject, intake_message, intake_summary, intake_external_ref, "
+        "customer_id, snapshot_company_name, snapshot_contact_name, snapshot_email, "
+        "snapshot_phone"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            "99999999-9999-4999-8999-999999999999",
+            "2026-08-20",
+            _NOW.isoformat(),
+            _NOW.isoformat(),
+            "manual",
+            "Neue Anfrage",
+            "{}",
+            "mittags",
+            "Hamburg",
+            25,
+            "caterer_suggestion",
+            0,
+            "not_required",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "Example GmbH",
+            "Example Contact",
+            "kunde@example.com",
+            "+49301234567",
+        ),
+    )
+    conn.commit()
+    apply_migrations(conn, "inquiries", repo_mod._MIGRATIONS)
+    conn.close()
+
+    inquiries = SQLiteInquiryRepository(db)
+    loaded = inquiries.get_by_id("99999999-9999-4999-8999-999999999999")
+    assert loaded is not None
+    assert loaded.customer_snapshot is not None
+    assert loaded.customer_snapshot.delivery_address_mode == "UNKNOWN"
+    assert loaded.customer_snapshot.invoice_address is None
+    assert loaded.customer_snapshot.delivery_address is None
+    inquiries.close()
+
+
+def test_sqlite_round_trip_addresses(tmp_path) -> None:
+    db = tmp_path / "core.db"
+    inquiries = SQLiteInquiryRepository(db)
+    snapshot = InquiryCustomerSnapshot(
+        company_name="ACME",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    inquiry = _inquiry(snapshot)
+    inquiries.save(inquiry)
+    loaded = inquiries.get_by_id(inquiry.inquiry_id)
+    assert loaded is not None
+    assert loaded.customer_snapshot == snapshot
+    mapped = customer_snapshot_to_mapping(loaded.customer_snapshot)
+    assert mapped is not None
+    assert (
+        json.loads(json.dumps(mapped["invoice_address"]))
+        == customer_snapshot_to_mapping(snapshot)["invoice_address"]
+    )
+    inquiries.close()

--- a/tests/unit/test_inquiry_contact_completeness.py
+++ b/tests/unit/test_inquiry_contact_completeness.py
@@ -648,10 +648,10 @@ def test_sqlite_round_trip_and_legacy_null_snapshot(tmp_path: Path) -> None:
     repo.close()
 
 
-def test_no_migration_v5(tmp_path: Path) -> None:
+def test_latest_inquiry_migration_is_v5() -> None:
     from catering_system.repositories.sqlite_inquiry_repository import _MIGRATIONS
 
-    assert max(number for number, _name, _fn in _MIGRATIONS) == 4
+    assert max(number for number, _name, _fn in _MIGRATIONS) == 5
 
 
 def test_completion_persists_in_sqlite(tmp_path: Path) -> None:

--- a/tests/unit/test_inquiry_customer_reference.py
+++ b/tests/unit/test_inquiry_customer_reference.py
@@ -483,6 +483,9 @@ def test_office_api_detail_exposes_optional_customer_reference_fields() -> None:
         "contact_name": "Alex",
         "email": None,
         "phone": None,
+        "invoice_address": None,
+        "delivery_address": None,
+        "delivery_address_mode": "UNKNOWN",
     }
 
 

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -802,6 +802,9 @@ def test_inquiry_detail_shape(api) -> None:
         "contact_name": "Example Contact",
         "email": "kunde@example.com",
         "phone": "+49301234567",
+        "invoice_address": None,
+        "delivery_address": None,
+        "delivery_address_mode": "UNKNOWN",
     }
     assert body["contact_completeness"] == "complete"
     assert body["missing_contact_fields"] == []

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -397,6 +397,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         ("inquiries", 2),
         ("inquiries", 3),
         ("inquiries", 4),
+        ("inquiries", 5),  # CUSTOMER_ADDRESS_SOURCE_V1-A
         ("orders", 1),
         ("orders", 2),
         ("orders", 3),


### PR DESCRIPTION
## Summary
- Extend `InquiryCustomerSnapshot` with `invoice_address`, `delivery_address`, and `delivery_address_mode` (`UNKNOWN` | `SAME_AS_INVOICE` | `SEPARATE`), including domain invariants and predictable address normalization (trim / collapse whitespace / casefold).
- SQLite migration 5 stores address JSON + mode; legacy contact-only rows load as `UNKNOWN` with both addresses `None`.
- CDP recipient builder resolves effective delivery from mode (`SAME_AS_INVOICE` → invoice; `UNKNOWN` → no delivery; `SEPARATE` → stored delivery + differ warning only when normalized addresses differ). Direct/remote mapping shape stays shared via `customer_snapshot_to/from_mapping`.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src/catering_system`
- [x] `coverage run -m pytest` + `coverage report` (≥90%)
- [x] Legacy migration → `UNKNOWN`
- [x] SQLite round-trip of mode + both addresses
- [x] No warning for `SAME_AS_INVOICE` / `UNKNOWN`; warning only for differing `SEPARATE`
- [x] Invalid `SEPARATE` without delivery rejected


Made with [Cursor](https://cursor.com)