### PR TITLE
Add offer PDF download endpoint

### DIFF
--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -54,6 +54,11 @@ from catering_system.domain.offer_document_snapshot import (
     OfferDocumentCreationBlocked,
     OfferDocumentVariantConflictError,
 )
+from catering_system.domain.offer_pdf import (
+    OfferPdfRenderError,
+    OfferPdfStaticContent,
+    OfferPdfUnsupportedCharacterError,
+)
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
@@ -115,6 +120,10 @@ from catering_system.services.inquiry_service import (
 from catering_system.services.offer_document_snapshot_service import (
     OfferDocumentNotFoundError,
     OfferDocumentSnapshotService,
+)
+from catering_system.services.offer_pdf_renderer import (
+    offer_document_pdf_filename,
+    render_offer_document_pdf,
 )
 from catering_system.services.offer_service import OfferService
 from catering_system.services.operational_core_service import OperationalCoreService
@@ -403,8 +412,14 @@ class OfficeApi:
     """All routes against one shared connection; commands run inside the
     CoreCommandExecutor so precondition + write + ledger are atomic."""
 
-    def __init__(self, connection: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        offer_pdf_static_content: OfferPdfStaticContent,
+    ) -> None:
         self._conn = connection
+        self.offer_pdf_static_content = offer_pdf_static_content
         self.inquiries = SQLiteInquiryRepository.from_connection(connection)
         bootstrap_customer_identity_schema(connection)
         self.orders = SQLiteOrderRepository.from_connection(connection)
@@ -1235,6 +1250,33 @@ class OfficeApi:
             "offer_document_snapshot_id": snapshot.offer_document_snapshot_id,
             "snapshot": views.offer_document_snapshot_summary(snapshot),
         }
+
+    def offer_document_pdf(
+        self, offer_id: str, offer_version_id: str | None
+    ) -> tuple[bytes, str]:
+        """Render the already-persisted immutable snapshot to PDF.
+
+        Read-only: never creates a snapshot, never touches Inquiry/Offer/
+        catalog. Same ownership check as the JSON read (offer_document)."""
+        if offer_version_id is None:
+            raise _invalid()
+        snapshot = self.offer_document_service.get_by_offer_version_id(offer_version_id)
+        if snapshot is None or snapshot.offer_id != offer_id:
+            raise ApiError(404, "not_found")
+        try:
+            pdf_bytes = render_offer_document_pdf(
+                snapshot, self.offer_pdf_static_content
+            )
+        except OfferPdfUnsupportedCharacterError as exc:
+            raise ApiError(422, "offer_pdf_unsupported_character") from exc
+        except OfferPdfRenderError as exc:
+            # Reachable case is configured static content that does not fit
+            # the reserved footer area — an operator-fixable validation
+            # failure, not an unexpected internal fault. The renderer's own
+            # messages never carry paths or library internals, and only the
+            # stable code below is returned to the client.
+            raise ApiError(422, "offer_pdf_render_failed") from exc
+        return pdf_bytes, offer_document_pdf_filename(snapshot)
 
     def cmd_prepare_next_version(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
@@ -2261,6 +2303,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         {"POST": "offer-document", "GET": "offer_document"},
     ),
     (
+        re.compile(r"^/office/v1/offers/(?P<offer_id>[^/]+)/offer-document/pdf$"),
+        "/office/v1/offers/{offer_id}/offer-document/pdf",
+        {"GET": "offer_document_pdf"},
+    ),
+    (
         re.compile(r"^/office/v1/tasks$"),
         "/office/v1/tasks",
         {"GET": "list_tasks"},
@@ -2529,6 +2576,28 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
             self.end_headers()
             self.wfile.write(payload)
 
+        def _respond_bytes(
+            self,
+            status: int,
+            payload: bytes,
+            *,
+            content_type: str,
+            filename: str | None = None,
+        ) -> None:
+            if len(payload) > _MAX_RESPONSE_BYTES:
+                raise ApiError(500, "internal")
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            if filename is not None:
+                self.send_header(
+                    "Content-Disposition", f'attachment; filename="{filename}"'
+                )
+            self.end_headers()
+            self.wfile.write(payload)
+
         def _error(
             self,
             status: int,
@@ -2783,6 +2852,19 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
                     else None
                 )
                 self._respond(200, api.offer_document(path_ids["offer_id"], version_id))
+            elif kind == "offer_document_pdf":
+                params = self._query({"offer_version_id"})
+                version_id = (
+                    _v_uuid(params["offer_version_id"])
+                    if "offer_version_id" in params
+                    else None
+                )
+                pdf_bytes, filename = api.offer_document_pdf(
+                    path_ids["offer_id"], version_id
+                )
+                self._respond_bytes(
+                    200, pdf_bytes, content_type="application/pdf", filename=filename
+                )
             elif kind == "inquiry_detail":
                 self._query(set())
                 self._respond(200, api.inquiry_detail(path_ids["id"]))
@@ -2919,12 +3001,74 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
 
 
 def create_office_api_server(
-    db_path: str, token: str, host: str = "127.0.0.1", port: int = 0
+    db_path: str,
+    token: str,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    *,
+    offer_pdf_static_content: OfferPdfStaticContent,
 ) -> HTTPServer:
     """Build connection, repositories and server in the calling thread —
     single-threaded on purpose (sqlite3 thread affinity, Entry 048)."""
-    api = OfficeApi(open_core_connection(db_path))
+    api = OfficeApi(
+        open_core_connection(db_path),
+        offer_pdf_static_content=offer_pdf_static_content,
+    )
     return HTTPServer((host, port), make_office_api_handler(api, token))
+
+
+def _offer_pdf_static_content_from_env() -> OfferPdfStaticContent:
+    """OFFER_PDF_DOWNLOAD_V1: no approved production company/legal text
+    exists yet. Required facts are read from environment variables and
+    startup refuses to proceed if any are missing — never invented,
+    never a test placeholder silently reaching production composition."""
+    import os
+
+    legal_name = os.environ.get("OFFICE_PDF_COMPANY_LEGAL_NAME", "").strip()
+    address_raw = os.environ.get("OFFICE_PDF_COMPANY_ADDRESS_LINES", "").strip()
+    acceptance = os.environ.get("OFFICE_PDF_ACCEPTANCE_STATEMENT", "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("OFFICE_PDF_COMPANY_LEGAL_NAME", legal_name),
+            ("OFFICE_PDF_COMPANY_ADDRESS_LINES", address_raw),
+            ("OFFICE_PDF_ACCEPTANCE_STATEMENT", acceptance),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit(
+            "Missing required offer-PDF static content environment "
+            "variable(s): " + ", ".join(missing) + " — refusing to start "
+            "with invented or placeholder company/legal text."
+        )
+    address_lines = tuple(
+        line.strip() for line in address_raw.split("|") if line.strip()
+    )
+    logo_path = os.environ.get("OFFICE_PDF_LOGO_PATH", "").strip()
+    logo_bytes = None
+    if logo_path:
+        with open(logo_path, "rb") as logo_file:
+            logo_bytes = logo_file.read()
+    return OfferPdfStaticContent(
+        company_legal_name=legal_name,
+        company_address_lines=address_lines,
+        acceptance_statement=acceptance,
+        company_phone=os.environ.get("OFFICE_PDF_COMPANY_PHONE", "").strip() or None,
+        company_email=os.environ.get("OFFICE_PDF_COMPANY_EMAIL", "").strip() or None,
+        company_web=os.environ.get("OFFICE_PDF_COMPANY_WEB", "").strip() or None,
+        company_register_text=(
+            os.environ.get("OFFICE_PDF_COMPANY_REGISTER_TEXT", "").strip() or None
+        ),
+        company_vat_id_text=(
+            os.environ.get("OFFICE_PDF_COMPANY_VAT_ID_TEXT", "").strip() or None
+        ),
+        footer_note=os.environ.get("OFFICE_PDF_FOOTER_NOTE", "").strip() or None,
+        bank_details_text=(
+            os.environ.get("OFFICE_PDF_BANK_DETAILS_TEXT", "").strip() or None
+        ),
+        logo_png_bytes=logo_bytes,
+    )
 
 
 def main() -> None:
@@ -2946,7 +3090,15 @@ def main() -> None:
             "refusing to start unauthenticated"
         )
 
-    server = create_office_api_server(args.db, token, args.host, args.port)
+    offer_pdf_static_content = _offer_pdf_static_content_from_env()
+
+    server = create_office_api_server(
+        args.db,
+        token,
+        args.host,
+        args.port,
+        offer_pdf_static_content=offer_pdf_static_content,
+    )
     print(f"Core Office API on http://{args.host}:{args.port}/office/v1/")
     server.serve_forever()
 

--- a/tests/helpers/offer_pdf_static_content.py
+++ b/tests/helpers/offer_pdf_static_content.py
@@ -1,0 +1,21 @@
+"""Obviously-fake OfferPdfStaticContent for tests.
+
+OFFER_PDF_DOWNLOAD_V1 makes the static company/legal content an explicit
+required dependency of OfficeApi, so every test that builds an API server
+must supply one. These values are deliberately marked as placeholders so
+they can never be mistaken for approved customer-facing wording.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.offer_pdf import OfferPdfStaticContent
+
+TEST_ACCEPTANCE_STATEMENT = "[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]"
+
+
+def fake_offer_pdf_static_content() -> OfferPdfStaticContent:
+    return OfferPdfStaticContent(
+        company_legal_name="TEST GmbH [PLATZHALTER]",
+        company_address_lines=("Teststraße 1", "20095 Hamburg"),
+        acceptance_statement=TEST_ACCEPTANCE_STATEMENT,
+    )

--- a/tests/unit/test_customer_address_source_v1_b.py
+++ b/tests/unit/test_customer_address_source_v1_b.py
@@ -225,13 +225,22 @@ def _api_seed(db_path: Path) -> dict[str, str]:
 @pytest.fixture()
 def addresses_api(tmp_path: Path):
     from catering_system.ui.office_api import create_office_api_server
+    from tests.helpers.offer_pdf_static_content import (
+        fake_offer_pdf_static_content,
+    )
 
     db = tmp_path / "core.db"
     ids = _api_seed(db)
     ready: queue.Queue = queue.Queue()
 
     def run() -> None:
-        server = create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        server = create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
         ready.put(server)
         server.serve_forever()
 

--- a/tests/unit/test_customer_identity_schema_bootstrap.py
+++ b/tests/unit/test_customer_identity_schema_bootstrap.py
@@ -214,11 +214,19 @@ def test_ambiguous_matches_have_deterministic_order(tmp_path: Path) -> None:
 
 
 def test_office_api_bootstrap_applies_foundation_schema(tmp_path: Path) -> None:
+    from catering_system.domain.offer_pdf import OfferPdfStaticContent
     from catering_system.repositories.core_transaction import open_core_connection
     from catering_system.ui.office_api import OfficeApi
 
     db = tmp_path / "core.db"
-    OfficeApi(open_core_connection(db))
+    OfficeApi(
+        open_core_connection(db),
+        offer_pdf_static_content=OfferPdfStaticContent(
+            company_legal_name="TEST GmbH [PLATZHALTER]",
+            company_address_lines=("Teststraße 1", "20095 Hamburg"),
+            acceptance_statement="[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]",
+        ),
+    )
     connection = sqlite3.connect(db)
     tables = {
         row[0]

--- a/tests/unit/test_fulfillment_source_v1.py
+++ b/tests/unit/test_fulfillment_source_v1.py
@@ -809,10 +809,18 @@ def test_k4_free_text_mentioning_lieferung_or_abholung_is_never_parsed() -> None
 
 
 def test_neg_office_api_rejects_invalid_fulfillment_mode(tmp_path: Path) -> None:
+    from catering_system.domain.offer_pdf import OfferPdfStaticContent
     from catering_system.repositories.core_transaction import open_core_connection
     from catering_system.ui.office_api import ApiError, OfficeApi
 
-    api = OfficeApi(open_core_connection(tmp_path / "core.db"))
+    api = OfficeApi(
+        open_core_connection(tmp_path / "core.db"),
+        offer_pdf_static_content=OfferPdfStaticContent(
+            company_legal_name="TEST GmbH [PLATZHALTER]",
+            company_address_lines=("Teststraße 1", "20095 Hamburg"),
+            acceptance_statement="[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]",
+        ),
+    )
     inquiry = api.inquiry_service.create_inquiry(
         event_date=date(2026, 8, 20),
         inquiry_source="manual",

--- a/tests/unit/test_inquiry_contact_completeness.py
+++ b/tests/unit/test_inquiry_contact_completeness.py
@@ -707,13 +707,22 @@ def contact_api(tmp_path: Path):
     import threading
 
     from catering_system.ui.office_api import create_office_api_server
+    from tests.helpers.offer_pdf_static_content import (
+        fake_offer_pdf_static_content,
+    )
 
     db = tmp_path / "core.db"
     ids = _api_seed(db)
     ready: queue.Queue = queue.Queue()
 
     def run() -> None:
-        server = create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        server = create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
         ready.put(server)
         server.serve_forever()
 

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
 from tests.helpers.order_seed import seed_order
 
+import hashlib
 import json
 import queue
 import sqlite3
@@ -152,7 +154,13 @@ def api(tmp_path: Path):
     def run() -> None:
         from catering_system.ui.office_api import create_office_api_server
 
-        server = create_office_api_server(str(db), _TOKEN, "127.0.0.1", 0)
+        server = create_office_api_server(
+            str(db),
+            _TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
         ready.put(server)
         server.serve_forever()
 
@@ -4488,3 +4496,211 @@ def test_offer_document_routes_require_bearer_auth(api) -> None:
         headers=no_auth,
     )
     assert (status, body["error"]) == (401, "unauthorized")
+
+
+# --- OFFER_PDF_DOWNLOAD_V1 — offer-document/pdf endpoint -------------------------
+
+
+def _offer_document_pdf_url(base: str, offer_id: str) -> str:
+    return f"{base}/office/v1/offers/{offer_id}/offer-document/pdf"
+
+
+def _prepared_offer_for_pdf(
+    api: tuple[str, dict[str, str], Path],
+    *,
+    inquiry_id: str | None = None,
+    contact_name: str = "Anna",
+) -> tuple[str, str, str, str]:
+    """Like _prepared_offer_for_document, but also creates the
+    OfferDocumentSnapshot (JSON create) so the PDF endpoint has something
+    real to read. Returns (base, offer_id, offer_version_id, offer_document_snapshot_id)."""
+    base, ids, db = api
+    resolved_inquiry = inquiry_id or ids["inquiry_offer_ready"]
+    _set_inquiry_customer_snapshot(
+        db,
+        resolved_inquiry,
+        replace(_pickup_eligible_invoice_snapshot(), contact_name=contact_name),
+    )
+    _ensure_inquiry_fulfillment_mode(base, resolved_inquiry, mode="PICKUP")
+    snapshot = _valid_offer_snapshot(inquiry_id=resolved_inquiry)
+    status, body, _h = _post(
+        _prepare_offer_url(base, resolved_inquiry),
+        args={"snapshot": snapshot},
+    )
+    assert status == 201
+    offer_id = body["offer_id"]
+    offer_version_id = body["offer_version_id"]
+    variant_id = snapshot["variants"][0]["variant_id"]  # type: ignore[index]
+
+    create_status, create_body, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_id,
+            "created_by": "office-api-test",
+        },
+    )
+    assert create_status == 201
+    return base, offer_id, offer_version_id, create_body["offer_document_snapshot_id"]
+
+
+def test_offer_document_pdf_download_returns_valid_pdf(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    status, data, headers = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    assert status == 200
+    assert data[:5] == b"%PDF-"
+    assert headers.get("Content-Type") == "application/pdf"
+
+
+def test_offer_document_pdf_content_disposition_filename(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    # read back the frozen document_reference the filename must be derived from
+    read_status, read_body, _h = _get(
+        f"{_offer_document_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    assert read_status == 200
+    document_reference = read_body["snapshot"]["document_reference"]
+
+    _status, _data, headers = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    assert headers.get("Content-Disposition") == (
+        f'attachment; filename="{document_reference}.pdf"'
+    )
+
+
+def test_offer_document_pdf_repeated_download_is_byte_identical(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    url = (
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    status1, data1, _h1 = _get_raw(url)
+    status2, data2, _h2 = _get_raw(url)
+    assert status1 == status2 == 200
+    assert data1 == data2
+    assert hashlib.sha256(data1).hexdigest() == hashlib.sha256(data2).hexdigest()
+
+
+def test_offer_document_pdf_missing_snapshot_returns_404(api) -> None:
+    base, ids, _db = api
+    offer_id = ids["inquiry_offer_ready"]
+    missing_version_id = str(uuid.uuid4())
+    status, data, _h = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={missing_version_id}"
+    )
+    assert status == 404
+    assert json.loads(data) == {"error": "not_found"}
+
+
+def test_offer_document_pdf_cross_offer_access_returns_404_without_leak(api) -> None:
+    base, ids, db = api
+    base_a, offer_a_id, version_a_id, _snap_a = _prepared_offer_for_pdf(
+        api, inquiry_id=ids["inquiry_offer_ready"]
+    )
+    other_inquiry_id = ids["inquiry_convertible"]
+    other_status, other_body, _h = _post(
+        _prepare_offer_url(base, other_inquiry_id),
+        args={"snapshot": _unique_offer_snapshot(inquiry_id=other_inquiry_id)},
+    )
+    assert other_status == 201
+    offer_b_id = other_body["offer_id"]
+    assert offer_b_id != offer_a_id
+
+    status, data, _h = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_b_id)}?offer_version_id={version_a_id}"
+    )
+    assert status == 404
+    assert json.loads(data) == {"error": "not_found"}
+    assert b"%PDF-" not in data
+
+
+def test_offer_document_pdf_routes_require_bearer_auth(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    no_auth: dict[str, str] = {}
+    status, data, _h = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}",
+        headers=no_auth,
+    )
+    assert status == 401
+    assert json.loads(data) == {"error": "unauthorized"}
+    assert b"%PDF-" not in data
+
+
+def test_offer_document_pdf_unsupported_character_returns_422(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(
+        api, contact_name="Анна Иванова"
+    )
+    status, data, _h = _get_raw(
+        f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}"
+    )
+    assert status == 422
+    assert json.loads(data) == {"error": "offer_pdf_unsupported_character"}
+    assert b"%PDF-" not in data
+
+
+def test_offer_document_pdf_download_does_not_create_new_snapshot(api) -> None:
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    _base, _db_ids, db = api
+    conn = sqlite3.connect(db)
+    before = conn.execute(
+        "SELECT COUNT(*) FROM offer_document_snapshots WHERE offer_id = ?",
+        (offer_id,),
+    ).fetchone()[0]
+    conn.close()
+    assert before == 1
+
+    for _ in range(3):
+        status, _data, _h = _get_raw(
+            f"{_offer_document_pdf_url(base, offer_id)}?offer_version_id={offer_version_id}"
+        )
+        assert status == 200
+
+    conn = sqlite3.connect(db)
+    after = conn.execute(
+        "SELECT COUNT(*) FROM offer_document_snapshots WHERE offer_id = ?",
+        (offer_id,),
+    ).fetchone()[0]
+    conn.close()
+    assert after == 1
+
+
+def test_offer_document_pdf_static_content_overflow_returns_422(api) -> None:
+    """Configured footer text too long for the reserved footer area is an
+    operator-fixable static-content validation failure (422), never a 500
+    and never a clipped PDF."""
+    from dataclasses import replace as dataclass_replace
+
+    base, offer_id, offer_version_id, _snapshot_id = _prepared_offer_for_pdf(api)
+    _base, _ids, db = api
+
+    oversized = dataclass_replace(
+        fake_offer_pdf_static_content(),
+        footer_note="Sehr langer Footertext. " * 40,
+    )
+    ready: queue.Queue = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.office_api import create_office_api_server
+
+        server = create_office_api_server(
+            str(db), _TOKEN, "127.0.0.1", 0, offer_pdf_static_content=oversized
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    threading.Thread(target=run, daemon=True).start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    try:
+        status, data, _h = _get_raw(
+            f"http://{host}:{port}/office/v1/offers/{offer_id}"
+            f"/offer-document/pdf?offer_version_id={offer_version_id}"
+        )
+        assert status == 422
+        assert json.loads(data) == {"error": "offer_pdf_render_failed"}
+        assert b"%PDF-" not in data
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/unit/test_office_panel_convert_accepted.py
+++ b/tests/unit/test_office_panel_convert_accepted.py
@@ -41,6 +41,9 @@ from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
 from catering_system.ui.office_api import create_office_api_server
+from tests.helpers.offer_pdf_static_content import (
+    fake_offer_pdf_static_content,
+)
 from catering_system.ui.office_panel_http import (
     create_office_panel_server,
     csrf_token_for_password,
@@ -350,7 +353,13 @@ def direct_world(tmp_path: Path):
     db = tmp_path / "convert-accepted.db"
     ids = _seed(db)
     api_url, api_server = _run_server_in_thread(
-        lambda: create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
     )
     panel_url, panel_server = _start_direct_panel(db)
     try:
@@ -443,7 +452,13 @@ def test_remote_panel_convert_accepted_parity(tmp_path: Path) -> None:
     ids = _seed(db)
     inquiry_id = ids["inquiry_convertible"]
     api_url, api_server = _run_server_in_thread(
-        lambda: create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
     )
     _accept_offer_via_api(api_url, inquiry_id)
     remote = RemoteCoreClient(api_url, _API_TOKEN)

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -38,6 +38,9 @@ from catering_system.repositories.sqlite_payment_reminder_repository import (
 )
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.ui.office_api import create_office_api_server
+from tests.helpers.offer_pdf_static_content import (
+    fake_offer_pdf_static_content,
+)
 from catering_system.ui.office_panel_http import (
     create_office_panel_server,
     csrf_token_for_password,
@@ -337,7 +340,13 @@ def direct_world(tmp_path: Path):
     db = tmp_path / "offer-actions.db"
     ids = _seed(db)
     api_url, api_server = _run_server_in_thread(
-        lambda: create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
     )
     panel_url, panel_server = _start_direct_panel(db)
     try:
@@ -722,7 +731,13 @@ def test_remote_offer_mark_sent_parity(tmp_path: Path) -> None:
     ids = _seed(db)
     inquiry_id = ids["inquiry_convertible"]
     api_url, api_server = _run_server_in_thread(
-        lambda: create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
     )
     offer_id, _version_id = _prepare_offer(api_url, inquiry_id)
     remote = RemoteCoreClient(api_url, _API_TOKEN)

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -51,6 +51,9 @@ from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
 from catering_system.ui.office_api import create_office_api_server
+from tests.helpers.offer_pdf_static_content import (
+    fake_offer_pdf_static_content,
+)
 from catering_system.ui.office_panel_http import (
     create_office_panel_server,
     csrf_token_for_password,
@@ -195,7 +198,13 @@ def _run_server_in_thread(build_server) -> tuple[str, HTTPServer]:
 
 def _start_api_server(db: Path) -> tuple[str, HTTPServer]:
     return _run_server_in_thread(
-        lambda: create_office_api_server(str(db), _API_TOKEN, "127.0.0.1", 0)
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
     )
 
 

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -484,11 +484,20 @@ def test_find_by_source_and_external_ref_no_match_returns_none() -> None:
 
 def _run_office_api_in_thread(db_path):  # noqa: ANN001, ANN202
     from catering_system.ui.office_api import create_office_api_server
+    from tests.helpers.offer_pdf_static_content import (
+        fake_offer_pdf_static_content,
+    )
 
     ready: queue.Queue = queue.Queue()
 
     def run() -> None:
-        server = create_office_api_server(str(db_path), _TOKEN, "127.0.0.1", 0)
+        server = create_office_api_server(
+            str(db_path),
+            _TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
         ready.put(server)
         server.serve_forever()
 


### PR DESCRIPTION
## Summary

- add authenticated read-only PDF download endpoint
- render existing immutable snapshot only
- enforce offer ownership
- inject explicit OfferPdfStaticContent
- return deterministic PDF bytes
- map renderer/config failures to 422
- no storage, sending, acceptance or conversion changes

## Verification

- 1906 tests passed
- coverage 90.3%
- Ruff, format, Mypy passed
- Node 24/24
- independent review: APPROVE — READY TO PUSH