### PR TITLE
Persist confirmation address facts in schema 2 snapshots

### DIFF
--- a/src/catering_system/domain/order_confirmation_document.py
+++ b/src/catering_system/domain/order_confirmation_document.py
@@ -1,4 +1,9 @@
-"""Frozen customer-facing Auftragsbestätigung snapshot — EMAIL_MVP_1 slice B1."""
+"""Frozen customer-facing Auftragsbestätigung snapshot — EMAIL_MVP_1 slice B1.
+
+CONFIRMATION_ADDRESS_SNAPSHOT_V1: schema 2 persists invoice/delivery address
+facts once at create time. Schema 1 is legacy without address facts
+(delivery_address_differs is None / NOT_STORED — never false-by-default).
+"""
 
 from __future__ import annotations
 
@@ -7,9 +12,16 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Literal
 
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    customer_addresses_equal,
+)
 from catering_system.domain.inquiry import PlanningMode
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION_V1 = 1
+SCHEMA_VERSION_V2 = 2
+SCHEMA_VERSION = SCHEMA_VERSION_V2
+SUPPORTED_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION_V1, SCHEMA_VERSION_V2})
 RecipientStatus = Literal["ready", "missing"]
 _DOCUMENT_HASH = re.compile(r"sha256:[0-9a-f]{64}\Z")
 
@@ -68,12 +80,42 @@ class OrderConfirmationDocumentSnapshot:
     document_hash: str
     schema_version: int = SCHEMA_VERSION
     document_warnings: tuple[str, ...] = ()
+    invoice_address: CustomerAddress | None = None
+    delivery_address: CustomerAddress | None = None
+    # None = NOT_STORED (schema 1 legacy). Schema 2 requires bool.
+    delivery_address_differs: bool | None = None
 
     def __post_init__(self) -> None:
-        if self.schema_version != SCHEMA_VERSION:
+        if self.schema_version not in SUPPORTED_SCHEMA_VERSIONS:
             raise ValueError("unsupported order confirmation document schema version")
         if not _DOCUMENT_HASH.fullmatch(self.document_hash):
             raise ValueError("document_hash must be sha256:<hex>")
+        if self.schema_version == SCHEMA_VERSION_V1:
+            if (
+                self.invoice_address is not None
+                or self.delivery_address is not None
+                or self.delivery_address_differs is not None
+            ):
+                raise ValueError(
+                    "schema 1 confirmation snapshot must not store address facts"
+                )
+            return
+        if self.delivery_address_differs is None:
+            raise ValueError("schema 2 requires delivery_address_differs as bool")
+        expected_differs = (
+            self.invoice_address is not None
+            and self.delivery_address is not None
+            and not customer_addresses_equal(
+                self.invoice_address, self.delivery_address
+            )
+        )
+        if self.delivery_address_differs != expected_differs:
+            raise ValueError("delivery_address_differs does not match addresses")
+
+    @property
+    def address_facts_stored(self) -> bool:
+        """True when invoice/delivery facts were persisted (schema 2)."""
+        return self.schema_version == SCHEMA_VERSION_V2
 
 
 def mask_recipient_email(email: str | None) -> str | None:

--- a/src/catering_system/services/order_confirmation_document_hash.py
+++ b/src/catering_system/services/order_confirmation_document_hash.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+from catering_system.domain.inquiry_customer_snapshot import customer_address_to_mapping
 from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentSnapshot,
+    SCHEMA_VERSION_V2,
 )
 
 
 def snapshot_hash_payload(
     snapshot: OrderConfirmationDocumentSnapshot,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "schema_version": snapshot.schema_version,
         "order_id": snapshot.order_id,
         "order_version_id": snapshot.order_version_id,
@@ -61,6 +63,16 @@ def snapshot_hash_payload(
         "payment_customer_visible_text": snapshot.payment_customer_visible_text,
         "document_warnings": list(snapshot.document_warnings),
     }
+    # Schema 1 hash payload must stay byte-identical to pre-V1 address work.
+    if snapshot.schema_version == SCHEMA_VERSION_V2:
+        payload["invoice_address"] = customer_address_to_mapping(
+            snapshot.invoice_address
+        )
+        payload["delivery_address"] = customer_address_to_mapping(
+            snapshot.delivery_address
+        )
+        payload["delivery_address_differs"] = snapshot.delivery_address_differs
+    return payload
 
 
 def compute_document_hash(snapshot: OrderConfirmationDocumentSnapshot) -> str:

--- a/src/catering_system/services/order_confirmation_document_preview.py
+++ b/src/catering_system/services/order_confirmation_document_preview.py
@@ -1,10 +1,15 @@
-"""Customer-facing Auftragsbestätigung preview projection and HTML renderer."""
+"""Customer-facing Auftragsbestätigung preview projection and HTML renderer.
+
+Persisted preview reads only from OrderConfirmationDocumentSnapshot.
+No Inquiry repository and no CustomerDocumentProjection live rebuild.
+"""
 
 from __future__ import annotations
 
 import html
 from dataclasses import dataclass
 
+from catering_system.domain.inquiry_customer_snapshot import customer_address_to_mapping
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentSnapshot,
 )
@@ -41,6 +46,12 @@ class OrderConfirmationDocumentPreview:
     payment_method_label: str
     payment_customer_visible_text: str
     footer_note: str
+    schema_version: int
+    address_facts_stored: bool
+    invoice_address: dict[str, str | None] | None
+    delivery_address: dict[str, str | None] | None
+    delivery_address_differs: bool | None
+    document_warnings: tuple[str, ...]
     watermark: str | None = None
 
 
@@ -56,6 +67,7 @@ def build_preview(
         if snapshot.guest_count_estimate is not None
         else "–"
     )
+    stored = snapshot.address_facts_stored
     return OrderConfirmationDocumentPreview(
         sender_name=_SENDER_NAME,
         sender_location=_SENDER_LOCATION,
@@ -86,6 +98,18 @@ def build_preview(
         payment_method_label=payment_method_label(snapshot.payment_method),
         payment_customer_visible_text=snapshot.payment_customer_visible_text,
         footer_note=_FOOTER_NOTE,
+        schema_version=snapshot.schema_version,
+        address_facts_stored=stored,
+        invoice_address=(
+            customer_address_to_mapping(snapshot.invoice_address) if stored else None
+        ),
+        delivery_address=(
+            customer_address_to_mapping(snapshot.delivery_address) if stored else None
+        ),
+        delivery_address_differs=(
+            snapshot.delivery_address_differs if stored else None
+        ),
+        document_warnings=snapshot.document_warnings,
         watermark=watermark,
     )
 
@@ -114,6 +138,12 @@ def preview_to_json(preview: OrderConfirmationDocumentPreview) -> dict[str, obje
         "payment_method_label": preview.payment_method_label,
         "payment_customer_visible_text": preview.payment_customer_visible_text,
         "footer_note": preview.footer_note,
+        "schema_version": preview.schema_version,
+        "address_facts_stored": preview.address_facts_stored,
+        "invoice_address": preview.invoice_address,
+        "delivery_address": preview.delivery_address,
+        "delivery_address_differs": preview.delivery_address_differs,
+        "document_warnings": list(preview.document_warnings),
         "watermark": preview.watermark,
     }
 
@@ -135,6 +165,13 @@ def render_preview_html(preview: OrderConfirmationDocumentPreview) -> str:
         recipient_lines.append('<p class="missing">Empfänger-E-Mail fehlt</p>')
     if preview.recipient_phone:
         recipient_lines.append(f"<p>{_e(preview.recipient_phone)}</p>")
+    address_section = _address_section_html(preview)
+    warnings_html = ""
+    if preview.document_warnings:
+        items = "".join(f"<li>{_e(code)}</li>" for code in preview.document_warnings)
+        warnings_html = (
+            f'<section class="section"><h2>Hinweise</h2><ul>{items}</ul></section>'
+        )
     position_rows = []
     for position in preview.positions:
         details = []
@@ -189,6 +226,8 @@ footer{{margin-top:2rem;padding-top:1rem;border-top:1px solid #ddd;font-size:0.9
 <p>Referenz: {_e(preview.document_reference)} · Erstellt am {_e(preview.created_at_text)}</p>
 </header>
 <section class="section"><h2>Kunde</h2>{"".join(recipient_lines) or "<p>–</p>"}</section>
+{address_section}
+{warnings_html}
 <section class="section"><h2>Veranstaltung</h2>
 <p>Datum: {_e(preview.event_date_text)}</p>
 <p>Zeit: {_e(preview.time_window_text)}</p>
@@ -211,6 +250,44 @@ footer{{margin-top:2rem;padding-top:1rem;border-top:1px solid #ddd;font-size:0.9
 </section>
 <footer><p>{_e(preview.footer_note)}</p></footer>
 </body></html>"""
+
+
+def _address_section_html(preview: OrderConfirmationDocumentPreview) -> str:
+    if not preview.address_facts_stored:
+        return (
+            '<section class="section"><h2>Adressen</h2>'
+            "<p>Adressdaten sind in diesem Dokumentstand nicht gespeichert.</p>"
+            "</section>"
+        )
+    differs_text = (
+        "ja"
+        if preview.delivery_address_differs is True
+        else "nein"
+        if preview.delivery_address_differs is False
+        else "–"
+    )
+    return (
+        '<section class="section"><h2>Adressen</h2>'
+        f"<p><strong>Rechnungsadresse</strong><br>{_format_address_html(preview.invoice_address)}</p>"
+        f"<p><strong>Lieferadresse</strong><br>{_format_address_html(preview.delivery_address)}</p>"
+        f"<p>Lieferadresse weicht ab: {_e(differs_text)}</p>"
+        "</section>"
+    )
+
+
+def _format_address_html(address: dict[str, str | None] | None) -> str:
+    if address is None:
+        return "–"
+    lines = [
+        address.get("street"),
+        " ".join(
+            part for part in (address.get("postal_code"), address.get("city")) if part
+        ).strip()
+        or None,
+        address.get("country"),
+    ]
+    rendered = "<br>".join(_e(line) for line in lines if line)
+    return rendered or "–"
 
 
 def _position_shape(position: object) -> dict[str, object]:

--- a/src/catering_system/services/order_confirmation_document_preview.py
+++ b/src/catering_system/services/order_confirmation_document_preview.py
@@ -259,17 +259,24 @@ def _address_section_html(preview: OrderConfirmationDocumentPreview) -> str:
             "<p>Adressdaten sind in diesem Dokumentstand nicht gespeichert.</p>"
             "</section>"
         )
-    differs_text = (
-        "ja"
-        if preview.delivery_address_differs is True
-        else "nein"
-        if preview.delivery_address_differs is False
-        else "–"
+    invoice_html = (
+        f"<p><strong>Rechnungsadresse</strong><br>"
+        f"{_format_address_html(preview.invoice_address)}</p>"
     )
+    # UNKNOWN / unset delivery: do not map differs=false to proven equality.
+    if preview.delivery_address is None:
+        return (
+            '<section class="section"><h2>Adressen</h2>'
+            f"{invoice_html}"
+            "<p><strong>Lieferadresse</strong><br>Lieferadresse nicht festgelegt</p>"
+            "</section>"
+        )
+    differs_text = "ja" if preview.delivery_address_differs is True else "nein"
     return (
         '<section class="section"><h2>Adressen</h2>'
-        f"<p><strong>Rechnungsadresse</strong><br>{_format_address_html(preview.invoice_address)}</p>"
-        f"<p><strong>Lieferadresse</strong><br>{_format_address_html(preview.delivery_address)}</p>"
+        f"{invoice_html}"
+        f"<p><strong>Lieferadresse</strong><br>"
+        f"{_format_address_html(preview.delivery_address)}</p>"
         f"<p>Lieferadresse weicht ab: {_e(differs_text)}</p>"
         "</section>"
     )

--- a/src/catering_system/services/order_confirmation_document_serialization.py
+++ b/src/catering_system/services/order_confirmation_document_serialization.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import validate_planning_mode
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_address_from_mapping,
+    customer_address_to_mapping,
+)
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentPosition,
     OrderConfirmationDocumentSnapshot,
     OrderConfirmationVatBucket,
     RecipientStatus,
-    SCHEMA_VERSION,
+    SCHEMA_VERSION_V1,
+    SCHEMA_VERSION_V2,
 )
 from catering_system.domain.order_payment_reminder import validate_payment_method
 
@@ -31,6 +37,10 @@ def snapshot_from_canonical_json(raw: str) -> OrderConfirmationDocumentSnapshot:
     buckets_raw = payload.get("vat_buckets")
     if not isinstance(positions_raw, list) or not isinstance(buckets_raw, list):
         raise ValueError("confirmation document snapshot JSON is incomplete")
+    schema_version = int(payload.get("schema_version", SCHEMA_VERSION_V1))
+    invoice_address, delivery_address, delivery_address_differs = _address_facts(
+        payload, schema_version=schema_version
+    )
     return OrderConfirmationDocumentSnapshot(
         document_snapshot_id=str(payload["document_snapshot_id"]),
         order_id=str(payload["order_id"]),
@@ -58,13 +68,16 @@ def snapshot_from_canonical_json(raw: str) -> OrderConfirmationDocumentSnapshot:
         payment_method=validate_payment_method(str(payload["payment_method"])),
         payment_customer_visible_text=str(payload["payment_customer_visible_text"]),
         document_hash=str(payload["document_hash"]),
-        schema_version=int(payload.get("schema_version", SCHEMA_VERSION)),
+        schema_version=schema_version,
         document_warnings=_document_warnings(payload.get("document_warnings")),
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+        delivery_address_differs=delivery_address_differs,
     )
 
 
 def _snapshot_payload(snapshot: OrderConfirmationDocumentSnapshot) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "document_snapshot_id": snapshot.document_snapshot_id,
         "order_id": snapshot.order_id,
         "order_version_id": snapshot.order_version_id,
@@ -118,6 +131,38 @@ def _snapshot_payload(snapshot: OrderConfirmationDocumentSnapshot) -> dict[str, 
         "schema_version": snapshot.schema_version,
         "document_warnings": list(snapshot.document_warnings),
     }
+    # Schema 1 canonical payload must omit address keys (legacy hash/shape).
+    if snapshot.schema_version == SCHEMA_VERSION_V2:
+        payload["invoice_address"] = customer_address_to_mapping(
+            snapshot.invoice_address
+        )
+        payload["delivery_address"] = customer_address_to_mapping(
+            snapshot.delivery_address
+        )
+        payload["delivery_address_differs"] = snapshot.delivery_address_differs
+    return payload
+
+
+def _address_facts(
+    payload: dict[str, object],
+    *,
+    schema_version: int,
+) -> tuple[CustomerAddress | None, CustomerAddress | None, bool | None]:
+    if schema_version == SCHEMA_VERSION_V1:
+        # Explicit NOT_STORED — do not invent delivery_address_differs=False.
+        return None, None, None
+    if schema_version != SCHEMA_VERSION_V2:
+        raise ValueError("unsupported order confirmation document schema version")
+    if "delivery_address_differs" not in payload:
+        raise ValueError("schema 2 snapshot requires delivery_address_differs")
+    differs_raw = payload["delivery_address_differs"]
+    if not isinstance(differs_raw, bool):
+        raise ValueError("delivery_address_differs must be a bool for schema 2")
+    return (
+        customer_address_from_mapping(payload.get("invoice_address")),
+        customer_address_from_mapping(payload.get("delivery_address")),
+        differs_raw,
+    )
 
 
 def _position(raw: object) -> OrderConfirmationDocumentPosition:

--- a/src/catering_system/services/order_confirmation_document_serialization.py
+++ b/src/catering_system/services/order_confirmation_document_serialization.py
@@ -150,17 +150,23 @@ def _address_facts(
 ) -> tuple[CustomerAddress | None, CustomerAddress | None, bool | None]:
     if schema_version == SCHEMA_VERSION_V1:
         # Explicit NOT_STORED — do not invent delivery_address_differs=False.
+        # Extra address keys on legacy payloads are ignored (tolerant reader).
         return None, None, None
     if schema_version != SCHEMA_VERSION_V2:
         raise ValueError("unsupported order confirmation document schema version")
-    if "delivery_address_differs" not in payload:
-        raise ValueError("schema 2 snapshot requires delivery_address_differs")
+    required = ("invoice_address", "delivery_address", "delivery_address_differs")
+    missing = [key for key in required if key not in payload]
+    if missing:
+        raise ValueError(
+            "schema 2 snapshot requires invoice_address, delivery_address, "
+            "and delivery_address_differs"
+        )
     differs_raw = payload["delivery_address_differs"]
     if not isinstance(differs_raw, bool):
         raise ValueError("delivery_address_differs must be a bool for schema 2")
     return (
-        customer_address_from_mapping(payload.get("invoice_address")),
-        customer_address_from_mapping(payload.get("delivery_address")),
+        customer_address_from_mapping(payload["invoice_address"]),
+        customer_address_from_mapping(payload["delivery_address"]),
         differs_raw,
     )
 

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -27,6 +27,7 @@ from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentSnapshot,
     OrderConfirmationVatBucket,
     RecipientStatus,
+    SCHEMA_VERSION_V2,
 )
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHOD_LABELS,
@@ -339,7 +340,11 @@ def _persist_snapshot_from_projection(
         payment_method=projection.payment_method,
         payment_customer_visible_text=projection.payment_customer_visible_text,
         document_hash=document_hash,
+        schema_version=SCHEMA_VERSION_V2,
         document_warnings=tuple(projection.recipient.warnings),
+        invoice_address=projection.recipient.invoice_address,
+        delivery_address=projection.recipient.delivery_address,
+        delivery_address_differs=projection.recipient.delivery_address_differs,
     )
 
 

--- a/tests/unit/test_confirmation_address_snapshot_v1.py
+++ b/tests/unit/test_confirmation_address_snapshot_v1.py
@@ -1,0 +1,313 @@
+"""CONFIRMATION_ADDRESS_SNAPSHOT_V1 — schema 2 address facts + legacy schema 1."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerAddress,
+)
+from catering_system.domain.inquiry_customer_snapshot import (
+    set_inquiry_customer_addresses,
+)
+from catering_system.domain.order_confirmation_document import (
+    SCHEMA_VERSION_V1,
+    SCHEMA_VERSION_V2,
+)
+from catering_system.services.order_confirmation_document_hash import (
+    compute_document_hash,
+    snapshot_hash_payload,
+)
+from catering_system.services.order_confirmation_document_preview import (
+    build_preview,
+    preview_to_json,
+)
+from catering_system.services.order_confirmation_document_serialization import (
+    snapshot_from_canonical_json,
+    snapshot_to_canonical_json,
+)
+from catering_system.ui import office_api_views as views
+from tests.unit.test_order_confirmation_document import _effective_order, _services
+
+# Golden legacy schema-1 canonical JSON (no address keys). Hash captured on
+# origin/main before CONFIRMATION_ADDRESS_SNAPSHOT_V1 — must remain stable.
+_LEGACY_V1_CANONICAL_JSON = (
+    '{"created_at":"2026-01-15T12:00:00+00:00","created_by":"fixture",'
+    '"document_hash":"sha256:e8a0f371e92b8cf417ddce34919cd4ab3d60174c4386d37ac379603196f5a31b",'
+    '"document_reference":"AB-TEST-V1",'
+    '"document_snapshot_id":"11111111-1111-4111-8111-111111111111",'
+    '"document_warnings":["DELIVERY_ADDRESS_DIFFERS_FROM_INVOICE"],'
+    '"event_date":"2026-06-01","gross_total_cents":1190,"guest_count_estimate":40,'
+    '"location_text":"Hamburg","net_total_cents":1000,'
+    '"offer_id":"44444444-4444-4444-8444-444444444444",'
+    '"offer_version_id":"55555555-5555-4555-8555-555555555555",'
+    '"order_id":"22222222-2222-4222-8222-222222222222",'
+    '"order_version_id":"33333333-3333-4333-8333-333333333333",'
+    '"payment_customer_visible_text":"Rechnung","payment_method":"RECHNUNG",'
+    '"planning_mode":"caterer_suggestion",'
+    '"positions":[{"composition":"Comp","description":"Desc","gross_cents":1190,'
+    '"kind":"MENU","name":"Buffet Classic","net_total_cents":1000,'
+    '"position_id":"pos-1","quantity":"40","related_position_id":null,'
+    '"unit_label":"Pers.","unit_net_cents":1000,"vat_cents":190,'
+    '"vat_rate_percent":19}],'
+    '"recipient_company":"Analytical Engines",'
+    '"recipient_email":"ada@example.invalid","recipient_name":"Ada Lovelace",'
+    '"recipient_phone":"+490000","recipient_status":"ready","schema_version":1,'
+    '"time_window_text":"10:00–14:00",'
+    '"vat_buckets":[{"base_net_cents":1000,"rate_percent":19,"vat_cents":190}],'
+    '"vat_total_cents":190}'
+)
+_LEGACY_V1_DOCUMENT_HASH = (
+    "sha256:e8a0f371e92b8cf417ddce34919cd4ab3d60174c4386d37ac379603196f5a31b"
+)
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _set_inquiry_addresses(
+    inquiries: object,
+    order: object,
+    *,
+    invoice: CustomerAddress | None,
+    delivery: CustomerAddress | None,
+    mode: str,
+) -> None:
+    inquiry = inquiries.get_by_id(order.source_inquiry_id)  # type: ignore[attr-defined]
+    assert inquiry is not None
+    inquiries.update(  # type: ignore[attr-defined]
+        set_inquiry_customer_addresses(
+            inquiry,
+            invoice_address=invoice,
+            delivery_address=delivery,
+            delivery_address_mode=mode,
+        )
+    )
+
+
+def test_a_same_as_invoice_persists_effective_delivery() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries, order, invoice=_INVOICE, delivery=None, mode="SAME_AS_INVOICE"
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    assert snapshot.schema_version == SCHEMA_VERSION_V2
+    assert snapshot.invoice_address == _INVOICE
+    assert snapshot.delivery_address == _INVOICE
+    assert snapshot.delivery_address_differs is False
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS not in snapshot.document_warnings
+    preview = build_preview(snapshot)
+    assert preview.address_facts_stored is True
+    assert preview.invoice_address == {
+        "street": "Bürostraße 1",
+        "postal_code": "20095",
+        "city": "Hamburg",
+        "country": "DE",
+    }
+    assert preview.delivery_address == preview.invoice_address
+    assert preview.delivery_address_differs is False
+
+
+def test_b_separate_persists_differs_warning() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries,
+        order,
+        invoice=_INVOICE,
+        delivery=_DELIVERY,
+        mode="SEPARATE",
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    assert snapshot.schema_version == SCHEMA_VERSION_V2
+    assert snapshot.invoice_address == _INVOICE
+    assert snapshot.delivery_address == _DELIVERY
+    assert snapshot.delivery_address_differs is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in snapshot.document_warnings
+    payload = json.loads(snapshot_to_canonical_json(snapshot))
+    assert payload["delivery_address_differs"] is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in payload["document_warnings"]
+
+
+def test_c_persisted_addresses_immutable_after_inquiry_change() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries, order, invoice=_INVOICE, delivery=None, mode="SAME_AS_INVOICE"
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    before_canonical = snapshot_to_canonical_json(snapshot)
+    before_preview = preview_to_json(build_preview(snapshot))
+
+    changed = CustomerAddress(
+        street="Neue Straße 99",
+        postal_code="22765",
+        city="Hamburg",
+        country="DE",
+    )
+    _set_inquiry_addresses(
+        inquiries,
+        order,
+        invoice=changed,
+        delivery=_DELIVERY,
+        mode="SEPARATE",
+    )
+    loaded = service.get_snapshot(order.order_id, snapshot.document_snapshot_id)
+    assert snapshot_to_canonical_json(loaded) == before_canonical
+    assert preview_to_json(build_preview(loaded)) == before_preview
+    assert loaded.invoice_address == _INVOICE
+    assert loaded.delivery_address == _INVOICE
+    assert loaded.delivery_address_differs is False
+
+
+def test_d_replay_returns_same_address_facts_without_rewrite() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries,
+        order,
+        invoice=_INVOICE,
+        delivery=_DELIVERY,
+        mode="SEPARATE",
+    )
+    first = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    assert len(documents._by_id) == 1
+    second = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    assert second.document_snapshot_id == first.document_snapshot_id
+    assert second.document_hash == first.document_hash
+    assert second.invoice_address == first.invoice_address
+    assert second.delivery_address == first.delivery_address
+    assert second.delivery_address_differs == first.delivery_address_differs
+    assert len(documents._by_id) == 1
+
+
+def test_e_legacy_schema_1_explicit_not_stored_and_stable_hash() -> None:
+    payload = json.loads(_LEGACY_V1_CANONICAL_JSON)
+    assert "invoice_address" not in payload
+    assert "delivery_address" not in payload
+    assert "delivery_address_differs" not in payload
+
+    loaded = snapshot_from_canonical_json(_LEGACY_V1_CANONICAL_JSON)
+    assert loaded.schema_version == SCHEMA_VERSION_V1
+    assert loaded.address_facts_stored is False
+    assert loaded.invoice_address is None
+    assert loaded.delivery_address is None
+    assert loaded.delivery_address_differs is None  # NOT_STORED, not false
+    assert loaded.document_hash == _LEGACY_V1_DOCUMENT_HASH
+    assert compute_document_hash(loaded) == _LEGACY_V1_DOCUMENT_HASH
+    assert "invoice_address" not in snapshot_hash_payload(loaded)
+    assert "delivery_address" not in snapshot_hash_payload(loaded)
+    assert "delivery_address_differs" not in snapshot_hash_payload(loaded)
+
+    roundtrip = snapshot_to_canonical_json(loaded)
+    assert json.loads(roundtrip) == payload
+    assert "invoice_address" not in json.loads(roundtrip)
+
+    preview = build_preview(loaded)
+    assert preview.address_facts_stored is False
+    assert preview.invoice_address is None
+    assert preview.delivery_address is None
+    assert preview.delivery_address_differs is None
+    preview_json = preview_to_json(preview)
+    assert preview_json["address_facts_stored"] is False
+    assert preview_json["delivery_address_differs"] is None
+
+
+def test_f_boundary_no_offer_or_inquiry_in_persisted_preview_path() -> None:
+    root = Path(__file__).resolve().parents[2]
+    service_text = (
+        root / "src/catering_system/services/order_confirmation_document_service.py"
+    ).read_text(encoding="utf-8")
+    preview_text = (
+        root / "src/catering_system/services/order_confirmation_document_preview.py"
+    ).read_text(encoding="utf-8")
+    assert "OfferRepository" not in service_text
+    assert "OfferRepository" not in preview_text
+    assert "InquiryRepository" not in preview_text
+    assert "CustomerDocumentProjectionService" not in preview_text
+    assert "build_customer_document_recipient" not in preview_text
+    sig = inspect.signature(build_preview)
+    assert list(sig.parameters) == ["snapshot", "watermark"]
+
+
+def test_g_api_preview_shape_exposes_address_contract_keys() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries,
+        order,
+        invoice=_INVOICE,
+        delivery=_DELIVERY,
+        mode="SEPARATE",
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    shape = views.confirmation_document_preview_shape(build_preview(snapshot))
+    required = {
+        "schema_version",
+        "address_facts_stored",
+        "invoice_address",
+        "delivery_address",
+        "delivery_address_differs",
+        "document_warnings",
+        "title",
+        "positions",
+        "watermark",
+    }
+    assert required.issubset(shape)
+    assert shape["schema_version"] == SCHEMA_VERSION_V2
+    assert shape["address_facts_stored"] is True
+    assert shape["delivery_address_differs"] is True
+    assert WARNING_DELIVERY_ADDRESS_DIFFERS in shape["document_warnings"]
+
+
+def test_unknown_mode_persists_nullable_projection_values() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries, order, invoice=_INVOICE, delivery=None, mode="UNKNOWN"
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    assert snapshot.schema_version == SCHEMA_VERSION_V2
+    assert snapshot.invoice_address == _INVOICE
+    assert snapshot.delivery_address is None
+    assert snapshot.delivery_address_differs is False

--- a/tests/unit/test_confirmation_address_snapshot_v1.py
+++ b/tests/unit/test_confirmation_address_snapshot_v1.py
@@ -6,6 +6,8 @@ import inspect
 import json
 from pathlib import Path
 
+import pytest
+
 from catering_system.domain.customer_document_projection import (
     WARNING_DELIVERY_ADDRESS_DIFFERS,
     CustomerAddress,
@@ -24,6 +26,7 @@ from catering_system.services.order_confirmation_document_hash import (
 from catering_system.services.order_confirmation_document_preview import (
     build_preview,
     preview_to_json,
+    render_preview_html,
 )
 from catering_system.services.order_confirmation_document_serialization import (
     snapshot_from_canonical_json,
@@ -311,3 +314,89 @@ def test_unknown_mode_persists_nullable_projection_values() -> None:
     assert snapshot.invoice_address == _INVOICE
     assert snapshot.delivery_address is None
     assert snapshot.delivery_address_differs is False
+    # JSON contract unchanged: null delivery + differs=false from CDP.
+    preview = build_preview(snapshot)
+    assert preview.delivery_address is None
+    assert preview.delivery_address_differs is False
+    html = render_preview_html(preview)
+    assert "Lieferadresse nicht festgelegt" in html
+    assert "weicht ab: nein" not in html
+    assert "weicht ab: ja" not in html
+
+
+def _schema2_payload_from_legacy(**overrides: object) -> dict[str, object]:
+    payload = json.loads(_LEGACY_V1_CANONICAL_JSON)
+    payload["schema_version"] = SCHEMA_VERSION_V2
+    payload["document_warnings"] = []
+    payload["invoice_address"] = {
+        "street": "Bürostraße 1",
+        "postal_code": "20095",
+        "city": "Hamburg",
+        "country": "DE",
+    }
+    payload["delivery_address"] = None
+    payload["delivery_address_differs"] = False
+    payload.update(overrides)
+    return payload
+
+
+def _dumps(payload: dict[str, object]) -> str:
+    return json.dumps(
+        payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+
+
+def test_schema2_rejects_missing_invoice_address_key() -> None:
+    payload = _schema2_payload_from_legacy()
+    del payload["invoice_address"]
+    with pytest.raises(ValueError, match="schema 2 snapshot requires"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_schema2_rejects_missing_delivery_address_key() -> None:
+    payload = _schema2_payload_from_legacy()
+    del payload["delivery_address"]
+    with pytest.raises(ValueError, match="schema 2 snapshot requires"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_schema2_rejects_missing_delivery_address_differs_key() -> None:
+    payload = _schema2_payload_from_legacy()
+    del payload["delivery_address_differs"]
+    with pytest.raises(ValueError, match="schema 2 snapshot requires"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_schema2_rejects_null_delivery_address_differs() -> None:
+    payload = _schema2_payload_from_legacy(delivery_address_differs=None)
+    with pytest.raises(ValueError, match="delivery_address_differs must be a bool"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_schema2_rejects_malformed_address_object() -> None:
+    payload = _schema2_payload_from_legacy(invoice_address={"street": "only"})
+    with pytest.raises(ValueError, match="address object keys must be exactly"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_schema2_rejects_unsupported_schema_version() -> None:
+    payload = _schema2_payload_from_legacy(schema_version=3)
+    with pytest.raises(ValueError, match="unsupported order confirmation document"):
+        snapshot_from_canonical_json(_dumps(payload))
+
+
+def test_same_as_invoice_html_may_show_differs_nein() -> None:
+    orders, _offers, inquiries, documents, service, _core, _offer = _services()
+    order, version = _effective_order(
+        (orders, _offers, inquiries, documents, service, _core, _offer)
+    )
+    _set_inquiry_addresses(
+        inquiries, order, invoice=_INVOICE, delivery=None, mode="SAME_AS_INVOICE"
+    )
+    snapshot = service.prepare_snapshot(
+        order.order_id, version.order_version_id, "office-panel"
+    )
+    html = render_preview_html(build_preview(snapshot))
+    assert "Lieferadresse nicht festgelegt" not in html
+    assert "weicht ab: nein" in html
+    assert "Bürostraße 1" in html

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3493,6 +3493,12 @@ def test_confirmation_document_preview_json_and_html(api) -> None:
     assert preview["net_total_eur"]
     assert preview["vat_total_eur"]
     assert preview["gross_total_eur"]
+    assert preview["schema_version"] == 2
+    assert preview["address_facts_stored"] is True
+    assert "invoice_address" in preview
+    assert "delivery_address" in preview
+    assert "delivery_address_differs" in preview
+    assert "document_warnings" in preview
     assert "canonical_snapshot_json" not in body
     assert "unit_net_cents" not in preview["positions"][0]
 

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -143,6 +143,9 @@ def test_snapshot_created_for_effective_order() -> None:
     assert snapshot.gross_total_cents == 24824
     assert snapshot.recipient_status == "ready"
     assert snapshot.document_hash.startswith("sha256:")
+    assert snapshot.schema_version == 2
+    assert snapshot.delivery_address_differs is False
+    assert snapshot.address_facts_stored is True
 
 
 def test_no_effective_version_blocked() -> None:
@@ -572,6 +575,10 @@ def test_address_warning_flows_into_confirmation_document() -> None:
         invoice_address=invoice,
         delivery_address=delivery,
     )
+    assert snapshot.schema_version == 2
+    assert snapshot.invoice_address == invoice
+    assert snapshot.delivery_address == delivery
+    assert snapshot.delivery_address_differs is True
     assert WARNING_DELIVERY_ADDRESS_DIFFERS in snapshot.document_warnings
 
 
@@ -922,7 +929,12 @@ def test_confirmation_document_service_has_no_offer_repository() -> None:
     text = (
         root / "src/catering_system/services/order_confirmation_document_service.py"
     ).read_text(encoding="utf-8")
+    preview = (
+        root / "src/catering_system/services/order_confirmation_document_preview.py"
+    ).read_text(encoding="utf-8")
     assert "OfferRepository" not in text
+    assert "OfferRepository" not in preview
+    assert "InquiryRepository" not in preview
     assert "conversion_link" not in text
     assert "parse_intake_contact" not in text
     assert "labelled_intake_context" not in text


### PR DESCRIPTION
## Summary
- New confirmation documents use `schema_version=2` and freeze `invoice_address`, effective `delivery_address`, `delivery_address_differs`, and `document_warnings` from `CustomerDocumentProjection` at first create.
- Persisted preview reads address facts only from `OrderConfirmationDocumentSnapshot` (no live Inquiry fallback). Schema 1 keeps explicit NOT_STORED (`delivery_address_differs=None`) and unchanged hash/canonical payload semantics.
- Acceptance coverage for SAME_AS_INVOICE / SEPARATE / immutability / replay / legacy hash stability / Offer boundary / API preview keys.

## Test plan
- [x] `pytest tests/unit/test_confirmation_address_snapshot_v1.py tests/unit/test_order_confirmation_document.py`
- [x] customer address + commercial + confirmation-related API tests
- [x] full `coverage run -m pytest` (1711 passed, 90.1%)
- [x] `ruff check` / `ruff format --check` / `mypy src/catering_system`
- [x] node staging-form + cloudflare worker tests
- [ ] review: no merge / no production deploy in this PR


Made with [Cursor](https://cursor.com)