### PR TITLE
Add offer PDF download to Office Panel

### DIFF
--- a/src/catering_system/ui/offer_pdf_static_content_env.py
+++ b/src/catering_system/ui/offer_pdf_static_content_env.py
@@ -1,0 +1,62 @@
+"""Shared OFFER_PDF_* environment contract for OfferPdfStaticContent.
+
+Used by both the Core Office API and the Office Panel's direct-mode startup
+so the two processes agree on exactly the same required/optional variables
+and the same fail-closed behavior: no approved production company/legal
+text is invented, and no test placeholder is allowed to silently reach
+production composition (OFFER_PDF_DOWNLOAD_V1 / OFFER_PDF_PANEL_DOWNLOAD_V1).
+"""
+
+from __future__ import annotations
+
+import os
+
+from catering_system.domain.offer_pdf import OfferPdfStaticContent
+
+
+def offer_pdf_static_content_from_env() -> OfferPdfStaticContent:
+    legal_name = os.environ.get("OFFICE_PDF_COMPANY_LEGAL_NAME", "").strip()
+    address_raw = os.environ.get("OFFICE_PDF_COMPANY_ADDRESS_LINES", "").strip()
+    acceptance = os.environ.get("OFFICE_PDF_ACCEPTANCE_STATEMENT", "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("OFFICE_PDF_COMPANY_LEGAL_NAME", legal_name),
+            ("OFFICE_PDF_COMPANY_ADDRESS_LINES", address_raw),
+            ("OFFICE_PDF_ACCEPTANCE_STATEMENT", acceptance),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit(
+            "Missing required offer-PDF static content environment "
+            "variable(s): " + ", ".join(missing) + " — refusing to start "
+            "with invented or placeholder company/legal text."
+        )
+    address_lines = tuple(
+        line.strip() for line in address_raw.split("|") if line.strip()
+    )
+    logo_path = os.environ.get("OFFICE_PDF_LOGO_PATH", "").strip()
+    logo_bytes = None
+    if logo_path:
+        with open(logo_path, "rb") as logo_file:
+            logo_bytes = logo_file.read()
+    return OfferPdfStaticContent(
+        company_legal_name=legal_name,
+        company_address_lines=address_lines,
+        acceptance_statement=acceptance,
+        company_phone=os.environ.get("OFFICE_PDF_COMPANY_PHONE", "").strip() or None,
+        company_email=os.environ.get("OFFICE_PDF_COMPANY_EMAIL", "").strip() or None,
+        company_web=os.environ.get("OFFICE_PDF_COMPANY_WEB", "").strip() or None,
+        company_register_text=(
+            os.environ.get("OFFICE_PDF_COMPANY_REGISTER_TEXT", "").strip() or None
+        ),
+        company_vat_id_text=(
+            os.environ.get("OFFICE_PDF_COMPANY_VAT_ID_TEXT", "").strip() or None
+        ),
+        footer_note=os.environ.get("OFFICE_PDF_FOOTER_NOTE", "").strip() or None,
+        bank_details_text=(
+            os.environ.get("OFFICE_PDF_BANK_DETAILS_TEXT", "").strip() or None
+        ),
+        logo_png_bytes=logo_bytes,
+    )

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -3017,60 +3017,6 @@ def create_office_api_server(
     return HTTPServer((host, port), make_office_api_handler(api, token))
 
 
-def _offer_pdf_static_content_from_env() -> OfferPdfStaticContent:
-    """OFFER_PDF_DOWNLOAD_V1: no approved production company/legal text
-    exists yet. Required facts are read from environment variables and
-    startup refuses to proceed if any are missing — never invented,
-    never a test placeholder silently reaching production composition."""
-    import os
-
-    legal_name = os.environ.get("OFFICE_PDF_COMPANY_LEGAL_NAME", "").strip()
-    address_raw = os.environ.get("OFFICE_PDF_COMPANY_ADDRESS_LINES", "").strip()
-    acceptance = os.environ.get("OFFICE_PDF_ACCEPTANCE_STATEMENT", "").strip()
-    missing = [
-        name
-        for name, value in (
-            ("OFFICE_PDF_COMPANY_LEGAL_NAME", legal_name),
-            ("OFFICE_PDF_COMPANY_ADDRESS_LINES", address_raw),
-            ("OFFICE_PDF_ACCEPTANCE_STATEMENT", acceptance),
-        )
-        if not value
-    ]
-    if missing:
-        raise SystemExit(
-            "Missing required offer-PDF static content environment "
-            "variable(s): " + ", ".join(missing) + " — refusing to start "
-            "with invented or placeholder company/legal text."
-        )
-    address_lines = tuple(
-        line.strip() for line in address_raw.split("|") if line.strip()
-    )
-    logo_path = os.environ.get("OFFICE_PDF_LOGO_PATH", "").strip()
-    logo_bytes = None
-    if logo_path:
-        with open(logo_path, "rb") as logo_file:
-            logo_bytes = logo_file.read()
-    return OfferPdfStaticContent(
-        company_legal_name=legal_name,
-        company_address_lines=address_lines,
-        acceptance_statement=acceptance,
-        company_phone=os.environ.get("OFFICE_PDF_COMPANY_PHONE", "").strip() or None,
-        company_email=os.environ.get("OFFICE_PDF_COMPANY_EMAIL", "").strip() or None,
-        company_web=os.environ.get("OFFICE_PDF_COMPANY_WEB", "").strip() or None,
-        company_register_text=(
-            os.environ.get("OFFICE_PDF_COMPANY_REGISTER_TEXT", "").strip() or None
-        ),
-        company_vat_id_text=(
-            os.environ.get("OFFICE_PDF_COMPANY_VAT_ID_TEXT", "").strip() or None
-        ),
-        footer_note=os.environ.get("OFFICE_PDF_FOOTER_NOTE", "").strip() or None,
-        bank_details_text=(
-            os.environ.get("OFFICE_PDF_BANK_DETAILS_TEXT", "").strip() or None
-        ),
-        logo_png_bytes=logo_bytes,
-    )
-
-
 def main() -> None:
     import os
 
@@ -3090,7 +3036,11 @@ def main() -> None:
             "refusing to start unauthenticated"
         )
 
-    offer_pdf_static_content = _offer_pdf_static_content_from_env()
+    from catering_system.ui.offer_pdf_static_content_env import (
+        offer_pdf_static_content_from_env,
+    )
+
+    offer_pdf_static_content = offer_pdf_static_content_from_env()
 
     server = create_office_api_server(
         args.db,

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3537,6 +3537,8 @@ def create_office_panel_server(
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
     commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
+    offer_document_repo: OfferDocumentSnapshotRepository | None = None,
+    offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
 ) -> HTTPServer:
     """Compatibility wrapper; server construction lives in office_panel_http."""
@@ -3566,6 +3568,8 @@ def create_office_panel_server(
         offer_repo=offer_repo,
         catalog_repo=catalog_repo,
         commercial_snapshot_repo=commercial_snapshot_repo,
+        offer_document_repo=offer_document_repo,
+        offer_pdf_static_content=offer_pdf_static_content,
         ui_version=ui_version,
     )
 
@@ -3716,8 +3720,14 @@ def main() -> None:
         from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
             SQLiteOrderCommercialSnapshotRepository,
         )
+        from catering_system.repositories.sqlite_offer_document_snapshot_repository import (
+            SQLiteOfferDocumentSnapshotRepository,
+        )
         from catering_system.repositories.bootstrap_customer_identity_schema import (
             bootstrap_customer_identity_schema,
+        )
+        from catering_system.ui.offer_pdf_static_content_env import (
+            offer_pdf_static_content_from_env,
         )
 
         connection = open_core_connection(args.db)
@@ -3729,6 +3739,10 @@ def main() -> None:
         commercial_snapshot_repo = (
             SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
         )
+        offer_document_repo = SQLiteOfferDocumentSnapshotRepository.from_connection(
+            connection
+        )
+        offer_pdf_static_content = offer_pdf_static_content_from_env()
         payment_reminder_repo = SQLitePaymentReminderRepository.from_connection(
             connection
         )
@@ -3769,6 +3783,8 @@ def main() -> None:
             offer_repo=offer_repo,
             catalog_repo=catalog_repo,
             commercial_snapshot_repo=commercial_snapshot_repo,
+            offer_document_repo=offer_document_repo,
+            offer_pdf_static_content=offer_pdf_static_content,
             ui_version=args.ui_version,
         )
         print(f"Office panel on http://{args.host}:{args.port}/ (user: office)")

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -51,8 +51,26 @@ from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
     validate_payment_method,
 )
+from catering_system.domain.offer_pdf import (
+    OfferPdfRenderError,
+    OfferPdfStaticContent,
+    OfferPdfUnsupportedCharacterError,
+)
+from catering_system.services.offer_document_snapshot_service import (
+    OfferDocumentSnapshotService,
+)
+from catering_system.services.offer_pdf_renderer import (
+    offer_document_pdf_filename,
+    render_offer_document_pdf,
+)
 from catering_system.repositories.in_memory_offer_repository import (
     InMemoryOfferRepository,
+)
+from catering_system.repositories.in_memory_offer_document_snapshot_repository import (
+    InMemoryOfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.offer_document_snapshot_repository import (
+    OfferDocumentSnapshotRepository,
 )
 from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
     InMemoryOrderCommercialSnapshotRepository,
@@ -164,6 +182,7 @@ from catering_system.ui.office_panel_tasks_list import render_aufgaben_list
 from catering_system.ui.office_panel_offer_detail import (
     OfferDetailFormFields,
     render_offer_detail,
+    surface_version_id,
 )
 from catering_system.ui.office_panel_offers_list import render_angebote_queue
 from catering_system.ui.office_panel_inquiry_detail import (
@@ -317,6 +336,12 @@ def render_rueckruf(
     return _page("Offene Rückrufe", body, active_section="callbacks", context=context)
 
 
+class OfferPdfUnavailableError(Exception):
+    """Raised when a PDF snapshot exists but cannot be rendered (renderer or
+    static content validation failure) — mapped by the HTTP layer to a clear
+    German 422 message, never a stack trace."""
+
+
 class OfficePanel:
     """Route handling and rendering; kept separate from the HTTP handler for testability."""
 
@@ -338,6 +363,8 @@ class OfficePanel:
         offer_repo: OfferRepository | None = None,
         catalog_repo: CatalogRepository | None = None,
         commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
+        offer_document_repo: OfferDocumentSnapshotRepository | None = None,
+        offer_pdf_static_content: OfferPdfStaticContent | None = None,
         ui_version: str = "legacy",
     ) -> None:
         if ui_version not in {"legacy", "v2"}:
@@ -345,6 +372,10 @@ class OfficePanel:
         self._inquiries = inquiry_repo
         self._orders = order_repo
         self._offers = offer_repo or InMemoryOfferRepository()
+        self._offer_documents = (
+            offer_document_repo or InMemoryOfferDocumentSnapshotRepository()
+        )
+        self.offer_pdf_static_content = offer_pdf_static_content
         self._commercial_snapshots = (
             commercial_snapshot_repo or InMemoryOrderCommercialSnapshotRepository()
         )
@@ -407,6 +438,9 @@ class OfficePanel:
                 document_repo,
                 outbound_repo,
                 self.core,
+            )
+            self.offer_document_service = OfferDocumentSnapshotService(
+                self._offers, self._inquiries, self._offer_documents
             )
         else:
             # Structurally duck-typed, not the same concrete class — the
@@ -709,12 +743,64 @@ class OfficePanel:
                 revision_prefill_url = build_offer_prefill_url(
                     self.configurator_url, inquiry
                 )
+        version_id = surface_version_id(detail)
+        pdf_download_url: str | None = None
+        if version_id and self.offer_document_exists(offer_id, version_id):
+            pdf_download_url = (
+                f"/offer/{quote(offer_id, safe='')}/offer-document/pdf"
+                f"?{urlencode({'offer_version_id': version_id})}"
+            )
         return render_offer_detail(
             detail,
             context=context,
             forms=forms,
             revision_prefill_url=revision_prefill_url or None,
+            pdf_download_url=pdf_download_url,
         )
+
+    def offer_document_exists(self, offer_id: str, offer_version_id: str) -> bool:
+        """Read-only existence check used only to decide whether the PDF
+        download link is shown — same ownership check as offer_document_pdf,
+        without doing any rendering work."""
+        if self._remote is not None:
+            return self._remote.offer_document_exists(offer_id, offer_version_id)
+        snapshot = self.offer_document_service.get_by_offer_version_id(offer_version_id)
+        return snapshot is not None and snapshot.offer_id == offer_id
+
+    def offer_document_pdf(
+        self, offer_id: str, offer_version_id: str
+    ) -> tuple[bytes, str] | None:
+        """Render the already-persisted immutable snapshot to PDF bytes for
+        download. Read-only: never creates a snapshot. Returns None when no
+        snapshot exists for this offer/version (404 case); raises
+        OfferPdfUnavailableError on renderer/static-content failure (422
+        case)."""
+        from catering_system.ui.remote_core_client import RemoteCoreError
+
+        if self._remote is not None:
+            try:
+                pdf_bytes, filename = self._remote.offer_document_pdf(
+                    offer_id, offer_version_id
+                )
+            except RemoteCoreError as exc:
+                if exc.status == 404:
+                    return None
+                if exc.status == 422:
+                    raise OfferPdfUnavailableError(exc.code) from exc
+                raise
+            return pdf_bytes, filename or f"{offer_id}.pdf"
+        snapshot = self.offer_document_service.get_by_offer_version_id(offer_version_id)
+        if snapshot is None or snapshot.offer_id != offer_id:
+            return None
+        if self.offer_pdf_static_content is None:
+            raise OfferPdfUnavailableError("offer PDF static content not configured")
+        try:
+            pdf_bytes = render_offer_document_pdf(
+                snapshot, self.offer_pdf_static_content
+            )
+        except (OfferPdfUnsupportedCharacterError, OfferPdfRenderError) as exc:
+            raise OfferPdfUnavailableError(str(exc)) from exc
+        return pdf_bytes, offer_document_pdf_filename(snapshot)
 
     def _offer_detail_dict(self, offer_id: str) -> dict[str, object]:
         if self._remote is not None:

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -43,6 +43,7 @@ from catering_system.integration.auerswald_sync import (
     resolve_missed_call,
 )
 from catering_system.ui.office_panel import (
+    OfferPdfUnavailableError,
     OfficePageContext,
     OfficePanel,
     _e,
@@ -54,6 +55,10 @@ from catering_system.ui.office_panel import (
     render_proposal_preview,
     render_proposal_preview_form,
     render_rueckruf,
+)
+from catering_system.domain.offer_pdf import OfferPdfStaticContent
+from catering_system.repositories.offer_document_snapshot_repository import (
+    OfferDocumentSnapshotRepository,
 )
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
@@ -241,6 +246,8 @@ def make_office_panel_handler(
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
     commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
+    offer_document_repo: OfferDocumentSnapshotRepository | None = None,
+    offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
 ) -> type[BaseHTTPRequestHandler]:
     panel = OfficePanel(
@@ -259,6 +266,8 @@ def make_office_panel_handler(
         offer_repo=offer_repo,
         catalog_repo=catalog_repo,
         commercial_snapshot_repo=commercial_snapshot_repo,
+        offer_document_repo=offer_document_repo,
+        offer_pdf_static_content=offer_pdf_static_content,
         ui_version=ui_version,
     )
     expected = "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
@@ -295,6 +304,16 @@ def make_office_panel_handler(
             self.send_response(status)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _pdf_bytes(self, payload: bytes, filename: str) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/pdf")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header(
+                "Content-Disposition", f'attachment; filename="{filename}"'
+            )
             self.end_headers()
             self.wfile.write(payload)
 
@@ -480,6 +499,13 @@ def make_office_panel_handler(
             elif len(parts) == 2 and parts[0] == "offer":
                 page = panel.render_offer(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
+            elif (
+                len(parts) == 4
+                and parts[0] == "offer"
+                and parts[2] == "offer-document"
+                and parts[3] == "pdf"
+            ):
+                self._offer_document_pdf_download(parts[1], parsed.query)
             elif len(parts) == 2 and parts[0] == "kontakt":
                 page = panel.render_kontakt(unquote(parts[1]), context=context)
                 self._html(page) if page else self.send_error(404)
@@ -583,6 +609,29 @@ def make_office_panel_handler(
                 self.send_error(404)
                 return
             self._html(html)
+
+        def _offer_document_pdf_download(self, offer_id: str, query: str) -> None:
+            """Proxy the immutable ANGEBOT PDF to the browser. The Office API
+            Bearer token is attached (remote mode) or never involved (direct
+            mode) entirely server-side — this handler only ever forwards PDF
+            bytes, never the token, to the client."""
+            version_id = parse_qs(query).get("offer_version_id", [""])[0]
+            if not version_id:
+                self.send_error(404)
+                return
+            try:
+                result = panel.offer_document_pdf(offer_id, version_id)
+            except OfferPdfUnavailableError:
+                self._error_page(
+                    "Das PDF konnte nicht erzeugt werden — bitte Support kontaktieren.",
+                    status=422,
+                )
+                return
+            if result is None:
+                self.send_error(404)
+                return
+            pdf_bytes, filename = result
+            self._pdf_bytes(pdf_bytes, filename)
 
         def _confirmation_fake_outbox(self, order_id: str) -> None:
             try:
@@ -805,6 +854,8 @@ def create_office_panel_server(
     offer_repo: OfferRepository | None = None,
     catalog_repo: CatalogRepository | None = None,
     commercial_snapshot_repo: OrderCommercialSnapshotRepository | None = None,
+    offer_document_repo: OfferDocumentSnapshotRepository | None = None,
+    offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
 ) -> HTTPServer:
     """Create the intentionally single-threaded office HTTP server."""
@@ -830,6 +881,8 @@ def create_office_panel_server(
             offer_repo=offer_repo,
             catalog_repo=catalog_repo,
             commercial_snapshot_repo=commercial_snapshot_repo,
+            offer_document_repo=offer_document_repo,
+            offer_pdf_static_content=offer_pdf_static_content,
             ui_version=ui_version,
         ),
     )

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -74,6 +74,14 @@ def _surface_version(detail: dict[str, object]) -> dict[str, object]:
     return versions[-1]
 
 
+def surface_version_id(detail: dict[str, object]) -> str:
+    """Public wrapper: the OfferVersion id actually displayed for this
+    detail (same resolution render_offer_detail uses internally) — needed
+    by the caller before rendering, to decide whether a PDF download link
+    exists for exactly the version about to be shown."""
+    return str(_surface_version(detail).get("offer_version_id", ""))
+
+
 def _version_list(detail: dict[str, object]) -> str:
     versions = cast(list[dict[str, object]], detail["versions"])
     current_id = str(detail["offer_version_id"])
@@ -315,6 +323,7 @@ def render_offer_detail(
     context: OfficePageContext,
     forms: OfferDetailFormFields,
     revision_prefill_url: str | None = None,
+    pdf_download_url: str | None = None,
 ) -> str:
     offer_id = str(detail["offer_id"])
     inquiry_id = str(detail["inquiry_id"])
@@ -372,8 +381,14 @@ def render_offer_detail(
                 acceptance_id=acceptance_id,
                 forms=forms,
             )
+    pdf_link = (
+        f'<p><a href="{_e(pdf_download_url)}">PDF herunterladen</a></p>'
+        if pdf_download_url is not None
+        else ""
+    )
     body = (
         f'<p class="subtitle">Angebot {_e(offer_id[:8])}</p>'
+        + pdf_link
         + action_section
         + '<section class="offer-detail-section">'
         "<h2>Status</h2>"

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -8,6 +8,7 @@ is sent to the frozen Core Office API.  It never opens ``core.db``.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import urllib.error
 import urllib.request
@@ -303,6 +304,16 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
 
 def _bad_response() -> NoReturn:
     raise RemoteCoreError(502, "invalid_response", unavailable=True)
+
+
+_CONTENT_DISPOSITION_FILENAME = re.compile(r'filename="([^"]+)"')
+
+
+def _filename_from_content_disposition(value: str | None) -> str | None:
+    if value is None:
+        return None
+    match = _CONTENT_DISPOSITION_FILENAME.search(value)
+    return match.group(1) if match else None
 
 
 def _dict(value: object) -> dict[str, object]:
@@ -1022,6 +1033,54 @@ class RemoteCoreClient:
             _bad_response()
         return raw.decode("utf-8")
 
+    def get_bytes(
+        self, path: str, query: Mapping[str, object] | None = None
+    ) -> tuple[bytes, str | None]:
+        """Raw binary GET (offer-document PDF download). The token is
+        attached here, server-side, and never reaches the browser. Unlike
+        get_text, HTTPError is handled explicitly so the real status code
+        (404/422/...) survives as a RemoteCoreError.status, not collapsed
+        into a generic 503 — callers need that to map errors correctly."""
+        request = urllib.request.Request(
+            self._url(path, query),
+            headers={"Authorization": f"Bearer {self._token}"},
+            method="GET",
+        )
+        try:
+            response = self._opener.open(request, timeout=_READ_TIMEOUT_SECONDS)
+        except urllib.error.HTTPError as exc:
+            if 300 <= exc.code < 400:
+                raise RemoteCoreError(
+                    502, "redirect_refused", unavailable=True
+                ) from exc
+            raw = exc.read(_MAX_RESPONSE_BYTES + 1)
+            code = "unexpected_status"
+            if (
+                exc.headers.get_content_type() == "application/json"
+                and len(raw) <= _MAX_RESPONSE_BYTES
+            ):
+                try:
+                    parsed = _dict(json.loads(raw.decode("utf-8")))
+                    _exact(parsed, {"error"})
+                    code = _str(parsed["error"])
+                except (UnicodeDecodeError, json.JSONDecodeError, RemoteCoreError):
+                    pass
+            raise RemoteCoreError(exc.code, code) from exc
+        except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+            raise RemoteCoreError(503, "unreachable", unavailable=True) from exc
+        with response:
+            if response.status != 200:
+                raise RemoteCoreError(
+                    response.status, "unexpected_status", unavailable=True
+                )
+            if response.headers.get_content_type() != "application/pdf":
+                _bad_response()
+            disposition = response.headers.get("Content-Disposition")
+            raw = response.read(_MAX_RESPONSE_BYTES + 1)
+        if len(raw) > _MAX_RESPONSE_BYTES:
+            _bad_response()
+        return raw, _filename_from_content_disposition(disposition)
+
     def command(
         self,
         path: str,
@@ -1623,6 +1682,30 @@ class RemoteCoreClient:
             _datetime(entry["at"])
             _str(entry["label"])
         return body
+
+    def offer_document_exists(self, offer_id: str, offer_version_id: str) -> bool:
+        """Read-only existence check for the frozen OfferDocumentSnapshot —
+        used only to decide whether the panel shows the download button."""
+        try:
+            self.get(
+                f"/office/v1/offers/{quote(offer_id, safe='')}/offer-document",
+                {"offer_version_id": offer_version_id},
+            )
+        except RemoteCoreError as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return True
+
+    def offer_document_pdf(
+        self, offer_id: str, offer_version_id: str
+    ) -> tuple[bytes, str | None]:
+        """Download the already-persisted immutable snapshot as PDF.
+        Never creates a snapshot; the Bearer token stays server-side."""
+        return self.get_bytes(
+            f"/office/v1/offers/{quote(offer_id, safe='')}/offer-document/pdf",
+            {"offer_version_id": offer_version_id},
+        )
 
     def list_contacts(self) -> dict[str, object]:
         body = self.get("/office/v1/contacts")

--- a/tests/unit/test_offer_pdf_static_content_env.py
+++ b/tests/unit/test_offer_pdf_static_content_env.py
@@ -1,0 +1,117 @@
+"""Shared OFFICE_PDF_* environment contract (used by Office API and Office
+Panel direct-mode startup) — fail-closed: no invented/placeholder company
+text may silently reach production composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from catering_system.ui.offer_pdf_static_content_env import (
+    offer_pdf_static_content_from_env,
+)
+from tests.helpers.offer_pdf_static_content import TEST_ACCEPTANCE_STATEMENT
+
+_REQUIRED_VARS = (
+    "OFFICE_PDF_COMPANY_LEGAL_NAME",
+    "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+    "OFFICE_PDF_ACCEPTANCE_STATEMENT",
+)
+_OPTIONAL_VARS = (
+    "OFFICE_PDF_COMPANY_PHONE",
+    "OFFICE_PDF_COMPANY_EMAIL",
+    "OFFICE_PDF_COMPANY_WEB",
+    "OFFICE_PDF_COMPANY_REGISTER_TEXT",
+    "OFFICE_PDF_COMPANY_VAT_ID_TEXT",
+    "OFFICE_PDF_FOOTER_NOTE",
+    "OFFICE_PDF_BANK_DETAILS_TEXT",
+    "OFFICE_PDF_LOGO_PATH",
+)
+
+
+def _clear_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _REQUIRED_VARS + _OPTIONAL_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _set_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_PDF_COMPANY_LEGAL_NAME", "Silberlöffel GmbH")
+    monkeypatch.setenv(
+        "OFFICE_PDF_COMPANY_ADDRESS_LINES", "Musterstraße 1|20095 Hamburg"
+    )
+    monkeypatch.setenv(
+        "OFFICE_PDF_ACCEPTANCE_STATEMENT", "Approved production wording."
+    )
+
+
+def test_missing_all_required_vars_fails_startup_with_clear_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all(monkeypatch)
+    with pytest.raises(SystemExit) as exc_info:
+        offer_pdf_static_content_from_env()
+    message = str(exc_info.value)
+    for name in _REQUIRED_VARS:
+        assert name in message
+
+
+def test_missing_one_required_var_fails_startup_naming_only_that_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    monkeypatch.delenv("OFFICE_PDF_ACCEPTANCE_STATEMENT", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        offer_pdf_static_content_from_env()
+    message = str(exc_info.value)
+    assert "OFFICE_PDF_ACCEPTANCE_STATEMENT" in message
+    assert "OFFICE_PDF_COMPANY_LEGAL_NAME" not in message
+    assert "OFFICE_PDF_COMPANY_ADDRESS_LINES" not in message
+
+
+def test_blank_required_var_is_treated_as_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    monkeypatch.setenv("OFFICE_PDF_COMPANY_LEGAL_NAME", "   ")
+    with pytest.raises(SystemExit) as exc_info:
+        offer_pdf_static_content_from_env()
+    assert "OFFICE_PDF_COMPANY_LEGAL_NAME" in str(exc_info.value)
+
+
+def test_valid_required_vars_produce_populated_static_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    content = offer_pdf_static_content_from_env()
+    assert content.company_legal_name == "Silberlöffel GmbH"
+    assert content.company_address_lines == ("Musterstraße 1", "20095 Hamburg")
+    assert content.acceptance_statement == "Approved production wording."
+    assert content.company_phone is None
+    assert content.logo_png_bytes is None
+
+
+def test_env_loaded_content_never_carries_the_test_placeholder_statement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production composition (Office API and Office Panel direct-mode
+    startup) reads real approved text through this loader only — it must
+    never produce the obviously-fake test placeholder used by tests/
+    helpers/offer_pdf_static_content.py."""
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    content = offer_pdf_static_content_from_env()
+    assert content.acceptance_statement != TEST_ACCEPTANCE_STATEMENT
+    assert "PLATZHALTER" not in content.company_legal_name
+    assert "TEST" not in content.company_legal_name.upper()
+
+
+def test_optional_vars_populate_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    monkeypatch.setenv("OFFICE_PDF_COMPANY_PHONE", "+49 40 1234567")
+    monkeypatch.setenv("OFFICE_PDF_FOOTER_NOTE", "Vielen Dank für Ihr Vertrauen.")
+    content = offer_pdf_static_content_from_env()
+    assert content.company_phone == "+49 40 1234567"
+    assert content.footer_note == "Vielen Dank für Ihr Vertrauen."

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -48,6 +48,9 @@ from catering_system.ui.office_api import create_office_api_server
 from tests.helpers.offer_pdf_static_content import (
     fake_offer_pdf_static_content,
 )
+from catering_system.ui.office_panel import (
+    create_office_panel_server as create_office_panel_server_compat,
+)
 from catering_system.ui.office_panel_http import (
     create_office_panel_server,
     csrf_token_for_password,
@@ -1203,6 +1206,120 @@ def test_remote_panel_pdf_download_never_exposes_office_api_token(
         assert headers.get("Content-Type") == "application/pdf"
         assert _API_TOKEN.encode() not in data
         assert all(_API_TOKEN not in value for value in headers.values())
+    finally:
+        panel_server.shutdown()
+        panel_server.server_close()
+        api_server.shutdown()
+        api_server.server_close()
+
+
+def test_compat_wrapper_forwards_offer_document_dependencies(tmp_path: Path) -> None:
+    """OFFER_PDF_PANEL_DOWNLOAD_V1 direct-mode review fix: office_panel.py's
+    create_office_panel_server (the compatibility wrapper main() calls in
+    direct mode) must forward offer_document_repo/offer_pdf_static_content
+    through to office_panel_http.create_office_panel_server — not silently
+    fall back to an ephemeral InMemory repository backed by nothing on disk.
+    The snapshot is created here through a separate SQLite connection (the
+    Office API server), so the panel can only see it if the repository it
+    was constructed with is genuinely reading from the same db file."""
+    db = tmp_path / "compat-wrapper-pdf.db"
+    ids = _seed(db)
+    api_url, api_server = _run_server_in_thread(
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
+    )
+    offer_id, offer_version_id, document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+
+    def build() -> HTTPServer:
+        conn = open_core_connection(db)
+        return create_office_panel_server_compat(
+            SQLiteInquiryRepository.from_connection(conn),
+            SQLiteOrderRepository.from_connection(conn),
+            _PASSWORD,
+            host="127.0.0.1",
+            port=0,
+            command_executor=CoreCommandExecutor(conn),
+            payment_reminder_repo=SQLitePaymentReminderRepository.from_connection(conn),
+            offer_repo=SQLiteOfferRepository.from_connection(conn),
+            offer_document_repo=SQLiteOfferDocumentSnapshotRepository.from_connection(
+                conn
+            ),
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+            ui_version="v2",
+        )
+
+    panel_url, panel_server = _run_server_in_thread(build)
+    try:
+        _status, html = _get(f"{panel_url}/offer/{offer_id}")
+        assert "PDF herunterladen" in html
+
+        status, data, headers = _get_raw(
+            f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+            f"?offer_version_id={offer_version_id}"
+        )
+        assert status == 200
+        assert data[:5] == b"%PDF-"
+        assert headers.get("Content-Type") == "application/pdf"
+        document_reference = document["snapshot"]["document_reference"]
+        assert headers.get("Content-Disposition") == (
+            f'attachment; filename="{document_reference}.pdf"'
+        )
+    finally:
+        panel_server.shutdown()
+        panel_server.server_close()
+        api_server.shutdown()
+        api_server.server_close()
+
+
+def test_compat_wrapper_without_offer_document_repo_shows_no_button(
+    tmp_path: Path,
+) -> None:
+    """Without offer_document_repo, the compat wrapper still falls back to
+    an empty InMemory repository (matching every other repo param on
+    OfficePanel) rather than raising — but that means an existing snapshot
+    is invisible, which is exactly the bug the direct-mode fix closes for
+    main()'s own wiring. This locks in the (safe, non-crashing) fallback
+    behavior for callers that genuinely don't pass the param."""
+    db = tmp_path / "compat-wrapper-no-doc-repo.db"
+    ids = _seed(db)
+    api_url, api_server = _run_server_in_thread(
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
+    )
+    offer_id, _offer_version_id, _document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+
+    def build() -> HTTPServer:
+        conn = open_core_connection(db)
+        return create_office_panel_server_compat(
+            SQLiteInquiryRepository.from_connection(conn),
+            SQLiteOrderRepository.from_connection(conn),
+            _PASSWORD,
+            host="127.0.0.1",
+            port=0,
+            command_executor=CoreCommandExecutor(conn),
+            payment_reminder_repo=SQLitePaymentReminderRepository.from_connection(conn),
+            offer_repo=SQLiteOfferRepository.from_connection(conn),
+            ui_version="v2",
+        )
+
+    panel_url, panel_server = _run_server_in_thread(build)
+    try:
+        _status, html = _get(f"{panel_url}/offer/{offer_id}")
+        assert "PDF herunterladen" not in html
     finally:
         panel_server.shutdown()
         panel_server.server_close()

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -12,6 +12,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
+from dataclasses import replace
 from datetime import date
 from http.server import HTTPServer
 from pathlib import Path
@@ -19,6 +20,9 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.offer_pdf import OfferPdfStaticContent
 from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.repositories.core_transaction import (
     CoreCommandExecutor,
@@ -26,6 +30,9 @@ from catering_system.repositories.core_transaction import (
 )
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_offer_document_snapshot_repository import (
+    SQLiteOfferDocumentSnapshotRepository,
 )
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
@@ -139,7 +146,11 @@ def _run_server_in_thread(build_server) -> tuple[str, HTTPServer]:
 
 
 def _valid_offer_snapshot(
-    *, inquiry_id: str, variant_label: str = "Variante A"
+    *,
+    inquiry_id: str,
+    variant_label: str = "Variante A",
+    variant_id: str = _VARIANT_ID,
+    position_id: str = _POSITION_ID,
 ) -> dict:
     payload: dict[str, object] = {
         "schema_version": "offer_snapshot_v1",
@@ -180,12 +191,12 @@ def _valid_offer_snapshot(
         },
         "variants": [
             {
-                "variant_id": _VARIANT_ID,
+                "variant_id": variant_id,
                 "label": variant_label,
                 "description": "Customer-visible alternative",
                 "positions": [
                     {
-                        "position_id": _POSITION_ID,
+                        "position_id": position_id,
                         "kind": "catalog",
                         "catalog_item_id": "catalog-1",
                         "name": "Fingerfood Paket",
@@ -241,10 +252,22 @@ def _api_post(
         return exc.code, json.loads(exc.read().decode())
 
 
-def _prepare_offer(api_url: str, inquiry_id: str) -> tuple[str, str]:
+def _prepare_offer(
+    api_url: str,
+    inquiry_id: str,
+    *,
+    variant_id: str = _VARIANT_ID,
+    position_id: str = _POSITION_ID,
+) -> tuple[str, str]:
     status, body = _api_post(
         f"{api_url}/office/v1/inquiries/{inquiry_id}/prepare-offer",
-        args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
+        args={
+            "snapshot": _valid_offer_snapshot(
+                inquiry_id=inquiry_id,
+                variant_id=variant_id,
+                position_id=position_id,
+            )
+        },
     )
     assert status == 201
     return body["offer_id"], body["offer_version_id"]
@@ -270,7 +293,83 @@ def _record_acceptance_api(api_url: str, offer_id: str, version_id: str) -> None
     )
 
 
-def _start_direct_panel(db: Path) -> tuple[str, HTTPServer]:
+def _pickup_eligible_snapshot() -> InquiryCustomerSnapshot:
+    return InquiryCustomerSnapshot(
+        company_name="ACME GmbH",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=CustomerAddress(
+            street="Bürostraße 1",
+            postal_code="20095",
+            city="Hamburg",
+            country="DE",
+        ),
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+
+
+def _set_customer_snapshot(
+    db: Path, inquiry_id: str, snapshot: InquiryCustomerSnapshot
+) -> None:
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    inquiries.update(replace(inquiry, customer_snapshot=snapshot))
+    inquiries.close()
+
+
+def _set_fulfillment_mode(
+    api_url: str, inquiry_id: str, *, mode: str = "PICKUP"
+) -> None:
+    _status, detail = _api_get(f"{api_url}/office/v1/inquiries/{inquiry_id}")
+    status, _body = _api_post(
+        f"{api_url}/office/v1/inquiries/{inquiry_id}/fulfillment-mode",
+        args={"fulfillment_mode": mode},
+        expect={"updated_at": detail["updated_at"]},
+    )
+    assert status == 200
+
+
+def _create_offer_document(
+    api_url: str, offer_id: str, offer_version_id: str, variant_id: str
+) -> dict:
+    status, body = _api_post(
+        f"{api_url}/office/v1/offers/{offer_id}/offer-document",
+        args={
+            "offer_version_id": offer_version_id,
+            "offer_variant_id": variant_id,
+            "created_by": "office-panel-test",
+        },
+    )
+    assert status in (200, 201)
+    return body
+
+
+def _prepare_offer_with_document(
+    api_url: str,
+    db: Path,
+    inquiry_id: str,
+    *,
+    variant_id: str = _VARIANT_ID,
+    position_id: str = _POSITION_ID,
+) -> tuple[str, str, dict]:
+    """Prepares a PICKUP-eligible offer and freezes its OfferDocumentSnapshot
+    via the real Office API, so the panel's PDF download link/route has a
+    genuine immutable snapshot to read."""
+    _set_customer_snapshot(db, inquiry_id, _pickup_eligible_snapshot())
+    _set_fulfillment_mode(api_url, inquiry_id, mode="PICKUP")
+    offer_id, offer_version_id = _prepare_offer(
+        api_url, inquiry_id, variant_id=variant_id, position_id=position_id
+    )
+    document = _create_offer_document(api_url, offer_id, offer_version_id, variant_id)
+    return offer_id, offer_version_id, document
+
+
+def _start_direct_panel(
+    db: Path, *, static_content: OfferPdfStaticContent | None = None
+) -> tuple[str, HTTPServer]:
     def build() -> HTTPServer:
         conn = open_core_connection(db)
         return create_office_panel_server(
@@ -282,6 +381,10 @@ def _start_direct_panel(db: Path) -> tuple[str, HTTPServer]:
             command_executor=CoreCommandExecutor(conn),
             payment_reminder_repo=SQLitePaymentReminderRepository.from_connection(conn),
             offer_repo=SQLiteOfferRepository.from_connection(conn),
+            offer_document_repo=SQLiteOfferDocumentSnapshotRepository.from_connection(
+                conn
+            ),
+            offer_pdf_static_content=static_content or fake_offer_pdf_static_content(),
             ui_version="v2",
         )
 
@@ -296,6 +399,26 @@ def _get(url: str) -> tuple[int, str]:
             return resp.status, resp.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         return exc.code, exc.read().decode("utf-8")
+
+
+def _get_raw(url: str) -> tuple[int, bytes, dict[str, str]]:
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", _AUTH)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read(), dict(resp.headers)
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers)
+
+
+def _api_get(url: str) -> tuple[int, dict]:
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", _API_AUTH["Authorization"])
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
 
 
 def _post(url: str, fields: dict[str, str]) -> tuple[int, str, str]:
@@ -848,3 +971,240 @@ def test_rejected_offer_has_no_lifecycle_actions(direct_world) -> None:
     assert "Kunde lehnt ab" not in html
     assert "Angebot zurückziehen" not in html
     assert "Abgelehnt" in html
+
+
+# --- OFFER_PDF_PANEL_DOWNLOAD_V1 — PDF download button + proxy route -------
+
+
+def test_offer_detail_shows_pdf_download_button_when_snapshot_exists(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, offer_version_id, _document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "PDF herunterladen" in html
+    assert (
+        f"/offer/{offer_id}/offer-document/pdf?offer_version_id={offer_version_id}"
+        in html
+    )
+
+
+def test_offer_detail_hides_pdf_download_button_when_snapshot_missing(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "PDF herunterladen" not in html
+    # Regression check: the rest of the Prepared-state detail page (existing
+    # lifecycle actions) must still render unchanged around the new link.
+    assert "Als versendet erfassen" in html or "sent_at" in html
+
+
+def test_offer_detail_pdf_button_coexists_with_mark_sent_action(direct_world) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, _version_id, _document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "PDF herunterladen" in html
+    fields = _offer_form_fields(html, "/mark-sent")
+    assert fields is not None  # mark-sent form still present alongside the link
+
+
+def test_panel_pdf_download_returns_valid_pdf(direct_world) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, offer_version_id, _document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    status, data, headers = _get_raw(
+        f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+        f"?offer_version_id={offer_version_id}"
+    )
+    assert status == 200
+    assert data[:5] == b"%PDF-"
+    assert headers.get("Content-Type") == "application/pdf"
+
+
+def test_panel_pdf_download_content_disposition_filename_preserved(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, offer_version_id, document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    document_reference = document["snapshot"]["document_reference"]
+    _status, _data, headers = _get_raw(
+        f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+        f"?offer_version_id={offer_version_id}"
+    )
+    assert headers.get("Content-Disposition") == (
+        f'attachment; filename="{document_reference}.pdf"'
+    )
+
+
+def test_panel_pdf_download_missing_snapshot_returns_404(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, offer_version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    status, _data, _headers = _get_raw(
+        f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+        f"?offer_version_id={offer_version_id}"
+    )
+    assert status == 404
+
+
+def test_panel_pdf_download_missing_version_query_returns_404(direct_world) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, _version_id, _document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    status, _data, _headers = _get_raw(
+        f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+    )
+    assert status == 404
+
+
+def test_panel_pdf_download_cross_offer_access_returns_404_without_leak(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_a_id, version_a_id, _doc_a = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    offer_b_id, version_b_id, doc_b = _prepare_offer_with_document(
+        api_url,
+        db,
+        ids["inquiry_rejected"],
+        variant_id=_OTHER_VARIANT,
+        position_id=str(uuid.uuid4()),
+    )
+    status, data, _headers = _get_raw(
+        f"{panel_url}/offer/{offer_a_id}/offer-document/pdf"
+        f"?offer_version_id={version_b_id}"
+    )
+    assert status == 404
+    reference_b = doc_b["snapshot"]["document_reference"]
+    assert reference_b.encode() not in data
+
+    status2, _data2, _headers2 = _get_raw(
+        f"{panel_url}/offer/{offer_b_id}/offer-document/pdf"
+        f"?offer_version_id={version_a_id}"
+    )
+    assert status2 == 404
+
+
+def test_panel_repeated_pdf_download_does_not_create_additional_snapshot(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, offer_version_id, document = _prepare_offer_with_document(
+        api_url, db, ids["inquiry_convertible"]
+    )
+    original_snapshot_id = document["offer_document_snapshot_id"]
+    url = (
+        f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+        f"?offer_version_id={offer_version_id}"
+    )
+    status1, data1, _h1 = _get_raw(url)
+    status2, data2, _h2 = _get_raw(url)
+    assert status1 == status2 == 200
+    assert data1 == data2
+
+    documents = SQLiteOfferDocumentSnapshotRepository(db)
+    snapshot = documents.get_by_offer_version_id(offer_version_id)
+    documents.close()
+    assert snapshot is not None
+    assert snapshot.offer_document_snapshot_id == original_snapshot_id
+
+
+def test_direct_pdf_download_renderer_failure_shows_clear_german_message(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "offer-pdf-422.db"
+    ids = _seed(db)
+    api_url, api_server = _run_server_in_thread(
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
+    )
+    oversized_content = OfferPdfStaticContent(
+        company_legal_name="TEST GmbH [PLATZHALTER]",
+        company_address_lines=("Teststraße 1", "20095 Hamburg"),
+        acceptance_statement="[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]",
+        footer_note="Sehr langer Footertext. " * 40,
+    )
+    panel_url, panel_server = _start_direct_panel(db, static_content=oversized_content)
+    try:
+        offer_id, offer_version_id, _document = _prepare_offer_with_document(
+            api_url, db, ids["inquiry_convertible"]
+        )
+        status, body, _headers = _get_raw(
+            f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+            f"?offer_version_id={offer_version_id}"
+        )
+        assert status == 422
+        text = body.decode("utf-8")
+        assert "PDF konnte nicht erzeugt werden" in text
+        assert "Traceback" not in text
+    finally:
+        panel_server.shutdown()
+        panel_server.server_close()
+        api_server.shutdown()
+        api_server.server_close()
+
+
+def test_remote_panel_pdf_download_never_exposes_office_api_token(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "remote-offer-pdf.db"
+    ids = _seed(db)
+    inquiry_id = ids["inquiry_convertible"]
+    api_url, api_server = _run_server_in_thread(
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+        )
+    )
+    offer_id, offer_version_id, _document = _prepare_offer_with_document(
+        api_url, db, inquiry_id
+    )
+    remote = RemoteCoreClient(api_url, _API_TOKEN)
+    panel_url, panel_server = _run_server_in_thread(
+        lambda: create_office_panel_server(
+            remote,
+            remote,
+            _PASSWORD,
+            host="127.0.0.1",
+            port=0,
+            remote=remote,
+            ui_version="v2",
+        )
+    )
+    try:
+        _status, html = _get(f"{panel_url}/offer/{offer_id}")
+        assert "PDF herunterladen" in html
+        assert _API_TOKEN not in html
+
+        status, data, headers = _get_raw(
+            f"{panel_url}/offer/{offer_id}/offer-document/pdf"
+            f"?offer_version_id={offer_version_id}"
+        )
+        assert status == 200
+        assert data[:5] == b"%PDF-"
+        assert headers.get("Content-Type") == "application/pdf"
+        assert _API_TOKEN.encode() not in data
+        assert all(_API_TOKEN not in value for value in headers.values())
+    finally:
+        panel_server.shutdown()
+        panel_server.server_close()
+        api_server.shutdown()
+        api_server.server_close()


### PR DESCRIPTION
## Summary

- add `PDF herunterladen` to the existing Offer view
- proxy PDF downloads through Office Panel without exposing the Office
  API token
- preserve PDF content type and attachment filename
- show the button only for the displayed OfferVersion when its immutable
  snapshot exists
- support both RemoteCoreClient and direct SQLite modes
- use shared fail-closed `OFFICE_PDF_*` configuration
- fix direct-mode wiring to use the SQLite snapshot repository

## Scope boundaries

Not included:

- PDF storage
- email sending
- signed-file upload
- AcceptanceEvidence changes
- Offer-to-Order conversion changes
- deployment or Lenovo changes

## Verification

- full suite: 1925 passed
- coverage: 90.2%
- focused delta review: 202 passed
- Ruff and format checks passed
- Mypy passed
- Node tests 24/24 passed
- independent review completed
- delta verdict: APPROVE DELTA — READY TO PUSH

## Commits

- a35f5db Add offer PDF download to Office Panel
- 460ab49 Fix direct-mode offer PDF wiring