### PR TITLE
CUSTOMER_ADDRESS_SOURCE_V1-B: Order Detail + panel form (slices 3–4)

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -33,6 +33,10 @@ from catering_system.domain.inquiry_contact_completeness import (
     derive_inquiry_contact_completeness,
     missing_contact_fields,
 )
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    canonicalize_customer_address,
+)
 from catering_system.services.offer_service import OfferService
 from catering_system.domain.offer import (
     ACCEPTANCE_CHANNELS,
@@ -172,6 +176,7 @@ from catering_system.ui.office_panel_order_detail import (
     _DOCUMENT_BLOCKER_LABELS,
     render_confirmation_card,
     render_confirmation_outbound_card,
+    render_customer_addresses_card,
     render_operational_pause_card,
     render_order_detail,
     version_change_prefill,
@@ -2315,6 +2320,34 @@ class OfficePanel:
             phone=phone,
         )
 
+    def set_inquiry_customer_addresses(
+        self, inquiry_id: str, form: dict[str, str]
+    ) -> Inquiry:
+        """Persist Rechnungs-/Lieferadresse via customer-addresses write path."""
+        mode = form.get("delivery_address_mode", "").strip()
+        invoice = canonicalize_customer_address(
+            CustomerAddress(
+                street=_opt_contact(form, "invoice_street"),
+                postal_code=_opt_contact(form, "invoice_postal_code"),
+                city=_opt_contact(form, "invoice_city"),
+                country=_opt_contact(form, "invoice_country"),
+            )
+        )
+        delivery = canonicalize_customer_address(
+            CustomerAddress(
+                street=_opt_contact(form, "delivery_street"),
+                postal_code=_opt_contact(form, "delivery_postal_code"),
+                city=_opt_contact(form, "delivery_city"),
+                country=_opt_contact(form, "delivery_country"),
+            )
+        )
+        return self.inquiry_service.set_inquiry_customer_addresses(
+            inquiry_id,
+            invoice_address=invoice,
+            delivery_address=delivery,
+            delivery_address_mode=mode,
+        )
+
     def render_inquiry(
         self,
         inquiry_id: str,
@@ -2706,6 +2739,7 @@ class OfficePanel:
         payment = self.payment_reminder_service.view(order_id)
         confirmation = self.confirmation_document_service.eligibility(order_id)
         live_preview = self._live_confirmation_preview(order_id)
+        source_inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
         snapshot_id = (
             confirmation.snapshot.document_snapshot_id
             if confirmation.snapshot is not None
@@ -2846,11 +2880,21 @@ class OfficePanel:
                         if not cancelled and pause_view.get("active")
                         else ""
                     ),
+                    customer_addresses_command_fields=(
+                        self._command_fields(
+                            {
+                                "updated_at": source_inquiry.updated_at.isoformat(),
+                            }
+                        )
+                        if not cancelled and source_inquiry is not None
+                        else ""
+                    ),
                     version_change_prefill=change_prefill if not cancelled else None,
                 ),
                 confirmation=confirmation,
                 live_preview=live_preview,
                 outbound=outbound,
+                source_inquiry=source_inquiry,
                 operational_pause=pause_view,
                 versions_total_count=versions_total_count,
                 versions_truncated=versions_truncated,
@@ -3058,6 +3102,20 @@ class OfficePanel:
                 if not cancelled and pause_view.get("active")
                 else ""
             ),
+            customer_addresses_command_fields=(
+                self._command_fields(
+                    {
+                        "updated_at": source_inquiry.updated_at.isoformat(),
+                    }
+                )
+                if not cancelled and source_inquiry is not None
+                else ""
+            ),
+        )
+        addresses_card = render_customer_addresses_card(
+            source_inquiry,
+            order,
+            detail_forms,
         )
         confirmation_card = render_confirmation_card(
             order,
@@ -3084,6 +3142,7 @@ class OfficePanel:
 <table><tr><th>Nr</th><th>Datum</th><th>Zeitfenster</th><th>Ort</th><th>Gäste</th>
 <th>Druck bestätigt</th><th>Status</th><th>Aktionen</th></tr>{"".join(rows)}</table>
 <h2>Zahlung</h2>{"".join(payment_rows)}{payment_form}
+{addresses_card}
 {confirmation_card}
 {outbound_card}
 {pause_card}

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -190,6 +190,14 @@ def office_command_error_message(code_or_text: str) -> str:
         return _INQUIRY_COMMAND_ERROR_LABELS["invalid_contact_value"]
     if "contact completion requires email or phone" in lowered:
         return _INQUIRY_COMMAND_ERROR_LABELS["invalid_contact_value"]
+    if "unsupported delivery_address_mode" in lowered:
+        return "Liefermodus ist ungültig."
+    if "SEPARATE mode requires delivery_address" in lowered:
+        return (
+            "Bei abweichender Lieferadresse muss eine Lieferadresse angegeben werden."
+        )
+    if "delivery_address must be None" in lowered:
+        return "Lieferadresse und Liefermodus passen nicht zusammen."
     if "intake requires email and phone" in lowered:
         return _INQUIRY_COMMAND_ERROR_LABELS["contact_information_incomplete"]
     if "inquiry conversion gate" in lowered or "verification" in lowered:
@@ -693,6 +701,14 @@ def make_office_panel_handler(
             elif action == "contact-completion":
                 panel.complete_inquiry_contacts(inquiry_id, self._form())
                 self._redirect(f"/inquiry/{inquiry_id}")
+            elif action == "customer-addresses":
+                form = self._form()
+                panel.set_inquiry_customer_addresses(inquiry_id, form)
+                return_order_id = form.get("return_order_id", "").strip()
+                if return_order_id:
+                    self._redirect(f"/order/{return_order_id}")
+                else:
+                    self._redirect(f"/inquiry/{inquiry_id}")
             elif action == "verify":
                 panel.inquiry_service.verify_customer_by_call(inquiry_id)
                 self._redirect(f"/inquiry/{inquiry_id}")

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 from typing import Literal
 
 from catering_system.domain.customer_document_preview import CustomerDocumentPreview
-from catering_system.domain.inquiry import PLANNING_MODES
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry import PLANNING_MODES, Inquiry
+from catering_system.domain.inquiry_customer_snapshot import DELIVERY_ADDRESS_MODES
 from catering_system.domain.order import (
     Order,
     OrderVersion,
@@ -20,6 +22,9 @@ from catering_system.domain.order_payment_reminder import (
     PaymentReminderView,
 )
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
+from catering_system.services.customer_document_projection import (
+    build_customer_document_recipient,
+)
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentEligibility,
 )
@@ -51,6 +56,15 @@ _DOCUMENT_WARNING_LABELS = {
         "Lieferadresse weicht von Rechnungsadresse ab"
     ),
 }
+
+_DELIVERY_MODE_LABELS = {
+    "UNKNOWN": "Unbekannt",
+    "SAME_AS_INVOICE": "Wie Rechnungsadresse",
+    "SEPARATE": "Abweichende Lieferadresse",
+}
+
+_NO_SEPARATE_DELIVERY = "keine separate Adresse"
+_NO_EFFECTIVE_DELIVERY = "nicht festgelegt"
 
 
 _OUTBOUND_STATE_LABELS = {
@@ -150,6 +164,7 @@ class OrderDetailFormFields:
     send_command_fields: str = ""
     pause_command_fields: str = ""
     resume_command_fields: str = ""
+    customer_addresses_command_fields: str = ""
     version_change_prefill: OrderVersionChangePrefill | None = None
 
 
@@ -736,6 +751,140 @@ def _live_preview_diagnostics(live_preview: ConfirmationLivePreviewView) -> str:
     return "".join(parts)
 
 
+def _format_customer_address(address: CustomerAddress | None) -> str:
+    if address is None:
+        return "–"
+    lines = [
+        value
+        for value in (
+            (address.street or "").strip(),
+            " ".join(
+                part
+                for part in (
+                    (address.postal_code or "").strip(),
+                    (address.city or "").strip(),
+                )
+                if part
+            ),
+            (address.country or "").strip(),
+        )
+        if value
+    ]
+    return "\n".join(lines) if lines else "–"
+
+
+def _address_input_block(prefix: str, address: CustomerAddress | None) -> str:
+    street = address.street if address is not None else ""
+    postal = address.postal_code if address is not None else ""
+    city = address.city if address is not None else ""
+    country = address.country if address is not None else ""
+    return (
+        f'<p><label>Straße</label><input name="{prefix}_street" '
+        f'value="{_e(street or "")}"></p>'
+        f'<p><label>PLZ</label><input name="{prefix}_postal_code" '
+        f'value="{_e(postal or "")}"></p>'
+        f'<p><label>Ort</label><input name="{prefix}_city" '
+        f'value="{_e(city or "")}"></p>'
+        f'<p><label>Land</label><input name="{prefix}_country" '
+        f'value="{_e(country or "")}"></p>'
+    )
+
+
+def _customer_addresses_form(
+    inquiry: Inquiry,
+    order: Order,
+    forms: OrderDetailFormFields,
+) -> str:
+    snapshot = inquiry.customer_snapshot
+    mode = snapshot.delivery_address_mode if snapshot is not None else "UNKNOWN"
+    invoice = snapshot.invoice_address if snapshot is not None else None
+    delivery = snapshot.delivery_address if snapshot is not None else None
+    options = "".join(
+        f'<option value="{_e(value)}"{" selected" if value == mode else ""}>'
+        f"{_e(_DELIVERY_MODE_LABELS[value])}</option>"
+        for value in DELIVERY_ADDRESS_MODES
+    )
+    delivery_display = "block" if mode == "SEPARATE" else "none"
+    delivery_fields_id = f"delivery-address-fields-{order.order_id}"
+    return (
+        '<details class="order-edit"><summary>Adressen bearbeiten</summary>'
+        '<div class="order-edit-body">'
+        f'<form method="post" action="/inquiry/{_e(inquiry.inquiry_id)}/customer-addresses" '
+        'onsubmit="return confirm('
+        "'Kundenadressen für die Auftragsbestätigung werden gespeichert.'"
+        ');">'
+        f"{forms.csrf_input}{forms.customer_addresses_command_fields}"
+        f'<input type="hidden" name="return_order_id" value="{_e(order.order_id)}">'
+        "<fieldset>"
+        "<p><strong>Rechnungsadresse</strong></p>"
+        + _address_input_block("invoice", invoice)
+        + "<p><label>Liefermodus</label>"
+        + (
+            f'<select name="delivery_address_mode" '
+            f"onchange=\"var box=document.getElementById('{_e(delivery_fields_id)}');"
+            "if(box){box.style.display=this.value==='SEPARATE'?'block':'none';}\">"
+        )
+        + f"{options}</select></p>"
+        f'<div id="{_e(delivery_fields_id)}" '
+        f'style="display:{delivery_display}">'
+        "<p><strong>Abweichende Lieferadresse</strong></p>"
+        + _address_input_block("delivery", delivery)
+        + "</div>"
+        '<p><button type="submit">Adressen speichern</button></p>'
+        "</fieldset></form></div></details>"
+    )
+
+
+def render_customer_addresses_card(
+    inquiry: Inquiry | None,
+    order: Order,
+    forms: OrderDetailFormFields,
+    *,
+    editable: bool = True,
+) -> str:
+    """Show stored vs effective delivery addresses for confirmation context."""
+    if inquiry is None:
+        return (
+            '<section class="order-card order-content-card order-addresses-card">'
+            "<h2>Kundenadressen</h2>"
+            '<p class="order-section-note">Keine Anfrage verknüpft.</p>'
+            "</section>"
+        )
+    snapshot = inquiry.customer_snapshot
+    mode = snapshot.delivery_address_mode if snapshot is not None else "UNKNOWN"
+    invoice = snapshot.invoice_address if snapshot is not None else None
+    stored_delivery = snapshot.delivery_address if snapshot is not None else None
+    recipient = build_customer_document_recipient(inquiry)
+    effective_delivery = recipient.delivery_address
+    if mode == "SEPARATE":
+        stored_label = _format_customer_address(stored_delivery)
+    else:
+        stored_label = _NO_SEPARATE_DELIVERY
+    if mode == "UNKNOWN":
+        effective_label = _NO_EFFECTIVE_DELIVERY
+    else:
+        effective_label = _format_customer_address(effective_delivery)
+    facts = (
+        f"<div><dt>Rechnungsadresse</dt>"
+        f'<dd style="white-space:pre-line">{_e(_format_customer_address(invoice))}</dd></div>'
+        f"<div><dt>Liefermodus</dt><dd>{_e(_DELIVERY_MODE_LABELS.get(mode, mode))}</dd></div>"
+        f"<div><dt>Gespeicherte Lieferadresse</dt>"
+        f'<dd style="white-space:pre-line">{_e(stored_label)}</dd></div>'
+        f"<div><dt>Effektive Lieferadresse</dt>"
+        f'<dd style="white-space:pre-line">{_e(effective_label)}</dd></div>'
+    )
+    form = (
+        _customer_addresses_form(inquiry, order, forms)
+        if editable and order.cancelled_at is None
+        else ""
+    )
+    return (
+        '<section class="order-card order-content-card order-addresses-card">'
+        "<h2>Kundenadressen</h2>"
+        f'<dl class="order-payment-facts">{facts}</dl>' + form + "</section>"
+    )
+
+
 def render_confirmation_card(
     order: Order,
     confirmation: OrderConfirmationDocumentEligibility,
@@ -980,6 +1129,7 @@ def render_order_detail(
     forms: OrderDetailFormFields,
     live_preview: ConfirmationLivePreviewView,
     *,
+    source_inquiry: Inquiry | None = None,
     operational_pause: Mapping[str, object] | None = None,
     versions_total_count: int,
     versions_truncated: bool,
@@ -1059,6 +1209,7 @@ def render_order_detail(
         + "</div>"
         '<aside class="order-detail-side">'
         + _primary_action(order, target, next_action, forms)
+        + render_customer_addresses_card(source_inquiry, order, forms)
         + _confirmation_card(order, confirmation, forms, live_preview)
         + render_confirmation_outbound_card(
             order, confirmation, outbound, forms, operational_pause=pause_view

--- a/tests/unit/test_customer_address_source_v1_b_panel.py
+++ b/tests/unit/test_customer_address_source_v1_b_panel.py
@@ -1,0 +1,445 @@
+"""CUSTOMER_ADDRESS_SOURCE_V1-B — Order Detail facts + panel form (slices 3–4)."""
+
+from __future__ import annotations
+
+import base64
+import queue
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import replace
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.repositories.core_transaction import (
+    CoreCommandExecutor,
+    open_core_connection,
+)
+from catering_system.repositories.sqlite_catalog_repository import (
+    SQLiteCatalogRepository,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_order_confirmation_document_repository import (
+    SQLiteOrderConfirmationDocumentRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.repositories.sqlite_payment_reminder_repository import (
+    SQLitePaymentReminderRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.services.offer_service import OfferService
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
+from catering_system.ui.office_panel_http import csrf_token_for_password
+from catering_system.ui.office_panel_order_detail import (
+    OrderDetailFormFields,
+    render_customer_addresses_card,
+)
+from tests.unit.test_offer_service import (
+    _INQUIRY_ID,
+    _acceptance_args,
+    _record_args,
+    _sample_inquiry,
+    _valid_snapshot,
+)
+
+_PASSWORD = "panel-address-pw"
+_AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
+_CSRF = csrf_token_for_password(_PASSWORD)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _empty_forms(**overrides: object) -> OrderDetailFormFields:
+    base: dict[str, object] = dict(
+        csrf_input="",
+        print_confirm_command_fields={},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        customer_addresses_command_fields="",
+    )
+    base.update(overrides)
+    return OrderDetailFormFields(**base)  # type: ignore[arg-type]
+
+
+def test_address_card_separate_shows_stored_and_effective() -> None:
+    inquiry = replace(
+        _sample_inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="ACME",
+            email="a@b.de",
+            phone="+49301",
+            invoice_address=_INVOICE,
+            delivery_address=_DELIVERY,
+            delivery_address_mode="SEPARATE",
+        ),
+    )
+    from catering_system.domain.order import Order
+
+    order = Order(
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_inquiry_id=inquiry.inquiry_id,
+        created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    assert "Rechnungsadresse" in card
+    assert "Bürostraße 1" in card
+    assert "Abweichende Lieferadresse" in card
+    assert "Gespeicherte Lieferadresse" in card
+    assert "Eventplatz 9" in card
+    assert "Effektive Lieferadresse" in card
+    assert "Adressen bearbeiten" in card
+    assert 'action="/inquiry/' in card
+    assert "customer-addresses" in card
+    assert 'name="return_order_id"' in card
+
+
+def test_address_card_same_as_invoice_distinguishes_stored_vs_effective() -> None:
+    inquiry = replace(
+        _sample_inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="ACME",
+            email="a@b.de",
+            phone="+49301",
+            invoice_address=_INVOICE,
+            delivery_address=None,
+            delivery_address_mode="SAME_AS_INVOICE",
+        ),
+    )
+    from catering_system.domain.order import Order
+
+    order = Order(
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_inquiry_id=inquiry.inquiry_id,
+        created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    assert "Wie Rechnungsadresse" in card
+    assert "keine separate Adresse" in card
+    assert card.count("Bürostraße 1") >= 2
+    assert "Eventplatz" not in card
+
+
+def test_address_card_unknown_has_no_effective_delivery() -> None:
+    inquiry = replace(
+        _sample_inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="ACME",
+            email="a@b.de",
+            phone="+49301",
+            invoice_address=_INVOICE,
+            delivery_address_mode="UNKNOWN",
+        ),
+    )
+    from catering_system.domain.order import Order
+
+    order = Order(
+        order_id="22222222-2222-4222-8222-222222222222",
+        source_inquiry_id=inquiry.inquiry_id,
+        created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    assert "Unbekannt" in card
+    assert "keine separate Adresse" in card
+    assert "nicht festgelegt" in card
+    assert "Bürostraße 1" in card
+
+
+def _seed_order_world(tmp_path: Path) -> tuple[Path, str, str]:
+    db = tmp_path / "core.db"
+    connection = open_core_connection(db)
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    orders = SQLiteOrderRepository.from_connection(connection)
+    offers = SQLiteOfferRepository.from_connection(connection)
+    commercial = SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
+    inquiry = replace(
+        _sample_inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="Example GmbH",
+            email="customer@example.invalid",
+            phone="+49301234567",
+        ),
+    )
+    inquiries.save(inquiry)
+    offer_service = OfferService(offers, inquiries, orders, commercial)
+    offer = offer_service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
+    version_id = offer.versions[0].offer_version_id
+    offer_service.record_sent_evidence(offer.offer_id, version_id, **_record_args())
+    updated = offer_service.record_acceptance_evidence(
+        offer.offer_id,
+        version_id,
+        "44444444-4444-4444-8444-444444444441",
+        **_acceptance_args(),
+    )
+    assert updated.acceptance_evidence is not None
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        "44444444-4444-4444-8444-444444444441",
+        updated.acceptance_evidence.acceptance_id,
+    )
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+    connection.commit()
+    connection.close()
+    return db, order.order_id, inquiry.inquiry_id
+
+
+def _panel(db: Path, *, ui_version: str = "v2") -> OfficePanel:
+    connection = open_core_connection(db)
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    orders = SQLiteOrderRepository.from_connection(connection)
+    return OfficePanel(
+        inquiries,
+        orders,
+        payment_reminder_repo=SQLitePaymentReminderRepository.from_connection(
+            connection
+        ),
+        confirmation_document_repo=SQLiteOrderConfirmationDocumentRepository.from_connection(
+            connection
+        ),
+        offer_repo=SQLiteOfferRepository.from_connection(connection),
+        catalog_repo=SQLiteCatalogRepository.from_connection(connection),
+        commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+            connection
+        ),
+        command_executor=CoreCommandExecutor(connection),
+        ui_version=ui_version,
+    )
+
+
+def test_order_detail_shows_separate_addresses_after_service_write(
+    tmp_path: Path,
+) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+    panel.inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    page = panel.render_order(order_id)
+    assert page is not None
+    assert "Kundenadressen" in page
+    assert "Bürostraße 1" in page
+    assert "Eventplatz 9" in page
+    assert "Abweichende Lieferadresse" in page
+    assert 'action="/inquiry/' in page
+    assert "customer-addresses" in page
+
+
+def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+    panel.inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    panel.inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    page = panel.render_order(order_id)
+    assert page is not None
+    assert "Wie Rechnungsadresse" in page
+    assert "keine separate Adresse" in page
+    assert "Eventplatz 9" not in page
+
+    panel.inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="UNKNOWN",
+    )
+    page = panel.render_order(order_id)
+    assert page is not None
+    assert "Unbekannt" in page
+    assert "nicht festgelegt" in page
+
+
+def test_contact_completion_after_address_form_preserves_addresses(
+    tmp_path: Path,
+) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+    panel.inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    inquiry = panel._inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    snap = inquiry.customer_snapshot
+    assert snap is not None
+    panel._inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=snap.company_name,
+                contact_name=snap.contact_name,
+                email=None,
+                phone=snap.phone,
+                invoice_address=snap.invoice_address,
+                delivery_address=snap.delivery_address,
+                delivery_address_mode=snap.delivery_address_mode,
+            ),
+        )
+    )
+    panel.complete_inquiry_contacts(
+        inquiry_id, {"contact_email": "neu@example.invalid"}
+    )
+    page = panel.render_order(order_id)
+    assert page is not None
+    assert "Eventplatz 9" in page
+    assert "Abweichende Lieferadresse" in page
+    loaded = panel._inquiries.get_by_id(inquiry_id)
+    assert loaded is not None
+    assert loaded.customer_snapshot is not None
+    assert loaded.customer_snapshot.email == "neu@example.invalid"
+    assert loaded.customer_snapshot.delivery_address_mode == "SEPARATE"
+
+
+def _start_panel_server(db: Path) -> tuple[str, HTTPServer]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        connection = open_core_connection(db)
+        server = create_office_panel_server(
+            SQLiteInquiryRepository.from_connection(connection),
+            SQLiteOrderRepository.from_connection(connection),
+            _PASSWORD,
+            host="127.0.0.1",
+            port=0,
+            command_executor=CoreCommandExecutor(connection),
+            payment_reminder_repo=SQLitePaymentReminderRepository.from_connection(
+                connection
+            ),
+            confirmation_document_repo=(
+                SQLiteOrderConfirmationDocumentRepository.from_connection(connection)
+            ),
+            offer_repo=SQLiteOfferRepository.from_connection(connection),
+            catalog_repo=SQLiteCatalogRepository.from_connection(connection),
+            commercial_snapshot_repo=SQLiteOrderCommercialSnapshotRepository.from_connection(
+                connection
+            ),
+            ui_version="v2",
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    threading.Thread(target=run, daemon=True).start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return f"http://{host}:{port}", server
+
+
+def _get(url: str) -> tuple[int, str]:
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", _AUTH)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _post(url: str, fields: dict[str, str]) -> tuple[int, str]:
+    body = urllib.parse.urlencode(fields).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Authorization", _AUTH)
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def test_panel_http_customer_addresses_form_round_trip(tmp_path: Path) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    base, server = _start_panel_server(db)
+    try:
+        status, page = _get(f"{base}/order/{order_id}")
+        assert status == 200
+        assert "Kundenadressen" in page
+        assert "Adressen bearbeiten" in page
+        status, _body = _post(
+            f"{base}/inquiry/{inquiry_id}/customer-addresses",
+            {
+                "_csrf_token": _CSRF,
+                "return_order_id": order_id,
+                "delivery_address_mode": "SEPARATE",
+                "invoice_street": _INVOICE.street or "",
+                "invoice_postal_code": _INVOICE.postal_code or "",
+                "invoice_city": _INVOICE.city or "",
+                "invoice_country": _INVOICE.country or "",
+                "delivery_street": _DELIVERY.street or "",
+                "delivery_postal_code": _DELIVERY.postal_code or "",
+                "delivery_city": _DELIVERY.city or "",
+                "delivery_country": _DELIVERY.country or "",
+            },
+        )
+        assert status in {200, 302}
+        status, page = _get(f"{base}/order/{order_id}")
+        assert status == 200
+        assert "Eventplatz 9" in page
+        assert "Abweichende Lieferadresse" in page
+        assert "Bürostraße 1" in page
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_legacy_and_v2_show_same_address_facts(tmp_path: Path) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    connection = open_core_connection(db)
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    service = InquiryService(inquiries)
+    service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=_INVOICE,
+        delivery_address=_DELIVERY,
+        delivery_address_mode="SEPARATE",
+    )
+    connection.commit()
+    v2 = _panel(db, ui_version="v2").render_order(order_id)
+    legacy = _panel(db, ui_version="legacy").render_order(order_id)
+    assert v2 is not None and legacy is not None
+    for page in (v2, legacy):
+        assert "Kundenadressen" in page
+        assert "Bürostraße 1" in page
+        assert "Eventplatz 9" in page
+        assert "Abweichende Lieferadresse" in page

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -1265,13 +1265,11 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
     assert "wirksam" in order_html
     assert "READY_TO_SEND: bereit." in order_html
 
-    cancel_command_id = _extract_hidden(
-        re.search(
-            r'(<form[^>]*action="/order/[^"]*/cancel"[^>]*>.*?</form>)', order_html
-        ).group(0),
-        "_command_id",
-    )
-    cancel_expect = _extract_hidden(order_html, "_expect_updated_at")
+    cancel_form = re.search(
+        r'(<form[^>]*action="/order/[^"]*/cancel"[^>]*>.*?</form>)', order_html
+    ).group(0)
+    cancel_command_id = _extract_hidden(cancel_form, "_command_id")
+    cancel_expect = _extract_hidden(cancel_form, "_expect_updated_at")
     status, _body = _post_form(
         f"{base}/order/{order_id}/cancel",
         {


### PR DESCRIPTION
## Summary
- Order Detail shows **Rechnungsadresse**, **Liefermodus**, **Gespeicherte Lieferadresse**, and **Effektive Lieferadresse**, distinguishing stored vs effective delivery (`SAME_AS_INVOICE` → stored none / effective = invoice; `UNKNOWN` → no effective delivery).
- Panel form (Unbekannt / Wie Rechnungsadresse / Abweichende Lieferadresse) posts to `/inquiry/{id}/customer-addresses` and returns to the order; delivery fields only for `SEPARATE`.
- Direct and legacy/v2 parity covered; remote cancel-form expect extraction fixed after adding a second `_expect_updated_at` on the page.

## Test plan
- [x] ruff / mypy
- [x] pytest 1703 + coverage ≥90%
- [x] SEPARATE shows both addresses; SAME clears stored delivery; UNKNOWN has no effective delivery
- [x] contact completion after address write preserves mode/addresses
- [x] HTTP form round-trip + legacy/v2 same facts


Made with [Cursor](https://cursor.com)