### PR TITLE
Add deterministic offer PDF renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,18 @@ name = "catering-system"
 version = "0.1.0"
 description = "Catering System MVP — Core-owned inquiry/order operational truth"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "reportlab==5.0.0",
+]
 
 [dependency-groups]
 dev = [
     "coverage[toml]>=7.9,<8",
     "mypy>=1.16,<2",
     "pytest>=9,<10",
+    "pypdf==6.14.2",
     "ruff==0.15.21",
+    "types-reportlab==4.5.1.20260724",
 ]
 
 [tool.pytest.ini_options]

--- a/src/catering_system/domain/offer_pdf.py
+++ b/src/catering_system/domain/offer_pdf.py
@@ -1,0 +1,83 @@
+"""Static, non-snapshot inputs for the OFFER_PDF_RENDERER_V1 renderer.
+
+``OfferPdfStaticContent`` carries every company/legal fact the renderer
+needs that is deliberately absent from ``OfferDocumentSnapshot`` (logo,
+legal address, acceptance wording, ...). It is composed and injected by the
+caller — the renderer must never read environment variables, files, the
+database or the network to obtain any of this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class OfferDocumentUnsupportedSchemaError(Exception):
+    """The snapshot's schema_version is not one this renderer understands."""
+
+
+class OfferPdfMissingStaticContentError(Exception):
+    """A required OfferPdfStaticContent fact is missing or blank."""
+
+
+class OfferPdfMalformedSnapshotError(Exception):
+    """Defense in depth: the snapshot violates a rendering precondition that
+    OfferDocumentSnapshot's own invariants should already have prevented."""
+
+
+class OfferPdfUnsupportedCharacterError(Exception):
+    """A text field contains a glyph the deterministic font setup cannot
+    render. Fails closed — never silently dropped, replaced or
+    transliterated."""
+
+    def __init__(self, *, field: str, text: str) -> None:
+        self.field = field
+        self.text = text
+        super().__init__(f"unsupported character(s) in {field}")
+
+
+class OfferPdfRenderError(Exception):
+    """Wraps an unexpected failure from the underlying PDF library so no
+    internal stack trace or path is exposed through a future API error."""
+
+
+@dataclass(frozen=True)
+class OfferPdfStaticContent:
+    """Immutable, explicitly-injected company/legal facts for one render call.
+
+    Required facts have no default so a missing value is a constructor-time
+    TypeError before __post_init__ even runs; blank-but-present values are
+    caught here.
+    """
+
+    company_legal_name: str
+    company_address_lines: tuple[str, ...]
+    acceptance_statement: str
+    company_phone: str | None = None
+    company_email: str | None = None
+    company_web: str | None = None
+    company_register_text: str | None = None
+    company_vat_id_text: str | None = None
+    footer_note: str | None = None
+    logo_png_bytes: bytes | None = None
+    bank_details_text: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.company_legal_name.strip():
+            raise OfferPdfMissingStaticContentError("company_legal_name is required")
+        if not self.company_address_lines or not any(
+            line.strip() for line in self.company_address_lines
+        ):
+            raise OfferPdfMissingStaticContentError("company_address_lines is required")
+        if not self.acceptance_statement.strip():
+            raise OfferPdfMissingStaticContentError("acceptance_statement is required")
+
+
+__all__ = [
+    "OfferDocumentUnsupportedSchemaError",
+    "OfferPdfMalformedSnapshotError",
+    "OfferPdfMissingStaticContentError",
+    "OfferPdfRenderError",
+    "OfferPdfStaticContent",
+    "OfferPdfUnsupportedCharacterError",
+]

--- a/src/catering_system/services/offer_pdf_renderer.py
+++ b/src/catering_system/services/offer_pdf_renderer.py
@@ -66,8 +66,26 @@ _MONTHS_DE = (
 _PAGE_SIZE = A4
 _LEFT_MARGIN = 20 * mm
 _RIGHT_MARGIN = 20 * mm
-_TOP_MARGIN = 18 * mm
-_BOTTOM_MARGIN = 16 * mm
+_TOP_MARGIN = 16 * mm
+
+# Footer geometry: two vertically stacked, never-overlapping bands.
+#   lower line  (fixed, one line):   document_reference (left) · Seite N (right)
+#   upper area  (wrapped Paragraph): footer_note / register / VAT-ID facts
+# _FOOTER_MAX_LINES is the deterministic maximum the upper area supports;
+# content that would need more lines fails closed (OfferPdfRenderError)
+# instead of being clipped. bottomMargin always reserves the worst case,
+# so wrapped footer content can never collide with story content
+# (positions/totals/acceptance) regardless of how short the actual text is.
+_FOOTER_FONT_SIZE = 8
+_FOOTER_LEADING = 9.5
+_FOOTER_MAX_LINES = 3
+_FOOTER_MAX_HEIGHT = _FOOTER_MAX_LINES * _FOOTER_LEADING
+_LOWER_FOOTER_Y = 8 * mm
+_FOOTER_GAP = 2 * mm
+_UPPER_FOOTER_Y = _LOWER_FOOTER_Y + _FOOTER_GAP
+_FOOTER_SAFETY_MARGIN = 2 * mm
+_BOTTOM_MARGIN = _UPPER_FOOTER_Y + _FOOTER_MAX_HEIGHT + _FOOTER_SAFETY_MARGIN
+_FOOTER_AVAILABLE_WIDTH = _PAGE_SIZE[0] - _LEFT_MARGIN - _RIGHT_MARGIN
 
 
 class _FixedTimeStamp:
@@ -106,6 +124,7 @@ def render_offer_document_pdf(
     _check_all_text(snapshot, static_content)
 
     styles = _styles()
+    _ensure_footer_fits(static_content, styles)
     story = _build_story(snapshot, static_content, styles)
 
     buf = io.BytesIO()
@@ -124,7 +143,7 @@ def render_offer_document_pdf(
             creator="silberloeffel-catering-offer-pdf-renderer",
             producer="silberloeffel-catering-offer-pdf-renderer",
         )
-        on_page = _page_decorator(snapshot, static_content)
+        on_page = _page_decorator(snapshot, static_content, styles)
         doc.build(story, onFirstPage=on_page, onLaterPages=on_page)
     except (
         OfferDocumentUnsupportedSchemaError,
@@ -264,6 +283,30 @@ def _company_footer_line(static: OfferPdfStaticContent) -> str | None:
     return " · ".join(parts) if parts else None
 
 
+def _footer_paragraph(
+    static: OfferPdfStaticContent, styles: _Styles
+) -> Paragraph | None:
+    line = _company_footer_line(static)
+    if line is None:
+        return None
+    return _p(line, styles.footer)
+
+
+def _ensure_footer_fits(static: OfferPdfStaticContent, styles: _Styles) -> None:
+    """Fail closed, before any PDF construction, when the supplied footer
+    facts need more vertical space than the reserved footer area supports.
+    Never silently clipped."""
+    paragraph = _footer_paragraph(static, styles)
+    if paragraph is None:
+        return
+    _, height = paragraph.wrap(_FOOTER_AVAILABLE_WIDTH, _FOOTER_MAX_HEIGHT * 100)
+    if height > _FOOTER_MAX_HEIGHT + 0.01:
+        raise OfferPdfRenderError(
+            "footer content (footer_note / company_register_text / "
+            "company_vat_id_text) exceeds the maximum supported footer height"
+        )
+
+
 # --- document assembly -----------------------------------------------------------
 
 
@@ -276,6 +319,7 @@ class _Styles:
     right: ParagraphStyle
     right_bold: ParagraphStyle
     table_header: ParagraphStyle
+    footer: ParagraphStyle
 
 
 def _styles() -> _Styles:
@@ -315,6 +359,13 @@ def _styles() -> _Styles:
             fontSize=8.5,
             leading=10,
             fontName="Helvetica-Bold",
+        ),
+        footer=ParagraphStyle(
+            "OfferFooter",
+            parent=base["Normal"],
+            fontSize=_FOOTER_FONT_SIZE,
+            leading=_FOOTER_LEADING,
+            textColor=colors.HexColor("#595959"),
         ),
     )
 
@@ -661,7 +712,9 @@ def _acceptance_block(static: OfferPdfStaticContent, styles: _Styles) -> list[Fl
     ]
 
 
-def _page_decorator(snapshot: OfferDocumentSnapshot, static: OfferPdfStaticContent):
+def _page_decorator(
+    snapshot: OfferDocumentSnapshot, static: OfferPdfStaticContent, styles: _Styles
+):
     def _on_page(pdf_canvas, doc) -> None:  # noqa: ANN001
         # invariant=1 alone pins /CreationDate + /ModDate to a hardcoded
         # placeholder (2000-01-01), not a real date. Override with the
@@ -677,12 +730,27 @@ def _page_decorator(snapshot: OfferDocumentSnapshot, static: OfferPdfStaticConte
             page_height - 12 * mm,
             f"{_TITLE} · {snapshot.document_reference}",
         )
-        pdf_canvas.drawRightString(
-            page_width - _RIGHT_MARGIN, 12 * mm, f"Seite {doc.page}"
+
+        # Lower footer line: document_reference (left) · Seite N (right).
+        # Fixed single line, always short and fixed-format — never wraps,
+        # never shares horizontal space with the upper wrapped area above it.
+        pdf_canvas.drawString(
+            _LEFT_MARGIN, _LOWER_FOOTER_Y, snapshot.document_reference
         )
-        footer_line = _company_footer_line(static)
-        if footer_line is not None:
-            pdf_canvas.drawString(_LEFT_MARGIN, 12 * mm, footer_line)
+        pdf_canvas.drawRightString(
+            page_width - _RIGHT_MARGIN, _LOWER_FOOTER_Y, f"Seite {doc.page}"
+        )
+
+        # Upper footer area: footer_note / register / VAT-ID, width-wrapped
+        # via a real Paragraph so long combined text never collides with
+        # the lower line or runs past the page — already proven to fit
+        # within _FOOTER_MAX_HEIGHT by _ensure_footer_fits before build().
+        paragraph = _footer_paragraph(static, styles)
+        if paragraph is not None:
+            paragraph.wrapOn(
+                pdf_canvas, _FOOTER_AVAILABLE_WIDTH, _FOOTER_MAX_HEIGHT * 100
+            )
+            paragraph.drawOn(pdf_canvas, _LEFT_MARGIN, _UPPER_FOOTER_Y)
         pdf_canvas.restoreState()
 
     return _on_page

--- a/src/catering_system/services/offer_pdf_renderer.py
+++ b/src/catering_system/services/offer_pdf_renderer.py
@@ -1,0 +1,656 @@
+"""OFFER_PDF_RENDERER_V1 — deterministic ANGEBOT / AUFTRAGSBESTÄTIGUNG PDF.
+
+Pure function: OfferDocumentSnapshot + OfferPdfStaticContent in, PDF bytes
+out. No repositories, no Inquiry/Offer/catalog access, no network, no
+environment/file reads, no mutation of the snapshot, no price/VAT
+recomputation — every cent and every VAT bucket is formatted, never
+recalculated.
+
+Determinism: ReportLab's ``invariant=1`` mode fixes object ordering and the
+trailer ``/ID``, but pins ``/CreationDate``/``/ModDate`` to a hardcoded
+placeholder rather than any real date. This module overrides the
+document's internal timestamp with one derived from ``snapshot.created_at``
+so metadata dates are both fixed *and* meaningful. Same snapshot + same
+static content must always produce byte-identical output — proven in
+tests, not merely claimed.
+
+Fonts: base-14 Helvetica (WinAnsi encoding) is used deliberately — no
+external font asset ships in this slice. Every user-supplied text field is
+preflighted against cp1252 (a very close proxy for WinAnsi) before any draw
+call; ReportLab itself does not raise for unsupported glyphs, it silently
+draws replacement boxes, so this module fails closed instead.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import (
+    Flowable,
+    Image,
+    KeepTogether,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.offer_document_snapshot import (
+    SCHEMA_VERSION,
+    OfferDocumentSnapshot,
+)
+from catering_system.domain.offer_pdf import (
+    OfferDocumentUnsupportedSchemaError,
+    OfferPdfMalformedSnapshotError,
+    OfferPdfRenderError,
+    OfferPdfStaticContent,
+    OfferPdfUnsupportedCharacterError,
+)
+from catering_system.domain.order_payment_reminder import PAYMENT_METHOD_LABELS
+
+_TITLE = "ANGEBOT / AUFTRAGSBESTÄTIGUNG"
+_FULFILLMENT_LABELS = {"DELIVERY": "Lieferung", "PICKUP": "Abholung"}
+_MONTHS_DE = (
+    "Januar", "Februar", "März", "April", "Mai", "Juni",
+    "Juli", "August", "September", "Oktober", "November", "Dezember",
+)  # fmt: skip
+
+_PAGE_SIZE = A4
+_LEFT_MARGIN = 20 * mm
+_RIGHT_MARGIN = 20 * mm
+_TOP_MARGIN = 18 * mm
+_BOTTOM_MARGIN = 16 * mm
+
+
+class _FixedTimeStamp:
+    """Mimics reportlab.pdfbase.pdfdoc.TimeStamp's public shape, but derived
+    from snapshot.created_at instead of wall-clock time or SOURCE_DATE_EPOCH."""
+
+    def __init__(self, created_at: datetime) -> None:
+        utc = created_at.astimezone(timezone.utc)
+        self.YMDhms = (utc.year, utc.month, utc.day, utc.hour, utc.minute, utc.second)
+        self.dhh = 0
+        self.dmm = 0
+
+
+def offer_document_pdf_filename(snapshot: OfferDocumentSnapshot) -> str:
+    return f"{snapshot.document_reference}.pdf"
+
+
+def render_offer_document_pdf(
+    snapshot: OfferDocumentSnapshot,
+    static_content: OfferPdfStaticContent,
+) -> bytes:
+    """Render one frozen offer document to PDF bytes.
+
+    Deterministic for a fixed ReportLab version: identical snapshot and
+    static content always produce identical bytes (see module docstring).
+    """
+    if snapshot.schema_version != SCHEMA_VERSION:
+        raise OfferDocumentUnsupportedSchemaError(
+            f"unsupported offer document schema version {snapshot.schema_version!r}"
+        )
+    if not snapshot.positions:
+        raise OfferPdfMalformedSnapshotError(
+            "offer document snapshot has no positions to render"
+        )
+
+    _check_all_text(snapshot, static_content)
+
+    styles = _styles()
+    story = _build_story(snapshot, static_content, styles)
+
+    buf = io.BytesIO()
+    try:
+        doc = SimpleDocTemplate(
+            buf,
+            pagesize=_PAGE_SIZE,
+            leftMargin=_LEFT_MARGIN,
+            rightMargin=_RIGHT_MARGIN,
+            topMargin=_TOP_MARGIN,
+            bottomMargin=_BOTTOM_MARGIN,
+            invariant=1,
+            title=_TITLE,
+            author=static_content.company_legal_name,
+            subject=snapshot.document_reference,
+            creator="silberloeffel-catering-offer-pdf-renderer",
+            producer="silberloeffel-catering-offer-pdf-renderer",
+        )
+        on_page = _page_decorator(snapshot, static_content)
+        doc.build(story, onFirstPage=on_page, onLaterPages=on_page)
+    except (
+        OfferDocumentUnsupportedSchemaError,
+        OfferPdfMalformedSnapshotError,
+        OfferPdfUnsupportedCharacterError,
+    ):
+        raise
+    except Exception as exc:  # pragma: no cover - defensive, no path leak
+        raise OfferPdfRenderError("failed to render offer document PDF") from exc
+    return buf.getvalue()
+
+
+# --- character preflight (fail closed, never silently mangled) ----------------
+
+
+def _ensure_renderable(value: str | None, field: str) -> None:
+    if not value:
+        return
+    try:
+        value.encode("cp1252")
+    except UnicodeEncodeError as exc:
+        raise OfferPdfUnsupportedCharacterError(field=field, text=value) from exc
+
+
+def _check_all_text(
+    snapshot: OfferDocumentSnapshot, static_content: OfferPdfStaticContent
+) -> None:
+    _ensure_renderable(snapshot.recipient_name, "recipient_name")
+    _ensure_renderable(snapshot.recipient_company, "recipient_company")
+    _ensure_renderable(snapshot.recipient_email, "recipient_email")
+    _ensure_renderable(snapshot.recipient_phone, "recipient_phone")
+    for label, address in (
+        ("invoice_address", snapshot.invoice_address),
+        ("delivery_address", snapshot.delivery_address),
+    ):
+        if address is None:
+            continue
+        _ensure_renderable(address.street, f"{label}.street")
+        _ensure_renderable(address.postal_code, f"{label}.postal_code")
+        _ensure_renderable(address.city, f"{label}.city")
+        _ensure_renderable(address.country, f"{label}.country")
+    _ensure_renderable(snapshot.time_window_text, "time_window_text")
+    _ensure_renderable(snapshot.location_text, "location_text")
+    _ensure_renderable(snapshot.customer_title, "customer_title")
+    _ensure_renderable(snapshot.customer_introduction, "customer_introduction")
+    _ensure_renderable(snapshot.customer_notes, "customer_notes")
+    _ensure_renderable(
+        snapshot.payment_customer_visible_text, "payment_customer_visible_text"
+    )
+    for index, position in enumerate(snapshot.positions):
+        prefix = f"positions[{index}]"
+        _ensure_renderable(position.name, f"{prefix}.name")
+        _ensure_renderable(position.description, f"{prefix}.description")
+        _ensure_renderable(position.composition, f"{prefix}.composition")
+        _ensure_renderable(position.quantity, f"{prefix}.quantity")
+        _ensure_renderable(position.unit_label, f"{prefix}.unit_label")
+
+    _ensure_renderable(static_content.company_legal_name, "company_legal_name")
+    for i, line in enumerate(static_content.company_address_lines):
+        _ensure_renderable(line, f"company_address_lines[{i}]")
+    _ensure_renderable(static_content.company_phone, "company_phone")
+    _ensure_renderable(static_content.company_email, "company_email")
+    _ensure_renderable(static_content.company_web, "company_web")
+    _ensure_renderable(static_content.company_register_text, "company_register_text")
+    _ensure_renderable(static_content.company_vat_id_text, "company_vat_id_text")
+    _ensure_renderable(static_content.footer_note, "footer_note")
+    _ensure_renderable(static_content.acceptance_statement, "acceptance_statement")
+    _ensure_renderable(static_content.bank_details_text, "bank_details_text")
+
+
+# --- formatting -----------------------------------------------------------------
+
+
+def _eur(cents: int) -> str:
+    sign = "-" if cents < 0 else ""
+    whole, frac = divmod(abs(cents), 100)
+    grouped = f"{whole:,}".replace(",", ".")
+    return f"{sign}{grouped},{frac:02d} €"
+
+
+def _vat_percent(rate_percent: int) -> str:
+    return f"{rate_percent} %"
+
+
+def _de_date(value: date) -> str:
+    return f"{value.day}. {_MONTHS_DE[value.month - 1]} {value.year}"
+
+
+def _de_date_short(value: date) -> str:
+    return f"{value.day:02d}.{value.month:02d}.{value.year:04d}"
+
+
+def _de_created_at(value: datetime) -> str:
+    utc = value.astimezone(timezone.utc)
+    return f"{_de_date_short(utc.date())}"
+
+
+def _payment_label(method: str) -> str:
+    return PAYMENT_METHOD_LABELS[method]  # type: ignore[index]
+
+
+def _payment_terms_line(method: str, customer_visible_text: str) -> str | None:
+    """None means: identical to the canonical label, suppress the duplicate."""
+    normalized = customer_visible_text.strip()
+    if not normalized:
+        return None
+    if normalized.casefold() == _payment_label(method).casefold():
+        return None
+    return normalized
+
+
+# --- document assembly -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Styles:
+    title: ParagraphStyle
+    h2: ParagraphStyle
+    body: ParagraphStyle
+    small: ParagraphStyle
+    right: ParagraphStyle
+    right_bold: ParagraphStyle
+    table_header: ParagraphStyle
+
+
+def _styles() -> _Styles:
+    base = getSampleStyleSheet()
+    return _Styles(
+        title=ParagraphStyle(
+            "OfferTitle", parent=base["Title"], fontSize=16, leading=19
+        ),
+        h2=ParagraphStyle(
+            "OfferH2",
+            parent=base["Heading2"],
+            fontSize=10.5,
+            leading=12,
+            spaceBefore=6,
+            spaceAfter=2,
+        ),
+        body=ParagraphStyle(
+            "OfferBody", parent=base["Normal"], fontSize=9.5, leading=13
+        ),
+        small=ParagraphStyle(
+            "OfferSmall", parent=base["Normal"], fontSize=8, leading=10
+        ),
+        right=ParagraphStyle(
+            "OfferRight", parent=base["Normal"], fontSize=9.5, leading=13, alignment=2
+        ),
+        right_bold=ParagraphStyle(
+            "OfferRightBold",
+            parent=base["Normal"],
+            fontSize=10.5,
+            leading=13,
+            alignment=2,
+            fontName="Helvetica-Bold",
+        ),
+        table_header=ParagraphStyle(
+            "OfferTableHeader",
+            parent=base["Normal"],
+            fontSize=8.5,
+            leading=10,
+            fontName="Helvetica-Bold",
+        ),
+    )
+
+
+def _esc(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _p(text: str, style: ParagraphStyle) -> Paragraph:
+    """Wrap one raw (unescaped) string. Internal newlines become <br/>."""
+    return Paragraph(_esc(text).replace("\n", "<br/>"), style)
+
+
+def _p_lines(lines: list[str], style: ParagraphStyle) -> Paragraph:
+    """Wrap several raw (unescaped) lines, each escaped individually and
+    joined with a real line break — never re-escape the joined markup."""
+    return Paragraph("<br/>".join(_esc(line) for line in lines if line), style)
+
+
+def _build_story(
+    snapshot: OfferDocumentSnapshot,
+    static: OfferPdfStaticContent,
+    styles: _Styles,
+) -> list[Flowable]:
+    story: list[Flowable] = []
+    story.extend(_header_block(snapshot, static, styles))
+    story.extend(_recipient_block(snapshot, styles))
+    story.extend(_event_block(snapshot, styles))
+    story.extend(_address_block(snapshot, styles))
+    story.extend(_narrative_block(snapshot, styles))
+    story.extend(_positions_block(snapshot, styles))
+    story.append(Spacer(1, 4))
+    story.append(KeepTogether(_totals_block(snapshot, styles)))
+    story.append(Spacer(1, 4))
+    story.append(KeepTogether(_payment_block(snapshot, static, styles)))
+    story.append(Spacer(1, 8))
+    story.append(KeepTogether(_acceptance_block(static, styles)))
+    return story
+
+
+def _header_block(
+    snapshot: OfferDocumentSnapshot, static: OfferPdfStaticContent, styles: _Styles
+) -> list[Flowable]:
+    blocks: list[Flowable] = []
+    if static.logo_png_bytes is not None:
+        img = Image(io.BytesIO(static.logo_png_bytes))
+        img.drawHeight = 16 * mm
+        img.drawWidth = img.drawHeight * (img.imageWidth / img.imageHeight)
+        blocks.append(img)
+    else:
+        blocks.append(_p(static.company_legal_name, styles.h2))
+    for line in static.company_address_lines:
+        if line.strip():
+            blocks.append(_p(line, styles.small))
+    blocks.append(Spacer(1, 6))
+    blocks.append(_p(_TITLE, styles.title))
+    blocks.append(
+        _p(
+            f"Referenz: {snapshot.document_reference} · "
+            f"Datum: {_de_created_at(snapshot.created_at)}",
+            styles.body,
+        )
+    )
+    blocks.append(Spacer(1, 4))
+    return blocks
+
+
+def _address_lines(address: CustomerAddress) -> list[str]:
+    """CustomerAddress fields are typed optional, but structural completeness
+    is already guaranteed by OfferDocumentSnapshot's own invariants for any
+    address reaching this renderer — the ``or ""`` fallback is defensive
+    typing, not an expected runtime path."""
+    return [
+        address.street or "",
+        f"{address.postal_code or ''} {address.city or ''}".strip(),
+        address.country or "",
+    ]
+
+
+def _recipient_block(
+    snapshot: OfferDocumentSnapshot, styles: _Styles
+) -> list[Flowable]:
+    blocks: list[Flowable] = [_p("Kunde", styles.h2)]
+    lines: list[str] = []
+    if snapshot.recipient_company:
+        lines.append(snapshot.recipient_company)
+    if snapshot.recipient_name:
+        lines.append(snapshot.recipient_name)
+    lines.extend(_address_lines(snapshot.invoice_address))
+    if snapshot.recipient_email:
+        lines.append(snapshot.recipient_email)
+    if snapshot.recipient_phone:
+        lines.append(snapshot.recipient_phone)
+    blocks.append(_p_lines(lines, styles.body))
+    return blocks
+
+
+def _event_block(snapshot: OfferDocumentSnapshot, styles: _Styles) -> list[Flowable]:
+    guests = (
+        f"ca. {snapshot.guest_count_estimate} Gäste"
+        if snapshot.guest_count_estimate is not None
+        else "–"
+    )
+    fulfillment = _FULFILLMENT_LABELS[snapshot.fulfillment_mode]
+    lines = [
+        f"Datum: {_de_date(snapshot.event_date)}",
+        f"Zeit: {snapshot.time_window_text}",
+        f"Ort: {snapshot.location_text}",
+        f"Gäste: {guests}",
+        f"Art: {fulfillment}",
+    ]
+    return [
+        _p("Veranstaltung", styles.h2),
+        _p_lines(lines, styles.body),
+    ]
+
+
+def _address_block(snapshot: OfferDocumentSnapshot, styles: _Styles) -> list[Flowable]:
+    blocks: list[Flowable] = [_p("Adressen", styles.h2)]
+    invoice_lines = _address_lines(snapshot.invoice_address)
+    invoice_table = Table(
+        [
+            [_p("Rechnungsadresse", styles.table_header)],
+            [_p_lines(invoice_lines, styles.body)],
+        ],
+        colWidths=[80 * mm],
+    )
+    invoice_table.setStyle(
+        TableStyle(
+            [
+                ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor("#bbbbbb")),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    row = [invoice_table]
+
+    if snapshot.fulfillment_mode == "DELIVERY":
+        delivery = snapshot.delivery_address
+        assert delivery is not None  # guaranteed by snapshot invariants
+        delivery_lines = _address_lines(delivery)
+        header_text = "Lieferadresse"
+        if snapshot.delivery_address_differs:
+            header_text = "Lieferadresse (abweichend)"
+        delivery_table = Table(
+            [
+                [_p(header_text, styles.table_header)],
+                [_p_lines(delivery_lines, styles.body)],
+            ],
+            colWidths=[80 * mm],
+        )
+        border_color = (
+            colors.HexColor("#888888")
+            if snapshot.delivery_address_differs
+            else colors.HexColor("#bbbbbb")
+        )
+        bg_color = (
+            colors.HexColor("#f0f0f0")
+            if snapshot.delivery_address_differs
+            else colors.white
+        )
+        delivery_table.setStyle(
+            TableStyle(
+                [
+                    ("BOX", (0, 0), (-1, -1), 0.5, border_color),
+                    ("BACKGROUND", (0, 0), (-1, -1), bg_color),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                    ("TOPPADDING", (0, 0), (-1, -1), 4),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ]
+            )
+        )
+        row.append(delivery_table)
+
+    outer = Table([row], colWidths=None)
+    outer.setStyle(
+        TableStyle(
+            [
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                ("TOPPADDING", (0, 0), (-1, -1), 0),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+            ]
+        )
+    )
+    blocks.append(outer)
+    return blocks
+
+
+def _narrative_block(
+    snapshot: OfferDocumentSnapshot, styles: _Styles
+) -> list[Flowable]:
+    blocks: list[Flowable] = []
+    if snapshot.customer_title:
+        blocks.append(_p(snapshot.customer_title, styles.h2))
+    if snapshot.customer_introduction:
+        blocks.append(_p(snapshot.customer_introduction, styles.body))
+        blocks.append(Spacer(1, 4))
+    if snapshot.customer_notes:
+        blocks.append(_p(snapshot.customer_notes, styles.body))
+        blocks.append(Spacer(1, 4))
+    return blocks
+
+
+def _positions_block(
+    snapshot: OfferDocumentSnapshot, styles: _Styles
+) -> list[Flowable]:
+    header: list[Flowable] = [
+        _p("Position", styles.table_header),
+        _p("Menge", styles.table_header),
+        _p("Einzelpreis", styles.table_header),
+        _p("Netto", styles.table_header),
+        _p("MwSt.", styles.table_header),
+        _p("Brutto", styles.table_header),
+    ]
+    rows: list[list[Flowable]] = [header]
+    for position in snapshot.positions:
+        name_parts = [position.name]
+        if position.description:
+            name_parts.append(position.description)
+        if position.composition:
+            name_parts.append(position.composition)
+        name_cell = _p_lines(name_parts, styles.body)
+        quantity_text = (
+            f"{position.quantity} {position.unit_label or ''}".strip()
+            if position.quantity
+            else "–"
+        )
+        rows.append(
+            [
+                name_cell,
+                _p(quantity_text, styles.body),
+                _p(_eur(position.unit_net_cents), styles.right),
+                _p(_eur(position.net_total_cents), styles.right),
+                _p(_vat_percent(position.vat_rate_percent), styles.right),
+                _p(_eur(position.gross_cents), styles.right),
+            ]
+        )
+    table = Table(
+        rows,
+        colWidths=[62 * mm, 20 * mm, 22 * mm, 22 * mm, 15 * mm, 22 * mm],
+        repeatRows=1,
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#cccccc")),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eeeeee")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return [_p("Leistungen", styles.h2), table]
+
+
+def _totals_block(snapshot: OfferDocumentSnapshot, styles: _Styles) -> list[Flowable]:
+    rows: list[list[Flowable]] = [
+        [
+            _p("Satz", styles.table_header),
+            _p("Netto", styles.table_header),
+            _p("MwSt.", styles.table_header),
+        ]
+    ]
+    for bucket in snapshot.vat_buckets:
+        rows.append(
+            [
+                _p(_vat_percent(bucket.rate_percent), styles.body),
+                _p(_eur(bucket.base_net_cents), styles.right),
+                _p(_eur(bucket.vat_cents), styles.right),
+            ]
+        )
+    table = Table(rows, colWidths=[30 * mm, 30 * mm, 30 * mm])
+    table.setStyle(
+        TableStyle(
+            [
+                ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#cccccc")),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eeeeee")),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    summary = Table(
+        [
+            [
+                _p("Summe netto:", styles.body),
+                _p(_eur(snapshot.net_total_cents), styles.right),
+            ],
+            [
+                _p("Summe MwSt.:", styles.body),
+                _p(_eur(snapshot.vat_total_cents), styles.right),
+            ],
+            [
+                _p("Summe brutto:", styles.right_bold),
+                _p(_eur(snapshot.gross_total_cents), styles.right_bold),
+            ],
+        ],
+        colWidths=[60 * mm, 30 * mm],
+    )
+    summary.setStyle(TableStyle([("LEFTPADDING", (0, 0), (-1, -1), 4)]))
+    return [_p("MwSt.-Übersicht", styles.h2), table, Spacer(1, 6), summary]
+
+
+def _payment_block(
+    snapshot: OfferDocumentSnapshot,
+    static: OfferPdfStaticContent,
+    styles: _Styles,
+) -> list[Flowable]:
+    blocks: list[Flowable] = [_p("Zahlung", styles.h2)]
+    label = _payment_label(snapshot.payment_method)
+    blocks.append(_p(f"Zahlungsart: {label}", styles.body))
+    terms = _payment_terms_line(
+        snapshot.payment_method, snapshot.payment_customer_visible_text
+    )
+    if terms is not None:
+        blocks.append(_p(f"Zahlungsbedingungen: {terms}", styles.body))
+    if snapshot.payment_method == "VORKASSE" and static.bank_details_text:
+        blocks.append(_p(static.bank_details_text, styles.body))
+    return blocks
+
+
+def _acceptance_block(static: OfferPdfStaticContent, styles: _Styles) -> list[Flowable]:
+    return [
+        _p("Annahme", styles.h2),
+        _p(static.acceptance_statement, styles.body),
+        Spacer(1, 12),
+        _p("Ort: _______________________  Datum: _______________________", styles.body),
+        Spacer(1, 10),
+        _p("Name: _______________________", styles.body),
+        Spacer(1, 10),
+        _p("Unterschrift: _______________________", styles.body),
+    ]
+
+
+def _page_decorator(snapshot: OfferDocumentSnapshot, static: OfferPdfStaticContent):
+    def _on_page(pdf_canvas, doc) -> None:  # noqa: ANN001
+        # invariant=1 alone pins /CreationDate + /ModDate to a hardcoded
+        # placeholder (2000-01-01), not a real date. Override with the
+        # frozen snapshot timestamp so metadata is both fixed and
+        # meaningful — idempotent across every page callback invocation.
+        pdf_canvas._doc._timeStamp = _FixedTimeStamp(snapshot.created_at)
+        pdf_canvas.saveState()
+        pdf_canvas.setFont("Helvetica", 8)
+        pdf_canvas.setFillGray(0.35)
+        page_width, page_height = _PAGE_SIZE
+        pdf_canvas.drawString(
+            _LEFT_MARGIN,
+            page_height - 12 * mm,
+            f"{_TITLE} · {snapshot.document_reference}",
+        )
+        pdf_canvas.drawRightString(
+            page_width - _RIGHT_MARGIN, 12 * mm, f"Seite {doc.page}"
+        )
+        if static.footer_note:
+            pdf_canvas.drawString(_LEFT_MARGIN, 12 * mm, static.footer_note)
+        pdf_canvas.restoreState()
+
+    return _on_page

--- a/src/catering_system/services/offer_pdf_renderer.py
+++ b/src/catering_system/services/offer_pdf_renderer.py
@@ -236,6 +236,34 @@ def _payment_terms_line(method: str, customer_visible_text: str) -> str | None:
     return normalized
 
 
+def _company_contact_line(static: OfferPdfStaticContent) -> str | None:
+    """Compact labeled 'Telefon: ... · E-Mail: ... · Web: ...' header line.
+
+    None when no contact value was supplied — never an empty label."""
+    parts: list[str] = []
+    if static.company_phone and static.company_phone.strip():
+        parts.append(f"Telefon: {static.company_phone.strip()}")
+    if static.company_email and static.company_email.strip():
+        parts.append(f"E-Mail: {static.company_email.strip()}")
+    if static.company_web and static.company_web.strip():
+        parts.append(f"Web: {static.company_web.strip()}")
+    return " · ".join(parts) if parts else None
+
+
+def _company_footer_line(static: OfferPdfStaticContent) -> str | None:
+    """Compact footer line: footer_note, then register/VAT-ID facts
+    verbatim, each only when supplied. No labels are invented for the
+    legal facts — they are rendered exactly as approved."""
+    parts: list[str] = []
+    if static.footer_note and static.footer_note.strip():
+        parts.append(static.footer_note.strip())
+    if static.company_register_text and static.company_register_text.strip():
+        parts.append(static.company_register_text.strip())
+    if static.company_vat_id_text and static.company_vat_id_text.strip():
+        parts.append(static.company_vat_id_text.strip())
+    return " · ".join(parts) if parts else None
+
+
 # --- document assembly -----------------------------------------------------------
 
 
@@ -341,6 +369,9 @@ def _header_block(
     for line in static.company_address_lines:
         if line.strip():
             blocks.append(_p(line, styles.small))
+    contact_line = _company_contact_line(static)
+    if contact_line is not None:
+        blocks.append(_p(contact_line, styles.small))
     blocks.append(Spacer(1, 6))
     blocks.append(_p(_TITLE, styles.title))
     blocks.append(
@@ -649,8 +680,9 @@ def _page_decorator(snapshot: OfferDocumentSnapshot, static: OfferPdfStaticConte
         pdf_canvas.drawRightString(
             page_width - _RIGHT_MARGIN, 12 * mm, f"Seite {doc.page}"
         )
-        if static.footer_note:
-            pdf_canvas.drawString(_LEFT_MARGIN, 12 * mm, static.footer_note)
+        footer_line = _company_footer_line(static)
+        if footer_line is not None:
+            pdf_canvas.drawString(_LEFT_MARGIN, 12 * mm, footer_line)
         pdf_canvas.restoreState()
 
     return _on_page

--- a/tests/unit/test_offer_pdf_renderer.py
+++ b/tests/unit/test_offer_pdf_renderer.py
@@ -1,0 +1,598 @@
+"""OFFER_PDF_RENDERER_V1 — deterministic ANGEBOT / AUFTRAGSBESTÄTIGUNG PDF.
+
+Pure renderer contract: OfferDocumentSnapshot + OfferPdfStaticContent in,
+PDF bytes out. Covers determinism, PDF validity, the domain boundary,
+content/formatting, pagination, static-content failure modes and the
+resolved payment-display contract.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import io
+import os
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pypdf import PdfReader
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+from catering_system.domain.offer_pdf import (
+    OfferDocumentUnsupportedSchemaError,
+    OfferPdfMalformedSnapshotError,
+    OfferPdfMissingStaticContentError,
+    OfferPdfStaticContent,
+    OfferPdfUnsupportedCharacterError,
+)
+from catering_system.services.offer_document_snapshot_hash import compute_document_hash
+from catering_system.services.offer_pdf_renderer import (
+    _eur,
+    _payment_terms_line,
+    offer_document_pdf_filename,
+    render_offer_document_pdf,
+)
+from tests.unit.test_offer_document_snapshot import _valid_snapshot
+
+_RENDERER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "catering_system"
+    / "services"
+    / "offer_pdf_renderer.py"
+)
+
+
+def _static(**overrides: object) -> OfferPdfStaticContent:
+    base: dict[str, object] = dict(
+        company_legal_name="TEST Catering GmbH [PLATZHALTER]",
+        company_address_lines=("Teststraße 1", "20095 Hamburg", "Deutschland"),
+        acceptance_statement="[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]",
+        footer_note="TEST FOOTER — Silberlöffel Event Catering Service",
+    )
+    base.update(overrides)
+    return OfferPdfStaticContent(**base)  # type: ignore[arg-type]
+
+
+def _text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() for page in reader.pages)
+
+
+# --- determinism ------------------------------------------------------------------
+
+
+def test_repeated_render_is_byte_identical() -> None:
+    snap = _valid_snapshot()
+    static = _static()
+    a = render_offer_document_pdf(snap, static)
+    b = render_offer_document_pdf(snap, static)
+    assert a == b
+    assert hashlib.sha256(a).hexdigest() == hashlib.sha256(b).hexdigest()
+
+
+def test_different_created_at_changes_output() -> None:
+    snap = _valid_snapshot()
+    other = replace(snap, created_at=datetime(2030, 1, 1, tzinfo=UTC))
+    other = replace(other, document_hash=compute_document_hash(other))
+    static = _static()
+    a = render_offer_document_pdf(snap, static)
+    b = render_offer_document_pdf(other, static)
+    assert a != b
+
+
+def test_metadata_creation_date_reflects_snapshot_created_at() -> None:
+    snap = _valid_snapshot()
+    pdf = render_offer_document_pdf(snap, _static())
+    assert b"D:20260720090000+00'00'" in pdf
+
+
+# --- PDF validity ----------------------------------------------------------------
+
+
+def test_output_starts_with_pdf_magic_bytes() -> None:
+    pdf = render_offer_document_pdf(_valid_snapshot(), _static())
+    assert pdf[:5] == b"%PDF-"
+
+
+def test_parser_opens_output_and_reports_expected_page_count() -> None:
+    pdf = render_offer_document_pdf(_valid_snapshot(), _static())
+    reader = PdfReader(io.BytesIO(pdf))
+    assert len(reader.pages) == 1
+
+
+def test_extracted_text_contains_expected_content() -> None:
+    text = _text(render_offer_document_pdf(_valid_snapshot(), _static()))
+    assert "ANGEBOT / AUFTRAGSBESTÄTIGUNG" in text
+    assert "Fingerfood Paket" in text
+
+
+# --- boundary ----------------------------------------------------------------------
+
+
+def test_renderer_module_has_no_forbidden_imports() -> None:
+    """AST-based, not a text grep: parses the real import graph so a rename
+    or an indirect import trick can't silently defeat the check."""
+    tree = ast.parse(_RENDERER_PATH.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+
+    forbidden_substrings = (
+        "repositories",
+        "inquiry",
+        "offer_service",
+        "catalog",
+        "urllib",
+        "http.client",
+        "socket",
+        "sqlite3",
+    )
+    violations = [
+        module
+        for module in imported
+        if any(bad in module.lower() for bad in forbidden_substrings)
+    ]
+    assert violations == []
+    assert "catering_system.domain.offer_document_snapshot" in imported
+    assert "catering_system.domain.offer_pdf" in imported
+
+
+def test_render_does_not_write_to_filesystem(tmp_path: Path) -> None:
+    before = set(os.listdir(tmp_path))
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        render_offer_document_pdf(_valid_snapshot(), _static())
+    finally:
+        os.chdir(cwd)
+    after = set(os.listdir(tmp_path))
+    assert before == after
+
+
+def test_snapshot_is_unchanged_after_render() -> None:
+    snap = _valid_snapshot()
+    before = replace(snap)
+    render_offer_document_pdf(snap, _static())
+    assert snap == before
+
+
+# --- content -----------------------------------------------------------------------
+
+
+def test_recipient_and_invoice_address_present() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert snap.recipient_name in text
+    assert snap.recipient_company in text
+    assert snap.invoice_address.street in text
+    assert "Rechnungsadresse" in text
+
+
+def test_delivery_address_visible_for_delivery() -> None:
+    snap = _valid_snapshot()  # DELIVERY, delivery_address == invoice_address here
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Lieferadresse" in text
+
+
+def test_differing_delivery_address_is_neutrally_highlighted() -> None:
+    delivery = CustomerAddress(
+        street="Eventplatz 9", postal_code="20457", city="Hamburg", country="DE"
+    )
+    snap = _valid_snapshot(delivery_address=delivery, delivery_address_differs=True)
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "abweichend" in text
+    assert delivery.street in text
+    # neutral label only — no marker/handwriting-style wording
+    assert "!!" not in text
+    assert "ACHTUNG" not in text.upper() or "achtung" not in text.lower()
+
+
+def test_pickup_suppresses_delivery_address() -> None:
+    snap = _valid_snapshot(
+        fulfillment_mode="PICKUP", delivery_address=None, delivery_address_differs=False
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Lieferadresse" not in text
+    assert "Abholung" in text
+
+
+def test_optional_narrative_omitted_when_absent() -> None:
+    snap = _valid_snapshot()
+    assert snap.customer_title is None
+    assert snap.customer_introduction is None
+    assert snap.customer_notes is None
+    pdf = render_offer_document_pdf(snap, _static())
+    # renders without error and without any narrative-section artifact
+    assert pdf[:5] == b"%PDF-"
+
+
+def test_narrative_sections_render_when_present() -> None:
+    snap = _valid_snapshot(
+        customer_title="Sommerfest 2026",
+        customer_introduction="Vielen Dank für Ihre Anfrage.",
+        customer_notes="Bitte pünktlich liefern.",
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Sommerfest 2026" in text
+    assert "Vielen Dank für Ihre Anfrage." in text
+    assert "Bitte pünktlich liefern." in text
+
+
+def test_positions_vat_and_totals_present() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Leistungen" in text
+    assert "MwSt.-Übersicht" in text
+    assert "Summe netto:" in text
+    assert "Summe MwSt.:" in text
+    assert "Summe brutto:" in text
+
+
+def test_acceptance_block_present() -> None:
+    static = _static()
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert static.acceptance_statement in text
+    assert "Ort:" in text
+    assert "Datum:" in text
+    assert "Name:" in text
+    assert "Unterschrift:" in text
+
+
+def test_static_footer_present() -> None:
+    static = _static(footer_note="TEST FOOTER Silberlöffel")
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert "TEST FOOTER Silberlöffel" in text
+
+
+# --- forbidden content -----------------------------------------------------------
+
+
+_FORBIDDEN_TERMS = (
+    "Kisten",
+    "Chafer",
+    "M-Gläser",
+    "Vorleger",
+    "Geschirr",
+    "Besteck",
+    "Rechnungsnummer",
+)
+
+
+def test_forbidden_internal_terms_and_invoice_number_absent() -> None:
+    text = _text(render_offer_document_pdf(_valid_snapshot(), _static()))
+    for term in _FORBIDDEN_TERMS:
+        assert term not in text
+
+
+def test_snapshot_id_and_document_hash_not_visible() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert snap.offer_document_snapshot_id not in text
+    assert snap.document_hash not in text
+
+
+def test_document_warnings_never_rendered_as_raw_codes() -> None:
+    delivery = CustomerAddress(
+        street="Eventplatz 9", postal_code="20457", city="Hamburg", country="DE"
+    )
+    snap = _valid_snapshot(
+        delivery_address=delivery,
+        delivery_address_differs=True,
+        document_warnings=("WARNING_DELIVERY_ADDRESS_DIFFERS",),
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "WARNING_DELIVERY_ADDRESS_DIFFERS" not in text
+
+
+# --- formatting ----------------------------------------------------------------------
+
+
+def test_eur_formatting_matches_de_de_convention() -> None:
+    assert _eur(0) == "0,00 €"
+    assert _eur(123456) == "1.234,56 €"
+    assert _eur(123456789) == "1.234.567,89 €"
+
+
+def test_vat_rate_formatting() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "7 %" in text
+
+
+def test_german_diacritics_and_euro_sign_round_trip() -> None:
+    snap = _valid_snapshot(location_text="Straße Bürostraße äöüß")
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "äöüß" in text
+    assert "€" in text
+
+
+def test_multiline_narrative_preserves_all_lines() -> None:
+    snap = _valid_snapshot(customer_notes="Zeile eins.\nZeile zwei.\nZeile drei.")
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Zeile eins." in text
+    assert "Zeile zwei." in text
+    assert "Zeile drei." in text
+
+
+def test_long_company_and_customer_names_render() -> None:
+    long_name = (
+        "Sehr Lange Firmierung Mit Vielen Wörtern Catering & Event GmbH & Co. KG"
+    )
+    snap = _valid_snapshot(recipient_company=long_name)
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Sehr Lange Firmierung" in text
+
+
+def test_optional_fields_absent_render_without_error() -> None:
+    snap = _valid_snapshot(
+        recipient_phone=None, guest_count_estimate=None, recipient_company=None
+    )
+    pdf = render_offer_document_pdf(snap, _static())
+    assert pdf[:5] == b"%PDF-"
+
+
+# --- pagination ------------------------------------------------------------------
+
+
+def _many_positions(snap: OfferDocumentSnapshot, count: int) -> OfferDocumentSnapshot:
+    base_pos = snap.positions[0]
+    positions = tuple(
+        replace(base_pos, position_id=f"pos-{i}", name=f"Fingerfood Paket {i}")
+        for i in range(count)
+    )
+    long = replace(snap, positions=positions)
+    return replace(long, document_hash=compute_document_hash(long))
+
+
+def test_standard_fixture_produces_one_page() -> None:
+    pdf = render_offer_document_pdf(_valid_snapshot(), _static())
+    assert len(PdfReader(io.BytesIO(pdf)).pages) == 1
+
+
+def test_long_fixture_spans_multiple_pages_without_truncation() -> None:
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, _static())
+    reader = PdfReader(io.BytesIO(pdf))
+    assert len(reader.pages) > 1
+    full_text = "\n".join(p.extract_text() for p in reader.pages)
+    assert "Fingerfood Paket 0" in full_text
+    assert "Fingerfood Paket 39" in full_text
+    assert "Annahme" in full_text
+
+
+def test_long_fixture_repeats_table_header() -> None:
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, _static())
+    reader = PdfReader(io.BytesIO(pdf))
+    header_hits = sum(1 for p in reader.pages if "Position" in p.extract_text())
+    assert header_hits >= 2
+
+
+def test_long_fixture_document_reference_repeated_on_every_page() -> None:
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, _static())
+    reader = PdfReader(io.BytesIO(pdf))
+    assert len(reader.pages) > 1
+    for page in reader.pages:
+        assert snap.document_reference in page.extract_text()
+
+
+def test_acceptance_block_on_final_page() -> None:
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, _static())
+    reader = PdfReader(io.BytesIO(pdf))
+    last_page_text = reader.pages[-1].extract_text()
+    assert "Annahme" in last_page_text
+    assert "Unterschrift:" in last_page_text
+    # acceptance is the last flowable in the story, so it never appears
+    # ahead of later positions content on an earlier page.
+    for page in reader.pages[:-1]:
+        assert "Annahme" not in page.extract_text()
+
+
+# --- schema/malformed defense -------------------------------------------------------
+
+
+def test_unsupported_schema_version_fails_closed() -> None:
+    snap = _valid_snapshot()
+    tampered = object.__new__(OfferDocumentSnapshot)
+    for field in snap.__dataclass_fields__:
+        object.__setattr__(tampered, field, getattr(snap, field))
+    object.__setattr__(tampered, "schema_version", 2)
+    with pytest.raises(OfferDocumentUnsupportedSchemaError):
+        render_offer_document_pdf(tampered, _static())
+
+
+def test_empty_positions_fails_closed() -> None:
+    snap = _valid_snapshot()
+    tampered = object.__new__(OfferDocumentSnapshot)
+    for field in snap.__dataclass_fields__:
+        object.__setattr__(tampered, field, getattr(snap, field))
+    object.__setattr__(tampered, "positions", ())
+    with pytest.raises(OfferPdfMalformedSnapshotError):
+        render_offer_document_pdf(tampered, _static())
+
+
+# --- unsupported characters --------------------------------------------------------
+
+
+def test_unsupported_character_in_recipient_name_raises() -> None:
+    snap = _valid_snapshot(recipient_name="Анна Иванова")
+    with pytest.raises(OfferPdfUnsupportedCharacterError) as excinfo:
+        render_offer_document_pdf(snap, _static())
+    assert excinfo.value.field == "recipient_name"
+
+
+def test_unsupported_character_in_static_content_raises() -> None:
+    snap = _valid_snapshot()
+    static = _static(footer_note="Анна")
+    with pytest.raises(OfferPdfUnsupportedCharacterError) as excinfo:
+        render_offer_document_pdf(snap, static)
+    assert excinfo.value.field == "footer_note"
+
+
+def test_unsupported_character_never_produces_partial_output() -> None:
+    """A rejected render must not leave a caller holding mangled bytes."""
+    snap = _valid_snapshot(recipient_name="Анна Иванова")
+    with pytest.raises(OfferPdfUnsupportedCharacterError):
+        render_offer_document_pdf(snap, _static())
+
+
+# --- static content --------------------------------------------------------------
+
+
+def test_missing_company_name_fails() -> None:
+    with pytest.raises(OfferPdfMissingStaticContentError):
+        OfferPdfStaticContent(
+            company_legal_name="",
+            company_address_lines=("x",),
+            acceptance_statement="y",
+        )
+
+
+def test_missing_company_address_fails() -> None:
+    with pytest.raises(OfferPdfMissingStaticContentError):
+        OfferPdfStaticContent(
+            company_legal_name="x", company_address_lines=(), acceptance_statement="y"
+        )
+    with pytest.raises(OfferPdfMissingStaticContentError):
+        OfferPdfStaticContent(
+            company_legal_name="x",
+            company_address_lines=("   ",),
+            acceptance_statement="y",
+        )
+
+
+def test_missing_acceptance_statement_fails() -> None:
+    with pytest.raises(OfferPdfMissingStaticContentError):
+        OfferPdfStaticContent(
+            company_legal_name="x",
+            company_address_lines=("y",),
+            acceptance_statement="",
+        )
+
+
+def test_blank_placeholder_static_content_cannot_be_constructed() -> None:
+    """Guards against an empty/whitespace placeholder silently reaching a
+    future production-style composition."""
+    with pytest.raises(OfferPdfMissingStaticContentError):
+        OfferPdfStaticContent(
+            company_legal_name="   ",
+            company_address_lines=("   ",),
+            acceptance_statement="   ",
+        )
+
+
+def test_vorkasse_bank_details_render_only_when_supplied() -> None:
+    snap = _valid_snapshot(
+        payment_method="VORKASSE", payment_customer_visible_text="Zahlung per Vorkasse"
+    )
+    with_bank = _static(bank_details_text="IBAN DE00 TEST 0000 0000 00")
+    without_bank = _static()
+
+    text_with = _text(render_offer_document_pdf(snap, with_bank))
+    assert "IBAN DE00 TEST 0000 0000 00" in text_with
+
+    text_without = _text(render_offer_document_pdf(snap, without_bank))
+    assert "IBAN" not in text_without
+
+
+def test_bank_details_absent_does_not_block_rendering() -> None:
+    snap = _valid_snapshot(
+        payment_method="VORKASSE", payment_customer_visible_text="Zahlung per Vorkasse"
+    )
+    pdf = render_offer_document_pdf(snap, _static())
+    assert pdf[:5] == b"%PDF-"
+
+
+def test_bank_details_not_rendered_for_non_vorkasse() -> None:
+    snap = _valid_snapshot()  # RECHNUNG in the base fixture
+    static = _static(bank_details_text="IBAN DE00 TEST 0000 0000 00")
+    text = _text(render_offer_document_pdf(snap, static))
+    assert "IBAN" not in text
+
+
+# --- payment contract (resolved) --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "label"),
+    [
+        ("VORKASSE", "Vorkasse"),
+        ("RECHNUNG", "Rechnung"),
+        ("BAR_VOR_ORT", "Bar vor Ort"),
+    ],
+)
+def test_canonical_payment_label_always_rendered(method: str, label: str) -> None:
+    snap = _valid_snapshot(payment_method=method, payment_customer_visible_text=label)
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert f"Zahlungsart: {label}" in text
+
+
+@pytest.mark.parametrize(
+    ("method", "text_value"),
+    [
+        ("RECHNUNG", "Zahlung per Rechnung"),
+        ("VORKASSE", "Zahlung per Vorkasse"),
+        ("RECHNUNG", "Rechnung laut Vereinbarung."),
+    ],
+)
+def test_richer_customer_visible_text_renders_alongside_label(
+    method: str, text_value: str
+) -> None:
+    snap = _valid_snapshot(
+        payment_method=method, payment_customer_visible_text=text_value
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert f"Zahlungsbedingungen: {text_value}" in text
+
+
+def test_exact_label_duplicate_is_suppressed() -> None:
+    snap = _valid_snapshot(
+        payment_method="RECHNUNG", payment_customer_visible_text="Rechnung"
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Zahlungsart: Rechnung" in text
+    assert "Zahlungsbedingungen:" not in text
+
+
+def test_case_insensitive_label_duplicate_is_suppressed() -> None:
+    assert _payment_terms_line("RECHNUNG", "RECHNUNG") is None
+    assert _payment_terms_line("RECHNUNG", "rechnung") is None
+
+
+def test_outer_whitespace_normalized_for_duplicate_comparison() -> None:
+    snap = _valid_snapshot(
+        payment_method="RECHNUNG", payment_customer_visible_text="  Rechnung  "
+    )
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Zahlungsbedingungen:" not in text
+
+
+def test_internal_text_and_punctuation_preserved_when_shown() -> None:
+    value = "Rechnung laut Vereinbarung."
+    line = _payment_terms_line("RECHNUNG", value)
+    assert line == value  # not rewritten, not stripped of punctuation
+
+
+def test_no_ueberweisung_invented() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert "Überweisung" not in text
+
+
+# --- filename ------------------------------------------------------------------------
+
+
+def test_filename_matches_document_reference() -> None:
+    snap = _valid_snapshot()
+    assert offer_document_pdf_filename(snap) == f"{snap.document_reference}.pdf"
+    assert snap.document_reference == "ANG-7B5A5A7D-V1"
+    assert offer_document_pdf_filename(snap) == "ANG-7B5A5A7D-V1.pdf"

--- a/tests/unit/test_offer_pdf_renderer.py
+++ b/tests/unit/test_offer_pdf_renderer.py
@@ -251,6 +251,114 @@ def test_static_footer_present() -> None:
     assert "TEST FOOTER Silberlöffel" in text
 
 
+# --- static company contact/legal details (REVIEW FIX) --------------------------
+
+
+def _static_with_contact_details(**overrides: object) -> OfferPdfStaticContent:
+    base: dict[str, object] = dict(
+        company_phone="+49 40 000000",
+        company_email="info@test.invalid",
+        company_web="www.test.invalid",
+        company_register_text="HRB TEST 00000",
+        company_vat_id_text="DE000000000",
+    )
+    base.update(overrides)
+    return _static(**base)
+
+
+def test_all_five_company_fields_render_when_supplied() -> None:
+    static = _static_with_contact_details()
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert "Telefon: +49 40 000000" in text
+    assert "E-Mail: info@test.invalid" in text
+    assert "Web: www.test.invalid" in text
+    assert "HRB TEST 00000" in text
+    assert "DE000000000" in text
+
+
+def test_optional_contact_and_legal_fields_omitted_without_blank_labels() -> None:
+    static = _static(
+        footer_note=None,
+        company_phone=None,
+        company_email=None,
+        company_web=None,
+        company_register_text=None,
+        company_vat_id_text=None,
+    )
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert "Telefon" not in text
+    assert "E-Mail" not in text
+    assert "Web" not in text
+    # no stray separator or empty footer line either
+    assert "· ·" not in text
+    assert " · \n" not in text
+
+
+def test_contact_fields_with_markup_characters_render_as_inert_text() -> None:
+    static = _static_with_contact_details(
+        company_phone="+49 40 000000",
+        company_email="info<test>@test.invalid & co",
+    )
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert "info<test>@test.invalid & co" in text
+
+
+def test_legal_footer_fields_with_markup_characters_render_as_inert_text() -> None:
+    static = _static_with_contact_details(
+        company_register_text="HRB <TEST> & Co 00000",
+    )
+    text = _text(render_offer_document_pdf(_valid_snapshot(), static))
+    assert "HRB <TEST> & Co 00000" in text
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "company_phone",
+        "company_email",
+        "company_web",
+        "company_register_text",
+        "company_vat_id_text",
+    ],
+)
+def test_unsupported_glyph_in_company_field_raises_before_pdf_returned(
+    field: str,
+) -> None:
+    static = _static_with_contact_details(**{field: "Анна"})
+    with pytest.raises(OfferPdfUnsupportedCharacterError) as excinfo:
+        render_offer_document_pdf(_valid_snapshot(), static)
+    assert excinfo.value.field == field
+
+
+def test_repeated_render_with_all_company_fields_is_byte_identical() -> None:
+    static = _static_with_contact_details()
+    snap = _valid_snapshot()
+    a = render_offer_document_pdf(snap, static)
+    b = render_offer_document_pdf(snap, static)
+    assert a == b
+    assert hashlib.sha256(a).hexdigest() == hashlib.sha256(b).hexdigest()
+
+
+def test_standard_fixture_with_company_fields_remains_one_page() -> None:
+    static = _static_with_contact_details()
+    pdf = render_offer_document_pdf(_valid_snapshot(), static)
+    assert len(PdfReader(io.BytesIO(pdf)).pages) == 1
+
+
+def test_long_fixture_with_company_fields_remains_valid_and_shows_footer() -> None:
+    static = _static_with_contact_details()
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, static)
+    reader = PdfReader(io.BytesIO(pdf))
+    assert len(reader.pages) > 1
+    full_text = "\n".join(p.extract_text() for p in reader.pages)
+    assert "HRB TEST 00000" in full_text
+    assert "DE000000000" in full_text
+    # same deterministic footer line on every page, not just the first
+    for page in reader.pages:
+        assert "HRB TEST 00000" in page.extract_text()
+
+
 # --- forbidden content -----------------------------------------------------------
 
 

--- a/tests/unit/test_offer_pdf_renderer.py
+++ b/tests/unit/test_offer_pdf_renderer.py
@@ -25,13 +25,21 @@ from catering_system.domain.offer_pdf import (
     OfferDocumentUnsupportedSchemaError,
     OfferPdfMalformedSnapshotError,
     OfferPdfMissingStaticContentError,
+    OfferPdfRenderError,
     OfferPdfStaticContent,
     OfferPdfUnsupportedCharacterError,
 )
 from catering_system.services.offer_document_snapshot_hash import compute_document_hash
 from catering_system.services.offer_pdf_renderer import (
+    _BOTTOM_MARGIN,
+    _FOOTER_AVAILABLE_WIDTH,
+    _FOOTER_LEADING,
+    _FOOTER_MAX_HEIGHT,
+    _UPPER_FOOTER_Y,
     _eur,
+    _footer_paragraph,
     _payment_terms_line,
+    _styles,
     offer_document_pdf_filename,
     render_offer_document_pdf,
 )
@@ -60,6 +68,12 @@ def _static(**overrides: object) -> OfferPdfStaticContent:
 def _text(pdf_bytes: bytes) -> str:
     reader = PdfReader(io.BytesIO(pdf_bytes))
     return "\n".join(page.extract_text() for page in reader.pages)
+
+
+def _normalize_ws(text: str) -> str:
+    """Collapse whitespace/newlines so a substring check survives a
+    Paragraph's own visual line wrap (pypdf inserts a newline per line)."""
+    return " ".join(text.split())
 
 
 # --- determinism ------------------------------------------------------------------
@@ -357,6 +371,141 @@ def test_long_fixture_with_company_fields_remains_valid_and_shows_footer() -> No
     # same deterministic footer line on every page, not just the first
     for page in reader.pages:
         assert "HRB TEST 00000" in page.extract_text()
+
+
+# --- footer layout (REVIEW FIX: no overlap with page number) --------------------
+
+_REALISTIC_FOOTER_NOTE = "Bei Rückfragen wenden Sie sich bitte an unser Büro."
+_REALISTIC_REGISTER_TEXT = "Handelsregister: Amtsgericht Hamburg, HRB 123456"
+_REALISTIC_VAT_ID_TEXT = "USt-IdNr. DE123456789"
+
+_VERY_LONG_FOOTER_NOTE = (
+    "Bei Rückfragen wenden Sie sich bitte an unser Büro in Hamburg, wir "
+    "freuen uns auf Ihre Nachricht. "
+)
+_VERY_LONG_REGISTER_TEXT = (
+    "Handelsregister: Amtsgericht Hamburg-Mitte, Handelsregisternummer "
+    "HRB 987654321 Abteilung B "
+)
+_VERY_LONG_VAT_ID_TEXT = (
+    "Umsatzsteuer-Identifikationsnummer gemäß Paragraph 27a "
+    "Umsatzsteuergesetz: DE999888777"
+)
+
+
+def _static_realistic_footer(**overrides: object) -> OfferPdfStaticContent:
+    base: dict[str, object] = dict(
+        footer_note=_REALISTIC_FOOTER_NOTE,
+        company_register_text=_REALISTIC_REGISTER_TEXT,
+        company_vat_id_text=_REALISTIC_VAT_ID_TEXT,
+    )
+    base.update(overrides)
+    return _static(**base)
+
+
+def test_realistic_combined_footer_fits_and_does_not_overlap_page_number() -> None:
+    """This exact combination (475pt at Helvetica 8) overflowed the old
+    single-baseline layout (~447pt available alongside 'Seite N'). With the
+    upper footer area now using the full page width and a separate lower
+    line for document_reference/Seite N, it must fit without any shared
+    horizontal space — measured directly, not inferred from text order."""
+    static = _static_realistic_footer()
+    paragraph = _footer_paragraph(static, _styles())
+    width, height = paragraph.wrap(_FOOTER_AVAILABLE_WIDTH, _FOOTER_MAX_HEIGHT * 100)
+    assert width <= _FOOTER_AVAILABLE_WIDTH
+    assert height <= _FOOTER_MAX_HEIGHT
+
+    pdf = render_offer_document_pdf(_valid_snapshot(), static)
+    text = _text(pdf)
+    assert _REALISTIC_FOOTER_NOTE in text
+    assert _REALISTIC_REGISTER_TEXT in text
+    assert _REALISTIC_VAT_ID_TEXT in text
+    assert len(PdfReader(io.BytesIO(pdf)).pages) == 1
+
+
+def test_very_long_footer_wraps_onto_multiple_lines_within_budget() -> None:
+    static = _static_realistic_footer(
+        footer_note=_VERY_LONG_FOOTER_NOTE,
+        company_register_text=_VERY_LONG_REGISTER_TEXT,
+        company_vat_id_text=_VERY_LONG_VAT_ID_TEXT,
+    )
+    paragraph = _footer_paragraph(static, _styles())
+    _, height = paragraph.wrap(_FOOTER_AVAILABLE_WIDTH, _FOOTER_MAX_HEIGHT * 100)
+    assert height > _FOOTER_LEADING  # genuinely wraps onto more than one line
+    assert height <= _FOOTER_MAX_HEIGHT  # still within the supported budget
+
+    pdf = render_offer_document_pdf(_valid_snapshot(), static)
+    text = _normalize_ws(_text(pdf))
+    assert _normalize_ws(_VERY_LONG_FOOTER_NOTE) in text
+    assert _normalize_ws(_VERY_LONG_REGISTER_TEXT) in text
+    assert _normalize_ws(_VERY_LONG_VAT_ID_TEXT) in text
+
+
+def test_short_footer_needs_only_one_line() -> None:
+    static = _static(footer_note="Kurzer Hinweis.")
+    paragraph = _footer_paragraph(static, _styles())
+    _, height = paragraph.wrap(_FOOTER_AVAILABLE_WIDTH, _FOOTER_MAX_HEIGHT * 100)
+    assert height == pytest.approx(_FOOTER_LEADING)
+
+
+def test_document_reference_and_page_number_present_on_lower_line() -> None:
+    snap = _valid_snapshot()
+    text = _text(render_offer_document_pdf(snap, _static()))
+    assert snap.document_reference in text
+    assert "Seite 1" in text
+
+
+def test_multipage_wrapped_footer_present_on_every_page() -> None:
+    static = _static_realistic_footer(
+        footer_note=_VERY_LONG_FOOTER_NOTE,
+        company_register_text=_VERY_LONG_REGISTER_TEXT,
+        company_vat_id_text=_VERY_LONG_VAT_ID_TEXT,
+    )
+    snap = _many_positions(_valid_snapshot(), 40)
+    pdf = render_offer_document_pdf(snap, static)
+    reader = PdfReader(io.BytesIO(pdf))
+    assert len(reader.pages) > 1
+    for page in reader.pages:
+        page_text = _normalize_ws(page.extract_text())
+        assert _normalize_ws(_VERY_LONG_REGISTER_TEXT) in page_text
+
+
+def test_reserved_footer_height_geometry_invariant() -> None:
+    """ReportLab-measured proof, not text-order inference: the document's
+    own bottomMargin always reserves at least the worst-case wrapped footer
+    area, so Platypus's frame layout structurally cannot place story
+    content (positions/totals/acceptance) inside the footer band."""
+    assert _BOTTOM_MARGIN >= _UPPER_FOOTER_Y + _FOOTER_MAX_HEIGHT
+
+
+def test_body_content_does_not_overlap_footer_area() -> None:
+    static = _static_realistic_footer()
+    pdf = render_offer_document_pdf(_valid_snapshot(), static)
+    text = _text(pdf)
+    # totals and acceptance are present (not pushed off/into the footer)
+    assert "Summe brutto:" in text
+    assert "Annahme" in text
+    assert len(PdfReader(io.BytesIO(pdf)).pages) == 1
+
+
+def test_extremely_long_footer_fails_closed_not_clipped() -> None:
+    excessive = "Sehr langer Footertext. " * 40
+    static = _static(footer_note=excessive)
+    with pytest.raises(OfferPdfRenderError):
+        render_offer_document_pdf(_valid_snapshot(), static)
+
+
+def test_repeated_render_with_wrapped_footer_is_byte_identical() -> None:
+    static = _static_realistic_footer(
+        footer_note=_VERY_LONG_FOOTER_NOTE,
+        company_register_text=_VERY_LONG_REGISTER_TEXT,
+        company_vat_id_text=_VERY_LONG_VAT_ID_TEXT,
+    )
+    snap = _valid_snapshot()
+    a = render_offer_document_pdf(snap, static)
+    b = render_offer_document_pdf(snap, static)
+    assert a == b
+    assert hashlib.sha256(a).hexdigest() == hashlib.sha256(b).hexdigest()
 
 
 # --- forbidden content -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a pure deterministic ReportLab renderer for `ANGEBOT / AUFTRAGSBESTÄTIGUNG`
- render only from immutable `OfferDocumentSnapshot` and explicit `OfferPdfStaticContent`
- produce byte-identical PDF output for identical inputs
- format dates, VAT and money using German customer-facing conventions
- support one-page normal offers and safe multi-page overflow
- render recipient, addresses, event, narrative, positions, totals, payment and acceptance sections
- render optional company contact, register and VAT-ID content
- reserve a width-aware multi-line footer area without overlapping page numbers or body content
- reject unsupported characters and excessive footer content without producing a partial PDF

## Scope boundaries

Not included:

- PDF API endpoint
- Office Panel UI
- PDF storage
- email sending
- signed-file upload
- AcceptanceEvidence changes
- Offer-to-Order conversion changes
- post-Order change documents
- production deployment

## Dependencies

- `reportlab==5.0.0` — runtime
- `pypdf==6.14.2` — dev/test only
- `types-reportlab==4.5.1.20260724` — dev/type-check only

## Verification

- 1876 full repository tests passed
- coverage 90.3%, threshold 90%
- renderer tests: 77 passed after review fixes
- Ruff check passed
- Ruff format check passed
- Mypy passed
- Node tests 24/24 passed
- deterministic one-page and multi-page PDF hashes verified
- independent review completed
- final delta verdict: `APPROVE DELTA — READY TO PUSH`

## Commits

- `da47bdb` Add deterministic offer PDF renderer
- `0469a94` Render static company details in offer PDF
- `94b9535` Fix offer PDF footer wrapping