### PR TITLE
Add immutable offer document snapshots

### DIFF
--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -18,6 +18,7 @@ from catering_system.domain.order_payment_reminder import (
 
 _MAX_EVENT_TEXT_LEN = 500
 _MAX_PAYMENT_VISIBLE_TEXT_LEN = 20_000
+_MAX_CUSTOMER_NARRATIVE_LEN = 20_000
 
 OfferState = Literal[
     "Prepared",
@@ -202,6 +203,12 @@ class OfferVersion:
     payment_method: PaymentMethod
     payment_customer_visible_text: str
     variants: tuple[OfferVariant, ...]
+    # OFFER_DOCUMENT_SNAPSHOT_V1: customer-facing narrative frozen from the
+    # source OfferSnapshot's customer_text. Blank/whitespace-only input is
+    # normalized to None before construction (never stored as "").
+    customer_title: str | None = None
+    customer_introduction: str | None = None
+    customer_notes: str | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.offer_version_id, "offer_version_id")
@@ -226,6 +233,19 @@ class OfferVersion:
             self.payment_customer_visible_text,
             "payment_customer_visible_text",
             max_len=_MAX_PAYMENT_VISIBLE_TEXT_LEN,
+        )
+        _optional_bounded_text(
+            self.customer_title, "customer_title", max_len=_MAX_EVENT_TEXT_LEN
+        )
+        _optional_bounded_text(
+            self.customer_introduction,
+            "customer_introduction",
+            max_len=_MAX_CUSTOMER_NARRATIVE_LEN,
+        )
+        _optional_bounded_text(
+            self.customer_notes,
+            "customer_notes",
+            max_len=_MAX_CUSTOMER_NARRATIVE_LEN,
         )
         if not self.variants:
             raise ValueError("an OfferVersion requires at least one variant")

--- a/src/catering_system/domain/offer_document_snapshot.py
+++ b/src/catering_system/domain/offer_document_snapshot.py
@@ -1,0 +1,356 @@
+"""Frozen customer-facing ANGEBOT / AUFTRAGSBESTÄTIGUNG snapshot.
+
+OFFER_DOCUMENT_SNAPSHOT_V1: the initial customer document, frozen before the
+first send and long before an Order exists. It anchors to one OfferVersion
+and the single OfferVariant the office chose to present.
+
+Boundary: this snapshot is never reused for a post-Order change. Changes to
+an existing Order get their own document anchored to a candidate
+OrderVersion (future ORDER_CHANGE_DOCUMENT_SNAPSHOT_V1), and this object is
+also distinct from the post-Order OrderConfirmationDocumentSnapshot.
+
+Schema 1 has no legacy tier: fulfillment and address facts are mandatory
+from the start, so there is no NOT_STORED state to defend against.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal
+
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    customer_addresses_equal,
+)
+from catering_system.domain.order_payment_reminder import (
+    PaymentMethod,
+    validate_payment_method,
+)
+
+SCHEMA_VERSION = 1
+SUPPORTED_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION})
+
+OfferDocumentFulfillmentMode = Literal["DELIVERY", "PICKUP"]
+OFFER_DOCUMENT_FULFILLMENT_MODES: tuple[OfferDocumentFulfillmentMode, ...] = (
+    "DELIVERY",
+    "PICKUP",
+)
+
+_DOCUMENT_HASH = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+OfferDocumentBlockerCode = Literal[
+    "OFFER_VERSION_NOT_PREPARED",
+    "OFFER_VARIANT_NOT_FOUND",
+    "MISSING_RECIPIENT_NAME",
+    "MISSING_RECIPIENT_CONTACT",
+    "INVOICE_ADDRESS_REQUIRED",
+    "FULFILLMENT_MODE_REQUIRED",
+    "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY",
+    "INVALID_COMMERCIAL_FACTS",
+]
+
+OFFER_DOCUMENT_BLOCKER_CODES: tuple[OfferDocumentBlockerCode, ...] = (
+    "OFFER_VERSION_NOT_PREPARED",
+    "OFFER_VARIANT_NOT_FOUND",
+    "MISSING_RECIPIENT_NAME",
+    "MISSING_RECIPIENT_CONTACT",
+    "INVOICE_ADDRESS_REQUIRED",
+    "FULFILLMENT_MODE_REQUIRED",
+    "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY",
+    "INVALID_COMMERCIAL_FACTS",
+)
+
+_BLOCKER_SORT_ORDER: dict[OfferDocumentBlockerCode, int] = {
+    code: index for index, code in enumerate(OFFER_DOCUMENT_BLOCKER_CODES)
+}
+
+
+def document_reference(offer_id: str, version_number: int) -> str:
+    """Deterministic customer-visible reference — never a Rechnungsnummer.
+
+    Derived from the Offer's own id, so it needs no sequential counter and
+    no Order id (no Order exists yet at document time).
+    """
+    if not offer_id.strip():
+        raise ValueError("offer_id is required")
+    if version_number < 1:
+        raise ValueError("version_number must be at least 1")
+    return f"ANG-{offer_id[:8].upper()}-V{version_number}"
+
+
+@dataclass(frozen=True)
+class OfferDocumentBlocker:
+    """One hard reason a customer offer document must not be created."""
+
+    code: OfferDocumentBlockerCode
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.code not in OFFER_DOCUMENT_BLOCKER_CODES:
+            raise ValueError(f"unsupported offer document blocker code: {self.code!r}")
+        if self.detail is not None and not self.detail.strip():
+            raise ValueError("detail must not be blank when provided")
+
+
+@dataclass(frozen=True)
+class OfferDocumentEligibility:
+    """Pure create decision for the customer offer document."""
+
+    allowed: bool
+    blockers: tuple[OfferDocumentBlocker, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.allowed != (self.blockers == ()):
+            raise ValueError("allowed must equal (blockers == ())")
+
+
+def sort_offer_document_blockers(
+    blockers: tuple[OfferDocumentBlocker, ...],
+) -> tuple[OfferDocumentBlocker, ...]:
+    """Stable deterministic order for tests and API surfaces."""
+    return tuple(
+        sorted(
+            blockers,
+            key=lambda item: (_BLOCKER_SORT_ORDER[item.code], item.detail or ""),
+        )
+    )
+
+
+class OfferDocumentCreationBlocked(Exception):
+    """Controlled refusal to create the customer offer document."""
+
+    def __init__(self, eligibility: OfferDocumentEligibility) -> None:
+        if eligibility.allowed or not eligibility.blockers:
+            raise ValueError(
+                "OfferDocumentCreationBlocked requires a blocked eligibility"
+            )
+        self.eligibility = eligibility
+        self.blockers = eligibility.blockers
+        codes = ", ".join(blocker.code for blocker in eligibility.blockers)
+        super().__init__(f"offer document creation blocked: {codes}")
+
+    @property
+    def primary_code(self) -> OfferDocumentBlockerCode:
+        return self.blockers[0].code
+
+    @property
+    def codes(self) -> tuple[OfferDocumentBlockerCode, ...]:
+        return tuple(blocker.code for blocker in self.blockers)
+
+
+class OfferDocumentVariantConflictError(Exception):
+    """One OfferVersion may present exactly one variant to the customer.
+
+    A different variant is a different commercial offer and requires a new
+    OfferVersion, never a second document for the same version.
+    """
+
+    def __init__(
+        self,
+        *,
+        offer_version_id: str,
+        existing_variant_id: str,
+        requested_variant_id: str,
+    ) -> None:
+        self.offer_version_id = offer_version_id
+        self.existing_variant_id = existing_variant_id
+        self.requested_variant_id = requested_variant_id
+        super().__init__(
+            "offer document already exists for offer_version_id="
+            f"{offer_version_id!r} with variant {existing_variant_id!r}; "
+            f"requested {requested_variant_id!r}"
+        )
+
+
+class OfferDocumentHashMismatchError(Exception):
+    """A persisted row failed re-verification and must not be trusted."""
+
+    def __init__(
+        self,
+        *,
+        offer_document_snapshot_id: str,
+        recomputed: str,
+        embedded: str,
+        row: str,
+    ) -> None:
+        self.offer_document_snapshot_id = offer_document_snapshot_id
+        self.recomputed = recomputed
+        self.embedded = embedded
+        self.row = row
+        super().__init__(
+            "offer document hash mismatch for "
+            f"offer_document_snapshot_id={offer_document_snapshot_id!r}"
+        )
+
+
+@dataclass(frozen=True)
+class OfferDocumentPosition:
+    """One frozen customer-visible line. Cents are copied, never recomputed."""
+
+    position_id: str
+    kind: str
+    name: str
+    unit_net_cents: int
+    net_total_cents: int
+    vat_rate_percent: int
+    vat_cents: int
+    gross_cents: int
+    related_position_id: str | None = None
+    description: str | None = None
+    composition: str | None = None
+    quantity: str | None = None
+    unit_label: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.position_id.strip():
+            raise ValueError("position_id is required")
+        if not self.name.strip():
+            raise ValueError("name is required")
+        for field, value in (
+            ("unit_net_cents", self.unit_net_cents),
+            ("net_total_cents", self.net_total_cents),
+            ("vat_cents", self.vat_cents),
+            ("gross_cents", self.gross_cents),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{field} must be an integer number of cents")
+            if value < 0:
+                raise ValueError(f"{field} must be non-negative")
+
+
+@dataclass(frozen=True)
+class OfferDocumentVatBucket:
+    """Aggregated VAT band, summed once at freeze time from frozen cents."""
+
+    rate_percent: int
+    base_net_cents: int
+    vat_cents: int
+
+    def __post_init__(self) -> None:
+        for field, value in (
+            ("base_net_cents", self.base_net_cents),
+            ("vat_cents", self.vat_cents),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{field} must be an integer number of cents")
+            if value < 0:
+                raise ValueError(f"{field} must be non-negative")
+
+
+@dataclass(frozen=True)
+class OfferDocumentSnapshot:
+    """Immutable ANGEBOT / AUFTRAGSBESTÄTIGUNG content, frozen before sending."""
+
+    offer_document_snapshot_id: str
+    offer_id: str
+    offer_version_id: str
+    offer_variant_id: str
+    document_reference: str
+    created_at: datetime
+    created_by: str
+    recipient_name: str | None
+    recipient_company: str | None
+    recipient_email: str | None
+    recipient_phone: str | None
+    invoice_address: CustomerAddress
+    fulfillment_mode: OfferDocumentFulfillmentMode
+    delivery_address: CustomerAddress | None
+    delivery_address_differs: bool
+    event_date: date
+    time_window_text: str
+    location_text: str
+    guest_count_estimate: int | None
+    positions: tuple[OfferDocumentPosition, ...]
+    vat_buckets: tuple[OfferDocumentVatBucket, ...]
+    net_total_cents: int
+    vat_total_cents: int
+    gross_total_cents: int
+    payment_method: PaymentMethod
+    payment_customer_visible_text: str
+    document_hash: str
+    schema_version: int = SCHEMA_VERSION
+    customer_title: str | None = None
+    customer_introduction: str | None = None
+    customer_notes: str | None = None
+    document_warnings: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+            raise ValueError("unsupported offer document schema version")
+        if not _DOCUMENT_HASH.fullmatch(self.document_hash):
+            raise ValueError("document_hash must be sha256:<64 lowercase hex>")
+        for field, value in (
+            ("offer_document_snapshot_id", self.offer_document_snapshot_id),
+            ("offer_id", self.offer_id),
+            ("offer_version_id", self.offer_version_id),
+            ("offer_variant_id", self.offer_variant_id),
+            ("document_reference", self.document_reference),
+            ("created_by", self.created_by),
+        ):
+            if not value.strip():
+                raise ValueError(f"{field} is required")
+        if self.created_at.tzinfo is None or self.created_at.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+
+        # Fulfillment is mandatory and binary here: UNKNOWN never reaches a
+        # persisted customer document (eligibility refuses it first).
+        if self.fulfillment_mode not in OFFER_DOCUMENT_FULFILLMENT_MODES:
+            raise ValueError("fulfillment_mode must be DELIVERY or PICKUP")
+
+        validate_payment_method(self.payment_method)
+        if not self.payment_customer_visible_text.strip():
+            raise ValueError("payment_customer_visible_text is required")
+
+        # Rechnungsadresse is required for both modes; PICKUP only removes the
+        # delivery-address requirement.
+        if not _address_complete(self.invoice_address):
+            raise ValueError(
+                "invoice_address requires street, postal_code, city and country"
+            )
+
+        if self.fulfillment_mode == "PICKUP":
+            if self.delivery_address is not None:
+                raise ValueError("PICKUP must not store a delivery address")
+            if self.delivery_address_differs:
+                raise ValueError("PICKUP must not store delivery_address_differs=True")
+        else:
+            if self.delivery_address is None:
+                raise ValueError("DELIVERY requires an effective delivery address")
+            expected_differs = not customer_addresses_equal(
+                self.invoice_address, self.delivery_address
+            )
+            if self.delivery_address_differs != expected_differs:
+                raise ValueError("delivery_address_differs does not match addresses")
+
+        money_fields: tuple[tuple[str, int], ...] = (
+            ("net_total_cents", self.net_total_cents),
+            ("vat_total_cents", self.vat_total_cents),
+            ("gross_total_cents", self.gross_total_cents),
+        )
+        for money_field, money_value in money_fields:
+            if isinstance(money_value, bool) or not isinstance(money_value, int):
+                raise ValueError(f"{money_field} must be an integer number of cents")
+            if money_value < 0:
+                raise ValueError(f"{money_field} must be non-negative")
+
+
+def _address_complete(address: CustomerAddress | None) -> bool:
+    """True only when every structured invoice-address part is present."""
+    if address is None:
+        return False
+    return all(
+        (value or "").strip()
+        for value in (
+            address.street,
+            address.postal_code,
+            address.city,
+            address.country,
+        )
+    )
+
+
+def address_is_complete(address: CustomerAddress | None) -> bool:
+    """Public form of the structural completeness rule (used by eligibility)."""
+    return _address_complete(address)

--- a/src/catering_system/repositories/in_memory_offer_document_snapshot_repository.py
+++ b/src/catering_system/repositories/in_memory_offer_document_snapshot_repository.py
@@ -1,0 +1,58 @@
+"""In-memory offer document snapshot repository — baseline for unit tests.
+
+Mirrors the SQLite adapter's guarantees: one snapshot per OfferVersion,
+insert-once, and the same runtime hash verification on every read so tests
+exercise the real read contract rather than a laxer one.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+from catering_system.repositories.offer_document_snapshot_repository import (
+    OfferDocumentSnapshotRepository,
+)
+from catering_system.services.offer_document_snapshot_serialization import (
+    snapshot_from_verified_row,
+    snapshot_to_canonical_json,
+)
+
+
+class InMemoryOfferDocumentSnapshotRepository(OfferDocumentSnapshotRepository):
+    def __init__(self) -> None:
+        # Stored as canonical JSON + row hash so the verification path is the
+        # same one SQLite uses.
+        self._rows: dict[str, tuple[str, str]] = {}
+        self._by_offer_version_id: dict[str, str] = {}
+
+    def get_by_id(
+        self, offer_document_snapshot_id: str
+    ) -> OfferDocumentSnapshot | None:
+        row = self._rows.get(offer_document_snapshot_id)
+        if row is None:
+            return None
+        canonical, row_hash = row
+        return snapshot_from_verified_row(canonical, row_hash)
+
+    def get_by_offer_version_id(
+        self, offer_version_id: str
+    ) -> OfferDocumentSnapshot | None:
+        snapshot_id = self._by_offer_version_id.get(offer_version_id)
+        if snapshot_id is None:
+            return None
+        return self.get_by_id(snapshot_id)
+
+    def insert(self, snapshot: OfferDocumentSnapshot) -> None:
+        if snapshot.offer_document_snapshot_id in self._rows:
+            raise KeyError(snapshot.offer_document_snapshot_id)
+        if snapshot.offer_version_id in self._by_offer_version_id:
+            raise ValueError(
+                "offer document snapshot already exists for offer_version_id="
+                f"{snapshot.offer_version_id!r}"
+            )
+        self._rows[snapshot.offer_document_snapshot_id] = (
+            snapshot_to_canonical_json(snapshot),
+            snapshot.document_hash,
+        )
+        self._by_offer_version_id[snapshot.offer_version_id] = (
+            snapshot.offer_document_snapshot_id
+        )

--- a/src/catering_system/repositories/offer_document_snapshot_repository.py
+++ b/src/catering_system/repositories/offer_document_snapshot_repository.py
@@ -1,0 +1,29 @@
+"""Persistence port for frozen customer offer document snapshots.
+
+Append-only: exactly one snapshot per OfferVersion, never updated, never
+deleted. The chosen variant is stored inside the snapshot, not in the key.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+
+
+class OfferDocumentSnapshotRepository(ABC):
+    @abstractmethod
+    def get_by_id(
+        self, offer_document_snapshot_id: str
+    ) -> OfferDocumentSnapshot | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_by_offer_version_id(
+        self, offer_version_id: str
+    ) -> OfferDocumentSnapshot | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert(self, snapshot: OfferDocumentSnapshot) -> None:
+        raise NotImplementedError

--- a/src/catering_system/repositories/sqlite_offer_document_snapshot_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_document_snapshot_repository.py
@@ -1,0 +1,171 @@
+"""SQLite persistence for frozen customer offer document snapshots.
+
+The owner trigger validates all three provenance ids against one
+``offer_variants`` row, which denormalizes offer_id + offer_version_id +
+variant_id together — so a single EXISTS proves the whole chain.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from pathlib import Path
+
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+from catering_system.repositories.offer_document_snapshot_repository import (
+    OfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.sqlite_migrations import apply_migrations
+from catering_system.services.offer_document_snapshot_serialization import (
+    snapshot_from_verified_row,
+    snapshot_to_canonical_json,
+)
+
+
+def _migration_1_create_table(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE offer_document_snapshots (
+            offer_document_snapshot_id TEXT PRIMARY KEY,
+            offer_id TEXT NOT NULL,
+            offer_version_id TEXT NOT NULL,
+            offer_variant_id TEXT NOT NULL,
+            document_reference TEXT NOT NULL,
+            schema_version INTEGER NOT NULL,
+            canonical_snapshot_json TEXT NOT NULL,
+            document_hash TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            UNIQUE (offer_version_id)
+        );
+        CREATE INDEX idx_offer_document_snapshots_offer_id
+            ON offer_document_snapshots (offer_id);
+        CREATE INDEX idx_offer_document_snapshots_offer_version_id
+            ON offer_document_snapshots (offer_version_id);
+        CREATE INDEX idx_offer_document_snapshots_document_reference
+            ON offer_document_snapshots (document_reference);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_offer_document_snapshot_owner_insert
+        BEFORE INSERT ON offer_document_snapshots
+        WHEN NOT EXISTS (
+            SELECT 1 FROM offer_variants ov
+            WHERE ov.offer_id = NEW.offer_id
+              AND ov.offer_version_id = NEW.offer_version_id
+              AND ov.variant_id = NEW.offer_variant_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'offer document snapshot owner is invalid');
+        END;
+        CREATE TRIGGER trg_offer_document_snapshot_immutable_update
+        BEFORE UPDATE ON offer_document_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'offer document snapshot is immutable');
+        END;
+        CREATE TRIGGER trg_offer_document_snapshot_immutable_delete
+        BEFORE DELETE ON offer_document_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'offer document snapshot is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = ((1, "create_offer_document_snapshots", _migration_1_create_table),)
+
+
+class SQLiteOfferDocumentSnapshotRepository(OfferDocumentSnapshotRepository):
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "offer_document_snapshots", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteOfferDocumentSnapshotRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "offer_document_snapshots", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get_by_id(
+        self, offer_document_snapshot_id: str
+    ) -> OfferDocumentSnapshot | None:
+        row = self._conn.execute(
+            "SELECT canonical_snapshot_json, document_hash FROM "
+            "offer_document_snapshots WHERE offer_document_snapshot_id = ?",
+            (offer_document_snapshot_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return snapshot_from_verified_row(row[0], row[1])
+
+    def get_by_offer_version_id(
+        self, offer_version_id: str
+    ) -> OfferDocumentSnapshot | None:
+        row = self._conn.execute(
+            "SELECT canonical_snapshot_json, document_hash FROM "
+            "offer_document_snapshots WHERE offer_version_id = ?",
+            (offer_version_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return snapshot_from_verified_row(row[0], row[1])
+
+    def find_by_document_reference(
+        self, document_reference: str
+    ) -> OfferDocumentSnapshot | None:
+        row = self._conn.execute(
+            "SELECT canonical_snapshot_json, document_hash FROM "
+            "offer_document_snapshots WHERE document_reference = ?",
+            (document_reference,),
+        ).fetchone()
+        if row is None:
+            return None
+        return snapshot_from_verified_row(row[0], row[1])
+
+    def insert(self, snapshot: OfferDocumentSnapshot) -> None:
+        canonical = snapshot_to_canonical_json(snapshot)
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO offer_document_snapshots (
+                    offer_document_snapshot_id,
+                    offer_id,
+                    offer_version_id,
+                    offer_variant_id,
+                    document_reference,
+                    schema_version,
+                    canonical_snapshot_json,
+                    document_hash,
+                    created_at,
+                    created_by
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot.offer_document_snapshot_id,
+                    snapshot.offer_id,
+                    snapshot.offer_version_id,
+                    snapshot.offer_variant_id,
+                    snapshot.document_reference,
+                    snapshot.schema_version,
+                    canonical,
+                    snapshot.document_hash,
+                    snapshot.created_at.isoformat(),
+                    snapshot.created_by,
+                ),
+            )

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -280,6 +280,17 @@ def _migration_6_offer_position_catalog_snapshot_fields(
             )
 
 
+def _migration_7_offer_version_customer_narrative(
+    connection: sqlite3.Connection,
+) -> None:
+    existing = {
+        row[1] for row in connection.execute("PRAGMA table_info(offer_versions)")
+    }
+    for name in ("customer_title", "customer_introduction", "customer_notes"):
+        if name not in existing:
+            connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
+
+
 _MIGRATIONS = (
     (1, "create_offer_tables", _migration_1_create_tables),
     (2, "unique_source_inquiry", _migration_2_unique_source_inquiry),
@@ -298,6 +309,11 @@ _MIGRATIONS = (
         6,
         "offer_position_catalog_snapshot_fields",
         _migration_6_offer_position_catalog_snapshot_fields,
+    ),
+    (
+        7,
+        "offer_version_customer_narrative",
+        _migration_7_offer_version_customer_narrative,
     ),
 )
 
@@ -606,8 +622,9 @@ class SQLiteOfferRepository:
                 offer_version_id, offer_id, version_number, created_at, valid_until,
                 snapshot_id, snapshot_hash, event_date, time_window_text,
                 location_text, guest_count, planning_mode, payment_method,
-                payment_customer_visible_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                payment_customer_visible_text, customer_title,
+                customer_introduction, customer_notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 version.offer_version_id,
@@ -624,6 +641,9 @@ class SQLiteOfferRepository:
                 version.planning_mode,
                 version.payment_method,
                 version.payment_customer_visible_text,
+                version.customer_title,
+                version.customer_introduction,
+                version.customer_notes,
             ),
         )
         for sort_order, variant in enumerate(version.variants):
@@ -755,7 +775,8 @@ class SQLiteOfferRepository:
             SELECT offer_version_id, version_number, created_at, valid_until,
                    snapshot_id, snapshot_hash, event_date, time_window_text,
                    location_text, guest_count, planning_mode, payment_method,
-                   payment_customer_visible_text
+                   payment_customer_visible_text, customer_title,
+                   customer_introduction, customer_notes
             FROM offer_versions
             WHERE offer_id = ?
             ORDER BY version_number
@@ -799,6 +820,9 @@ class SQLiteOfferRepository:
                     payment_method=validate_payment_method(row[11]),
                     payment_customer_visible_text=row[12],
                     variants=variants,
+                    customer_title=row[13],
+                    customer_introduction=row[14],
+                    customer_notes=row[15],
                 )
             )
         return tuple(versions)

--- a/src/catering_system/services/offer_document_eligibility.py
+++ b/src/catering_system/services/offer_document_eligibility.py
@@ -1,0 +1,115 @@
+"""Pure create eligibility for the customer offer document.
+
+No repositories, no persistence, no rendering: value objects in, decision
+out. Mirrors services/customer_document_eligibility.py, but the fulfillment
+and address rules are the OFFER_DOCUMENT_SNAPSHOT_V1 ones.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from catering_system.domain.customer_document_projection import (
+    CustomerDocumentRecipient,
+)
+from catering_system.domain.inquiry import FulfillmentMode
+from catering_system.domain.offer import Offer, derive_offer_state
+from catering_system.domain.offer_document_snapshot import (
+    OfferDocumentBlocker,
+    OfferDocumentEligibility,
+    address_is_complete,
+    sort_offer_document_blockers,
+)
+
+_PLACEHOLDER_NAME = "Kunde"
+
+
+def evaluate_offer_document_eligibility(
+    *,
+    offer: Offer,
+    offer_version_id: str,
+    offer_variant_id: str,
+    recipient: CustomerDocumentRecipient,
+    fulfillment_mode: FulfillmentMode,
+    today: date,
+) -> OfferDocumentEligibility:
+    """Decide whether a NEW offer document may be frozen for this version."""
+    blockers: list[OfferDocumentBlocker] = []
+
+    version = next(
+        (item for item in offer.versions if item.offer_version_id == offer_version_id),
+        None,
+    )
+    if version is None:
+        # An unknown version cannot carry a variant either; report both facts
+        # rather than guessing which one the caller got wrong.
+        blockers.append(OfferDocumentBlocker(code="OFFER_VERSION_NOT_PREPARED"))
+        blockers.append(OfferDocumentBlocker(code="OFFER_VARIANT_NOT_FOUND"))
+    else:
+        if derive_offer_state(offer, offer_version_id, today=today) != "Prepared":
+            blockers.append(OfferDocumentBlocker(code="OFFER_VERSION_NOT_PREPARED"))
+        if not any(
+            variant.variant_id == offer_variant_id for variant in version.variants
+        ):
+            blockers.append(OfferDocumentBlocker(code="OFFER_VARIANT_NOT_FOUND"))
+
+    if not _has_usable_name(recipient):
+        blockers.append(OfferDocumentBlocker(code="MISSING_RECIPIENT_NAME"))
+
+    if not _has_usable_contact(recipient):
+        blockers.append(OfferDocumentBlocker(code="MISSING_RECIPIENT_CONTACT"))
+
+    # Rechnungsadresse is required for BOTH modes. PICKUP removes only the
+    # delivery-address requirement, never the invoice-address requirement.
+    if not address_is_complete(recipient.invoice_address):
+        blockers.append(OfferDocumentBlocker(code="INVOICE_ADDRESS_REQUIRED"))
+
+    # fulfillment_mode is the sole source for these two blockers — never
+    # inferred from address presence, text or payment.
+    if fulfillment_mode == "UNKNOWN":
+        blockers.append(OfferDocumentBlocker(code="FULFILLMENT_MODE_REQUIRED"))
+    elif fulfillment_mode == "DELIVERY" and recipient.delivery_address is None:
+        blockers.append(
+            OfferDocumentBlocker(code="DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY")
+        )
+
+    if version is not None and not _commercial_facts_valid(version, offer_variant_id):
+        blockers.append(OfferDocumentBlocker(code="INVALID_COMMERCIAL_FACTS"))
+
+    ordered = sort_offer_document_blockers(tuple(blockers))
+    return OfferDocumentEligibility(allowed=not ordered, blockers=ordered)
+
+
+def _has_usable_name(recipient: CustomerDocumentRecipient) -> bool:
+    name = recipient.name.strip()
+    if name and name != _PLACEHOLDER_NAME:
+        return True
+    return bool((recipient.company_name or "").strip())
+
+
+def _has_usable_contact(recipient: CustomerDocumentRecipient) -> bool:
+    email = (recipient.email or "").strip()
+    phone = (recipient.phone or "").strip()
+    return bool(email) or bool(phone)
+
+
+def _commercial_facts_valid(version: object, offer_variant_id: str) -> bool:
+    """Defense in depth: OfferVersion invariants should already guarantee this.
+
+    Only checks that the selected variant carries at least one position and
+    that payment terms are present; per-position cents are validated by the
+    OfferPosition dataclass itself at construction time.
+    """
+    variant = next(
+        (
+            item
+            for item in getattr(version, "variants", ())
+            if item.variant_id == offer_variant_id
+        ),
+        None,
+    )
+    if variant is None:
+        return True  # OFFER_VARIANT_NOT_FOUND already reports this case
+    if not variant.positions:
+        return False
+    return bool(getattr(version, "payment_customer_visible_text", "").strip())

--- a/src/catering_system/services/offer_document_snapshot_hash.py
+++ b/src/catering_system/services/offer_document_snapshot_hash.py
@@ -1,0 +1,81 @@
+"""Canonical hash for OfferDocumentSnapshot — OFFER_DOCUMENT_SNAPSHOT_V1.
+
+The hash covers every contractual, customer-visible fact of the document.
+It deliberately excludes creation metadata (created_at/created_by) and all
+future transport/acceptance evidence, so re-sending or later accepting the
+same document never changes what the customer agreed to.
+
+Three distinct hashes exist in the wider flow and must not be confused:
+``document_hash`` (this one, the business content), ``original_pdf_hash``
+(bytes actually sent) and ``signed_file_hash`` (bytes returned signed).
+The latter two are not equal to each other and are out of this slice.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.inquiry_customer_snapshot import customer_address_to_mapping
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+from catering_system.domain.offer_snapshot import compute_snapshot_hash
+
+
+def snapshot_hash_payload(snapshot: OfferDocumentSnapshot) -> dict[str, object]:
+    """Deterministic hash payload; key order is normalized by the serializer."""
+    return {
+        "schema_version": snapshot.schema_version,
+        "document_reference": snapshot.document_reference,
+        "offer_id": snapshot.offer_id,
+        "offer_version_id": snapshot.offer_version_id,
+        "offer_variant_id": snapshot.offer_variant_id,
+        "recipient_name": snapshot.recipient_name,
+        "recipient_company": snapshot.recipient_company,
+        "recipient_email": snapshot.recipient_email,
+        "recipient_phone": snapshot.recipient_phone,
+        "invoice_address": customer_address_to_mapping(snapshot.invoice_address),
+        "fulfillment_mode": snapshot.fulfillment_mode,
+        "delivery_address": customer_address_to_mapping(snapshot.delivery_address),
+        "delivery_address_differs": snapshot.delivery_address_differs,
+        "event_date": snapshot.event_date.isoformat(),
+        "time_window_text": snapshot.time_window_text,
+        "location_text": snapshot.location_text,
+        "guest_count_estimate": snapshot.guest_count_estimate,
+        "customer_title": snapshot.customer_title,
+        "customer_introduction": snapshot.customer_introduction,
+        "customer_notes": snapshot.customer_notes,
+        "positions": [
+            {
+                "position_id": position.position_id,
+                "kind": position.kind,
+                "name": position.name,
+                "description": position.description,
+                "composition": position.composition,
+                "quantity": position.quantity,
+                "unit_label": position.unit_label,
+                "unit_net_cents": position.unit_net_cents,
+                "net_total_cents": position.net_total_cents,
+                "vat_rate_percent": position.vat_rate_percent,
+                "vat_cents": position.vat_cents,
+                "gross_cents": position.gross_cents,
+                "related_position_id": position.related_position_id,
+            }
+            for position in snapshot.positions
+        ],
+        "vat_buckets": [
+            {
+                "rate_percent": bucket.rate_percent,
+                "base_net_cents": bucket.base_net_cents,
+                "vat_cents": bucket.vat_cents,
+            }
+            for bucket in snapshot.vat_buckets
+        ],
+        "net_total_cents": snapshot.net_total_cents,
+        "vat_total_cents": snapshot.vat_total_cents,
+        "gross_total_cents": snapshot.gross_total_cents,
+        "payment_method": snapshot.payment_method,
+        "payment_customer_visible_text": snapshot.payment_customer_visible_text,
+        "document_warnings": list(snapshot.document_warnings),
+    }
+
+
+def compute_document_hash(snapshot: OfferDocumentSnapshot) -> str:
+    """sha256 over the canonical business payload (RFC 8785-style ordering)."""
+    return compute_snapshot_hash(snapshot_hash_payload(snapshot))

--- a/src/catering_system/services/offer_document_snapshot_serialization.py
+++ b/src/catering_system/services/offer_document_snapshot_serialization.py
@@ -1,0 +1,248 @@
+"""Canonical JSON for OfferDocumentSnapshot persistence + runtime verification.
+
+Unlike the older OrderConfirmationDocumentSnapshot reader, every persisted
+read here re-derives the hash and compares it against both stored copies
+(the one embedded in the canonical JSON and the one in the table column).
+A mismatch raises instead of returning a partially trusted document.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_address_from_mapping,
+    customer_address_to_mapping,
+)
+from catering_system.domain.offer_document_snapshot import (
+    SCHEMA_VERSION,
+    OFFER_DOCUMENT_FULFILLMENT_MODES,
+    OfferDocumentFulfillmentMode,
+    OfferDocumentHashMismatchError,
+    OfferDocumentPosition,
+    OfferDocumentSnapshot,
+    OfferDocumentVatBucket,
+)
+from catering_system.domain.order_payment_reminder import validate_payment_method
+from catering_system.services.offer_document_snapshot_hash import compute_document_hash
+
+
+def snapshot_to_canonical_json(snapshot: OfferDocumentSnapshot) -> str:
+    return json.dumps(
+        _snapshot_payload(snapshot),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def snapshot_from_canonical_json(raw: str) -> OfferDocumentSnapshot:
+    """Parse without trusting the hash — callers that read persisted rows
+    must use ``snapshot_from_verified_row`` instead."""
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("offer document snapshot JSON must be an object")
+    schema_version = int(payload.get("schema_version", SCHEMA_VERSION))
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError("unsupported offer document schema version")
+    positions_raw = payload.get("positions")
+    buckets_raw = payload.get("vat_buckets")
+    if not isinstance(positions_raw, list) or not isinstance(buckets_raw, list):
+        raise ValueError("offer document snapshot JSON is incomplete")
+    invoice_address = customer_address_from_mapping(payload["invoice_address"])
+    if invoice_address is None:
+        raise ValueError("offer document snapshot requires an invoice address")
+    return OfferDocumentSnapshot(
+        offer_document_snapshot_id=str(payload["offer_document_snapshot_id"]),
+        offer_id=str(payload["offer_id"]),
+        offer_version_id=str(payload["offer_version_id"]),
+        offer_variant_id=str(payload["offer_variant_id"]),
+        document_reference=str(payload["document_reference"]),
+        created_at=datetime.fromisoformat(str(payload["created_at"])),
+        created_by=str(payload["created_by"]),
+        recipient_name=_optional_str(payload.get("recipient_name")),
+        recipient_company=_optional_str(payload.get("recipient_company")),
+        recipient_email=_optional_str(payload.get("recipient_email")),
+        recipient_phone=_optional_str(payload.get("recipient_phone")),
+        invoice_address=invoice_address,
+        fulfillment_mode=_fulfillment_mode(payload.get("fulfillment_mode")),
+        delivery_address=_delivery_address(payload.get("delivery_address")),
+        delivery_address_differs=_bool(payload["delivery_address_differs"]),
+        event_date=date.fromisoformat(str(payload["event_date"])),
+        time_window_text=str(payload["time_window_text"]),
+        location_text=str(payload["location_text"]),
+        guest_count_estimate=_optional_int(payload.get("guest_count_estimate")),
+        customer_title=_optional_str(payload.get("customer_title")),
+        customer_introduction=_optional_str(payload.get("customer_introduction")),
+        customer_notes=_optional_str(payload.get("customer_notes")),
+        positions=tuple(_position(item) for item in positions_raw),
+        vat_buckets=tuple(_bucket(item) for item in buckets_raw),
+        net_total_cents=_int(payload["net_total_cents"]),
+        vat_total_cents=_int(payload["vat_total_cents"]),
+        gross_total_cents=_int(payload["gross_total_cents"]),
+        payment_method=validate_payment_method(str(payload["payment_method"])),
+        payment_customer_visible_text=str(payload["payment_customer_visible_text"]),
+        document_hash=str(payload["document_hash"]),
+        schema_version=schema_version,
+        document_warnings=_document_warnings(payload.get("document_warnings")),
+    )
+
+
+def snapshot_from_verified_row(
+    canonical_json: str, row_document_hash: str
+) -> OfferDocumentSnapshot:
+    """Mandatory read path for persisted rows.
+
+    Recomputes the business hash and requires it to match BOTH stored copies.
+    Checking both distinguishes a mutated JSON body (neither matches), a
+    mutated row column (only the embedded one matches) and a mutated embedded
+    value (only the row column matches).
+    """
+    snapshot = snapshot_from_canonical_json(canonical_json)
+    recomputed = compute_document_hash(snapshot)
+    if recomputed != snapshot.document_hash or recomputed != row_document_hash:
+        raise OfferDocumentHashMismatchError(
+            offer_document_snapshot_id=snapshot.offer_document_snapshot_id,
+            recomputed=recomputed,
+            embedded=snapshot.document_hash,
+            row=row_document_hash,
+        )
+    return snapshot
+
+
+def _snapshot_payload(snapshot: OfferDocumentSnapshot) -> dict[str, object]:
+    return {
+        "offer_document_snapshot_id": snapshot.offer_document_snapshot_id,
+        "offer_id": snapshot.offer_id,
+        "offer_version_id": snapshot.offer_version_id,
+        "offer_variant_id": snapshot.offer_variant_id,
+        "document_reference": snapshot.document_reference,
+        "created_at": snapshot.created_at.isoformat(),
+        "created_by": snapshot.created_by,
+        "recipient_name": snapshot.recipient_name,
+        "recipient_company": snapshot.recipient_company,
+        "recipient_email": snapshot.recipient_email,
+        "recipient_phone": snapshot.recipient_phone,
+        "invoice_address": customer_address_to_mapping(snapshot.invoice_address),
+        "fulfillment_mode": snapshot.fulfillment_mode,
+        "delivery_address": customer_address_to_mapping(snapshot.delivery_address),
+        "delivery_address_differs": snapshot.delivery_address_differs,
+        "event_date": snapshot.event_date.isoformat(),
+        "time_window_text": snapshot.time_window_text,
+        "location_text": snapshot.location_text,
+        "guest_count_estimate": snapshot.guest_count_estimate,
+        "customer_title": snapshot.customer_title,
+        "customer_introduction": snapshot.customer_introduction,
+        "customer_notes": snapshot.customer_notes,
+        "positions": [
+            {
+                "position_id": position.position_id,
+                "kind": position.kind,
+                "name": position.name,
+                "description": position.description,
+                "composition": position.composition,
+                "quantity": position.quantity,
+                "unit_label": position.unit_label,
+                "unit_net_cents": position.unit_net_cents,
+                "net_total_cents": position.net_total_cents,
+                "vat_rate_percent": position.vat_rate_percent,
+                "vat_cents": position.vat_cents,
+                "gross_cents": position.gross_cents,
+                "related_position_id": position.related_position_id,
+            }
+            for position in snapshot.positions
+        ],
+        "vat_buckets": [
+            {
+                "rate_percent": bucket.rate_percent,
+                "base_net_cents": bucket.base_net_cents,
+                "vat_cents": bucket.vat_cents,
+            }
+            for bucket in snapshot.vat_buckets
+        ],
+        "net_total_cents": snapshot.net_total_cents,
+        "vat_total_cents": snapshot.vat_total_cents,
+        "gross_total_cents": snapshot.gross_total_cents,
+        "payment_method": snapshot.payment_method,
+        "payment_customer_visible_text": snapshot.payment_customer_visible_text,
+        "document_hash": snapshot.document_hash,
+        "schema_version": snapshot.schema_version,
+        "document_warnings": list(snapshot.document_warnings),
+    }
+
+
+def _fulfillment_mode(value: object) -> OfferDocumentFulfillmentMode:
+    if not isinstance(value, str) or value not in OFFER_DOCUMENT_FULFILLMENT_MODES:
+        raise ValueError("fulfillment_mode must be DELIVERY or PICKUP")
+    return value
+
+
+def _delivery_address(value: object) -> CustomerAddress | None:
+    if value is None:
+        return None
+    return customer_address_from_mapping(value)
+
+
+def _position(raw: object) -> OfferDocumentPosition:
+    if not isinstance(raw, dict):
+        raise ValueError("position must be an object")
+    return OfferDocumentPosition(
+        position_id=str(raw["position_id"]),
+        kind=str(raw["kind"]),
+        name=str(raw["name"]),
+        unit_net_cents=_int(raw["unit_net_cents"]),
+        net_total_cents=_int(raw["net_total_cents"]),
+        vat_rate_percent=_int(raw["vat_rate_percent"]),
+        vat_cents=_int(raw["vat_cents"]),
+        gross_cents=_int(raw["gross_cents"]),
+        related_position_id=_optional_str(raw.get("related_position_id")),
+        description=_optional_str(raw.get("description")),
+        composition=_optional_str(raw.get("composition")),
+        quantity=_optional_str(raw.get("quantity")),
+        unit_label=_optional_str(raw.get("unit_label")),
+    )
+
+
+def _bucket(raw: object) -> OfferDocumentVatBucket:
+    if not isinstance(raw, dict):
+        raise ValueError("vat bucket must be an object")
+    return OfferDocumentVatBucket(
+        rate_percent=_int(raw["rate_percent"]),
+        base_net_cents=_int(raw["base_net_cents"]),
+        vat_cents=_int(raw["vat_cents"]),
+    )
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("invalid integer")
+    return value
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return _int(value)
+
+
+def _bool(value: object) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError("expected a boolean")
+    return value
+
+
+def _document_warnings(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("document_warnings must be a list")
+    return tuple(str(item) for item in value)

--- a/src/catering_system/services/offer_document_snapshot_service.py
+++ b/src/catering_system/services/offer_document_snapshot_service.py
@@ -74,6 +74,13 @@ class OfferDocumentSnapshotService:
         # working after the Offer has moved on to Sent.
         existing = self._snapshots.get_by_offer_version_id(offer_version_id)
         if existing is not None:
+            # Ownership before variant-conflict: offer_version_id is unique
+            # across the whole system, but the caller's offer_id must still
+            # be the true owner. A mismatch is treated exactly like an
+            # unknown offer/version (never a stale-data leak of another
+            # offer's recipient, addresses, narrative or totals).
+            if existing.offer_id != offer_id:
+                raise OfferDocumentNotFoundError(offer_id)
             if existing.offer_variant_id != offer_variant_id:
                 raise OfferDocumentVariantConflictError(
                     offer_version_id=offer_version_id,

--- a/src/catering_system/services/offer_document_snapshot_service.py
+++ b/src/catering_system/services/offer_document_snapshot_service.py
@@ -1,0 +1,261 @@
+"""Freeze and read the customer ANGEBOT / AUFTRAGSBESTÄTIGUNG document.
+
+Lifecycle: idempotency lookup → load Offer/Version/Variant → read Inquiry
+once for structured customer facts → evaluate eligibility → build frozen
+facts from already-frozen cents → hash → insert once.
+
+After insertion there is no live fallback: reads go through the snapshot
+repository only, and the future PDF renderer will receive the snapshot
+alone. No Offer/Inquiry/catalog access happens on the read path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, date, datetime
+
+from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
+    CustomerDocumentRecipient,
+)
+from catering_system.domain.offer import Offer, OfferVariant, OfferVersion
+from catering_system.domain.offer_document_snapshot import (
+    OfferDocumentCreationBlocked,
+    OfferDocumentFulfillmentMode,
+    OfferDocumentPosition,
+    OfferDocumentSnapshot,
+    OfferDocumentVariantConflictError,
+    OfferDocumentVatBucket,
+    document_reference,
+)
+from catering_system.repositories.inquiry_repository import InquiryRepository
+from catering_system.repositories.offer_document_snapshot_repository import (
+    OfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.offer_repository import OfferRepository
+from catering_system.services.customer_document_projection import (
+    build_customer_document_recipient,
+)
+from catering_system.services.offer_document_eligibility import (
+    evaluate_offer_document_eligibility,
+)
+from catering_system.services.offer_document_snapshot_hash import compute_document_hash
+
+
+class OfferDocumentNotFoundError(LookupError):
+    """Raised when the requested Offer, OfferVersion or variant is unknown."""
+
+
+class OfferDocumentSnapshotService:
+    def __init__(
+        self,
+        offer_repository: OfferRepository,
+        inquiry_repository: InquiryRepository,
+        snapshot_repository: OfferDocumentSnapshotRepository,
+        *,
+        now: Callable[[], datetime] | None = None,
+        today: Callable[[], date] | None = None,
+    ) -> None:
+        self._offers = offer_repository
+        self._inquiries = inquiry_repository
+        self._snapshots = snapshot_repository
+        self._now = now or (lambda: datetime.now(UTC))
+        self._today = today or date.today
+
+    def prepare_offer_document(
+        self,
+        offer_id: str,
+        offer_version_id: str,
+        offer_variant_id: str,
+        created_by: str,
+    ) -> OfferDocumentSnapshot:
+        # 1/2. Idempotency first, before any state gate: a replay must keep
+        # working after the Offer has moved on to Sent.
+        existing = self._snapshots.get_by_offer_version_id(offer_version_id)
+        if existing is not None:
+            if existing.offer_variant_id != offer_variant_id:
+                raise OfferDocumentVariantConflictError(
+                    offer_version_id=offer_version_id,
+                    existing_variant_id=existing.offer_variant_id,
+                    requested_variant_id=offer_variant_id,
+                )
+            return existing
+
+        # 3/4. Load exact Offer, OfferVersion and OfferVariant.
+        offer = self._offers.get(offer_id)
+        if offer is None:
+            raise OfferDocumentNotFoundError(offer_id)
+        version = next(
+            (
+                item
+                for item in offer.versions
+                if item.offer_version_id == offer_version_id
+            ),
+            None,
+        )
+        if version is None:
+            raise OfferDocumentNotFoundError(offer_version_id)
+
+        # 6. Read the Inquiry exactly once for the structured customer facts
+        # the OfferVersion does not carry.
+        inquiry = self._inquiries.get_by_id(offer.source_inquiry_id)
+        fulfillment_mode = (
+            inquiry.fulfillment_mode if inquiry is not None else "UNKNOWN"
+        )
+        # 7. Reuse the existing recipient/address resolution (it already
+        # suppresses delivery address and the differs warning for PICKUP).
+        recipient = build_customer_document_recipient(
+            inquiry, fulfillment_mode=fulfillment_mode
+        )
+
+        # 5/8. Every blocker is evaluated before anything is written.
+        eligibility = evaluate_offer_document_eligibility(
+            offer=offer,
+            offer_version_id=offer_version_id,
+            offer_variant_id=offer_variant_id,
+            recipient=recipient,
+            fulfillment_mode=fulfillment_mode,
+            today=self._today(),
+        )
+        if not eligibility.allowed:
+            raise OfferDocumentCreationBlocked(eligibility)
+
+        variant = next(
+            item for item in version.variants if item.variant_id == offer_variant_id
+        )
+
+        # 9-12. Build frozen facts, derive the reference, hash, insert once.
+        snapshot = _build_snapshot(
+            offer=offer,
+            version=version,
+            variant=variant,
+            recipient=recipient,
+            fulfillment_mode=fulfillment_mode,
+            created_at=self._now(),
+            created_by=created_by,
+        )
+        self._snapshots.insert(snapshot)
+        return snapshot
+
+    def get_by_id(
+        self, offer_document_snapshot_id: str
+    ) -> OfferDocumentSnapshot | None:
+        return self._snapshots.get_by_id(offer_document_snapshot_id)
+
+    def get_by_offer_version_id(
+        self, offer_version_id: str
+    ) -> OfferDocumentSnapshot | None:
+        return self._snapshots.get_by_offer_version_id(offer_version_id)
+
+
+def _build_snapshot(
+    *,
+    offer: Offer,
+    version: OfferVersion,
+    variant: OfferVariant,
+    recipient: CustomerDocumentRecipient,
+    fulfillment_mode: str,
+    created_at: datetime,
+    created_by: str,
+) -> OfferDocumentSnapshot:
+    """Pure assembly from already-frozen values. No price or VAT is recomputed."""
+    positions = tuple(_position(item) for item in variant.positions)
+    vat_buckets = _vat_buckets(variant)
+    net_total = sum(item.net_total_cents for item in variant.positions)
+    vat_total = sum(item.vat_amount_cents for item in variant.positions)
+    gross_total = sum(item.gross_total_cents for item in variant.positions)
+
+    mode: OfferDocumentFulfillmentMode = (
+        "PICKUP" if fulfillment_mode == "PICKUP" else "DELIVERY"
+    )
+    warnings = tuple(
+        warning
+        for warning in recipient.warnings
+        if warning == WARNING_DELIVERY_ADDRESS_DIFFERS
+    )
+    assert recipient.invoice_address is not None  # guaranteed by eligibility
+    snapshot = OfferDocumentSnapshot(
+        offer_document_snapshot_id=str(uuid.uuid4()),
+        offer_id=offer.offer_id,
+        offer_version_id=version.offer_version_id,
+        offer_variant_id=variant.variant_id,
+        document_reference=document_reference(offer.offer_id, version.version_number),
+        created_at=created_at,
+        created_by=created_by,
+        recipient_name=recipient.name,
+        recipient_company=recipient.company_name,
+        recipient_email=recipient.email,
+        recipient_phone=recipient.phone,
+        invoice_address=recipient.invoice_address,
+        fulfillment_mode=mode,
+        delivery_address=recipient.delivery_address,
+        delivery_address_differs=recipient.delivery_address_differs,
+        event_date=version.event_date,
+        time_window_text=version.time_window_text,
+        location_text=version.location_text,
+        guest_count_estimate=version.guest_count,
+        customer_title=version.customer_title,
+        customer_introduction=version.customer_introduction,
+        customer_notes=version.customer_notes,
+        positions=positions,
+        vat_buckets=vat_buckets,
+        net_total_cents=net_total,
+        vat_total_cents=vat_total,
+        gross_total_cents=gross_total,
+        payment_method=version.payment_method,
+        payment_customer_visible_text=version.payment_customer_visible_text,
+        document_hash="sha256:" + "0" * 64,
+        document_warnings=warnings,
+    )
+    return _with_hash(snapshot)
+
+
+def _with_hash(snapshot: OfferDocumentSnapshot) -> OfferDocumentSnapshot:
+    """Second construction with the real hash (the field is part of identity)."""
+    from dataclasses import replace
+
+    return replace(snapshot, document_hash=compute_document_hash(snapshot))
+
+
+def _position(position: object) -> OfferDocumentPosition:
+    return OfferDocumentPosition(
+        position_id=position.position_id,  # type: ignore[attr-defined]
+        kind=position.kind,  # type: ignore[attr-defined]
+        name=position.name,  # type: ignore[attr-defined]
+        unit_net_cents=position.unit_net_cents,  # type: ignore[attr-defined]
+        net_total_cents=position.net_total_cents,  # type: ignore[attr-defined]
+        vat_rate_percent=position.vat_rate_percent,  # type: ignore[attr-defined]
+        vat_cents=position.vat_amount_cents,  # type: ignore[attr-defined]
+        gross_cents=position.gross_total_cents,  # type: ignore[attr-defined]
+        related_position_id=position.related_position_id,  # type: ignore[attr-defined]
+        description=position.description,  # type: ignore[attr-defined]
+        composition=position.composition,  # type: ignore[attr-defined]
+        quantity=(
+            format(position.quantity, "f")  # type: ignore[attr-defined]
+            if position.quantity is not None  # type: ignore[attr-defined]
+            else None
+        ),
+        unit_label=position.unit_label,  # type: ignore[attr-defined]
+    )
+
+
+def _vat_buckets(variant: OfferVariant) -> tuple[OfferDocumentVatBucket, ...]:
+    """Aggregate frozen per-position cents into stable, rate-ordered bands."""
+    bases: dict[int, int] = {}
+    amounts: dict[int, int] = {}
+    for position in variant.positions:
+        bases[position.vat_rate_percent] = (
+            bases.get(position.vat_rate_percent, 0) + position.net_total_cents
+        )
+        amounts[position.vat_rate_percent] = (
+            amounts.get(position.vat_rate_percent, 0) + position.vat_amount_cents
+        )
+    return tuple(
+        OfferDocumentVatBucket(
+            rate_percent=rate,
+            base_net_cents=bases[rate],
+            vat_cents=amounts[rate],
+        )
+        for rate in sorted(bases)
+    )

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -661,7 +661,25 @@ def _build_version_from_snapshot(
         variants=tuple(
             _map_variant(variant, offer_version_id) for variant in snapshot.variants
         ),
+        customer_title=_normalize_narrative(snapshot.customer_text.title),
+        customer_introduction=_normalize_narrative(snapshot.customer_text.introduction),
+        customer_notes=_normalize_narrative(snapshot.customer_text.notes),
     )
+
+
+def _normalize_narrative(value: str | None) -> str | None:
+    """OFFER_DOCUMENT_SNAPSHOT_V1 narrative rule.
+
+    None stays None; blank/whitespace-only becomes None (never stored as an
+    empty string); non-blank keeps its inner text and line breaks with only
+    the outer whitespace trimmed. ``introduction``/``notes`` arrive unstripped
+    and may legitimately be empty (_require_long_text), so this is the single
+    place that decides absence.
+    """
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
 
 
 def _map_variant(variant: OfferSnapshotVariant, offer_version_id: str) -> OfferVariant:

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -50,6 +50,10 @@ from catering_system.domain.offer import (
     AcceptanceChannel,
     SentChannel,
 )
+from catering_system.domain.offer_document_snapshot import (
+    OfferDocumentCreationBlocked,
+    OfferDocumentVariantConflictError,
+)
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
@@ -73,6 +77,9 @@ from catering_system.repositories.office_api_ledger import (
 )
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_offer_document_snapshot_repository import (
+    SQLiteOfferDocumentSnapshotRepository,
 )
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
@@ -104,6 +111,10 @@ from catering_system.repositories.sqlite_order_confirmation_outbound_repository 
 from catering_system.services.inquiry_service import (
     InquiryService,
     validate_inquiry_source,
+)
+from catering_system.services.offer_document_snapshot_service import (
+    OfferDocumentNotFoundError,
+    OfferDocumentSnapshotService,
 )
 from catering_system.services.offer_service import OfferService
 from catering_system.services.operational_core_service import OperationalCoreService
@@ -414,6 +425,9 @@ class OfficeApi:
         self.operational_pauses = SQLiteOrderOperationalPauseRepository.from_connection(
             connection
         )
+        self.offer_documents = SQLiteOfferDocumentSnapshotRepository.from_connection(
+            connection
+        )
         self.ledger = OfficeCommandLedger(connection)
         self.events = DeferredEventSink()
         self.executor = CoreCommandExecutor(connection, self.events)
@@ -425,6 +439,12 @@ class OfficeApi:
             self.inquiries,
             self.orders,
             self.commercial_snapshots,
+            today=views.berlin_today,
+        )
+        self.offer_document_service = OfferDocumentSnapshotService(
+            self.offers,
+            self.inquiries,
+            self.offer_documents,
             today=views.berlin_today,
         )
         self.payment_reminder_service = PaymentReminderService(
@@ -1170,6 +1190,50 @@ class OfficeApi:
             "offer_id": offer.offer_id,
             "offer_version_id": version.offer_version_id,
             "snapshot_id": version.snapshot_id,
+        }
+
+    def cmd_offer_document(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        """Freeze the customer ANGEBOT / AUFTRAGSBESTÄTIGUNG for one version."""
+        offer_id = path_ids["offer_id"]
+        offer_version_id = _v_uuid(args["offer_version_id"])
+        offer_variant_id = _v_uuid(args["offer_variant_id"])
+        created_by = _v_str(args["created_by"], 200)
+        existing = self.offer_document_service.get_by_offer_version_id(offer_version_id)
+        try:
+            snapshot = self.offer_document_service.prepare_offer_document(
+                offer_id,
+                offer_version_id,
+                offer_variant_id,
+                created_by,
+            )
+        except OfferDocumentNotFoundError:
+            raise ApiError(404, "not_found") from None
+        except OfferDocumentVariantConflictError as exc:
+            raise ApiError(409, "offer_document_variant_conflict") from exc
+        except OfferDocumentCreationBlocked as exc:
+            raise ApiError(422, "offer_document_blocked", reasons=exc.codes) from exc
+        status = 200 if existing is not None else 201
+        return status, {
+            "offer_id": snapshot.offer_id,
+            "offer_document_snapshot_id": snapshot.offer_document_snapshot_id,
+            "snapshot": views.offer_document_snapshot_summary(snapshot),
+        }
+
+    def offer_document(
+        self, offer_id: str, offer_version_id: str | None
+    ) -> dict[str, object]:
+        """Read the frozen document for one OfferVersion (snapshot only)."""
+        if offer_version_id is None:
+            raise _invalid()
+        snapshot = self.offer_document_service.get_by_offer_version_id(offer_version_id)
+        if snapshot is None or snapshot.offer_id != offer_id:
+            raise ApiError(404, "not_found")
+        return {
+            "offer_id": snapshot.offer_id,
+            "offer_document_snapshot_id": snapshot.offer_document_snapshot_id,
+            "snapshot": views.offer_document_snapshot_summary(snapshot),
         }
 
     def cmd_prepare_next_version(
@@ -1974,6 +2038,9 @@ _VERSION_ARGS = _ArgKeys(
 )
 _NO_ARGS = _ArgKeys(required=frozenset())
 _SNAPSHOT_ARGS = _ArgKeys(required=frozenset({"snapshot"}))
+_OFFER_DOCUMENT_ARGS = _ArgKeys(
+    required=frozenset({"offer_version_id", "offer_variant_id", "created_by"})
+)
 _MARK_SENT_ARGS = _ArgKeys(
     required=frozenset(
         {
@@ -2064,6 +2131,7 @@ _COMMANDS: dict[str, _CommandSpec] = {
         _SNAPSHOT_ARGS,
         {"latest_version_number"},
     ),
+    "offer-document": _CommandSpec("cmd_offer_document", _OFFER_DOCUMENT_ARGS, set()),
     "mark-sent": _CommandSpec("cmd_mark_sent", _MARK_SENT_ARGS, set()),
     "record-acceptance": _CommandSpec(
         "cmd_record_acceptance", _RECORD_ACCEPTANCE_ARGS, set()
@@ -2186,6 +2254,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/offers/(?P<offer_id>[^/]+)/prepare-next-version$"),
         "/office/v1/offers/{offer_id}/prepare-next-version",
         {"POST": "prepare-next-version"},
+    ),
+    (
+        re.compile(r"^/office/v1/offers/(?P<offer_id>[^/]+)/offer-document$"),
+        "/office/v1/offers/{offer_id}/offer-document",
+        {"POST": "offer-document", "GET": "offer_document"},
     ),
     (
         re.compile(r"^/office/v1/tasks$"),
@@ -2702,6 +2775,14 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
             elif kind == "offer_detail":
                 self._query(set())
                 self._respond(200, api.offer_detail(path_ids["offer_id"]))
+            elif kind == "offer_document":
+                params = self._query({"offer_version_id"})
+                version_id = (
+                    _v_uuid(params["offer_version_id"])
+                    if "offer_version_id" in params
+                    else None
+                )
+                self._respond(200, api.offer_document(path_ids["offer_id"], version_id))
             elif kind == "inquiry_detail":
                 self._query(set())
                 self._respond(200, api.inquiry_detail(path_ids["id"]))

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -671,6 +671,34 @@ def confirmation_document_summary_shape(
     }
 
 
+def offer_document_snapshot_summary(snapshot: object) -> dict[str, object]:
+    """Inspection shape for a frozen offer document (OFFER_DOCUMENT_SNAPSHOT_V1).
+
+    Evidence only: identity, provenance, schema and hash. No storage paths
+    exist in this slice, and no PDF/send/acceptance facts are exposed.
+    """
+    from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+
+    assert isinstance(snapshot, OfferDocumentSnapshot)
+    return {
+        "offer_document_snapshot_id": snapshot.offer_document_snapshot_id,
+        "offer_id": snapshot.offer_id,
+        "offer_version_id": snapshot.offer_version_id,
+        "offer_variant_id": snapshot.offer_variant_id,
+        "document_reference": snapshot.document_reference,
+        "schema_version": snapshot.schema_version,
+        "document_hash": snapshot.document_hash,
+        "created_at": snapshot.created_at.isoformat(),
+        "created_by": snapshot.created_by,
+        "fulfillment_mode": snapshot.fulfillment_mode,
+        "delivery_address_differs": snapshot.delivery_address_differs,
+        "net_total_cents": snapshot.net_total_cents,
+        "vat_total_cents": snapshot.vat_total_cents,
+        "gross_total_cents": snapshot.gross_total_cents,
+        "document_warnings": list(snapshot.document_warnings),
+    }
+
+
 def confirmation_document_preview_shape(
     preview: OrderConfirmationDocumentPreview,
 ) -> dict[str, object]:

--- a/tests/unit/test_offer_document_snapshot.py
+++ b/tests/unit/test_offer_document_snapshot.py
@@ -1,0 +1,293 @@
+"""OFFER_DOCUMENT_SNAPSHOT_V1 — domain, hash, serialization, tamper detection.
+
+Covers the frozen ANGEBOT / AUFTRAGSBESTÄTIGUNG snapshot in isolation, with
+no service/repository involved: structural invariants, deterministic
+reference, canonical hash contract, and the mandatory runtime hash
+verification on every read.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+from datetime import UTC, date, datetime
+
+import pytest
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.offer_document_snapshot import (
+    SCHEMA_VERSION,
+    OfferDocumentHashMismatchError,
+    OfferDocumentPosition,
+    OfferDocumentSnapshot,
+    OfferDocumentVatBucket,
+    document_reference,
+)
+from catering_system.services.offer_document_snapshot_hash import compute_document_hash
+from catering_system.services.offer_document_snapshot_serialization import (
+    snapshot_from_canonical_json,
+    snapshot_from_verified_row,
+    snapshot_to_canonical_json,
+)
+
+_NOW = datetime(2026, 7, 20, 9, 0, tzinfo=UTC)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1", postal_code="20095", city="Hamburg", country="DE"
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9", postal_code="20457", city="Hamburg", country="DE"
+)
+
+
+def _valid_snapshot(**overrides: object) -> OfferDocumentSnapshot:
+    base = dict(
+        offer_document_snapshot_id=str(uuid.uuid4()),
+        offer_id="7b5a5a7d-1111-4111-8111-111111111111",
+        offer_version_id=str(uuid.uuid4()),
+        offer_variant_id=str(uuid.uuid4()),
+        document_reference="ANG-7B5A5A7D-V1",
+        created_at=_NOW,
+        created_by="office-panel",
+        recipient_name="Anna",
+        recipient_company="ACME GmbH",
+        recipient_email="anna@example.invalid",
+        recipient_phone=None,
+        invoice_address=_INVOICE,
+        fulfillment_mode="DELIVERY",
+        delivery_address=_INVOICE,
+        delivery_address_differs=False,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count_estimate=80,
+        positions=(
+            OfferDocumentPosition(
+                position_id="pos-1",
+                kind="catalog",
+                name="Fingerfood Paket",
+                unit_net_cents=290,
+                net_total_cents=23200,
+                vat_rate_percent=7,
+                vat_cents=1624,
+                gross_cents=24824,
+                quantity="80",
+                unit_label="Stück",
+            ),
+        ),
+        vat_buckets=(
+            OfferDocumentVatBucket(
+                rate_percent=7, base_net_cents=23200, vat_cents=1624
+            ),
+        ),
+        net_total_cents=23200,
+        vat_total_cents=1624,
+        gross_total_cents=24824,
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        document_hash="sha256:" + "0" * 64,
+        schema_version=SCHEMA_VERSION,
+    )
+    base.update(overrides)
+    snapshot = OfferDocumentSnapshot(**base)  # type: ignore[arg-type]
+    if overrides.get("document_hash") is None and "document_hash" not in overrides:
+        snapshot = replace(snapshot, document_hash=compute_document_hash(snapshot))
+    return snapshot
+
+
+# --- document_reference -------------------------------------------------------
+
+
+def test_document_reference_is_deterministic_and_filename_safe() -> None:
+    ref = document_reference("7b5a5a7d-1111-4111-8111-111111111111", 1)
+    assert ref == "ANG-7B5A5A7D-V1"
+    assert ref == document_reference("7b5a5a7d-1111-4111-8111-111111111111", 1)
+    assert " " not in ref
+    assert "/" not in ref
+
+
+def test_document_reference_rejects_blank_offer_id_or_bad_version() -> None:
+    with pytest.raises(ValueError):
+        document_reference("", 1)
+    with pytest.raises(ValueError):
+        document_reference("offer-1", 0)
+
+
+# --- structural invariants -----------------------------------------------------
+
+
+def test_schema_version_must_be_exactly_one() -> None:
+    with pytest.raises(ValueError, match="unsupported offer document schema version"):
+        _valid_snapshot(schema_version=2)
+
+
+def test_document_hash_format_enforced() -> None:
+    with pytest.raises(ValueError, match="document_hash"):
+        _valid_snapshot(document_hash="not-a-hash")
+
+
+def test_fulfillment_mode_must_be_delivery_or_pickup() -> None:
+    with pytest.raises(ValueError, match="DELIVERY or PICKUP"):
+        _valid_snapshot(fulfillment_mode="UNKNOWN")
+
+
+def test_invoice_address_must_be_structurally_complete() -> None:
+    incomplete = CustomerAddress(street="Only street")
+    with pytest.raises(ValueError, match="invoice_address"):
+        _valid_snapshot(invoice_address=incomplete)
+
+
+def test_delivery_requires_effective_delivery_address() -> None:
+    with pytest.raises(ValueError, match="DELIVERY requires"):
+        _valid_snapshot(
+            fulfillment_mode="DELIVERY",
+            delivery_address=None,
+            delivery_address_differs=False,
+        )
+
+
+def test_pickup_forbids_delivery_address() -> None:
+    with pytest.raises(ValueError, match="PICKUP must not store a delivery address"):
+        _valid_snapshot(
+            fulfillment_mode="PICKUP",
+            delivery_address=_DELIVERY,
+            delivery_address_differs=False,
+        )
+
+
+def test_pickup_forbids_differs_true() -> None:
+    with pytest.raises(ValueError, match="delivery_address_differs"):
+        _valid_snapshot(
+            fulfillment_mode="PICKUP",
+            delivery_address=None,
+            delivery_address_differs=True,
+        )
+
+
+def test_delivery_address_differs_must_match_computed_equality() -> None:
+    with pytest.raises(ValueError, match="delivery_address_differs does not match"):
+        _valid_snapshot(
+            fulfillment_mode="DELIVERY",
+            delivery_address=_DELIVERY,
+            delivery_address_differs=False,
+        )
+
+
+def test_negative_cents_rejected() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        _valid_snapshot(net_total_cents=-1)
+
+
+def test_snapshot_and_positions_are_frozen() -> None:
+    snap = _valid_snapshot()
+    with pytest.raises(Exception):
+        snap.document_reference = "ANG-OTHER-V1"  # type: ignore[misc]
+    with pytest.raises(Exception):
+        snap.positions[0].name = "changed"  # type: ignore[misc]
+
+
+# --- hash contract --------------------------------------------------------------
+
+
+def test_every_contractual_fact_changes_the_hash() -> None:
+    base = _valid_snapshot()
+    mutations = [
+        {"document_reference": "ANG-OTHER0-V1"},
+        {"recipient_name": "Someone Else"},
+        {"event_date": date(2026, 9, 1)},
+        {"customer_title": "Different title"},
+        {"positions": (replace(base.positions[0], net_total_cents=1),)},
+        {"payment_method": "VORKASSE"},
+        {"document_warnings": ("SOME_WARNING",)},
+    ]
+    for mutation in mutations:
+        changed = replace(base, **mutation)  # type: ignore[arg-type]
+        changed = replace(changed, document_hash=compute_document_hash(changed))
+        assert changed.document_hash != base.document_hash, mutation
+
+
+def test_created_at_and_created_by_do_not_affect_hash() -> None:
+    base = _valid_snapshot()
+    same_content = replace(
+        base, created_at=datetime(2030, 1, 1, tzinfo=UTC), created_by="someone-else"
+    )
+    assert compute_document_hash(same_content) == compute_document_hash(base)
+
+
+def test_hash_differs_between_delivery_and_pickup() -> None:
+    delivery = _valid_snapshot(
+        fulfillment_mode="DELIVERY",
+        delivery_address=_INVOICE,
+        delivery_address_differs=False,
+    )
+    pickup = _valid_snapshot(
+        fulfillment_mode="PICKUP",
+        delivery_address=None,
+        delivery_address_differs=False,
+    )
+    assert compute_document_hash(delivery) != compute_document_hash(pickup)
+
+
+def test_canonical_json_key_ordering_is_stable() -> None:
+    snap = _valid_snapshot()
+    a = snapshot_to_canonical_json(snap)
+    b = snapshot_to_canonical_json(snap)
+    assert a == b
+    payload = json.loads(a)
+    assert list(payload.keys()) == sorted(payload.keys())
+
+
+def test_canonical_round_trip_preserves_every_field() -> None:
+    snap = _valid_snapshot(
+        customer_title="Sommerfest",
+        customer_introduction="Intro",
+        customer_notes="Notes",
+    )
+    loaded = snapshot_from_canonical_json(snapshot_to_canonical_json(snap))
+    assert loaded == snap
+
+
+# --- runtime hash verification (mandatory on every read) ----------------------
+
+
+def test_valid_row_reads_successfully() -> None:
+    snap = _valid_snapshot()
+    canonical = snapshot_to_canonical_json(snap)
+    loaded = snapshot_from_verified_row(canonical, snap.document_hash)
+    assert loaded == snap
+
+
+def test_modified_canonical_json_is_detected() -> None:
+    snap = _valid_snapshot()
+    canonical = snapshot_to_canonical_json(snap)
+    tampered = canonical.replace('"net_total_cents":23200', '"net_total_cents":1')
+    with pytest.raises(OfferDocumentHashMismatchError):
+        snapshot_from_verified_row(tampered, snap.document_hash)
+
+
+def test_modified_row_hash_column_is_detected() -> None:
+    snap = _valid_snapshot()
+    canonical = snapshot_to_canonical_json(snap)
+    with pytest.raises(OfferDocumentHashMismatchError):
+        snapshot_from_verified_row(canonical, "sha256:" + "b" * 64)
+
+
+def test_modified_embedded_document_hash_is_detected() -> None:
+    snap = _valid_snapshot()
+    canonical = snapshot_to_canonical_json(snap)
+    tampered = canonical.replace(snap.document_hash, "sha256:" + "c" * 64)
+    with pytest.raises(OfferDocumentHashMismatchError):
+        snapshot_from_verified_row(tampered, snap.document_hash)
+
+
+def test_malformed_canonical_json_fails_closed() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        snapshot_from_verified_row("{not valid json", "sha256:" + "0" * 64)
+
+
+def test_unsupported_schema_version_in_payload_rejected() -> None:
+    snap = _valid_snapshot()
+    payload = json.loads(snapshot_to_canonical_json(snap))
+    payload["schema_version"] = 2
+    with pytest.raises(ValueError, match="unsupported offer document schema version"):
+        snapshot_from_canonical_json(json.dumps(payload))

--- a/tests/unit/test_offer_document_snapshot_repository.py
+++ b/tests/unit/test_offer_document_snapshot_repository.py
@@ -1,0 +1,214 @@
+"""OFFER_DOCUMENT_SNAPSHOT_V1 — SQLite repository, owner trigger, immutability.
+
+Uses two SQLiteOfferRepository/SQLiteOfferDocumentSnapshotRepository
+instances against the same file so the owner trigger's EXISTS check against
+the real ``offer_variants`` table is exercised, not a fake.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_offer_document_snapshot_repository import (
+    _MIGRATIONS,
+    SQLiteOfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
+from catering_system.services.offer_document_snapshot_service import (
+    OfferDocumentSnapshotService,
+)
+from catering_system.services.offer_service import OfferService
+from tests.unit.test_offer_service import _INQUIRY_ID, _sample_inquiry, _valid_snapshot
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1", postal_code="20095", city="Hamburg", country="DE"
+)
+
+
+def _prepared_offer(db: Path):
+    """Real SQLite-backed Offer with one Prepared version + variant, plus a
+    complete DELIVERY-eligible Inquiry — shared setup for the tests below."""
+    offers = SQLiteOfferRepository(db)
+    inquiries_repo = InMemoryInquiryRepository()  # Inquiry stays in-memory;
+    # only Offer/OfferVersion/OfferVariant need to be real SQLite rows for
+    # the owner trigger to validate against.
+    snapshot = InquiryCustomerSnapshot(
+        company_name="ACME GmbH",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    inquiry = replace(
+        _sample_inquiry(), customer_snapshot=snapshot, fulfillment_mode="DELIVERY"
+    )
+    inquiries_repo.save(inquiry)
+    offer_service = OfferService(offers, inquiries_repo, InMemoryOrderRepository())
+    offer = offer_service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
+    offers.close()
+    return offer, inquiries_repo
+
+
+def test_prepare_offer_document_persists_and_reloads(tmp_path: Path) -> None:
+    db = tmp_path / "offer.db"
+    offer, inquiries_repo = _prepared_offer(db)
+    version = offer.versions[0]
+
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    offers = SQLiteOfferRepository(db)
+    doc_service = OfferDocumentSnapshotService(offers, inquiries_repo, documents)
+    snap = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    documents.close()
+    offers.close()
+
+    documents2 = SQLiteOfferDocumentSnapshotRepository(db)
+    reloaded = documents2.get_by_offer_version_id(version.offer_version_id)
+    assert reloaded is not None
+    assert reloaded.offer_document_snapshot_id == snap.offer_document_snapshot_id
+    assert reloaded.document_hash == snap.document_hash
+    documents2.close()
+
+
+def test_owner_trigger_rejects_row_with_no_matching_offer_variant(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "offer.db"
+    _prepared_offer(db)  # ensures the offers schema exists in this file
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    conn = sqlite3.connect(db)
+    with pytest.raises(sqlite3.IntegrityError, match="owner is invalid"):
+        conn.execute(
+            "INSERT INTO offer_document_snapshots ("
+            "offer_document_snapshot_id, offer_id, offer_version_id, "
+            "offer_variant_id, document_reference, schema_version, "
+            "canonical_snapshot_json, document_hash, created_at, created_by"
+            ") VALUES ('s1','no-such-offer','no-such-version','no-such-variant',"
+            "'ANG-DEADBEEF-V1',1,'{}','sha256:"
+            + "0" * 64
+            + "','2026-01-01T00:00:00+00:00','office')"
+        )
+        conn.commit()
+    conn.close()
+    documents.close()
+
+
+def test_immutable_update_and_delete_are_rejected(tmp_path: Path) -> None:
+    db = tmp_path / "offer.db"
+    offer, inquiries_repo = _prepared_offer(db)
+    version = offer.versions[0]
+    offers = SQLiteOfferRepository(db)
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    doc_service = OfferDocumentSnapshotService(offers, inquiries_repo, documents)
+    snap = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        documents._conn.execute(  # noqa: SLF001
+            "UPDATE offer_document_snapshots SET created_by = 'someone-else' "
+            "WHERE offer_document_snapshot_id = ?",
+            (snap.offer_document_snapshot_id,),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        documents._conn.execute(  # noqa: SLF001
+            "DELETE FROM offer_document_snapshots WHERE offer_document_snapshot_id = ?",
+            (snap.offer_document_snapshot_id,),
+        )
+    offers.close()
+    documents.close()
+
+
+def test_unique_offer_version_id_enforced_at_db_layer(tmp_path: Path) -> None:
+    db = tmp_path / "offer.db"
+    offer, inquiries_repo = _prepared_offer(db)
+    version = offer.versions[0]
+    offers = SQLiteOfferRepository(db)
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    doc_service = OfferDocumentSnapshotService(offers, inquiries_repo, documents)
+    doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    # Bypass the service's idempotency check to prove the DB itself refuses
+    # a second row for the same offer_version_id.
+    from catering_system.services.offer_document_snapshot_serialization import (
+        snapshot_to_canonical_json,
+    )
+
+    existing = documents.get_by_offer_version_id(version.offer_version_id)
+    duplicate = replace(existing, offer_document_snapshot_id="a-different-id")
+    with pytest.raises(sqlite3.IntegrityError):
+        documents._conn.execute(  # noqa: SLF001
+            "INSERT INTO offer_document_snapshots ("
+            "offer_document_snapshot_id, offer_id, offer_version_id, "
+            "offer_variant_id, document_reference, schema_version, "
+            "canonical_snapshot_json, document_hash, created_at, created_by"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                duplicate.offer_document_snapshot_id,
+                duplicate.offer_id,
+                duplicate.offer_version_id,
+                duplicate.offer_variant_id,
+                duplicate.document_reference,
+                duplicate.schema_version,
+                snapshot_to_canonical_json(duplicate),
+                duplicate.document_hash,
+                duplicate.created_at.isoformat(),
+                duplicate.created_by,
+            ),
+        )
+    offers.close()
+    documents.close()
+
+
+def test_migration_is_idempotent(tmp_path: Path) -> None:
+    from catering_system.repositories.sqlite_migrations import apply_migrations
+
+    db = tmp_path / "offer_documents.db"
+    conn = sqlite3.connect(db)
+    apply_migrations(conn, "offer_document_snapshots", _MIGRATIONS)
+    apply_migrations(conn, "offer_document_snapshots", _MIGRATIONS)
+    rows = conn.execute(
+        "SELECT COUNT(*) FROM schema_migrations WHERE component = "
+        "'offer_document_snapshots'"
+    ).fetchone()
+    assert rows == (1,)
+    conn.close()
+
+
+def test_unrelated_offer_data_and_hashes_unchanged_after_snapshot_table_exists(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "offer.db"
+    offer, inquiries_repo = _prepared_offer(db)
+    original_version = offer.versions[0]
+    # Creating the sibling table/migration must not touch existing Offer rows.
+    SQLiteOfferDocumentSnapshotRepository(db).close()
+    offers = SQLiteOfferRepository(db)
+    reloaded_offer = offers.get(offer.offer_id)
+    offers.close()
+    assert reloaded_offer.versions[0].snapshot_hash == original_version.snapshot_hash
+    assert reloaded_offer.versions[0].customer_title == original_version.customer_title

--- a/tests/unit/test_offer_document_snapshot_service.py
+++ b/tests/unit/test_offer_document_snapshot_service.py
@@ -338,6 +338,52 @@ def test_different_variant_for_same_version_is_rejected() -> None:
         )
 
 
+def test_replay_rejects_mismatched_offer_id() -> None:
+    """REVIEW FIX: prepare_offer_document's replay branch must confirm the
+    resolved snapshot belongs to the offer_id the caller supplied, not just
+    the offer_version_id. A caller passing a different Offer's id together
+    with a real version/variant from Offer A must be treated exactly like an
+    unknown offer/version (404-equivalent), never a leak of Offer A's
+    recipient/addresses/narrative/positions/totals."""
+    offers, inquiries, documents, doc_service, offer_a = _world()
+    version_a = offer_a.versions[0]
+    variant_a_id = version_a.variants[0].variant_id
+    snap = doc_service.prepare_offer_document(
+        offer_a.offer_id, version_a.offer_version_id, variant_a_id, "office"
+    )
+
+    other_inquiry_id = "33333333-3333-4333-8333-333333333333"
+    other_inquiry = replace(
+        _sample_inquiry(inquiry_id=other_inquiry_id),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="Other GmbH",
+            contact_name="Bea",
+            email="bea@example.invalid",
+            phone="+49309999999",
+            invoice_address=_INVOICE,
+            delivery_address=None,
+            delivery_address_mode="SAME_AS_INVOICE",
+        ),
+        fulfillment_mode="DELIVERY",
+    )
+    inquiries.save(other_inquiry)
+    offer_service = OfferService(offers, inquiries, InMemoryOrderRepository())
+    offer_b = offer_service.prepare_offer_version(
+        other_inquiry_id, _valid_snapshot(inquiry_id=other_inquiry_id)
+    )
+    assert offer_b.offer_id != offer_a.offer_id
+
+    with pytest.raises(OfferDocumentNotFoundError):
+        doc_service.prepare_offer_document(
+            offer_b.offer_id, version_a.offer_version_id, variant_a_id, "office"
+        )
+
+    # Offer A's snapshot is untouched, and no second row was created for it.
+    reloaded = documents.get_by_offer_version_id(version_a.offer_version_id)
+    assert reloaded == snap
+    assert len(documents._rows) == 1  # noqa: SLF001
+
+
 def test_only_one_snapshot_row_exists_per_version(tmp_path: Path) -> None:
     _offers, _inquiries, documents, doc_service, offer = _world()
     version = offer.versions[0]

--- a/tests/unit/test_offer_document_snapshot_service.py
+++ b/tests/unit/test_offer_document_snapshot_service.py
@@ -1,0 +1,427 @@
+"""OFFER_DOCUMENT_SNAPSHOT_V1 — prepare_offer_document service contract.
+
+Eligibility, idempotency/variant-conflict, immutability against later
+mutation, and the boundary rule that the persisted read path never touches
+Inquiry/Offer/catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.offer_document_snapshot import (
+    OfferDocumentCreationBlocked,
+    OfferDocumentVariantConflictError,
+)
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_offer_document_snapshot_repository import (
+    InMemoryOfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.in_memory_offer_repository import (
+    InMemoryOfferRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.offer_document_snapshot_service import (
+    OfferDocumentNotFoundError,
+    OfferDocumentSnapshotService,
+)
+from catering_system.services.offer_service import OfferService
+from tests.unit.test_offer_service import _INQUIRY_ID, _sample_inquiry, _valid_snapshot
+
+_NOW = datetime(2026, 7, 20, 9, 0, tzinfo=UTC)
+_TODAY = date(2026, 7, 20)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1", postal_code="20095", city="Hamburg", country="DE"
+)
+_DELIVERY = CustomerAddress(
+    street="Eventplatz 9", postal_code="20457", city="Hamburg", country="DE"
+)
+
+
+def _world(
+    *,
+    fulfillment_mode: str = "DELIVERY",
+    invoice_address: CustomerAddress | None = _INVOICE,
+    delivery_address: CustomerAddress | None = None,
+    delivery_address_mode: str = "SAME_AS_INVOICE",
+    contact_complete: bool = True,
+):
+    offers = InMemoryOfferRepository()
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    documents = InMemoryOfferDocumentSnapshotRepository()
+
+    snapshot = InquiryCustomerSnapshot(
+        company_name="ACME GmbH",
+        contact_name="Anna" if contact_complete else None,
+        email="anna@example.invalid" if contact_complete else None,
+        phone="+49301234567" if contact_complete else None,
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+        delivery_address_mode=delivery_address_mode,
+    )
+    inquiry = replace(
+        _sample_inquiry(),
+        customer_snapshot=snapshot,
+        fulfillment_mode=fulfillment_mode,
+    )
+    inquiries.save(inquiry)
+
+    offer_service = OfferService(offers, inquiries, orders)
+    offer = offer_service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
+    doc_service = OfferDocumentSnapshotService(
+        offers, inquiries, documents, now=lambda: _NOW, today=lambda: _TODAY
+    )
+    return offers, inquiries, documents, doc_service, offer
+
+
+# --- eligibility -----------------------------------------------------------------
+
+
+def test_unknown_fulfillment_rejected() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="UNKNOWN"
+    )
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert "FULFILLMENT_MODE_REQUIRED" in excinfo.value.codes
+    assert documents.get_by_offer_version_id(version.offer_version_id) is None
+
+
+def test_missing_invoice_address_rejected_for_delivery() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="DELIVERY",
+        invoice_address=None,
+    )
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert "INVOICE_ADDRESS_REQUIRED" in excinfo.value.codes
+    assert documents.get_by_offer_version_id(version.offer_version_id) is None
+
+
+def test_incomplete_invoice_address_rejected_for_pickup() -> None:
+    incomplete = CustomerAddress(street="Only street")
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="PICKUP",
+        invoice_address=incomplete,
+        delivery_address_mode="UNKNOWN",
+    )
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert "INVOICE_ADDRESS_REQUIRED" in excinfo.value.codes
+    # PICKUP never requires DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY.
+    assert "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY" not in excinfo.value.codes
+
+
+def test_delivery_without_effective_address_rejected() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="DELIVERY",
+        invoice_address=_INVOICE,
+        delivery_address_mode="UNKNOWN",
+    )
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY" in excinfo.value.codes
+
+
+def test_pickup_with_invoice_address_and_no_delivery_address_succeeds() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="PICKUP",
+        invoice_address=_INVOICE,
+        delivery_address_mode="UNKNOWN",
+    )
+    version = offer.versions[0]
+    snap = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    assert snap.fulfillment_mode == "PICKUP"
+    assert snap.delivery_address is None
+    assert snap.delivery_address_differs is False
+
+
+def test_missing_recipient_name_rejected() -> None:
+    """Reachable via the full flow: Offer preparation only requires
+    email/phone completeness (inquiry_contact_complete), never name/company —
+    so an Inquiry can have neither contact_name nor company_name and still
+    reach document-snapshot eligibility."""
+    _offers, _inquiries, documents, doc_service, offer = _world(
+        fulfillment_mode="PICKUP",
+        invoice_address=_INVOICE,
+        delivery_address_mode="UNKNOWN",
+    )
+    version = offer.versions[0]
+    inquiry = _inquiries.get_by_id(offer.source_inquiry_id)
+    nameless = replace(inquiry.customer_snapshot, contact_name=None, company_name=None)
+    _inquiries.update(replace(inquiry, customer_snapshot=nameless))
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert "MISSING_RECIPIENT_NAME" in excinfo.value.codes
+
+
+def test_missing_recipient_contact_rejected_at_eligibility_layer() -> None:
+    """Offer preparation itself requires inquiry_contact_complete (email or
+    phone), so this blocker cannot be reached through the full
+    prepare_offer_document flow — it is tested directly against the pure
+    eligibility function instead, the same way the sibling
+    MISSING_CUSTOMER_CONTACT is tested for the Order-side document."""
+    from datetime import date as _date
+
+    from catering_system.domain.customer_document_projection import (
+        CustomerDocumentRecipient,
+    )
+    from catering_system.services.offer_document_eligibility import (
+        evaluate_offer_document_eligibility,
+    )
+
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    recipient = CustomerDocumentRecipient(
+        name="Kunde",
+        company_name=None,
+        email=None,
+        phone=None,
+        invoice_address=_INVOICE,
+        delivery_address=_INVOICE,
+        delivery_address_differs=False,
+    )
+    result = evaluate_offer_document_eligibility(
+        offer=offer,
+        offer_version_id=version.offer_version_id,
+        offer_variant_id=version.variants[0].variant_id,
+        recipient=recipient,
+        fulfillment_mode="DELIVERY",
+        today=_date(2026, 7, 20),
+    )
+    codes = tuple(b.code for b in result.blockers)
+    assert "MISSING_RECIPIENT_CONTACT" in codes
+
+
+def test_unknown_variant_rejected() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentCreationBlocked) as excinfo:
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            "not-a-real-variant",
+            "office",
+        )
+    assert "OFFER_VARIANT_NOT_FOUND" in excinfo.value.codes
+
+
+def test_unknown_offer_or_version_raises_not_found() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    with pytest.raises(OfferDocumentNotFoundError):
+        doc_service.prepare_offer_document(
+            "not-a-real-offer",
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    with pytest.raises(OfferDocumentNotFoundError):
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            "not-a-real-version",
+            version.variants[0].variant_id,
+            "office",
+        )
+
+
+# --- idempotency / variant conflict ----------------------------------------------
+
+
+def test_replay_same_version_and_variant_returns_same_snapshot() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    first = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    second = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    assert second.offer_document_snapshot_id == first.offer_document_snapshot_id
+    assert second.document_hash == first.document_hash
+
+
+def test_replay_works_after_offer_becomes_sent() -> None:
+    offers, inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    first = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    offer_service = OfferService(offers, inquiries, InMemoryOrderRepository())
+    offer_service.record_sent_evidence(
+        offer.offer_id,
+        version.offer_version_id,
+        sent_at=_NOW,
+        channel="email",
+        recipient_reference="anna@example.invalid",
+        evidence_reference="msg-1",
+        recorded_by="office",
+    )
+    replay = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    assert replay.offer_document_snapshot_id == first.offer_document_snapshot_id
+
+
+def test_different_variant_for_same_version_is_rejected() -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    with pytest.raises(OfferDocumentVariantConflictError):
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            "a-different-variant-id",
+            "office",
+        )
+
+
+def test_only_one_snapshot_row_exists_per_version(tmp_path: Path) -> None:
+    _offers, _inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    for _ in range(3):
+        doc_service.prepare_offer_document(
+            offer.offer_id,
+            version.offer_version_id,
+            version.variants[0].variant_id,
+            "office",
+        )
+    assert len(documents._rows) == 1  # noqa: SLF001
+
+
+# --- immutability ------------------------------------------------------------------
+
+
+def test_later_inquiry_mutation_does_not_alter_snapshot() -> None:
+    offers, inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    snap = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    inquiry = inquiries.get_by_id(offer.source_inquiry_id)
+    inquiries.update(replace(inquiry, fulfillment_mode="PICKUP"))
+    reloaded = documents.get_by_offer_version_id(version.offer_version_id)
+    assert reloaded.fulfillment_mode == "DELIVERY"
+    assert reloaded.document_hash == snap.document_hash
+
+
+def test_new_offer_version_does_not_alter_old_snapshot() -> None:
+    offers, inquiries, documents, doc_service, offer = _world()
+    version = offer.versions[0]
+    snap = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    offer_service = OfferService(offers, inquiries, InMemoryOrderRepository())
+    offer_service.record_sent_evidence(
+        offer.offer_id,
+        version.offer_version_id,
+        sent_at=_NOW,
+        channel="email",
+        recipient_reference="anna@example.invalid",
+        evidence_reference="msg-1",
+        recorded_by="office",
+    )
+    next_snapshot = _valid_snapshot()
+    next_snapshot["snapshot_id"] = "99999999-9999-4999-8999-999999999999"
+    from catering_system.domain.offer_snapshot import compute_snapshot_hash
+
+    next_snapshot["snapshot_hash"] = compute_snapshot_hash(next_snapshot)
+    offer_service.prepare_next_offer_version(
+        offer.offer_id,
+        next_snapshot,
+        expected_latest_version_number=1,
+    )
+    reloaded = documents.get_by_offer_version_id(version.offer_version_id)
+    assert reloaded.offer_document_snapshot_id == snap.offer_document_snapshot_id
+    assert reloaded.document_hash == snap.document_hash
+
+
+# --- boundary ------------------------------------------------------------------
+
+
+def test_persisted_read_path_does_not_import_inquiry_or_offer_repositories() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
+    text = (root / "services" / "offer_document_snapshot_serialization.py").read_text(
+        encoding="utf-8"
+    )
+    assert "InquiryRepository" not in text
+    assert "OfferRepository" not in text
+    assert "inquiry_repository" not in text.lower()
+    assert "offer_repository" not in text.lower()
+
+
+def test_hash_module_has_no_repository_or_catalog_dependency() -> None:
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system"
+    text = (root / "services" / "offer_document_snapshot_hash.py").read_text(
+        encoding="utf-8"
+    )
+    assert "Repository" not in text
+    assert "catalog" not in text.lower()

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -457,6 +457,214 @@ def test_sqlite_offer_roundtrip_preserves_event_and_payment_facts(
     assert loaded.versions[1].guest_count == 120
 
 
+def test_sqlite_offer_roundtrip_preserves_customer_narrative(
+    tmp_path: Path,
+) -> None:
+    v1 = _version(1, snapshot_hash=_HASH_V1)
+    v1 = OfferVersion(
+        offer_version_id=v1.offer_version_id,
+        offer_id=v1.offer_id,
+        version_number=v1.version_number,
+        created_at=v1.created_at,
+        valid_until=v1.valid_until,
+        snapshot_id=v1.snapshot_id,
+        snapshot_hash=v1.snapshot_hash,
+        **_version_facts(),
+        variants=v1.variants,
+        # Already normalized (outer-trimmed, internal newlines kept) — the
+        # normalization step itself is OfferService's job (see
+        # test_offer_service.py); this test only proves the SQLite
+        # repository round-trips the resulting value byte-for-byte.
+        customer_title="Sommerfest 2026",
+        customer_introduction="Liebe Familie Muster,\n\nvielen Dank.",
+        customer_notes="Bitte pünktlich liefern.",
+    )
+    offer = _offer(versions=(v1,))
+    repo = SQLiteOfferRepository(tmp_path / "narrative.db")
+    repo.save(offer)
+    repo.close()
+
+    reopened = SQLiteOfferRepository(tmp_path / "narrative.db")
+    loaded = reopened.get(_OFFER_ID)
+    reopened.close()
+    assert loaded is not None
+    loaded_v1 = loaded.versions[0]
+    assert loaded_v1.customer_title == "Sommerfest 2026"
+    # Internal newlines/text are preserved exactly through the round-trip.
+    assert loaded_v1.customer_introduction == "Liebe Familie Muster,\n\nvielen Dank."
+    assert loaded_v1.customer_notes == "Bitte pünktlich liefern."
+
+
+def test_sqlite_offer_roundtrip_preserves_none_customer_narrative(
+    tmp_path: Path,
+) -> None:
+    offer = _offer()  # default _version() carries no narrative fields (all None)
+    repo = SQLiteOfferRepository(tmp_path / "narrative_none.db")
+    repo.save(offer)
+    loaded = repo.get(_OFFER_ID)
+    assert loaded is not None
+    v1 = loaded.versions[0]
+    assert v1.customer_title is None
+    assert v1.customer_introduction is None
+    assert v1.customer_notes is None
+
+
+def test_pre_migration_7_rows_load_with_narrative_fields_none(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "pre_migration.db"
+    conn = sqlite3.connect(db)
+    apply_migrations(conn, "offers", _MIGRATIONS[:6])
+    conn.execute(
+        "INSERT INTO offers (offer_id, source_inquiry_id, created_at) VALUES (?, ?, ?)",
+        (_OFFER_ID, _INQUIRY_ID, _NOW.isoformat()),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_versions (
+            offer_version_id, offer_id, version_number, created_at, valid_until,
+            snapshot_id, snapshot_hash, event_date, time_window_text,
+            location_text, guest_count, planning_mode, payment_method,
+            payment_customer_visible_text
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _V1_ID,
+            _OFFER_ID,
+            1,
+            _NOW.isoformat(),
+            date(2026, 7, 31).isoformat(),
+            "77777777-7777-7777-7777-777777777771",
+            _HASH_V1,
+            _EVENT_DATE.isoformat(),
+            "18:00–22:00",
+            "Hamburg",
+            80,
+            "caterer_suggestion",
+            "RECHNUNG",
+            "Zahlung per Rechnung",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO offer_variants "
+        "(variant_id, offer_version_id, offer_id, label, sort_order) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (_A_ID, _V1_ID, _OFFER_ID, "Variante A", 0),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_positions (
+            position_id, variant_id, offer_version_id, kind, name,
+            unit_net_cents, net_total_cents, vat_rate_percent,
+            vat_amount_cents, gross_total_cents, related_position_id,
+            sort_order
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _POS_A,
+            _A_ID,
+            _V1_ID,
+            "catalog",
+            "Fingerfood Paket",
+            290,
+            23200,
+            7,
+            1624,
+            24824,
+            None,
+            0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repo = SQLiteOfferRepository(db)  # migration 7 runs defensively on open
+    loaded = repo.get(_OFFER_ID)
+    repo.close()
+    assert loaded is not None
+    v1 = loaded.versions[0]
+    assert v1.customer_title is None
+    assert v1.customer_introduction is None
+    assert v1.customer_notes is None
+
+
+def test_prepare_offer_document_after_sqlite_reload_gets_frozen_narrative(
+    tmp_path: Path,
+) -> None:
+    from dataclasses import replace as _replace
+
+    from catering_system.domain.customer_document_projection import CustomerAddress
+    from catering_system.domain.inquiry_customer_snapshot import (
+        InquiryCustomerSnapshot,
+    )
+    from catering_system.repositories.in_memory_inquiry_repository import (
+        InMemoryInquiryRepository,
+    )
+    from catering_system.repositories.in_memory_order_repository import (
+        InMemoryOrderRepository,
+    )
+    from catering_system.repositories.sqlite_offer_document_snapshot_repository import (
+        SQLiteOfferDocumentSnapshotRepository,
+    )
+    from catering_system.services.offer_document_snapshot_service import (
+        OfferDocumentSnapshotService,
+    )
+    from catering_system.services.offer_service import OfferService
+    from tests.unit.test_offer_service import (
+        _INQUIRY_ID as _SVC_INQUIRY_ID,
+    )
+    from tests.unit.test_offer_service import (
+        _sample_inquiry,
+        _valid_snapshot,
+    )
+
+    db = tmp_path / "narrative_prepare.db"
+    invoice = CustomerAddress(
+        street="Bürostraße 1", postal_code="20095", city="Hamburg", country="DE"
+    )
+    inquiries = InMemoryInquiryRepository()
+    inquiry = _replace(
+        _sample_inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="ACME GmbH",
+            contact_name="Anna",
+            email="anna@example.invalid",
+            phone="+49301234567",
+            invoice_address=invoice,
+            delivery_address=None,
+            delivery_address_mode="SAME_AS_INVOICE",
+        ),
+        fulfillment_mode="DELIVERY",
+    )
+    inquiries.save(inquiry)
+
+    offers = SQLiteOfferRepository(db)
+    offer_service = OfferService(offers, inquiries, InMemoryOrderRepository())
+    # _valid_snapshot()'s customer_text carries fixed narrative values
+    # ("Sommerfest" / "Customer-visible introduction" / "...notes").
+    snapshot_in = _valid_snapshot()
+    offer = offer_service.prepare_offer_version(_SVC_INQUIRY_ID, snapshot_in)
+    version = offer.versions[0]
+    offers.close()
+
+    # Reopen a fresh repository/connection to force a real SQLite round-trip.
+    offers = SQLiteOfferRepository(db)
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    doc_service = OfferDocumentSnapshotService(offers, inquiries, documents)
+    doc = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    offers.close()
+    documents.close()
+
+    assert doc.customer_title == "Sommerfest"
+    assert doc.customer_introduction == "Customer-visible introduction"
+    assert doc.customer_notes == "Customer-visible conditions and notes"
+
+
 def test_sqlite_offer_version_event_facts_are_immutable(tmp_path: Path) -> None:
     repo = SQLiteOfferRepository(tmp_path / "offer.db")
     repo.save(_offer())
@@ -493,6 +701,7 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         (4, "offer_version_event_and_payment_facts"),
         (5, "offer_variant_and_position_print_fields"),
         (6, "offer_position_catalog_snapshot_fields"),
+        (7, "offer_version_customer_narrative"),
     ]
     conn = sqlite3.connect(db)
     apply_migrations(conn, "offers", _MIGRATIONS)
@@ -500,4 +709,4 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM schema_migrations WHERE component = 'offers'"
     ).fetchone()
     conn.close()
-    assert rows_after == (6,)
+    assert rows_after == (7,)

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -335,6 +335,56 @@ def test_prepare_offer_version_happy_path() -> None:
     assert offers.get_by_source_inquiry_id(_INQUIRY_ID) == offer
 
 
+def test_prepare_offer_version_narrative_normalization() -> None:
+    """OFFER_DOCUMENT_SNAPSHOT_V1 narrative rule: None stays None; blank/
+    whitespace-only becomes None; non-blank keeps inner text/newlines with
+    only the outer whitespace trimmed."""
+    offers = _CountingOfferRepository()
+    _inquiries, _orders, _offers, service = _world(
+        inquiry=_sample_inquiry(), offers=offers
+    )
+    payload = _valid_snapshot()
+    payload["customer_text"] = {
+        "title": "  Sommerfest 2026  ",
+        "introduction": "  Liebe Familie Muster,\n\nvielen Dank.  ",
+        "notes": "   ",  # blank after trim
+    }
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, payload)
+
+    version = offer.versions[0]
+    assert version.customer_title == "Sommerfest 2026"
+    assert version.customer_introduction == "Liebe Familie Muster,\n\nvielen Dank."
+    assert version.customer_notes is None
+
+
+def test_prepare_offer_version_narrative_blank_introduction_and_notes_become_none() -> (
+    None
+):
+    # customer_text.title is required/non-blank at the snapshot-validation
+    # layer (_require_short_text), so it can never arrive as blank here —
+    # only introduction/notes (_require_long_text) permit an empty string.
+    offers = _CountingOfferRepository()
+    _inquiries, _orders, _offers, service = _world(
+        inquiry=_sample_inquiry(), offers=offers
+    )
+    payload = _valid_snapshot()
+    payload["customer_text"] = {
+        "title": "Sommerfest",
+        "introduction": "",
+        "notes": "",
+    }
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, payload)
+
+    version = offer.versions[0]
+    assert version.customer_title == "Sommerfest"
+    assert version.customer_introduction is None
+    assert version.customer_notes is None
+
+
 def test_prepare_offer_version_missing_inquiry() -> None:
     offers = _CountingOfferRepository()
     _inquiries, _orders, _offers, service = _world(offers=offers)

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -4325,6 +4325,79 @@ def test_offer_document_variant_conflict(api) -> None:
     assert (status2, body2["error"]) == (409, "offer_document_variant_conflict")
 
 
+def test_offer_document_create_rejects_mismatched_offer_id(api) -> None:
+    """REVIEW FIX: POSTing Offer B's path with Offer A's real version/variant
+    must 404, never return (or leak) Offer A's document."""
+    base, ids, _db = api
+    _base_a, offer_a_id, version_a_id, variant_a_id = _prepared_offer_for_document(
+        api, inquiry_id=ids["inquiry_offer_ready"]
+    )
+    # Offer B only needs to exist as a real, distinct Offer — it is never
+    # itself made document-eligible. Its snapshot must use fresh
+    # variant/position ids (_unique_offer_snapshot) so it doesn't collide
+    # with Offer A's fixed-id fixture snapshot in the shared offer_variants
+    # table.
+    other_inquiry_id = ids["inquiry_convertible"]
+    other_status, other_body, _h = _post(
+        _prepare_offer_url(base, other_inquiry_id),
+        args={"snapshot": _unique_offer_snapshot(inquiry_id=other_inquiry_id)},
+    )
+    assert other_status == 201
+    offer_b_id = other_body["offer_id"]
+    assert offer_b_id != offer_a_id
+
+    # Establish the real snapshot for Offer A first (this is what a replay
+    # under the wrong offer_id must not be able to reach).
+    create_status, create_body, _h = _post(
+        _offer_document_url(base, offer_a_id),
+        args={
+            "offer_version_id": version_a_id,
+            "offer_variant_id": variant_a_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert create_status == 201
+
+    status, body, _h = _post(
+        _offer_document_url(base, offer_b_id),
+        args={
+            "offer_version_id": version_a_id,
+            "offer_variant_id": variant_a_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert (status, body["error"]) == (404, "not_found")
+    leaked_keys = {
+        "document_reference",
+        "document_hash",
+        "recipient",
+        "recipient_name",
+        "recipient_company",
+        "recipient_email",
+        "recipient_phone",
+        "invoice_address",
+        "delivery_address",
+        "positions",
+        "vat_buckets",
+        "net_total_cents",
+        "vat_total_cents",
+        "gross_total_cents",
+        "snapshot",
+        "offer_document_snapshot_id",
+    }
+    assert not leaked_keys & set(body)
+
+    # Offer A's document is unaffected and reads back exactly as created.
+    read_status, read_body, _h = _get(
+        f"{_offer_document_url(base, offer_a_id)}?offer_version_id={version_a_id}"
+    )
+    assert read_status == 200
+    assert (
+        read_body["offer_document_snapshot_id"]
+        == create_body["offer_document_snapshot_id"]
+    )
+
+
 def test_offer_document_eligibility_blocked_missing_invoice_address(api) -> None:
     base, ids, db = api
     resolved_inquiry = ids["inquiry_offer_ready"]

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
@@ -4188,3 +4189,229 @@ def test_confirmation_outbound_routes_require_bearer_auth(api) -> None:
     ):
         status, body, _h = _get(url, headers=no_auth)
         assert (status, body["error"]) == (401, "unauthorized")
+
+
+# --- OFFER_DOCUMENT_SNAPSHOT_V1 — offer-document endpoint ---------------------
+
+
+def _offer_document_url(base: str, offer_id: str) -> str:
+    return f"{base}/office/v1/offers/{offer_id}/offer-document"
+
+
+def _pickup_eligible_invoice_snapshot() -> InquiryCustomerSnapshot:
+    return InquiryCustomerSnapshot(
+        company_name="ACME GmbH",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=CustomerAddress(
+            street="Bürostraße 1",
+            postal_code="20095",
+            city="Hamburg",
+            country="DE",
+        ),
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+
+
+def _prepared_offer_for_document(
+    api: tuple[str, dict[str, str], Path],
+    *,
+    inquiry_id: str | None = None,
+) -> tuple[str, str, str, str]:
+    """Returns (base, offer_id, offer_version_id, offer_variant_id) for a
+    freshly Prepared, PICKUP-eligible offer (invoice address only)."""
+    base, ids, db = api
+    resolved_inquiry = inquiry_id or ids["inquiry_offer_ready"]
+    _set_inquiry_customer_snapshot(
+        db, resolved_inquiry, _pickup_eligible_invoice_snapshot()
+    )
+    _ensure_inquiry_fulfillment_mode(base, resolved_inquiry, mode="PICKUP")
+    snapshot = _valid_offer_snapshot(inquiry_id=resolved_inquiry)
+    status, body, _h = _post(
+        _prepare_offer_url(base, resolved_inquiry),
+        args={"snapshot": snapshot},
+    )
+    assert status == 201
+    variant_id = snapshot["variants"][0]["variant_id"]  # type: ignore[index]
+    return base, body["offer_id"], body["offer_version_id"], variant_id
+
+
+def test_offer_document_create_success(api) -> None:
+    base, offer_id, offer_version_id, variant_id = _prepared_offer_for_document(api)
+    status, body, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert status == 201
+    assert body["offer_id"] == offer_id
+    snapshot = body["snapshot"]
+    assert snapshot["offer_version_id"] == offer_version_id
+    assert snapshot["offer_variant_id"] == variant_id
+    assert snapshot["fulfillment_mode"] == "PICKUP"
+    assert snapshot["document_reference"].startswith("ANG-")
+    assert snapshot["document_hash"].startswith("sha256:")
+
+
+def test_offer_document_replay_is_idempotent(api) -> None:
+    base, offer_id, offer_version_id, variant_id = _prepared_offer_for_document(api)
+    args = {
+        "offer_version_id": offer_version_id,
+        "offer_variant_id": variant_id,
+        "created_by": "office-api-test",
+    }
+    status1, body1, _h = _post(_offer_document_url(base, offer_id), args=args)
+    assert status1 == 201
+    status2, body2, _h = _post(_offer_document_url(base, offer_id), args=args)
+    assert status2 == 200
+    assert body2["offer_document_snapshot_id"] == body1["offer_document_snapshot_id"]
+    assert body2["snapshot"]["document_hash"] == body1["snapshot"]["document_hash"]
+
+
+def _two_variant_offer_snapshot(*, inquiry_id: str) -> dict[str, object]:
+    payload = _valid_offer_snapshot(inquiry_id=inquiry_id)
+    second_variant_id = "44444444-4444-4444-8444-444444444442"
+    second_position_id = "88888888-8888-4888-8888-888888888882"
+    second_variant = json.loads(json.dumps(payload["variants"][0]))
+    second_variant["variant_id"] = second_variant_id
+    second_variant["label"] = "Variante B"
+    second_variant["positions"][0]["position_id"] = second_position_id
+    payload["variants"].append(second_variant)  # type: ignore[union-attr]
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+    return payload
+
+
+def test_offer_document_variant_conflict(api) -> None:
+    base, ids, db = api
+    resolved_inquiry = ids["inquiry_offer_ready"]
+    _set_inquiry_customer_snapshot(
+        db, resolved_inquiry, _pickup_eligible_invoice_snapshot()
+    )
+    _ensure_inquiry_fulfillment_mode(base, resolved_inquiry, mode="PICKUP")
+    snapshot = _two_variant_offer_snapshot(inquiry_id=resolved_inquiry)
+    status, body, _h = _post(
+        _prepare_offer_url(base, resolved_inquiry),
+        args={"snapshot": snapshot},
+    )
+    assert status == 201
+    offer_id = body["offer_id"]
+    offer_version_id = body["offer_version_id"]
+    variant_ids = [v["variant_id"] for v in snapshot["variants"]]  # type: ignore[index]
+    assert len(variant_ids) >= 2, "test requires an offer with 2+ variants"
+
+    first = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_ids[0],
+            "created_by": "office-api-test",
+        },
+    )
+    assert first[0] == 201
+
+    status2, body2, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_ids[1],
+            "created_by": "office-api-test",
+        },
+    )
+    assert (status2, body2["error"]) == (409, "offer_document_variant_conflict")
+
+
+def test_offer_document_eligibility_blocked_missing_invoice_address(api) -> None:
+    base, ids, db = api
+    resolved_inquiry = ids["inquiry_offer_ready"]
+    # No invoice address set on the inquiry's customer_snapshot.
+    _ensure_inquiry_fulfillment_mode(base, resolved_inquiry, mode="PICKUP")
+    snapshot = _valid_offer_snapshot(inquiry_id=resolved_inquiry)
+    status, body, _h = _post(
+        _prepare_offer_url(base, resolved_inquiry),
+        args={"snapshot": snapshot},
+    )
+    assert status == 201
+    offer_id = body["offer_id"]
+    offer_version_id = body["offer_version_id"]
+    variant_id = snapshot["variants"][0]["variant_id"]  # type: ignore[index]
+
+    status2, body2, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert (status2, body2["error"]) == (422, "offer_document_blocked")
+    assert "INVOICE_ADDRESS_REQUIRED" in body2["reasons"]
+
+    conn = sqlite3.connect(db)
+    count = conn.execute(
+        "SELECT COUNT(*) FROM offer_document_snapshots WHERE offer_id = ?",
+        (offer_id,),
+    ).fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_offer_document_read_after_create(api) -> None:
+    base, offer_id, offer_version_id, variant_id = _prepared_offer_for_document(api)
+    create_status, create_body, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert create_status == 201
+
+    read_status, read_body, _h = _get(
+        f"{_offer_document_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    assert read_status == 200
+    assert (
+        read_body["offer_document_snapshot_id"]
+        == create_body["offer_document_snapshot_id"]
+    )
+    assert (
+        read_body["snapshot"]["document_hash"]
+        == create_body["snapshot"]["document_hash"]
+    )
+
+
+def test_offer_document_read_not_found(api) -> None:
+    base, ids, _db = api
+    offer_id = str(uuid.uuid4())
+    missing_version_id = str(uuid.uuid4())
+    status, body, _h = _get(
+        f"{_offer_document_url(base, offer_id)}?offer_version_id={missing_version_id}"
+    )
+    assert (status, body["error"]) == (404, "not_found")
+
+
+def test_offer_document_routes_require_bearer_auth(api) -> None:
+    base, ids, _db = api
+    offer_id = str(uuid.uuid4())
+    no_auth: dict[str, str] = {}
+    status, body, _h = _get(
+        f"{_offer_document_url(base, offer_id)}?offer_version_id={offer_id}",
+        headers=no_auth,
+    )
+    assert (status, body["error"]) == (401, "unauthorized")
+    status, body, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_id,
+            "offer_variant_id": offer_id,
+            "created_by": "office-api-test",
+        },
+        headers=no_auth,
+    )
+    assert (status, body["error"]) == (401, "unauthorized")


### PR DESCRIPTION
## Summary

- add immutable `OfferDocumentSnapshot` for the initial `ANGEBOT / AUFTRAGSBESTÄTIGUNG`
- persist frozen customer narrative on `OfferVersion`
- add SQLite migration 7 for narrative fields
- add append-only snapshot persistence with owner and immutability triggers
- verify the canonical document hash on every persisted read
- enforce invoice-address, fulfillment and delivery eligibility
- provide idempotent Office API create/read endpoints
- prevent cross-offer document replay and disclosure

## Scope boundaries

Not included:

- PDF rendering
- email sending
- signed-file storage
- acceptance-evidence changes
- Offer-to-Order conversion changes
- Office Panel UI
- post-Order change documents
- production deployment

## Verification

- 1818 tests passed
- coverage 90.2%, threshold 90%
- Ruff check passed
- Ruff format check passed
- Mypy passed
- Node tests 24/24 passed
- independent review completed
- delta review verdict: `APPROVE DELTA — READY TO PUSH`

Commits:

- `e23778f` Add immutable offer document snapshots
- `cb05f37` Fix offer document replay ownership