### PR TITLE
Add catalog admin completion foundation

### DIFF
--- a/src/catering_system/domain/catalog.py
+++ b/src/catering_system/domain/catalog.py
@@ -59,12 +59,30 @@ ALLERGEN_LABELS: dict[AllergenCode, str] = {
     "N": "Weichtiere",
 }
 
+PricingUnit = Literal["per_person", "stueck", "pauschal"]
+
+PRICING_UNITS: tuple[PricingUnit, ...] = ("per_person", "stueck", "pauschal")
+
+# CATALOG_ADMIN_COMPLETION_V1A: intentionally re-declared, not imported from
+# domain/offer.py — offer.py's VatRatePercent is authoritative for a frozen
+# OfferPosition; this one is only ever a catalog *default/suggestion*
+# (decision #1) and importing from offer.py would create a domain import
+# cycle (offer.py never depends on catalog.py). Values are kept in sync by
+# convention (German catering VAT: reduced 7% / standard 19%), not by import.
+_CATALOG_VAT_RATES_PERCENT: tuple[int, ...] = (7, 19)
+
 _MAX_NAME_LEN = 500
 _MAX_TEXT_LEN = 20_000
+_MAX_CATEGORY_LEN = 200
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
+# CATALOG_ADMIN_COMPLETION_V1A review fix: lowercase ASCII segments of
+# a-z0-9 joined by single hyphen/underscore separators — first and last
+# character must be alphanumeric, so leading/trailing/doubled separators
+# are rejected (e.g. "-dessert", "dessert-", "food--hot" all fail).
+_CATEGORY_RE = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
 
 
 def _require_uuid(value: str, field: str) -> None:
@@ -93,6 +111,43 @@ def allergen_labels(codes: tuple[AllergenCode, ...]) -> tuple[str, ...]:
     return tuple(ALLERGEN_LABELS[code] for code in codes)
 
 
+def validate_pricing_unit(value: str) -> PricingUnit:
+    if value not in PRICING_UNITS:
+        raise ValueError("pricing_unit must be one of: " + ", ".join(PRICING_UNITS))
+    return value
+
+
+def validate_catalog_vat_rate_percent(value: int) -> int:
+    if value not in _CATALOG_VAT_RATES_PERCENT:
+        raise ValueError(
+            "vat_rate_percent must be one of: "
+            + ", ".join(str(rate) for rate in _CATALOG_VAT_RATES_PERCENT)
+        )
+    return value
+
+
+def validate_category(value: str) -> str:
+    """Stable ASCII key (decision #6), not a display label: lowercase a-z0-9
+    segments joined by single hyphen/underscore separators — matches
+    ``[a-z0-9]+(?:[-_][a-z0-9]+)*``, e.g. "fingerfood", "service-personal",
+    "warme_speisen". No closed set/table (grouping is by exact key match),
+    but the key format itself is closed. Leading/trailing whitespace is
+    trimmed before validation; nothing else is silently transformed — an
+    invalid key (uppercase, spaces, non-ASCII, leading/trailing/doubled
+    separators, empty) is rejected, never coerced into a valid one."""
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError("category is required")
+    if len(trimmed) > _MAX_CATEGORY_LEN:
+        raise ValueError("category exceeds length limit")
+    if not _CATEGORY_RE.match(trimmed):
+        raise ValueError(
+            "category must be a lowercase key matching "
+            "[a-z0-9]+(?:[-_][a-z0-9]+)* (e.g. 'fingerfood', 'service-personal')"
+        )
+    return trimmed
+
+
 @dataclass(frozen=True)
 class CatalogDish:
     dish_id: str
@@ -105,6 +160,15 @@ class CatalogDish:
     active: bool
     created_at: datetime
     updated_at: datetime
+    # CATALOG_ADMIN_COMPLETION_V1A: NULL for legacy rows created before this
+    # slice (decision #2) — no fictitious backfill (decision #3). Required
+    # only at *creation* time (decision #4), enforced by
+    # CatalogDishCreatePayload, not here: this dataclass also represents
+    # existing legacy dishes read straight from storage, which must keep
+    # loading with these unset.
+    category: str | None = None
+    pricing_unit: PricingUnit | None = None
+    vat_rate_percent: int | None = None
 
     def __post_init__(self) -> None:
         _require_uuid(self.dish_id, "dish_id")
@@ -124,6 +188,18 @@ class CatalogDish:
         object.__setattr__(self, "allergens", validate_allergen_codes(self.allergens))
         _require_aware(self.created_at, "created_at")
         _require_aware(self.updated_at, "updated_at")
+        if self.category is not None:
+            object.__setattr__(self, "category", validate_category(self.category))
+        if self.pricing_unit is not None:
+            object.__setattr__(
+                self, "pricing_unit", validate_pricing_unit(self.pricing_unit)
+            )
+        if self.vat_rate_percent is not None:
+            object.__setattr__(
+                self,
+                "vat_rate_percent",
+                validate_catalog_vat_rate_percent(self.vat_rate_percent),
+            )
 
 
 @dataclass(frozen=True)
@@ -159,6 +235,54 @@ class CatalogDishNotFoundError(LookupError):
 
 class CatalogDishStaleError(ValueError):
     """Raised when optimistic concurrency on updated_at fails."""
+
+
+class CatalogDishAlreadyExistsError(ValueError):
+    """Raised when a dish_id already exists (insert_dish_if_absent contract)."""
+
+
+@dataclass(frozen=True)
+class CatalogDishCreatePayload:
+    """CATALOG_ADMIN_COMPLETION_V1A: creating a new dish requires the fields
+    legacy rows are allowed to omit (decision #4) — name, category,
+    pricing_unit, current_unit_net_cents, vat_rate_percent are all required
+    here, unlike on CatalogDish itself where they stay optional for legacy
+    reads (decision #2/#3)."""
+
+    name: str
+    category: str
+    pricing_unit: PricingUnit
+    current_unit_net_cents: int
+    vat_rate_percent: int
+    description: str | None = None
+    composition: str | None = None
+    notes: str | None = None
+    allergens: tuple[AllergenCode, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("name is required")
+        if len(self.name) > _MAX_NAME_LEN:
+            raise ValueError("name exceeds length limit")
+        for field_name, value in (
+            ("description", self.description),
+            ("composition", self.composition),
+            ("notes", self.notes),
+        ):
+            if value is not None and len(value) > _MAX_TEXT_LEN:
+                raise ValueError(f"{field_name} exceeds length limit")
+        if self.current_unit_net_cents < 0:
+            raise ValueError("current_unit_net_cents must be non-negative")
+        object.__setattr__(self, "category", validate_category(self.category))
+        object.__setattr__(
+            self, "pricing_unit", validate_pricing_unit(self.pricing_unit)
+        )
+        object.__setattr__(
+            self,
+            "vat_rate_percent",
+            validate_catalog_vat_rate_percent(self.vat_rate_percent),
+        )
+        object.__setattr__(self, "allergens", validate_allergen_codes(self.allergens))
 
 
 @dataclass(frozen=True)

--- a/src/catering_system/repositories/sqlite_catalog_repository.py
+++ b/src/catering_system/repositories/sqlite_catalog_repository.py
@@ -7,12 +7,14 @@ import sqlite3
 from contextlib import nullcontext
 from datetime import date, datetime
 from pathlib import Path
+from typing import cast
 
 from catering_system.domain.catalog import (
     CatalogDish,
     CatalogDishNotFoundError,
     CatalogDishStaleError,
     CatalogPriceHistoryEntry,
+    PricingUnit,
     validate_allergen_codes,
 )
 from catering_system.repositories.sqlite_migrations import apply_migrations
@@ -63,7 +65,22 @@ def _migration_1_create_catalog_tables(connection: sqlite3.Connection) -> None:
     )
 
 
-_MIGRATIONS = ((1, "catalog_dishes_v1", _migration_1_create_catalog_tables),)
+def _migration_2_add_admin_completion_columns(connection: sqlite3.Connection) -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A (decision #2): nullable columns only —
+    legacy rows keep NULL, no fictitious backfill (decision #3)."""
+    connection.execute("ALTER TABLE catalog_dishes ADD COLUMN category TEXT")
+    connection.execute("ALTER TABLE catalog_dishes ADD COLUMN pricing_unit TEXT")
+    connection.execute("ALTER TABLE catalog_dishes ADD COLUMN vat_rate_percent INTEGER")
+
+
+_MIGRATIONS = (
+    (1, "catalog_dishes_v1", _migration_1_create_catalog_tables),
+    (
+        2,
+        "catalog_dishes_admin_completion_v1a",
+        _migration_2_add_admin_completion_columns,
+    ),
+)
 
 
 class SQLiteCatalogRepository:
@@ -103,7 +120,8 @@ class SQLiteCatalogRepository:
             f"""
             SELECT dish_id, name, description, composition, notes,
                    current_unit_net_cents, allergens_json, active,
-                   created_at, updated_at
+                   created_at, updated_at, category, pricing_unit,
+                   vat_rate_percent
             FROM catalog_dishes
             {where}
             ORDER BY active DESC, name COLLATE NOCASE ASC, dish_id ASC
@@ -132,7 +150,8 @@ class SQLiteCatalogRepository:
             """
             SELECT dish_id, name, description, composition, notes,
                    current_unit_net_cents, allergens_json, active,
-                   created_at, updated_at
+                   created_at, updated_at, category, pricing_unit,
+                   vat_rate_percent
             FROM catalog_dishes
             WHERE dish_id = ?
             """,
@@ -171,8 +190,9 @@ class SQLiteCatalogRepository:
                 INSERT INTO catalog_dishes (
                     dish_id, name, description, composition, notes,
                     current_unit_net_cents, allergens_json, active,
-                    created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    created_at, updated_at, category, pricing_unit,
+                    vat_rate_percent
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     dish.dish_id,
@@ -185,6 +205,9 @@ class SQLiteCatalogRepository:
                     int(dish.active),
                     dish.created_at.isoformat(),
                     dish.updated_at.isoformat(),
+                    dish.category,
+                    dish.pricing_unit,
+                    dish.vat_rate_percent,
                 ),
             )
             if self._manage_transactions:
@@ -215,7 +238,8 @@ class SQLiteCatalogRepository:
                 UPDATE catalog_dishes
                 SET name = ?, description = ?, composition = ?, notes = ?,
                     current_unit_net_cents = ?, allergens_json = ?, active = ?,
-                    updated_at = ?
+                    updated_at = ?, category = ?, pricing_unit = ?,
+                    vat_rate_percent = ?
                 WHERE dish_id = ?
                 """,
                 (
@@ -227,6 +251,9 @@ class SQLiteCatalogRepository:
                     json.dumps(list(dish.allergens)),
                     int(dish.active),
                     dish.updated_at.isoformat(),
+                    dish.category,
+                    dish.pricing_unit,
+                    dish.vat_rate_percent,
                     dish.dish_id,
                 ),
             )
@@ -287,6 +314,7 @@ def _row_to_dish(row: tuple[object, ...]) -> CatalogDish:
     allergens_raw = json.loads(str(row[6]))
     if not isinstance(allergens_raw, list):
         raise ValueError("allergens_json must decode to a list")
+    pricing_unit_raw = row[11]
     return CatalogDish(
         dish_id=str(row[0]),
         name=str(row[1]),
@@ -298,6 +326,13 @@ def _row_to_dish(row: tuple[object, ...]) -> CatalogDish:
         active=bool(row[7]),
         created_at=datetime.fromisoformat(str(row[8])),
         updated_at=datetime.fromisoformat(str(row[9])),
+        category=_optional_sql_text(row[10]),
+        pricing_unit=(
+            cast(PricingUnit, str(pricing_unit_raw))
+            if pricing_unit_raw is not None
+            else None
+        ),
+        vat_rate_percent=_sql_int(row[12]) if row[12] is not None else None,
     )
 
 

--- a/src/catering_system/services/catalog_dish_write_service.py
+++ b/src/catering_system/services/catalog_dish_write_service.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 
 from catering_system.domain.catalog import (
     CatalogDish,
+    CatalogDishAlreadyExistsError,
+    CatalogDishCreatePayload,
     CatalogDishNotFoundError,
     CatalogDishStaleError,
     CatalogDishUpdatePayload,
@@ -21,6 +23,97 @@ _DEFAULT_CHANGED_BY = "office"
 class CatalogDishWriteService:
     def __init__(self, catalog_repository: CatalogRepository) -> None:
         self._catalog = catalog_repository
+
+    def create_dish(
+        self,
+        create: CatalogDishCreatePayload,
+        *,
+        now: datetime | None = None,
+    ) -> CatalogDish:
+        """CATALOG_ADMIN_COMPLETION_V1A: a new dish is always created
+        inactive (decision #8) — activation is a separate, explicit
+        operation. dish_id is minted here, never client-supplied, matching
+        every other Core-minted id in this codebase."""
+        commit_time = now or datetime.now(tz=UTC)
+        dish = CatalogDish(
+            dish_id=str(uuid.uuid4()),
+            name=create.name.strip(),
+            description=create.description,
+            composition=create.composition,
+            notes=create.notes,
+            current_unit_net_cents=create.current_unit_net_cents,
+            allergens=create.allergens,
+            active=False,
+            created_at=commit_time,
+            updated_at=commit_time,
+            category=create.category,
+            pricing_unit=create.pricing_unit,
+            vat_rate_percent=create.vat_rate_percent,
+        )
+        if not self._catalog.insert_dish_if_absent(dish):
+            raise CatalogDishAlreadyExistsError(dish.dish_id)
+        return dish
+
+    def _set_active(
+        self,
+        dish_id: str,
+        *,
+        active: bool,
+        expected_updated_at: datetime,
+        now: datetime | None = None,
+    ) -> CatalogDish:
+        """Shared activate/deactivate body: idempotent when the dish is
+        already in the target state (repeated activate/deactivate is a
+        no-op, not an error), but staleness is still checked first even for
+        the no-op path — optimistic concurrency must reject an outdated
+        client view regardless of whether anything would actually change."""
+        current = self._catalog.get_dish(dish_id)
+        if current is None:
+            raise CatalogDishNotFoundError(dish_id)
+        if current.updated_at != expected_updated_at:
+            raise CatalogDishStaleError(dish_id)
+        if current.active == active:
+            return current
+        commit_time = now or datetime.now(tz=UTC)
+        updated = CatalogDish(
+            dish_id=current.dish_id,
+            name=current.name,
+            description=current.description,
+            composition=current.composition,
+            notes=current.notes,
+            current_unit_net_cents=current.current_unit_net_cents,
+            allergens=current.allergens,
+            active=active,
+            created_at=current.created_at,
+            updated_at=commit_time,
+            category=current.category,
+            pricing_unit=current.pricing_unit,
+            vat_rate_percent=current.vat_rate_percent,
+        )
+        self._catalog.update_dish(updated, expected_updated_at=expected_updated_at)
+        return updated
+
+    def activate_dish(
+        self,
+        dish_id: str,
+        *,
+        expected_updated_at: datetime,
+        now: datetime | None = None,
+    ) -> CatalogDish:
+        return self._set_active(
+            dish_id, active=True, expected_updated_at=expected_updated_at, now=now
+        )
+
+    def deactivate_dish(
+        self,
+        dish_id: str,
+        *,
+        expected_updated_at: datetime,
+        now: datetime | None = None,
+    ) -> CatalogDish:
+        return self._set_active(
+            dish_id, active=False, expected_updated_at=expected_updated_at, now=now
+        )
 
     def update_dish(
         self,
@@ -48,6 +141,13 @@ class CatalogDishWriteService:
             active=update.active,
             created_at=current.created_at,
             updated_at=commit_time,
+            # CATALOG_ADMIN_COMPLETION_V1A: this endpoint's payload has no
+            # way to set these fields yet — carry the current values
+            # forward so an unrelated text/price/active edit never wipes
+            # them back to NULL.
+            category=current.category,
+            pricing_unit=current.pricing_unit,
+            vat_rate_percent=current.vat_rate_percent,
         )
         price_changed = update.current_unit_net_cents != current.current_unit_net_cents
         history_entry: CatalogPriceHistoryEntry | None = None

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -178,10 +178,13 @@ from catering_system.services.catalog_dish_service import CatalogDishService
 from catering_system.services.catalog_dish_write_service import CatalogDishWriteService
 from catering_system.domain.catalog import (
     AllergenCode,
+    CatalogDishAlreadyExistsError,
+    CatalogDishCreatePayload,
     CatalogDishNotFoundError,
     CatalogDishStaleError,
     CatalogDishUpdatePayload,
     validate_allergen_codes,
+    validate_pricing_unit,
 )
 from catering_system.ui import office_api_views as views
 
@@ -764,6 +767,78 @@ class OfficeApi:
         if result.price_history_entry_id is not None:
             body["price_history_entry_id"] = result.price_history_entry_id
         return 200, body
+
+    def cmd_create_catalog_dish(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        """CATALOG_ADMIN_COMPLETION_V1A: dish_id is minted server-side, never
+        client-supplied — no expect/staleness check applies (a create has no
+        prior state). New dishes are always active=false (decision #8)."""
+        try:
+            dish = self.catalog_dish_write_service.create_dish(
+                CatalogDishCreatePayload(
+                    name=_v_str(args["name"], 500),
+                    category=_v_str(args["category"], 200),
+                    pricing_unit=_v_enum(args["pricing_unit"], validate_pricing_unit),
+                    current_unit_net_cents=_v_int(args["current_unit_net_cents"]),
+                    vat_rate_percent=_v_int(args["vat_rate_percent"]),
+                    description=_v_catalog_text(args.get("description"), 20_000),
+                    composition=_v_catalog_text(args.get("composition"), 20_000),
+                    notes=_v_catalog_text(args.get("notes"), 20_000),
+                    allergens=(
+                        _v_allergen_codes(args["allergens"])
+                        if "allergens" in args
+                        else ()
+                    ),
+                )
+            )
+        except CatalogDishAlreadyExistsError as exc:
+            raise ApiError(409, "already_exists") from exc
+        except ValueError as exc:
+            raise ApiError(422, "validation_error") from exc
+        return 201, {
+            "dish_id": dish.dish_id,
+            "active": dish.active,
+            "updated_at": dish.updated_at.isoformat(),
+        }
+
+    def _cmd_set_catalog_dish_active(
+        self, path_ids: dict[str, str], expect: dict, *, active: bool
+    ) -> tuple[int, dict[str, object]]:
+        dish_id = _v_catalog_uuid(path_ids["id"])
+        current = self.catalog_dish_service.get_dish(dish_id)
+        if current is None:
+            raise ApiError(404, "not_found")
+        if _v_datetime(expect["updated_at"]) != current.updated_at:
+            raise ApiError(409, "stale_state")
+        try:
+            if active:
+                dish = self.catalog_dish_write_service.activate_dish(
+                    dish_id, expected_updated_at=current.updated_at
+                )
+            else:
+                dish = self.catalog_dish_write_service.deactivate_dish(
+                    dish_id, expected_updated_at=current.updated_at
+                )
+        except CatalogDishNotFoundError as exc:
+            raise ApiError(404, "not_found") from exc
+        except CatalogDishStaleError as exc:
+            raise ApiError(409, "stale_state") from exc
+        return 200, {
+            "dish_id": dish.dish_id,
+            "active": dish.active,
+            "updated_at": dish.updated_at.isoformat(),
+        }
+
+    def cmd_activate_catalog_dish(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        return self._cmd_set_catalog_dish_active(path_ids, expect, active=True)
+
+    def cmd_deactivate_catalog_dish(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        return self._cmd_set_catalog_dish_active(path_ids, expect, active=False)
 
     def list_emails(self) -> dict[str, object]:
         return {
@@ -2152,6 +2227,18 @@ _CATALOG_DISH_UPDATE_ARGS = _ArgKeys(
     ),
     optional=frozenset({"description", "composition", "notes", "effective_from"}),
 )
+_CATALOG_DISH_CREATE_ARGS = _ArgKeys(
+    required=frozenset(
+        {
+            "name",
+            "category",
+            "pricing_unit",
+            "current_unit_net_cents",
+            "vat_rate_percent",
+        }
+    ),
+    optional=frozenset({"description", "composition", "notes", "allergens"}),
+)
 
 _COMMANDS: dict[str, _CommandSpec] = {
     "create_inquiry": _CommandSpec("cmd_create_inquiry", _CREATE_ARGS, set()),
@@ -2236,6 +2323,15 @@ _COMMANDS: dict[str, _CommandSpec] = {
     ),
     "update_catalog_dish": _CommandSpec(
         "cmd_update_catalog_dish", _CATALOG_DISH_UPDATE_ARGS, {"updated_at"}
+    ),
+    "create_catalog_dish": _CommandSpec(
+        "cmd_create_catalog_dish", _CATALOG_DISH_CREATE_ARGS, set()
+    ),
+    "activate_catalog_dish": _CommandSpec(
+        "cmd_activate_catalog_dish", _NO_ARGS, {"updated_at"}
+    ),
+    "deactivate_catalog_dish": _CommandSpec(
+        "cmd_deactivate_catalog_dish", _NO_ARGS, {"updated_at"}
     ),
 }
 
@@ -2340,7 +2436,7 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
     (
         re.compile(r"^/office/v1/catalog/dishes$"),
         "/office/v1/catalog/dishes",
-        {"GET": "list_catalog_dishes"},
+        {"GET": "list_catalog_dishes", "POST": "create_catalog_dish"},
     ),
     (
         re.compile(r"^/office/v1/catalog/dishes/(?P<id>[^/]+)$"),
@@ -2356,6 +2452,16 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/catalog/dishes/(?P<id>[^/]+)/update$"),
         "/office/v1/catalog/dishes/{id}/update",
         {"POST": "update_catalog_dish"},
+    ),
+    (
+        re.compile(r"^/office/v1/catalog/dishes/(?P<id>[^/]+)/activate$"),
+        "/office/v1/catalog/dishes/{id}/activate",
+        {"POST": "activate_catalog_dish"},
+    ),
+    (
+        re.compile(r"^/office/v1/catalog/dishes/(?P<id>[^/]+)/deactivate$"),
+        "/office/v1/catalog/dishes/{id}/deactivate",
+        {"POST": "deactivate_catalog_dish"},
     ),
     (
         re.compile(r"^/office/v1/offers$"),

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -1169,6 +1169,10 @@ def catalog_dish_list_row(dish: CatalogDish) -> dict[str, object]:
         "allergens": list(dish.allergens),
         "allergen_labels": list(allergen_labels(dish.allergens)),
         "active": dish.active,
+        # CATALOG_ADMIN_COMPLETION_V1A: null for legacy rows (decision #2/#3)
+        "category": dish.category,
+        "pricing_unit": dish.pricing_unit,
+        "vat_rate_percent": dish.vat_rate_percent,
     }
 
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -77,6 +77,7 @@ from catering_system.services.order_confirmation_outbound_service import (
     OutboundSendSummary,
 )
 from catering_system.domain.order_confirmation_outbound import FakeOutboxMessage
+from catering_system.domain.catalog import validate_pricing_unit
 from catering_system.services.inquiry_service import validate_inquiry_source
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
@@ -444,6 +445,19 @@ def _optional_int(value: object) -> int | None:
     if value is None:
         return None
     return _int(value)
+
+
+def _optional_pricing_unit(value: object) -> str | None:
+    """CATALOG_ADMIN_COMPLETION_V1A review fix: fail-closed against the
+    closed pricing_unit set, not just a loose string type-check — NULL
+    stays valid for legacy rows, but an unknown non-null value (a tampered
+    or buggy Office API response) is rejected as an invalid contract."""
+    if value is None:
+        return None
+    try:
+        return validate_pricing_unit(_str(value))
+    except ValueError:
+        _bad_response()
 
 
 def _guest_count(value: object) -> int | None:
@@ -1783,6 +1797,9 @@ class RemoteCoreClient:
                     "allergens",
                     "allergen_labels",
                     "active",
+                    "category",
+                    "pricing_unit",
+                    "vat_rate_percent",
                 },
             )
             _uuid4(row["dish_id"])
@@ -1794,6 +1811,9 @@ class RemoteCoreClient:
             for label in _list(row["allergen_labels"]):
                 _str(label)
             _bool(row["active"])
+            _optional_str(row["category"])
+            _optional_pricing_unit(row["pricing_unit"])
+            _optional_int(row["vat_rate_percent"])
         _nonnegative_int(body["total_count"])
         _bool(body["truncated"])
         return body
@@ -1815,6 +1835,9 @@ class RemoteCoreClient:
                 "allergens",
                 "allergen_labels",
                 "active",
+                "category",
+                "pricing_unit",
+                "vat_rate_percent",
                 "description",
                 "composition",
                 "notes",
@@ -1825,6 +1848,9 @@ class RemoteCoreClient:
         )
         if _uuid4(body["dish_id"]) != dish_id:
             _bad_response()
+        _optional_str(body["category"])
+        _optional_pricing_unit(body["pricing_unit"])
+        _optional_int(body["vat_rate_percent"])
         for raw in _list(body["price_history"]):
             entry = _dict(raw)
             _exact(

--- a/tests/unit/test_catalog_dish_write_service.py
+++ b/tests/unit/test_catalog_dish_write_service.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, date, datetime
 
 import pytest
 
 from catering_system.domain.catalog import (
     CatalogDish,
+    CatalogDishAlreadyExistsError,
+    CatalogDishCreatePayload,
     CatalogDishNotFoundError,
     CatalogDishStaleError,
     CatalogDishUpdatePayload,
@@ -167,3 +170,183 @@ def test_update_missing_dish_raises_not_found() -> None:
             ),
             expected_updated_at=_NOW,
         )
+
+
+def test_update_preserves_admin_completion_fields_not_in_payload() -> None:
+    """Editing a dish through the pre-existing update endpoint must never
+    silently wipe category/pricing_unit/vat_rate_percent back to NULL —
+    that payload has no way to set them (CATALOG_ADMIN_COMPLETION_V1A)."""
+    dish = _dish(category="fingerfood", pricing_unit="stueck", vat_rate_percent=7)
+    service = _service(dish)
+    result = service.update_dish(
+        _DISH_ID,
+        update=CatalogDishUpdatePayload(
+            name="Schnitzel Wiener Art",
+            description="Alt",
+            composition="mit Kartoffeln",
+            notes=None,
+            current_unit_net_cents=850,
+            allergens=("A",),
+            active=True,
+        ),
+        expected_updated_at=_NOW,
+        now=_LATER,
+    )
+    assert result.dish.category == "fingerfood"
+    assert result.dish.pricing_unit == "stueck"
+    assert result.dish.vat_rate_percent == 7
+
+
+# --- CATALOG_ADMIN_COMPLETION_V1A: create/activate/deactivate ---------------
+
+
+def _create_payload(**overrides: object) -> CatalogDishCreatePayload:
+    base: dict[str, object] = {
+        "name": "Lachs-Canape",
+        "category": "fingerfood",
+        "pricing_unit": "stueck",
+        "current_unit_net_cents": 250,
+        "vat_rate_percent": 7,
+    }
+    base.update(overrides)
+    return CatalogDishCreatePayload(**base)  # type: ignore[arg-type]
+
+
+def test_create_dish_full_dish_is_inactive() -> None:
+    service = _service()
+    dish = service.create_dish(
+        _create_payload(
+            description="Frisch",
+            composition="Lachs, Brot",
+            notes="Küchennotiz",
+            allergens=("A", "D"),
+        ),
+        now=_NOW,
+    )
+    assert dish.active is False
+    assert dish.name == "Lachs-Canape"
+    assert dish.category == "fingerfood"
+    assert dish.pricing_unit == "stueck"
+    assert dish.current_unit_net_cents == 250
+    assert dish.vat_rate_percent == 7
+    assert dish.description == "Frisch"
+    assert dish.composition == "Lachs, Brot"
+    assert dish.notes == "Küchennotiz"
+    assert dish.allergens == ("A", "D")
+    assert dish.created_at == _NOW
+    assert dish.updated_at == _NOW
+
+
+def test_create_dish_mints_a_fresh_dish_id_each_call() -> None:
+    service = _service()
+    first = service.create_dish(_create_payload(), now=_NOW)
+    second = service.create_dish(_create_payload(name="Andere"), now=_NOW)
+    assert first.dish_id != second.dish_id
+
+
+def test_create_dish_read_roundtrip_via_repository() -> None:
+    repo = InMemoryCatalogRepository()
+    service = CatalogDishWriteService(repo)
+    created = service.create_dish(_create_payload(), now=_NOW)
+    fetched = repo.get_dish(created.dish_id)
+    assert fetched == created
+    listed = repo.list_dishes()
+    assert [row.dish_id for row in listed] == [created.dish_id]
+
+
+def test_create_dish_duplicate_dish_id_rejected_at_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dish_id is server-minted (uuid4) so a real collision can't happen
+    through normal use — but the repository guarantee create_dish relies on
+    must hold. Force two calls to mint the same id to exercise the actual
+    service code path end to end: the second is rejected, not silently
+    overwritten, and CatalogDishAlreadyExistsError surfaces the failure."""
+    import catering_system.services.catalog_dish_write_service as write_service_module
+
+    fixed_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    monkeypatch.setattr(write_service_module.uuid, "uuid4", lambda: fixed_id)
+
+    repo = InMemoryCatalogRepository()
+    service = CatalogDishWriteService(repo)
+    first = service.create_dish(_create_payload(), now=_NOW)
+    assert first.dish_id == str(fixed_id)
+
+    with pytest.raises(CatalogDishAlreadyExistsError):
+        service.create_dish(_create_payload(name="Andere"), now=_LATER)
+
+    unchanged = repo.get_dish(first.dish_id)
+    assert unchanged == first
+
+
+def test_activate_dish_flips_active_and_bumps_updated_at() -> None:
+    service = _service(_dish(active=False))
+    activated = service.activate_dish(_DISH_ID, expected_updated_at=_NOW, now=_LATER)
+    assert activated.active is True
+    assert activated.updated_at == _LATER
+
+
+def test_deactivate_dish_flips_active_and_bumps_updated_at() -> None:
+    service = _service(_dish(active=True))
+    deactivated = service.deactivate_dish(
+        _DISH_ID, expected_updated_at=_NOW, now=_LATER
+    )
+    assert deactivated.active is False
+    assert deactivated.updated_at == _LATER
+
+
+def test_repeated_activate_is_idempotent_no_op() -> None:
+    service = _service(_dish(active=False))
+    first = service.activate_dish(_DISH_ID, expected_updated_at=_NOW, now=_LATER)
+    assert first.active is True
+    second = service.activate_dish(
+        _DISH_ID, expected_updated_at=first.updated_at, now=_LATER
+    )
+    assert second.active is True
+    assert second.updated_at == first.updated_at
+
+
+def test_repeated_deactivate_is_idempotent_no_op() -> None:
+    service = _service(_dish(active=True))
+    first = service.deactivate_dish(_DISH_ID, expected_updated_at=_NOW, now=_LATER)
+    assert first.active is False
+    second = service.deactivate_dish(
+        _DISH_ID, expected_updated_at=first.updated_at, now=_LATER
+    )
+    assert second.active is False
+    assert second.updated_at == first.updated_at
+
+
+def test_activate_dish_rejects_stale_updated_at() -> None:
+    service = _service(_dish(active=False))
+    with pytest.raises(CatalogDishStaleError):
+        service.activate_dish(_DISH_ID, expected_updated_at=_LATER)
+
+
+def test_deactivate_dish_rejects_stale_updated_at() -> None:
+    service = _service(_dish(active=True))
+    with pytest.raises(CatalogDishStaleError):
+        service.deactivate_dish(_DISH_ID, expected_updated_at=_LATER)
+
+
+def test_activate_dish_missing_dish_raises_not_found() -> None:
+    service = _service()
+    with pytest.raises(CatalogDishNotFoundError):
+        service.activate_dish(_DISH_ID, expected_updated_at=_NOW)
+
+
+def test_deactivate_dish_missing_dish_raises_not_found() -> None:
+    service = _service()
+    with pytest.raises(CatalogDishNotFoundError):
+        service.deactivate_dish(_DISH_ID, expected_updated_at=_NOW)
+
+
+def test_activate_dish_preserves_admin_completion_fields() -> None:
+    dish = _dish(
+        active=False, category="fingerfood", pricing_unit="stueck", vat_rate_percent=7
+    )
+    service = _service(dish)
+    activated = service.activate_dish(_DISH_ID, expected_updated_at=_NOW, now=_LATER)
+    assert activated.category == "fingerfood"
+    assert activated.pricing_unit == "stueck"
+    assert activated.vat_rate_percent == 7

--- a/tests/unit/test_catalog_domain_validation.py
+++ b/tests/unit/test_catalog_domain_validation.py
@@ -8,9 +8,13 @@ import pytest
 
 from catering_system.domain.catalog import (
     CatalogDish,
+    CatalogDishCreatePayload,
     CatalogDishUpdatePayload,
     CatalogPriceHistoryEntry,
     validate_allergen_codes,
+    validate_catalog_vat_rate_percent,
+    validate_category,
+    validate_pricing_unit,
 )
 
 
@@ -171,3 +175,188 @@ def test_catalog_update_payload_rejects_long_name() -> None:
             allergens=(),
             active=True,
         )
+
+
+# --- CATALOG_ADMIN_COMPLETION_V1A --------------------------------------------
+
+
+def _create_payload(**overrides: object) -> CatalogDishCreatePayload:
+    base: dict[str, object] = {
+        "name": "Lachs-Canape",
+        "category": "fingerfood",
+        "pricing_unit": "stueck",
+        "current_unit_net_cents": 250,
+        "vat_rate_percent": 7,
+    }
+    base.update(overrides)
+    return CatalogDishCreatePayload(**base)  # type: ignore[arg-type]
+
+
+def test_catalog_dish_legacy_row_allows_null_admin_completion_fields() -> None:
+    """A row read from storage before this slice existed must still
+    construct — category/pricing_unit/vat_rate_percent stay optional on
+    CatalogDish itself (decision #2/#3), unlike on the create payload."""
+    now = datetime(2026, 7, 14, 10, 0, tzinfo=UTC)
+    dish = CatalogDish(
+        dish_id="11111111-1111-4111-8111-111111111111",
+        name="Legacy",
+        description=None,
+        composition=None,
+        notes=None,
+        current_unit_net_cents=100,
+        allergens=(),
+        active=True,
+        created_at=now,
+        updated_at=now,
+    )
+    assert dish.category is None
+    assert dish.pricing_unit is None
+    assert dish.vat_rate_percent is None
+
+
+def test_catalog_dish_rejects_invalid_pricing_unit_when_set() -> None:
+    now = datetime(2026, 7, 14, 10, 0, tzinfo=UTC)
+    with pytest.raises(ValueError, match="pricing_unit must be one of"):
+        CatalogDish(
+            dish_id="11111111-1111-4111-8111-111111111111",
+            name="Test",
+            description=None,
+            composition=None,
+            notes=None,
+            current_unit_net_cents=100,
+            allergens=(),
+            active=True,
+            created_at=now,
+            updated_at=now,
+            pricing_unit="kg",  # type: ignore[arg-type]
+        )
+
+
+def test_catalog_dish_rejects_invalid_vat_rate_when_set() -> None:
+    now = datetime(2026, 7, 14, 10, 0, tzinfo=UTC)
+    with pytest.raises(ValueError, match="vat_rate_percent must be one of"):
+        CatalogDish(
+            dish_id="11111111-1111-4111-8111-111111111111",
+            name="Test",
+            description=None,
+            composition=None,
+            notes=None,
+            current_unit_net_cents=100,
+            allergens=(),
+            active=True,
+            created_at=now,
+            updated_at=now,
+            vat_rate_percent=13,
+        )
+
+
+def test_validate_pricing_unit_accepts_all_three_values() -> None:
+    for value in ("per_person", "stueck", "pauschal"):
+        assert validate_pricing_unit(value) == value
+
+
+def test_validate_pricing_unit_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="pricing_unit must be one of"):
+        validate_pricing_unit("kg")
+
+
+def test_validate_catalog_vat_rate_percent_accepts_7_and_19() -> None:
+    assert validate_catalog_vat_rate_percent(7) == 7
+    assert validate_catalog_vat_rate_percent(19) == 19
+
+
+def test_validate_catalog_vat_rate_percent_rejects_other_values() -> None:
+    with pytest.raises(ValueError, match="vat_rate_percent must be one of"):
+        validate_catalog_vat_rate_percent(0)
+
+
+def test_validate_category_requires_non_empty() -> None:
+    with pytest.raises(ValueError, match="category is required"):
+        validate_category("   ")
+    with pytest.raises(ValueError, match="category is required"):
+        validate_category("")
+
+
+def test_validate_category_rejects_long_value() -> None:
+    with pytest.raises(ValueError, match="category exceeds length limit"):
+        validate_category("a" * 201)
+
+
+def test_validate_category_trims_surrounding_whitespace_then_validates() -> None:
+    """Trim at the edges is allowed, but the trimmed result still has to be
+    a valid key — trimming never rescues an otherwise-invalid value."""
+    assert validate_category("  fingerfood  ") == "fingerfood"
+    with pytest.raises(ValueError, match="category must be a lowercase key"):
+        validate_category("  Fingerfood  ")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "fingerfood",
+        "hauptgericht",
+        "getraenke",
+        "service-personal",
+        "warme_speisen",
+        "dessert2",
+    ],
+)
+def test_validate_category_accepts_valid_ascii_keys(value: str) -> None:
+    assert validate_category(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Fingerfood",
+        "finger food",
+        "getränke",
+        "-dessert",
+        "dessert-",
+        "food--hot",
+        "food__hot",
+    ],
+)
+def test_validate_category_rejects_invalid_ascii_keys(value: str) -> None:
+    with pytest.raises(ValueError, match="category must be a lowercase key"):
+        validate_category(value)
+
+
+def test_catalog_dish_create_payload_full_dish() -> None:
+    payload = _create_payload(
+        description="Frisch",
+        composition="Lachs, Brot",
+        notes="Küchennotiz",
+        allergens=("A", "D"),
+    )
+    assert payload.name == "Lachs-Canape"
+    assert payload.category == "fingerfood"
+    assert payload.pricing_unit == "stueck"
+    assert payload.current_unit_net_cents == 250
+    assert payload.vat_rate_percent == 7
+    assert payload.allergens == ("A", "D")
+
+
+def test_catalog_dish_create_payload_rejects_missing_category() -> None:
+    with pytest.raises(ValueError, match="category is required"):
+        _create_payload(category="   ")
+
+
+def test_catalog_dish_create_payload_rejects_invalid_pricing_unit() -> None:
+    with pytest.raises(ValueError, match="pricing_unit must be one of"):
+        _create_payload(pricing_unit="kg")
+
+
+def test_catalog_dish_create_payload_rejects_invalid_vat_rate() -> None:
+    with pytest.raises(ValueError, match="vat_rate_percent must be one of"):
+        _create_payload(vat_rate_percent=5)
+
+
+def test_catalog_dish_create_payload_rejects_negative_price() -> None:
+    with pytest.raises(ValueError, match="current_unit_net_cents must be non-negative"):
+        _create_payload(current_unit_net_cents=-1)
+
+
+def test_catalog_dish_create_payload_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="name is required"):
+        _create_payload(name="   ")

--- a/tests/unit/test_catalog_offer_regression.py
+++ b/tests/unit/test_catalog_offer_regression.py
@@ -5,18 +5,29 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from pathlib import Path
 
-from catering_system.domain.catalog import CatalogDish, CatalogDishUpdatePayload
+from catering_system.domain.catalog import (
+    CatalogDish,
+    CatalogDishCreatePayload,
+    CatalogDishUpdatePayload,
+)
 from catering_system.domain.offer import (
     Offer,
     OfferPosition,
     OfferVariant,
     OfferVersion,
 )
+from catering_system.repositories.in_memory_catalog_repository import (
+    InMemoryCatalogRepository,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
 from catering_system.repositories.sqlite_catalog_repository import (
     SQLiteCatalogRepository,
 )
 from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
 from catering_system.services.catalog_dish_write_service import CatalogDishWriteService
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 
 _NOW = datetime(2026, 7, 16, 8, 0, tzinfo=UTC)
 _DISH_ID = "11111111-1111-4111-8111-111111111111"
@@ -118,3 +129,78 @@ def test_offer_position_unchanged_after_catalog_price_update(tmp_path: Path) -> 
         assert len(catalog_repo.list_price_history(_DISH_ID)) == 1
     finally:
         catalog_repo.close()
+
+
+def test_catalog_admin_completion_writes_do_not_touch_offer_or_order_snapshots() -> (
+    None
+):
+    """CATALOG_ADMIN_COMPLETION_V1A: creating a new dish and
+    activating/deactivating it are pure catalog Stammdaten writes — a
+    previously-frozen OfferPosition and OrderCommercialSnapshot (both
+    already-immutable-by-design) must be byte-for-byte unaffected."""
+    frozen_position = OfferPosition(
+        position_id=_POSITION_ID,
+        kind="catalog",
+        name="Schnitzel",
+        unit_net_cents=850,
+        net_total_cents=8500,
+        vat_rate_percent=7,
+        vat_amount_cents=595,
+        gross_total_cents=9095,
+    )
+    offer = Offer(
+        offer_id=_OFFER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        versions=(
+            OfferVersion(
+                offer_version_id=_VERSION_ID,
+                offer_id=_OFFER_ID,
+                version_number=1,
+                created_at=_NOW,
+                valid_until=date(2026, 12, 31),
+                snapshot_id="77777777-7777-4777-8777-777777777771",
+                snapshot_hash="sha256:" + ("a" * 64),
+                event_date=_EVENT_DATE,
+                time_window_text="18:00–22:00",
+                location_text="Hamburg",
+                guest_count=80,
+                planning_mode="caterer_suggestion",
+                payment_method="RECHNUNG",
+                payment_customer_visible_text="Zahlung per Rechnung",
+                variants=(
+                    OfferVariant(
+                        variant_id=_VARIANT_ID,
+                        offer_version_id=_VERSION_ID,
+                        label="Standard",
+                        positions=(frozen_position,),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    catalog_repo = InMemoryCatalogRepository()
+    write_service = CatalogDishWriteService(catalog_repo)
+    commercial_snapshots = InMemoryOrderCommercialSnapshotRepository()
+    frozen_snapshot = seed_commercial_snapshot(
+        commercial_snapshots, "order-1", created_at=_NOW, position_name="Schnitzel"
+    )
+
+    new_dish = write_service.create_dish(
+        CatalogDishCreatePayload(
+            name="Neues Gericht",
+            category="fingerfood",
+            pricing_unit="stueck",
+            current_unit_net_cents=250,
+            vat_rate_percent=7,
+        ),
+        now=_NOW,
+    )
+    write_service.activate_dish(
+        new_dish.dish_id, expected_updated_at=new_dish.updated_at
+    )
+
+    assert offer.versions[0].variants[0].positions[0] == frozen_position
+    reloaded_snapshot = commercial_snapshots.get_by_id(frozen_snapshot.snapshot_id)
+    assert reloaded_snapshot == frozen_snapshot

--- a/tests/unit/test_catalog_repository.py
+++ b/tests/unit/test_catalog_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import UTC, date, datetime
 from pathlib import Path
 
@@ -116,3 +117,248 @@ def test_sqlite_catalog_update_and_price_history(tmp_path: Path) -> None:
         assert history[0].new_unit_net_cents == 900
     finally:
         repo.close()
+
+
+# --- CATALOG_ADMIN_COMPLETION_V1A -------------------------------------------
+
+
+def test_sqlite_catalog_create_read_list_roundtrip_with_new_fields(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    repo = SQLiteCatalogRepository(db)
+    try:
+        dish = CatalogDish(
+            dish_id=_DISH_ID,
+            name="Lachs-Canape",
+            description="Frisch",
+            composition="Lachs, Brot",
+            notes=None,
+            current_unit_net_cents=250,
+            allergens=("D",),
+            active=False,
+            created_at=_NOW,
+            updated_at=_NOW,
+            category="fingerfood",
+            pricing_unit="stueck",
+            vat_rate_percent=7,
+        )
+        assert repo.insert_dish_if_absent(dish) is True
+        fetched = repo.get_dish(_DISH_ID)
+        assert fetched == dish
+        listed = repo.list_dishes()
+        assert len(listed) == 1
+        assert listed[0] == dish
+    finally:
+        repo.close()
+
+
+def test_sqlite_catalog_duplicate_dish_id_rejected_with_new_fields(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    repo = SQLiteCatalogRepository(db)
+    try:
+        dish = CatalogDish(
+            dish_id=_DISH_ID,
+            name="Lachs-Canape",
+            description=None,
+            composition=None,
+            notes=None,
+            current_unit_net_cents=250,
+            allergens=(),
+            active=False,
+            created_at=_NOW,
+            updated_at=_NOW,
+            category="fingerfood",
+            pricing_unit="stueck",
+            vat_rate_percent=7,
+        )
+        assert repo.insert_dish_if_absent(dish) is True
+        assert repo.insert_dish_if_absent(dish) is False
+        assert repo.count_dishes() == 1
+    finally:
+        repo.close()
+
+
+def _build_legacy_v1_db(db: Path, *, dish_id: str = _DISH_ID) -> None:
+    """Builds a database that only ever saw migration 1 (pre
+    CATALOG_ADMIN_COMPLETION_V1A) with one legacy row inserted directly
+    against the old schema — no category/pricing_unit/vat_rate_percent
+    columns exist yet."""
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE catalog_dishes (
+            dish_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            composition TEXT,
+            notes TEXT,
+            current_unit_net_cents INTEGER NOT NULL,
+            allergens_json TEXT NOT NULL,
+            active INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE catalog_price_history (
+            entry_id TEXT PRIMARY KEY,
+            dish_id TEXT NOT NULL,
+            old_unit_net_cents INTEGER,
+            new_unit_net_cents INTEGER NOT NULL,
+            changed_at TEXT NOT NULL,
+            changed_by TEXT NOT NULL,
+            effective_from TEXT,
+            FOREIGN KEY (dish_id) REFERENCES catalog_dishes (dish_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE schema_migrations (
+            component TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            applied_at TEXT NOT NULL,
+            PRIMARY KEY (component, version)
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO schema_migrations (component, version, name, applied_at) "
+        "VALUES ('catalog', 1, 'catalog_dishes_v1', '2026-01-01T00:00:00Z')"
+    )
+    conn.execute(
+        """
+        INSERT INTO catalog_dishes (
+            dish_id, name, description, composition, notes,
+            current_unit_net_cents, allergens_json, active,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            dish_id,
+            "Legacy Schnitzel",
+            "Alt",
+            None,
+            None,
+            850,
+            "[]",
+            1,
+            _NOW.isoformat(),
+            _NOW.isoformat(),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_sqlite_catalog_migration_preserves_legacy_row_and_adds_new_columns(
+    tmp_path: Path,
+) -> None:
+    """Simulates a database that only ever saw migration 1 (pre this slice):
+    a legacy row inserted directly against the old schema must still be
+    readable — with NULL new fields, no fictitious backfill — once the
+    repository (and therefore migration 2) runs against it."""
+    db = tmp_path / "core.db"
+    _build_legacy_v1_db(db)
+
+    repo = SQLiteCatalogRepository(db)
+    try:
+        legacy = repo.get_dish(_DISH_ID)
+        assert legacy is not None
+        assert legacy.name == "Legacy Schnitzel"
+        assert legacy.category is None
+        assert legacy.pricing_unit is None
+        assert legacy.vat_rate_percent is None
+
+        new_id = "22222222-2222-4222-8222-222222222222"
+        new_dish = CatalogDish(
+            dish_id=new_id,
+            name="Neues Gericht",
+            description=None,
+            composition=None,
+            notes=None,
+            current_unit_net_cents=300,
+            allergens=(),
+            active=False,
+            created_at=_NOW,
+            updated_at=_NOW,
+            category="fingerfood",
+            pricing_unit="pauschal",
+            vat_rate_percent=19,
+        )
+        assert repo.insert_dish_if_absent(new_dish) is True
+        fetched_new = repo.get_dish(new_id)
+        assert fetched_new == new_dish
+        assert repo.count_dishes() == 2
+    finally:
+        repo.close()
+
+    verify_conn = sqlite3.connect(str(db))
+    try:
+        versions = {
+            row[0]
+            for row in verify_conn.execute(
+                "SELECT version FROM schema_migrations WHERE component = 'catalog'"
+            ).fetchall()
+        }
+        assert versions == {1, 2}
+    finally:
+        verify_conn.close()
+
+
+def test_sqlite_catalog_migration_v2_idempotent_on_repeated_open(
+    tmp_path: Path,
+) -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A review fix: migration v2 must not be
+    reapplied (and must not error, e.g. via a duplicate-column ALTER TABLE)
+    the second time a process opens an already-migrated database — the
+    normal shape of a service restart."""
+    db = tmp_path / "core.db"
+    _build_legacy_v1_db(db)
+
+    first_open = SQLiteCatalogRepository(db)
+    first_open.close()
+
+    second_open = SQLiteCatalogRepository(db)
+    try:
+        legacy = second_open.get_dish(_DISH_ID)
+        assert legacy is not None
+        assert legacy.name == "Legacy Schnitzel"
+        assert legacy.category is None
+        assert legacy.pricing_unit is None
+        assert legacy.vat_rate_percent is None
+        assert second_open.count_dishes() == 1
+    finally:
+        second_open.close()
+
+    # A third open, to be sure it's not just "twice happens to work".
+    third_open = SQLiteCatalogRepository(db)
+    try:
+        assert third_open.count_dishes() == 1
+    finally:
+        third_open.close()
+
+    verify_conn = sqlite3.connect(str(db))
+    try:
+        versions = {
+            row[0]
+            for row in verify_conn.execute(
+                "SELECT version FROM schema_migrations WHERE component = 'catalog'"
+            ).fetchall()
+        }
+        assert versions == {1, 2}
+        columns = {
+            row[1]
+            for row in verify_conn.execute(
+                "PRAGMA table_info(catalog_dishes)"
+            ).fetchall()
+        }
+        assert {"category", "pricing_unit", "vat_rate_percent"} <= columns
+    finally:
+        verify_conn.close()

--- a/tests/unit/test_catalog_seed.py
+++ b/tests/unit/test_catalog_seed.py
@@ -67,3 +67,40 @@ def test_seed_import_idempotent(tmp_path: Path) -> None:
         assert repo.list_price_history(dish.dish_id) == []
     finally:
         repo.close()
+
+
+def test_seed_compatible_with_admin_completion_schema(tmp_path: Path) -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A: the seed script needs no code changes
+    to keep working against the migrated schema — it has never populated
+    category/pricing_unit/vat_rate_percent, and decision #3 (no fictitious
+    backfill) means it must keep producing NULL for them, not guess."""
+    seed_catalog = _load_seed_module().seed_catalog
+    db = tmp_path / "core.db"
+    items = tmp_path / "items.json"
+    items.write_text(
+        json.dumps(
+            [
+                {
+                    "id": _DISH_ID,
+                    "name": "Schnitzel",
+                    "price": "8.50",
+                    "allergens": ["A"],
+                    "active": True,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    inserted, skipped = seed_catalog(db, items)
+    assert inserted == 1
+    assert skipped == 0
+
+    repo = SQLiteCatalogRepository(db)
+    try:
+        dish = repo.list_dishes()[0]
+        assert dish.category is None
+        assert dish.pricing_unit is None
+        assert dish.vat_rate_percent is None
+    finally:
+        repo.close()

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3066,8 +3066,16 @@ def test_list_catalog_dishes_schema(api) -> None:
         "allergens",
         "allergen_labels",
         "active",
+        "category",
+        "pricing_unit",
+        "vat_rate_percent",
     }
     assert row["price_display"] == "3,20 €"
+    # _seed_catalog_dish predates CATALOG_ADMIN_COMPLETION_V1A — legacy row,
+    # no fictitious backfill.
+    assert row["category"] is None
+    assert row["pricing_unit"] is None
+    assert row["vat_rate_percent"] is None
 
 
 @pytest.mark.parametrize(
@@ -3196,6 +3204,323 @@ def test_update_catalog_dish_stale_state_409(api) -> None:
         expect={"updated_at": "2020-01-01T00:00:00+00:00"},
     )
     assert (status, body["error"]) == (409, "stale_state")
+
+
+# --- CATALOG_ADMIN_COMPLETION_V1A: create/activate/deactivate ---------------
+
+
+def _create_dish_url(base: str) -> str:
+    return f"{base}/office/v1/catalog/dishes"
+
+
+def _full_dish_create_args(**overrides: object) -> dict[str, object]:
+    args: dict[str, object] = {
+        "name": "Lachs-Canape",
+        "category": "fingerfood",
+        "pricing_unit": "stueck",
+        "current_unit_net_cents": 250,
+        "vat_rate_percent": 7,
+        "description": "Frisch",
+        "composition": "Lachs, Brot",
+        "notes": "Küchennotiz",
+        "allergens": ["A", "D"],
+    }
+    args.update(overrides)
+    return args
+
+
+def test_create_catalog_dish_full_dish_is_inactive(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(_create_dish_url(base), args=_full_dish_create_args())
+    assert status == 201
+    assert body["active"] is False
+    dish_id = body["dish_id"]
+
+    status, detail, _h = _get(f"{base}/office/v1/catalog/dishes/{dish_id}")
+    assert status == 200
+    assert detail["name"] == "Lachs-Canape"
+    assert detail["category"] == "fingerfood"
+    assert detail["pricing_unit"] == "stueck"
+    assert detail["vat_rate_percent"] == 7
+    assert detail["active"] is False
+    assert detail["allergens"] == ["A", "D"]
+
+
+def test_create_catalog_dish_minimal_required_fields(api) -> None:
+    base, _ids, _db = api
+    args = {
+        "name": "Minimal",
+        "category": "sonstiges",
+        "pricing_unit": "per_person",
+        "current_unit_net_cents": 100,
+        "vat_rate_percent": 19,
+    }
+    status, body, _h = _post(_create_dish_url(base), args=args)
+    assert status == 201
+    assert body["active"] is False
+
+
+def test_create_catalog_dish_missing_required_field_returns_400(api) -> None:
+    base, _ids, _db = api
+    args = _full_dish_create_args()
+    del args["category"]
+    status, body, _h = _post(_create_dish_url(base), args=args)
+    assert (status, body["error"]) == (400, "invalid_request")
+
+
+def test_create_catalog_dish_invalid_pricing_unit_returns_400(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(
+        _create_dish_url(base), args=_full_dish_create_args(pricing_unit="kg")
+    )
+    assert (status, body["error"]) == (400, "invalid_request")
+
+
+def test_create_catalog_dish_empty_category_returns_422(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(
+        _create_dish_url(base), args=_full_dish_create_args(category="   ")
+    )
+    assert (status, body["error"]) == (422, "validation_error")
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        "Fingerfood",
+        "finger food",
+        "getränke",
+        "-dessert",
+        "dessert-",
+        "food--hot",
+        "food__hot",
+    ],
+)
+def test_create_catalog_dish_invalid_category_key_returns_422(
+    api, category: str
+) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(
+        _create_dish_url(base), args=_full_dish_create_args(category=category)
+    )
+    assert (status, body["error"]) == (422, "validation_error")
+
+
+def test_create_catalog_dish_accepts_hyphen_and_underscore_category(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(
+        _create_dish_url(base),
+        args=_full_dish_create_args(category="service-personal"),
+    )
+    assert status == 201
+    dish_id = body["dish_id"]
+    status, detail, _h = _get(f"{base}/office/v1/catalog/dishes/{dish_id}")
+    assert detail["category"] == "service-personal"
+
+    status, body2, _h = _post(
+        _create_dish_url(base),
+        args=_full_dish_create_args(name="Warme Suppe", category="warme_speisen"),
+    )
+    assert status == 201
+    dish_id2 = body2["dish_id"]
+    status, detail2, _h = _get(f"{base}/office/v1/catalog/dishes/{dish_id2}")
+    assert detail2["category"] == "warme_speisen"
+
+
+def test_create_catalog_dish_invalid_vat_returns_422(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _post(
+        _create_dish_url(base), args=_full_dish_create_args(vat_rate_percent=13)
+    )
+    assert (status, body["error"]) == (422, "validation_error")
+
+
+def _activate_url(base: str, dish_id: str) -> str:
+    return f"{base}/office/v1/catalog/dishes/{dish_id}/activate"
+
+
+def _deactivate_url(base: str, dish_id: str) -> str:
+    return f"{base}/office/v1/catalog/dishes/{dish_id}/deactivate"
+
+
+def test_activate_catalog_dish_success(api) -> None:
+    base, _ids, _db = api
+    _status, created, _h = _post(_create_dish_url(base), args=_full_dish_create_args())
+    dish_id = created["dish_id"]
+    status, body, _h = _post(
+        _activate_url(base, dish_id),
+        args={},
+        expect={"updated_at": created["updated_at"]},
+    )
+    assert status == 200
+    assert body["active"] is True
+
+    status, detail, _h = _get(f"{base}/office/v1/catalog/dishes/{dish_id}")
+    assert detail["active"] is True
+
+
+def test_deactivate_catalog_dish_success(api) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=True)
+    repo = SQLiteCatalogRepository(db)
+    try:
+        updated_at = repo.get_dish(_CATALOG_DISH_ID).updated_at.isoformat()  # type: ignore[union-attr]
+    finally:
+        repo.close()
+    status, body, _h = _post(
+        _deactivate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": updated_at},
+    )
+    assert status == 200
+    assert body["active"] is False
+
+
+def test_activate_catalog_dish_repeated_is_idempotent(api) -> None:
+    base, _ids, _db = api
+    _status, created, _h = _post(_create_dish_url(base), args=_full_dish_create_args())
+    dish_id = created["dish_id"]
+    status1, body1, _h = _post(
+        _activate_url(base, dish_id),
+        args={},
+        expect={"updated_at": created["updated_at"]},
+    )
+    assert status1 == 200
+    status2, body2, _h = _post(
+        _activate_url(base, dish_id),
+        args={},
+        expect={"updated_at": body1["updated_at"]},
+    )
+    assert status2 == 200
+    assert body2["updated_at"] == body1["updated_at"]
+
+
+def test_deactivate_catalog_dish_repeated_is_idempotent(api) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=True)
+    repo = SQLiteCatalogRepository(db)
+    try:
+        updated_at = repo.get_dish(_CATALOG_DISH_ID).updated_at.isoformat()  # type: ignore[union-attr]
+    finally:
+        repo.close()
+    status1, body1, _h = _post(
+        _deactivate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": updated_at},
+    )
+    assert status1 == 200
+    status2, body2, _h = _post(
+        _deactivate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": body1["updated_at"]},
+    )
+    assert status2 == 200
+    assert body2["updated_at"] == body1["updated_at"]
+
+
+def test_activate_catalog_dish_stale_state_409(api) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=False)
+    status, body, _h = _post(
+        _activate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": "2020-01-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (409, "stale_state")
+
+
+def test_deactivate_catalog_dish_stale_state_409(api) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=True)
+    status, body, _h = _post(
+        _deactivate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": "2020-01-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (409, "stale_state")
+
+
+def test_activate_catalog_dish_missing_dish_returns_404(api) -> None:
+    base, _ids, _db = api
+    missing_id = "99999999-9999-4999-8999-999999999999"
+    status, body, _h = _post(
+        _activate_url(base, missing_id),
+        args={},
+        expect={"updated_at": "2026-01-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (404, "not_found")
+
+
+def test_deactivate_catalog_dish_missing_dish_returns_404(api) -> None:
+    base, _ids, _db = api
+    missing_id = "99999999-9999-4999-8999-999999999999"
+    status, body, _h = _post(
+        _deactivate_url(base, missing_id),
+        args={},
+        expect={"updated_at": "2026-01-01T00:00:00+00:00"},
+    )
+    assert (status, body["error"]) == (404, "not_found")
+
+
+def test_create_catalog_dish_routes_require_bearer_auth(api) -> None:
+    base, _ids, _db = api
+    no_auth: dict[str, str] = {}
+    status, body, _h = _post(
+        _create_dish_url(base),
+        args=_full_dish_create_args(),
+        headers=no_auth,
+    )
+    assert (status, body["error"]) == (401, "unauthorized")
+
+
+def test_activate_catalog_dish_requires_bearer_auth_and_does_not_change_dish(
+    api,
+) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=False)
+    repo = SQLiteCatalogRepository(db)
+    try:
+        updated_at = repo.get_dish(_CATALOG_DISH_ID).updated_at.isoformat()  # type: ignore[union-attr]
+    finally:
+        repo.close()
+    no_auth: dict[str, str] = {}
+    status, body, _h = _post(
+        _activate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": updated_at},
+        headers=no_auth,
+    )
+    assert (status, body["error"]) == (401, "unauthorized")
+
+    status, detail, _h = _get(f"{base}/office/v1/catalog/dishes/{_CATALOG_DISH_ID}")
+    assert status == 200
+    assert detail["active"] is False
+    assert detail["updated_at"] == updated_at
+
+
+def test_deactivate_catalog_dish_requires_bearer_auth_and_does_not_change_dish(
+    api,
+) -> None:
+    base, _ids, db = api
+    _seed_catalog_dish(db, active=True)
+    repo = SQLiteCatalogRepository(db)
+    try:
+        updated_at = repo.get_dish(_CATALOG_DISH_ID).updated_at.isoformat()  # type: ignore[union-attr]
+    finally:
+        repo.close()
+    no_auth: dict[str, str] = {}
+    status, body, _h = _post(
+        _deactivate_url(base, _CATALOG_DISH_ID),
+        args={},
+        expect={"updated_at": updated_at},
+        headers=no_auth,
+    )
+    assert (status, body["error"]) == (401, "unauthorized")
+
+    status, detail, _h = _get(f"{base}/office/v1/catalog/dishes/{_CATALOG_DISH_ID}")
+    assert status == 200
+    assert detail["active"] is True
+    assert detail["updated_at"] == updated_at
 
 
 # --- confirmation document (EMAIL_MVP_1 / outbound pack B1) -------------------

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -416,6 +416,9 @@ def test_list_catalog_dishes_accepts_valid_payload() -> None:
                 "allergens": ["A"],
                 "allergen_labels": ["Gluten"],
                 "active": True,
+                "category": None,
+                "pricing_unit": None,
+                "vat_rate_percent": None,
             }
         ],
         "total_count": 1,
@@ -440,6 +443,9 @@ def test_catalog_dish_detail_accepts_valid_payload() -> None:
         "allergens": ["A"],
         "allergen_labels": ["Gluten"],
         "active": True,
+        "category": "fingerfood",
+        "pricing_unit": "stueck",
+        "vat_rate_percent": 7,
         "description": "Desc",
         "composition": "Comp",
         "notes": "Notes",
@@ -452,6 +458,145 @@ def test_catalog_dish_detail_accepts_valid_payload() -> None:
         parsed = RemoteCoreClient(url, _TOKEN).catalog_dish_detail(dish_id)
         assert parsed is not None
         assert parsed["dish_id"] == dish_id
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _catalog_dish_row(dish_id: str, **overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "dish_id": dish_id,
+        "name": "Fingerfood",
+        "current_unit_net_cents": 290,
+        "price_display": "2,90 EUR",
+        "allergens": ["A"],
+        "allergen_labels": ["Gluten"],
+        "active": True,
+        "category": None,
+        "pricing_unit": None,
+        "vat_rate_percent": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_list_catalog_dishes_accepts_valid_pricing_unit() -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A review fix: a real (non-null) pricing_unit
+    from the closed set must parse successfully."""
+    dish_id = str(uuid.uuid4())
+    payload = {
+        "dishes": [
+            _catalog_dish_row(
+                dish_id,
+                category="fingerfood",
+                pricing_unit="stueck",
+                vat_rate_percent=7,
+            )
+        ],
+        "total_count": 1,
+        "truncated": False,
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        parsed = RemoteCoreClient(url, _TOKEN).list_catalog_dishes()
+        assert parsed["dishes"][0]["pricing_unit"] == "stueck"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_list_catalog_dishes_accepts_null_legacy_pricing_unit() -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A review fix: NULL stays valid — a legacy
+    row (created before this slice) has no pricing_unit at all."""
+    dish_id = str(uuid.uuid4())
+    payload = {
+        "dishes": [_catalog_dish_row(dish_id)],
+        "total_count": 1,
+        "truncated": False,
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        parsed = RemoteCoreClient(url, _TOKEN).list_catalog_dishes()
+        assert parsed["dishes"][0]["pricing_unit"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_list_catalog_dishes_rejects_unknown_pricing_unit() -> None:
+    """CATALOG_ADMIN_COMPLETION_V1A review fix: fail-closed against the
+    closed pricing_unit set — a tampered/buggy non-null value that isn't
+    per_person/stueck/pauschal must be rejected as an invalid contract,
+    not passed through as an opaque string."""
+    dish_id = str(uuid.uuid4())
+    payload = {
+        "dishes": [_catalog_dish_row(dish_id, pricing_unit="kg")],
+        "total_count": 1,
+        "truncated": False,
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        with pytest.raises(RemoteCoreError):
+            RemoteCoreClient(url, _TOKEN).list_catalog_dishes()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_catalog_dish_detail_accepts_null_legacy_pricing_unit() -> None:
+    dish_id = str(uuid.uuid4())
+    payload = {
+        "dish_id": dish_id,
+        "name": "Fingerfood",
+        "current_unit_net_cents": 290,
+        "price_display": "2,90 EUR",
+        "allergens": ["A"],
+        "allergen_labels": ["Gluten"],
+        "active": True,
+        "category": None,
+        "pricing_unit": None,
+        "vat_rate_percent": None,
+        "description": None,
+        "composition": None,
+        "notes": None,
+        "created_at": "2026-07-14T10:00:00+02:00",
+        "updated_at": "2026-07-14T10:00:00+02:00",
+        "price_history": [],
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        parsed = RemoteCoreClient(url, _TOKEN).catalog_dish_detail(dish_id)
+        assert parsed is not None
+        assert parsed["pricing_unit"] is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_catalog_dish_detail_rejects_unknown_pricing_unit() -> None:
+    dish_id = str(uuid.uuid4())
+    payload = {
+        "dish_id": dish_id,
+        "name": "Fingerfood",
+        "current_unit_net_cents": 290,
+        "price_display": "2,90 EUR",
+        "allergens": ["A"],
+        "allergen_labels": ["Gluten"],
+        "active": True,
+        "category": "fingerfood",
+        "pricing_unit": "kg",
+        "vat_rate_percent": 7,
+        "description": None,
+        "composition": None,
+        "notes": None,
+        "created_at": "2026-07-14T10:00:00+02:00",
+        "updated_at": "2026-07-14T10:00:00+02:00",
+        "price_history": [],
+    }
+    url, server = _serve(_json_handler(payload))
+    try:
+        with pytest.raises(RemoteCoreError):
+            RemoteCoreClient(url, _TOKEN).catalog_dish_detail(dish_id)
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
- extend existing CatalogDish instead of introducing a parallel model
- add category, pricing_unit, and default VAT fields
- add create, activate, and deactivate operations
- preserve legacy catalog rows through nullable migration columns
- preserve immutable Offer and Order commercial snapshots
- add strict RemoteCoreClient response validation

## Database
- catalog migration v2
- no backfill
- legacy rows keep NULL for new fields
- repeated startup is idempotent

## Category contract
- regex: ^[a-z0-9]+(?:[-_][a-z0-9]+)*$
- lowercase ASCII stable keys
- invalid keys are rejected, not silently transformed

## Verification
- 2004 tests passed
- coverage 90.3%
- ruff check passed
- ruff format check passed
- mypy passed
- git diff --check passed

## Out of scope
- Office Panel catalog administration UI
- Offer item editor
- pricing_unit to OfferPosition mapping
- order commercial revisions
- production groups
- production deployment