### PR TITLE
CUSTOMER_ADDRESS_SOURCE_V1-B: address write API (slices 1–2)

### DIFF
--- a/src/catering_system/domain/inquiry_contact_completeness.py
+++ b/src/catering_system/domain/inquiry_contact_completeness.py
@@ -126,6 +126,8 @@ def complete_inquiry_contact_information(
     - a stored non-empty value is never replaced (conflicting input raises);
     - an identical resubmission is idempotent (returns the inquiry unchanged);
     - contact_name/company_name are preserved untouched;
+    - invoice_address/delivery_address/delivery_address_mode are preserved
+      untouched (CUSTOMER_ADDRESS_SOURCE_V1-B);
     - the result is a new frozen snapshot value object.
     """
     from dataclasses import replace as dataclass_replace
@@ -164,6 +166,11 @@ def complete_inquiry_contact_information(
         contact_name=snapshot.contact_name if snapshot is not None else None,
         email=next_email,
         phone=next_phone,
+        invoice_address=snapshot.invoice_address if snapshot is not None else None,
+        delivery_address=snapshot.delivery_address if snapshot is not None else None,
+        delivery_address_mode=(
+            snapshot.delivery_address_mode if snapshot is not None else "UNKNOWN"
+        ),
     )
     if snapshot is not None and next_snapshot == snapshot:
         return inquiry

--- a/src/catering_system/domain/inquiry_customer_snapshot.py
+++ b/src/catering_system/domain/inquiry_customer_snapshot.py
@@ -6,7 +6,7 @@ CUSTOMER_ADDRESS_SOURCE_V1-A: invoice/delivery addresses + delivery_address_mode
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from catering_system.domain.customer_document_projection import (
     CustomerAddress,
@@ -17,6 +17,9 @@ from catering_system.intake.intake_contact import (
     normalize_email,
 )
 from catering_system.domain.phone_normalization import normalize_phone
+
+if TYPE_CHECKING:
+    from catering_system.domain.inquiry import Inquiry
 
 DeliveryAddressMode = Literal["UNKNOWN", "SAME_AS_INVOICE", "SEPARATE"]
 DELIVERY_ADDRESS_MODES: tuple[DeliveryAddressMode, ...] = (
@@ -84,6 +87,46 @@ def validate_delivery_address_mode(value: str) -> DeliveryAddressMode:
     if value not in _DELIVERY_ADDRESS_MODE_SET:
         raise ValueError(f"unsupported delivery_address_mode: {value!r}")
     return cast(DeliveryAddressMode, value)
+
+
+def set_inquiry_customer_addresses(
+    inquiry: "Inquiry",
+    *,
+    invoice_address: CustomerAddress | None,
+    delivery_address: CustomerAddress | None,
+    delivery_address_mode: DeliveryAddressMode | str,
+) -> "Inquiry":
+    """Replace snapshot address facts; preserve contact fields untouched.
+
+    UNKNOWN / SAME_AS_INVOICE store delivery_address as None (any provided
+    delivery is ignored). SEPARATE requires a non-null delivery_address —
+    validated by InquiryCustomerSnapshot invariants.
+    """
+    from dataclasses import replace as dataclass_replace
+
+    from catering_system.domain.inquiry import Inquiry as _Inquiry
+
+    if not isinstance(inquiry, _Inquiry):
+        raise TypeError("inquiry must be an Inquiry")
+    if not isinstance(delivery_address_mode, str):
+        raise TypeError("delivery_address_mode must be a str")
+    mode = validate_delivery_address_mode(delivery_address_mode)
+    stored_delivery = (
+        None if mode in {"UNKNOWN", "SAME_AS_INVOICE"} else delivery_address
+    )
+    snapshot = inquiry.customer_snapshot
+    next_snapshot = InquiryCustomerSnapshot(
+        company_name=snapshot.company_name if snapshot is not None else None,
+        contact_name=snapshot.contact_name if snapshot is not None else None,
+        email=snapshot.email if snapshot is not None else None,
+        phone=snapshot.phone if snapshot is not None else None,
+        invoice_address=invoice_address,
+        delivery_address=stored_delivery,
+        delivery_address_mode=mode,
+    )
+    if snapshot is not None and next_snapshot == snapshot:
+        return inquiry
+    return dataclass_replace(inquiry, customer_snapshot=next_snapshot)
 
 
 def validate_customer_id_reference(value: str) -> str:

--- a/src/catering_system/services/inquiry_service.py
+++ b/src/catering_system/services/inquiry_service.py
@@ -32,9 +32,12 @@ from catering_system.domain.inquiry_contact_completeness import (
     derive_contact_completeness,
 )
 from catering_system.domain.inquiry_customer_snapshot import (
+    DeliveryAddressMode,
     InquiryCustomerSnapshot,
+    set_inquiry_customer_addresses,
     snapshot_from_structured_contact,
 )
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.repositories.inquiry_repository import InquiryRepository
 
 _ALLOWED_SOURCES: frozenset[str] = frozenset(
@@ -318,6 +321,33 @@ class InquiryService:
         updated = replace(updated, updated_at=_utc_now())
         self._repository.update(updated)
         _log.info("inquiry contact information completed inquiry_id=%s", inquiry_id)
+        self._emit(InquiryUpdated(inquiry_id=inquiry_id))
+        return updated
+
+    def set_inquiry_customer_addresses(
+        self,
+        inquiry_id: str,
+        *,
+        invoice_address: CustomerAddress | None,
+        delivery_address: CustomerAddress | None,
+        delivery_address_mode: DeliveryAddressMode | str,
+    ) -> Inquiry:
+        """Replace Rechnungs-/Lieferadresse on the inquiry snapshot (V1-B)."""
+        _log.info("set_inquiry_customer_addresses called inquiry_id=%s", inquiry_id)
+        current = self._repository.get_by_id(inquiry_id)
+        if current is None:
+            raise KeyError(inquiry_id)
+        updated = set_inquiry_customer_addresses(
+            current,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+            delivery_address_mode=delivery_address_mode,
+        )
+        if updated.customer_snapshot == current.customer_snapshot:
+            return current
+        updated = replace(updated, updated_at=_utc_now())
+        self._repository.update(updated)
+        _log.info("inquiry customer addresses updated inquiry_id=%s", inquiry_id)
         self._emit(InquiryUpdated(inquiry_id=inquiry_id))
         return updated
 

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -38,6 +38,11 @@ from catering_system.domain.inquiry_contact_completeness import (
     derive_inquiry_contact_completeness,
     missing_contact_fields,
 )
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_address_from_mapping,
+    customer_snapshot_to_mapping,
+    validate_delivery_address_mode,
+)
 from catering_system.domain.offer import (
     ACCEPTANCE_CHANNELS,
     SENT_CHANNELS,
@@ -1011,6 +1016,35 @@ class OfficeApi:
             "missing_contact_fields": list(missing_contact_fields(completeness)),
         }
 
+    def cmd_customer_addresses(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        current = self._require_inquiry(path_ids["id"])
+        if _v_datetime(expect["updated_at"]) != current.updated_at:
+            raise ApiError(409, "stale_state")
+        mode_raw = args["delivery_address_mode"]
+        try:
+            if not isinstance(mode_raw, str):
+                raise TypeError("delivery_address_mode must be a str")
+            mode = validate_delivery_address_mode(mode_raw)
+            invoice_address = customer_address_from_mapping(args["invoice_address"])
+            delivery_address = customer_address_from_mapping(args["delivery_address"])
+            updated = self.inquiry_service.set_inquiry_customer_addresses(
+                current.inquiry_id,
+                invoice_address=invoice_address,
+                delivery_address=delivery_address,
+                delivery_address_mode=mode,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ApiError(422, "invalid_customer_addresses") from exc
+        return 200, {
+            "inquiry_id": updated.inquiry_id,
+            "updated_at": updated.updated_at.isoformat(),
+            "customer_snapshot": customer_snapshot_to_mapping(
+                updated.customer_snapshot
+            ),
+        }
+
     def cmd_update_inquiry(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
     ) -> tuple[int, dict[str, object]]:
@@ -1877,6 +1911,15 @@ _CONTACT_COMPLETION_ARGS = _ArgKeys(
     required=frozenset(),
     optional=frozenset({"email", "phone"}),
 )
+_CUSTOMER_ADDRESSES_ARGS = _ArgKeys(
+    required=frozenset(
+        {
+            "invoice_address",
+            "delivery_address_mode",
+            "delivery_address",
+        }
+    ),
+)
 _UPDATE_ARGS = _ArgKeys(
     required=frozenset(
         {
@@ -1980,6 +2023,9 @@ _COMMANDS: dict[str, _CommandSpec] = {
     "contact-completion": _CommandSpec(
         "cmd_contact_completion", _CONTACT_COMPLETION_ARGS, {"updated_at"}
     ),
+    "customer-addresses": _CommandSpec(
+        "cmd_customer_addresses", _CUSTOMER_ADDRESSES_ARGS, {"updated_at"}
+    ),
     "verify": _CommandSpec("cmd_verify", _NO_ARGS, set()),
     "convert": _CommandSpec("cmd_convert", _NO_ARGS, set()),
     "prepare-offer": _CommandSpec("cmd_prepare_offer", _SNAPSHOT_ARGS, set()),
@@ -2080,6 +2126,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/inquiries/(?P<id>[^/]+)/contact-completion$"),
         "/office/v1/inquiries/{id}/contact-completion",
         {"POST": "contact-completion"},
+    ),
+    (
+        re.compile(r"^/office/v1/inquiries/(?P<id>[^/]+)/customer-addresses$"),
+        "/office/v1/inquiries/{id}/customer-addresses",
+        {"POST": "customer-addresses"},
     ),
     (
         re.compile(r"^/office/v1/inquiries/(?P<id>[^/]+)/verify$"),

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -49,7 +49,11 @@ from catering_system.domain.inquiry_contact_completeness import (
     complete_inquiry_contact_information,
 )
 from catering_system.domain.inquiry_customer_snapshot import (
+    DeliveryAddressMode,
+    customer_address_to_mapping,
     customer_snapshot_from_mapping,
+    customer_snapshot_to_mapping,
+    set_inquiry_customer_addresses,
     snapshot_from_structured_contact,
 )
 from catering_system.domain.order_payment_reminder import (
@@ -2505,6 +2509,50 @@ class _RemoteInquiryService:
         updated = complete_inquiry_contact_information(
             current, email=email, phone=phone
         )
+        return replace(updated, updated_at=_datetime(result["updated_at"]))
+
+    def set_inquiry_customer_addresses(
+        self,
+        inquiry_id: str,
+        *,
+        invoice_address: CustomerAddress | None,
+        delivery_address: CustomerAddress | None,
+        delivery_address_mode: DeliveryAddressMode | str,
+    ) -> Inquiry:
+        current = self._client.get_by_id(inquiry_id)
+        if current is None:
+            raise RemoteCoreError(404, "not_found")
+        args: dict[str, object] = {
+            "invoice_address": customer_address_to_mapping(invoice_address),
+            "delivery_address": customer_address_to_mapping(delivery_address),
+            "delivery_address_mode": delivery_address_mode,
+        }
+        expected_at = self._client.form_value("_expect_updated_at")
+        result = self._client.command(
+            f"/office/v1/inquiries/{quote(inquiry_id, safe='')}/customer-addresses",
+            args,
+            {"updated_at": expected_at or current.updated_at.isoformat()},
+            expected={200},
+            result_keys={
+                "inquiry_id",
+                "updated_at",
+                "customer_snapshot",
+            },
+        )
+        if _uuid4(result["inquiry_id"]) != inquiry_id:
+            _bad_response()
+        mapped = result["customer_snapshot"]
+        if not isinstance(mapped, dict):
+            _bad_response()
+        # Reapply domain locally for redirect render parity (no silent defaults).
+        updated = set_inquiry_customer_addresses(
+            current,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+            delivery_address_mode=delivery_address_mode,
+        )
+        if customer_snapshot_to_mapping(updated.customer_snapshot) != mapped:
+            _bad_response()
         return replace(updated, updated_at=_datetime(result["updated_at"]))
 
     def verify_customer_by_call(self, inquiry_id: str) -> Inquiry:

--- a/tests/unit/test_customer_address_source_v1_b.py
+++ b/tests/unit/test_customer_address_source_v1_b.py
@@ -1,0 +1,410 @@
+"""CUSTOMER_ADDRESS_SOURCE_V1-B — preservation + write API (slices 1–2)."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import uuid
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry import Inquiry
+from catering_system.domain.inquiry_contact_completeness import (
+    complete_inquiry_contact_information,
+)
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot,
+    customer_address_to_mapping,
+    customer_snapshot_to_mapping,
+    set_inquiry_customer_addresses,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+
+_NOW = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+_API_TOKEN = "customer-addresses-test-token"
+_API_AUTH = {"Authorization": f"Bearer {_API_TOKEN}"}
+
+
+def _inquiry(snapshot: InquiryCustomerSnapshot | None) -> Inquiry:
+    return Inquiry(
+        inquiry_id="99999999-9999-4999-8999-999999999999",
+        event_date=date(2026, 8, 20),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        customer_snapshot=snapshot,
+    )
+
+
+def _addressed_snapshot() -> InquiryCustomerSnapshot:
+    return InquiryCustomerSnapshot(
+        company_name="ACME",
+        contact_name="Anna",
+        phone="+49301234567",
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+
+
+def test_contact_completion_preserves_addresses_and_mode() -> None:
+    inquiry = _inquiry(_addressed_snapshot())
+    updated = complete_inquiry_contact_information(
+        inquiry, email="Nachtrag@Example.com"
+    )
+    assert updated.customer_snapshot is not None
+    assert updated.customer_snapshot.email == "nachtrag@example.com"
+    assert updated.customer_snapshot.phone == "+49301234567"
+    assert updated.customer_snapshot.invoice_address == _INVOICE
+    assert updated.customer_snapshot.delivery_address == _DELIVERY
+    assert updated.customer_snapshot.delivery_address_mode == "SEPARATE"
+    assert updated.customer_snapshot.company_name == "ACME"
+    assert updated.customer_snapshot.contact_name == "Anna"
+
+
+def test_set_addresses_same_as_invoice_clears_delivery() -> None:
+    inquiry = _inquiry(
+        InquiryCustomerSnapshot(
+            contact_name="Anna",
+            phone="+49301",
+            invoice_address=_INVOICE,
+            delivery_address=_DELIVERY,
+            delivery_address_mode="SEPARATE",
+        )
+    )
+    updated = set_inquiry_customer_addresses(
+        inquiry,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,  # ignored
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    assert updated.customer_snapshot is not None
+    assert updated.customer_snapshot.delivery_address_mode == "SAME_AS_INVOICE"
+    assert updated.customer_snapshot.delivery_address is None
+    assert updated.customer_snapshot.invoice_address == _INVOICE
+    assert updated.customer_snapshot.phone == "+49301"
+
+
+def test_set_addresses_unknown_clears_delivery() -> None:
+    inquiry = _inquiry(_addressed_snapshot())
+    updated = set_inquiry_customer_addresses(
+        inquiry,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="UNKNOWN",
+    )
+    assert updated.customer_snapshot is not None
+    assert updated.customer_snapshot.delivery_address is None
+    assert updated.customer_snapshot.delivery_address_mode == "UNKNOWN"
+
+
+def test_set_addresses_separate_requires_delivery() -> None:
+    with pytest.raises(ValueError, match="SEPARATE mode requires delivery_address"):
+        set_inquiry_customer_addresses(
+            _inquiry(InquiryCustomerSnapshot(contact_name="Anna")),
+            invoice_address=_INVOICE,
+            delivery_address=None,
+            delivery_address_mode="SEPARATE",
+        )
+
+
+def test_set_addresses_preserves_contact_fields() -> None:
+    inquiry = _inquiry(
+        InquiryCustomerSnapshot(
+            company_name="ACME",
+            contact_name="Anna",
+            email="a@b.de",
+            phone="+49301",
+        )
+    )
+    updated = set_inquiry_customer_addresses(
+        inquiry,
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    snap = updated.customer_snapshot
+    assert snap is not None
+    assert snap.company_name == "ACME"
+    assert snap.contact_name == "Anna"
+    assert snap.email == "a@b.de"
+    assert snap.phone == "+49301"
+
+
+def test_service_round_trip_sqlite(tmp_path: Path) -> None:
+    repo = SQLiteInquiryRepository(tmp_path / "core.db")
+    service = InquiryService(repo)
+    created = service.create_inquiry(
+        inquiry_source="manual",
+        contact_phone="+49301234567",
+        contact_name="Anna",
+        **_create_kwargs(),
+    )
+    updated = service.set_inquiry_customer_addresses(
+        created.inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    loaded = repo.get_by_id(created.inquiry_id)
+    assert loaded is not None
+    assert loaded.customer_snapshot == updated.customer_snapshot
+    assert loaded.customer_snapshot is not None
+    assert loaded.customer_snapshot.delivery_address_mode == "SEPARATE"
+    completed = service.complete_inquiry_contact_information(
+        created.inquiry_id, email="a@b.de"
+    )
+    assert completed.customer_snapshot is not None
+    assert completed.customer_snapshot.invoice_address == _INVOICE
+    assert completed.customer_snapshot.delivery_address == _DELIVERY
+    assert completed.customer_snapshot.delivery_address_mode == "SEPARATE"
+    repo.close()
+
+
+# --- API ---------------------------------------------------------------------
+
+
+def _create_kwargs() -> dict[str, object]:
+    return {
+        "event_date": date(2026, 8, 20),
+        "crm_stage": "Neue Anfrage",
+        "customer_linkage": {},
+        "time_window_text": "mittags",
+        "location_text": "Hamburg",
+        "guest_count_estimate": 20,
+        "planning_mode": "caterer_suggestion",
+        "call_verification_required": False,
+        "call_verification_status": "not_required",
+    }
+
+
+def _api_seed(db_path: Path) -> dict[str, str]:
+    repo = SQLiteInquiryRepository(db_path)
+    service = InquiryService(repo)
+    inquiry = service.create_inquiry(
+        inquiry_source="manual",
+        contact_email="kunde@example.com",
+        contact_phone="+49301234567",
+        contact_name="Anna",
+        **_create_kwargs(),
+    )
+    repo.close()
+    return {
+        "inquiry_id": inquiry.inquiry_id,
+        "updated_at": inquiry.updated_at.isoformat(),
+    }
+
+
+@pytest.fixture()
+def addresses_api(tmp_path: Path):
+    from catering_system.ui.office_api import create_office_api_server
+
+    db = tmp_path / "core.db"
+    ids = _api_seed(db)
+    ready: queue.Queue = queue.Queue()
+
+    def run() -> None:
+        server = create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        ready.put(server)
+        server.serve_forever()
+
+    threading.Thread(target=run, daemon=True).start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    yield f"http://{host}:{port}", ids
+    server.shutdown()
+    server.server_close()
+
+
+def _api_get(url: str):  # noqa: ANN202
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(url, headers=_API_AUTH)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _api_set_addresses(
+    base: str,
+    inquiry_id: str,
+    *,
+    args: dict,
+    expect: dict,
+    headers: dict | None = None,
+):  # noqa: ANN202
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps(
+        {"command_id": str(uuid.uuid4()), "expect": expect, "args": args}
+    ).encode()
+    all_headers = {"Content-Type": "application/json"}
+    all_headers.update(headers if headers is not None else _API_AUTH)
+    req = urllib.request.Request(
+        f"{base}/office/v1/inquiries/{inquiry_id}/customer-addresses",
+        data=body,
+        headers=all_headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _payload(
+    *,
+    mode: str,
+    invoice: CustomerAddress | None = _INVOICE,
+    delivery: CustomerAddress | None = None,
+) -> dict[str, object]:
+    return {
+        "invoice_address": customer_address_to_mapping(invoice),
+        "delivery_address": customer_address_to_mapping(delivery),
+        "delivery_address_mode": mode,
+    }
+
+
+def test_api_customer_addresses_separate_success(addresses_api) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args=_payload(mode="SEPARATE", delivery=_DELIVERY),
+        expect={"updated_at": ids["updated_at"]},
+    )
+    assert status == 200
+    assert body["customer_snapshot"]["delivery_address_mode"] == "SEPARATE"
+    assert body["customer_snapshot"]["delivery_address"] == customer_address_to_mapping(
+        _DELIVERY
+    )
+    status, detail = _api_get(f"{base}/office/v1/inquiries/{ids['inquiry_id']}")
+    assert status == 200
+    assert detail["customer_snapshot"] == body["customer_snapshot"]
+
+
+def test_api_customer_addresses_same_as_invoice_stores_null_delivery(
+    addresses_api,
+) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args=_payload(mode="SAME_AS_INVOICE", delivery=_DELIVERY),
+        expect={"updated_at": ids["updated_at"]},
+    )
+    assert status == 200
+    snap = body["customer_snapshot"]
+    assert snap["delivery_address_mode"] == "SAME_AS_INVOICE"
+    assert snap["delivery_address"] is None
+    assert snap["invoice_address"] == customer_address_to_mapping(_INVOICE)
+
+
+def test_api_customer_addresses_separate_missing_delivery_422(addresses_api) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args=_payload(mode="SEPARATE", delivery=None),
+        expect={"updated_at": ids["updated_at"]},
+    )
+    assert (status, body["error"]) == (422, "invalid_customer_addresses")
+
+
+def test_api_customer_addresses_invalid_mode_422(addresses_api) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args=_payload(mode="OTHER"),
+        expect={"updated_at": ids["updated_at"]},
+    )
+    assert (status, body["error"]) == (422, "invalid_customer_addresses")
+
+
+def test_api_customer_addresses_unknown_inquiry_404(addresses_api) -> None:
+    base, _ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        str(uuid.uuid4()),
+        args=_payload(mode="UNKNOWN"),
+        expect={"updated_at": "2026-07-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (404, "not_found")
+
+
+def test_api_customer_addresses_stale_409(addresses_api) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args=_payload(mode="UNKNOWN"),
+        expect={"updated_at": "2020-01-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (409, "stale_state")
+
+
+def test_api_customer_addresses_missing_arg_key_400(addresses_api) -> None:
+    base, ids = addresses_api
+    status, body = _api_set_addresses(
+        base,
+        ids["inquiry_id"],
+        args={
+            "invoice_address": customer_address_to_mapping(_INVOICE),
+            "delivery_address_mode": "UNKNOWN",
+        },
+        expect={"updated_at": ids["updated_at"]},
+    )
+    assert (status, body["error"]) == (400, "invalid_request")
+
+
+def test_mapping_shape_stable_after_write() -> None:
+    inquiry = set_inquiry_customer_addresses(
+        _inquiry(InquiryCustomerSnapshot(contact_name="Anna")),
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    mapped = customer_snapshot_to_mapping(inquiry.customer_snapshot)
+    assert mapped is not None
+    assert set(mapped) == {
+        "company_name",
+        "contact_name",
+        "email",
+        "phone",
+        "invoice_address",
+        "delivery_address",
+        "delivery_address_mode",
+    }


### PR DESCRIPTION
## Summary
- Fix `complete_inquiry_contact_information` so it preserves `invoice_address`, `delivery_address`, and `delivery_address_mode` (contact fields only).
- Add domain/service setter `set_inquiry_customer_addresses` with V1-A mode rules (`UNKNOWN`/`SAME_AS_INVOICE` store delivery as `null`; `SEPARATE` requires delivery).
- Add `POST /office/v1/inquiries/{id}/customer-addresses` with strict args + controlled `422`/`404`/`409`, and remote client exact-key parity (local domain re-apply, no silent defaults).

## Out of scope (slices 3–4)
- Order Detail address facts UI
- Panel write form

## Test plan
- [x] ruff / mypy
- [x] pytest 1695 + coverage ≥90%
- [x] regression: completion keeps addresses/mode
- [x] API SEPARATE success; SAME_AS_INVOICE clears delivery; invalid SEPARATE → 422; missing inquiry → 404


Made with [Cursor](https://cursor.com)