### PR TITLE
Fix CSRF token in catalog edit form

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -1292,9 +1292,15 @@ class OfficePanel:
         history = service.list_price_history(dish_id)
         return api_views.catalog_dish_detail_view(dish, history)
 
-    def _catalog_update_command_fields(self, updated_at: str) -> str:
+    def _catalog_update_command_fields(
+        self, updated_at: str, *, context: OfficePageContext
+    ) -> str:
+        # CATALOG_EDIT_CSRF_FIX_V1: every other mutating form pairs
+        # _csrf_input(context) with _command_fields(...) — this one didn't,
+        # so a real browser submit of the rendered page was rejected by
+        # do_POST's global CSRF check (office_panel_http.py) with 403.
         expect = {"updated_at": updated_at}
-        fields = self._command_fields(expect)
+        fields = _csrf_input(context) + self._command_fields(expect)
         if self._remote is None:
             fields += (
                 f'<input type="hidden" name="_expect_updated_at" '
@@ -1317,7 +1323,7 @@ class OfficePanel:
         return render_gericht_edit(
             detail,
             command_fields=self._catalog_update_command_fields(
-                str(detail["updated_at"])
+                str(detail["updated_at"]), context=context
             ),
             context=context,
             error_message=error_message,

--- a/tests/unit/test_office_panel_catalog.py
+++ b/tests/unit/test_office_panel_catalog.py
@@ -77,6 +77,7 @@ def _get(url: str) -> tuple[int, str]:
 
 
 def _post(url: str, fields: dict[str, str]) -> tuple[int, str]:
+    import urllib.error
     import urllib.parse
     import urllib.request
 
@@ -84,8 +85,27 @@ def _post(url: str, fields: dict[str, str]) -> tuple[int, str]:
     req = urllib.request.Request(url, data=data, method="POST")
     req.add_header("Authorization", _auth_header())
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
-    with urllib.request.urlopen(req) as resp:
-        return resp.status, resp.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _extract_csrf_token(html: str) -> str:
+    import re
+
+    match = re.search(r'name="_csrf_token" value="([^"]*)"', html)
+    assert match, "edit form is missing the _csrf_token hidden field"
+    return match.group(1)
+
+
+def _extract_expect_updated_at(html: str) -> str:
+    import re
+
+    match = re.search(r'name="_expect_updated_at" value="([^"]+)"', html)
+    assert match
+    return match.group(1)
 
 
 def test_gerichte_list_renders(catalog_panel: str) -> None:
@@ -118,6 +138,90 @@ def test_gericht_edit_form_renders(catalog_panel: str) -> None:
     assert 'name="allergen_A"' in body
     assert 'name="price_net"' in body
     assert 'name="_expect_updated_at"' in body
+
+
+def test_gericht_edit_form_includes_csrf_token(catalog_panel: str) -> None:
+    """CATALOG_EDIT_CSRF_FIX_V1: the rendered edit page must carry the same
+    hidden _csrf_token field every other mutating form does — without it, a
+    real browser submit is rejected by do_POST's global CSRF check."""
+    status, body = _get(f"{catalog_panel}/gerichte/{_DISH_ID}/edit")
+    assert status == 200
+    assert _extract_csrf_token(body) == _CSRF_TOKEN
+
+
+def test_gericht_update_post_with_token_from_rendered_form_succeeds(
+    catalog_panel: str,
+) -> None:
+    """Proves the fix end-to-end: extract the CSRF token from the actual
+    rendered page (not a precomputed constant) and confirm the submit is
+    accepted — this is what a real browser does."""
+    _status, edit_html = _get(f"{catalog_panel}/gerichte/{_DISH_ID}/edit")
+    token = _extract_csrf_token(edit_html)
+    updated_at = _extract_expect_updated_at(edit_html)
+    status, _body = _post(
+        f"{catalog_panel}/gerichte/{_DISH_ID}/update",
+        {
+            "_csrf_token": token,
+            "_expect_updated_at": updated_at,
+            "name": "Schnitzel <test>",
+            "description": "Beschreibung",
+            "composition": "Zusammensetzung",
+            "notes": "",
+            "price_net": "8,50",
+            "allergen_A": "1",
+            "allergen_C": "1",
+            "allergen_G": "1",
+            "active": "1",
+        },
+    )
+    assert status == 200
+
+
+def test_gericht_update_post_without_csrf_token_returns_403(
+    catalog_panel: str,
+) -> None:
+    _status, edit_html = _get(f"{catalog_panel}/gerichte/{_DISH_ID}/edit")
+    updated_at = _extract_expect_updated_at(edit_html)
+    status, _body = _post(
+        f"{catalog_panel}/gerichte/{_DISH_ID}/update",
+        {
+            "_expect_updated_at": updated_at,
+            "name": "Sollte nicht gespeichert werden",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": "8,50",
+            "active": "1",
+        },
+    )
+    assert status == 403
+    status, detail = _get(f"{catalog_panel}/gerichte/{_DISH_ID}")
+    assert status == 200
+    assert "Sollte nicht gespeichert werden" not in detail
+
+
+def test_gericht_update_post_with_wrong_csrf_token_returns_403(
+    catalog_panel: str,
+) -> None:
+    _status, edit_html = _get(f"{catalog_panel}/gerichte/{_DISH_ID}/edit")
+    updated_at = _extract_expect_updated_at(edit_html)
+    status, _body = _post(
+        f"{catalog_panel}/gerichte/{_DISH_ID}/update",
+        {
+            "_csrf_token": "wrong-token",
+            "_expect_updated_at": updated_at,
+            "name": "Sollte nicht gespeichert werden",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": "8,50",
+            "active": "1",
+        },
+    )
+    assert status == 403
+    status, detail = _get(f"{catalog_panel}/gerichte/{_DISH_ID}")
+    assert status == 200
+    assert "Sollte nicht gespeichert werden" not in detail
 
 
 def test_gericht_update_post_success(catalog_panel: str) -> None:


### PR DESCRIPTION
## Summary
- add the missing CSRF hidden field to the existing catalog edit form
- preserve existing optimistic concurrency fields
- keep direct and remote mode behavior identical
- do not change catalog business logic or API contracts

## Bug
The existing `/gerichte/{dish_id}/edit` form did not render `_csrf_token`,
while all Office Panel POST requests require CSRF validation.
Real browser submissions could therefore fail with HTTP 403.

## Verification
- token from the rendered form is accepted
- missing token returns 403
- invalid token returns 403
- rejected requests do not change the dish
- direct/remote parity preserved
- 2008 tests passed
- coverage 90.3%
- ruff passed
- mypy passed
- git diff --check passed

## Scope
- 2 files changed
- no Office API changes
- no Offer or Order changes
- no production or deployment changes