### PR TITLE
Add catalog administration panel

### DIFF
--- a/src/catering_system/repositories/catalog_repository.py
+++ b/src/catering_system/repositories/catalog_repository.py
@@ -10,10 +10,18 @@ from catering_system.domain.catalog import CatalogDish, CatalogPriceHistoryEntry
 
 
 class CatalogRepository(Protocol):
+    # CATALOG_ADMIN_PANEL_V1: `active` replaces the earlier `active_only`
+    # flag, which could only ever express "active" or "everything". The
+    # Inaktiv view needs the third state, and it has to be applied in the
+    # query — filtering a page that LIMIT already truncated would report an
+    # empty result whenever the excluded rows happen to fill it.
+    #   True  -> only active dishes
+    #   False -> only inactive dishes
+    #   None  -> no status filter
     def list_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
@@ -22,7 +30,7 @@ class CatalogRepository(Protocol):
     def count_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
     ) -> int: ...
 

--- a/src/catering_system/repositories/in_memory_catalog_repository.py
+++ b/src/catering_system/repositories/in_memory_catalog_repository.py
@@ -20,21 +20,21 @@ class InMemoryCatalogRepository:
     def list_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[CatalogDish]:
-        rows = self._filtered(active_only=active_only, q=q)
+        rows = self._filtered(active=active, q=q)
         return rows[offset : offset + limit]
 
     def count_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
     ) -> int:
-        return len(self._filtered(active_only=active_only, q=q))
+        return len(self._filtered(active=active, q=q))
 
     def get_dish(self, dish_id: str) -> CatalogDish | None:
         return self._dishes.get(dish_id)
@@ -73,10 +73,11 @@ class InMemoryCatalogRepository:
     def close(self) -> None:
         return None
 
-    def _filtered(self, *, active_only: bool, q: str | None) -> list[CatalogDish]:
+    def _filtered(self, *, active: bool | None, q: str | None) -> list[CatalogDish]:
         rows = list(self._dishes.values())
-        if active_only:
-            rows = [row for row in rows if row.active]
+        # Mirrors the SQL WHERE: narrow before the caller's slice, never after.
+        if active is not None:
+            rows = [row for row in rows if row.active is active]
         if q:
             needle = q.casefold()
             rows = [row for row in rows if needle in row.name.casefold()]

--- a/src/catering_system/repositories/sqlite_catalog_repository.py
+++ b/src/catering_system/repositories/sqlite_catalog_repository.py
@@ -110,12 +110,12 @@ class SQLiteCatalogRepository:
     def list_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[CatalogDish]:
-        where, params = self._filters(active_only=active_only, q=q)
+        where, params = self._filters(active=active, q=q)
         rows = self._conn.execute(
             f"""
             SELECT dish_id, name, description, composition, notes,
@@ -134,10 +134,10 @@ class SQLiteCatalogRepository:
     def count_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
     ) -> int:
-        where, params = self._filters(active_only=active_only, q=q)
+        where, params = self._filters(active=active, q=q)
         row = self._conn.execute(
             f"SELECT COUNT(*) FROM catalog_dishes {where}",
             params,
@@ -283,11 +283,15 @@ class SQLiteCatalogRepository:
                 self._conn.commit()
 
     @staticmethod
-    def _filters(*, active_only: bool, q: str | None) -> tuple[str, list[object]]:
+    def _filters(*, active: bool | None, q: str | None) -> tuple[str, list[object]]:
         clauses: list[str] = []
         params: list[object] = []
-        if active_only:
-            clauses.append("active = 1")
+        # CATALOG_ADMIN_PANEL_V1: bound as a parameter and applied in WHERE, so
+        # both the status filter and the search narrow the rows before
+        # ORDER BY/LIMIT rather than after.
+        if active is not None:
+            clauses.append("active = ?")
+            params.append(1 if active else 0)
         if q:
             clauses.append("name LIKE ? ESCAPE '\\'")
             params.append(f"%{_escape_like(q)}%")

--- a/src/catering_system/services/catalog_dish_service.py
+++ b/src/catering_system/services/catalog_dish_service.py
@@ -36,16 +36,21 @@ class CatalogDishService:
     def list_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> CatalogDishListResult:
+        """CATALOG_ADMIN_PANEL_V1: `active` (True/False/None) goes straight to
+        the repository, so both the status filter and the search narrow the
+        rows inside the query — ahead of the page limit. `total_count` counts
+        that same filtered set, which is what makes `truncated` mean "more
+        rows matching *this* filter" rather than "more rows in the catalog"."""
         page_size = min(max(limit, 1), _MAX_PAGE_SIZE)
         offset = max(offset, 0)
-        total = self._catalog.count_dishes(active_only=active_only, q=q)
+        total = self._catalog.count_dishes(active=active, q=q)
         rows = self._catalog.list_dishes(
-            active_only=active_only,
+            active=active,
             q=q,
             limit=page_size,
             offset=offset,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -264,6 +264,28 @@ def _v_query_bool(value: str) -> bool:
     raise _invalid()
 
 
+def _catalog_active_filter(params: dict[str, str]) -> bool | None:
+    """CATALOG_ADMIN_PANEL_V1: resolves the catalog list's status filter.
+
+    `active` is the current contract — true/false select one status, omitted
+    means no filter. `active_only` is kept as a legacy alias because it is a
+    published query parameter: `active_only=true` still means "active only",
+    and `active_only=false` keeps its original meaning of *no* filter (it
+    never selected inactive dishes).
+
+    Sending both is rejected with 400 rather than resolved by precedence:
+    `active=false&active_only=true` has no honest answer, and silently
+    picking one would hide a caller's bug behind a wrong dish list.
+    """
+    if "active" in params and "active_only" in params:
+        raise _invalid()
+    if "active" in params:
+        return _v_query_bool(params["active"])
+    if "active_only" in params:
+        return True if _v_query_bool(params["active_only"]) else None
+    return None
+
+
 def _v_date(value: object) -> date:
     if not isinstance(value, str) or not _DATE_RE.fullmatch(value):
         raise _invalid()
@@ -688,7 +710,7 @@ class OfficeApi:
     def list_catalog_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
@@ -697,7 +719,7 @@ class OfficeApi:
             raise _invalid()
         return views.catalog_dish_list_view(
             self.catalog_dish_service.list_dishes(
-                active_only=active_only,
+                active=active,
                 q=q,
                 limit=limit,
                 offset=offset,
@@ -2895,12 +2917,8 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
                 self._query(set())
                 self._respond(200, api.contact_detail(path_ids["contact_key"]))
             elif kind == "list_catalog_dishes":
-                params = self._query({"active_only", "q", "limit", "offset"})
-                active_only = (
-                    _v_query_bool(params["active_only"])
-                    if "active_only" in params
-                    else False
-                )
+                params = self._query({"active", "active_only", "q", "limit", "offset"})
+                active = _catalog_active_filter(params)
                 catalog_q_raw = params.get("q")
                 catalog_q = (
                     _v_str(catalog_q_raw, _MAX_Q_CHARS).strip()
@@ -2913,7 +2931,7 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
                 self._respond(
                     200,
                     api.list_catalog_dishes(
-                        active_only=active_only,
+                        active=active,
                         q=catalog_q,
                         limit=limit,
                         offset=offset,

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, Any, cast
@@ -152,8 +155,13 @@ from catering_system.services.catalog_dish_write_service import CatalogDishWrite
 from catering_system.domain.catalog import (
     AllergenCode,
     ALLERGEN_CODES,
+    CatalogDishAlreadyExistsError,
+    CatalogDishCreatePayload,
+    CatalogDishNotFoundError,
     CatalogDishStaleError,
     CatalogDishUpdatePayload,
+    validate_category,
+    validate_pricing_unit,
 )
 from catering_system.services.email_intake_projection_service import (
     EmailIntakeProjectionService,
@@ -175,6 +183,7 @@ from catering_system.ui.office_panel_contacts_list import render_kontakte_list
 from catering_system.ui.office_panel_catalog_list import render_gerichte_list
 from catering_system.ui.office_panel_catalog_detail import render_gericht_detail
 from catering_system.ui.office_panel_catalog_edit import render_gericht_edit
+from catering_system.ui.office_panel_catalog_new import render_gericht_new
 from catering_system.ui.office_panel_email_detail import render_email_detail
 from catering_system.ui.office_panel_emails_list import render_email_list
 from catering_system.ui.office_panel_calendar_list import render_kalender_list
@@ -340,6 +349,91 @@ class OfferPdfUnavailableError(Exception):
     """Raised when a PDF snapshot exists but cannot be rendered (renderer or
     static content validation failure) — mapped by the HTTP layer to a clear
     German 422 message, never a stack trace."""
+
+
+# CATALOG_ADMIN_PANEL_V1: the Aktiv/Inaktiv selector's accepted values;
+# anything else falls back to "all" rather than erroring, matching how the
+# existing Kontakte status filter treats an unknown query string.
+_CATALOG_STATUS_FILTERS = ("all", "active", "inactive")
+
+# Selector value -> the neutral `active` filter carried down to the query.
+_CATALOG_ACTIVE_BY_FILTER: dict[str, bool | None] = {
+    "all": None,
+    "active": True,
+    "inactive": False,
+}
+
+
+class CatalogCommandError(ValueError):
+    """A catalog write rejected for a reason the operator should see.
+
+    Carries the HTTP status alongside the message key so direct and remote
+    mode answer identically *and* keep the meaning of the failure. Collapsing
+    everything onto 400 would tell a caller that a missing dish, a concurrent
+    edit and a malformed price are the same kind of problem — and would
+    regress the remote path, which already surfaced the API's real status.
+
+    Stays a ValueError so any caller that only knows the old contract still
+    catches it.
+    """
+
+    def __init__(self, code: str, status: int) -> None:
+        super().__init__(code)
+        self.code = code
+        self.status = status
+
+
+# Catalog failure -> (message key, HTTP status). The keys are deliberately
+# catalog-prefixed: the API's own codes (not_found, stale_state, …) are
+# generic across every command, so an unprefixed entry in the shared label
+# table would put "Das Gericht …" in front of an unrelated inquiry error.
+_CATALOG_NOT_FOUND = ("catalog_not_found", 404)
+_CATALOG_STALE = ("catalog_stale_state", 409)
+_CATALOG_EXISTS = ("catalog_already_exists", 409)
+_CATALOG_INVALID_DOMAIN = ("catalog_validation_error", 422)
+_CATALOG_INVALID_INPUT = ("catalog_invalid_input", 400)
+_CATALOG_INVALID_PRICE = ("catalog_invalid_price", 400)
+
+# Remote Office API error codes -> the same (key, status) pairs, so a remote
+# rejection is indistinguishable from the direct-mode one it mirrors.
+_CATALOG_REMOTE_ERRORS: dict[str, tuple[str, int]] = {
+    "not_found": _CATALOG_NOT_FOUND,
+    "stale_state": _CATALOG_STALE,
+    "already_exists": _CATALOG_EXISTS,
+    "validation_error": _CATALOG_INVALID_DOMAIN,
+    "invalid_request": _CATALOG_INVALID_INPUT,
+}
+
+# A price the operator typed: digits, then at most one separator followed by
+# one or two digits. No sign (a negative price is not a catalog price), no
+# exponent, no thousands separator — "1.000,50" is ambiguous, so it is
+# rejected rather than guessed at. Anything with a third decimal is refused
+# instead of being quietly rounded into a price nobody entered.
+_CATALOG_PRICE_RE = re.compile(r"^\d+(?:[.,]\d{1,2})?$")
+
+
+def parse_catalog_price_input(raw: str) -> int:
+    """CATALOG_ADMIN_PANEL_V1: gate in front of the shared
+    ``parse_catalog_price_cents``. That helper quantizes, so "1,999" would
+    become 2,00 € with no warning; this refuses the input instead. Shape is
+    checked here, the Decimal conversion stays there — no float anywhere.
+
+    A separator-less amount is normalised to euros first. The shared helper
+    reads a bare integer as *cents*, which would make "12" 0,12 € while
+    "12,00" is 12,00 € — a hundredfold difference between two spellings of
+    the same number, in a field labelled €. Every rendered form pre-fills
+    "12,00", so this only affects a hand-typed value, and euros is the only
+    reading consistent with the label. The shared helper is left untouched
+    for any other caller.
+    """
+    text = raw.strip()
+    if text.endswith("€"):
+        text = text[:-1].strip()
+    if not _CATALOG_PRICE_RE.fullmatch(text):
+        raise CatalogCommandError(*_CATALOG_INVALID_PRICE)
+    if "." not in text and "," not in text:
+        text = f"{text}.00"
+    return api_views.parse_catalog_price_cents(text)
 
 
 class OfficePanel:
@@ -1255,19 +1349,60 @@ class OfficePanel:
             note_text=form.get("note_text", ""),
         )
 
-    def _catalog_list_payload(self) -> dict[str, object]:
+    def _catalog_list_payload(
+        self, *, q: str | None = None, active: bool | None = None
+    ) -> dict[str, object]:
         if self._remote is not None:
-            return self._remote.list_catalog_dishes()
+            return self._remote.list_catalog_dishes(q=q, active=active)
         service = CatalogDishService(self._catalog)
-        return api_views.catalog_dish_list_view(service.list_dishes())
+        return api_views.catalog_dish_list_view(service.list_dishes(q=q, active=active))
 
     def render_gerichte(
-        self, *, context: OfficePageContext = _EMPTY_PAGE_CONTEXT
+        self,
+        q: str = "",
+        status: str = "all",
+        *,
+        context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
     ) -> str:
-        return render_gerichte_list(self._catalog_list_payload(), context=context)
+        """CATALOG_ADMIN_PANEL_V1: both the search and the Aktiv/Inaktiv
+        filter are pushed all the way down to the query (SQL WHERE in direct
+        mode, `q`/`active` on the read endpoint in remote mode), so they
+        narrow the rows *before* the 100-row page limit. Filtering here
+        instead would answer "Keine Gerichte gefunden" whenever the excluded
+        dishes happened to fill the first page."""
+        query = q.strip()
+        status_filter = status if status in _CATALOG_STATUS_FILTERS else "all"
+        payload = self._catalog_list_payload(
+            q=query or None,
+            active=_CATALOG_ACTIVE_BY_FILTER[status_filter],
+        )
+        return render_gerichte_list(
+            payload,
+            search_query=query,
+            status_filter=status_filter,
+            context=context,
+        )
+
+    def render_gericht_new(
+        self,
+        *,
+        context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
+        form: dict[str, str] | None = None,
+        error_message: str | None = None,
+    ) -> str:
+        return render_gericht_new(
+            command_fields=_csrf_input(context) + self._command_fields(),
+            context=context,
+            form=form or {},
+            error_message=error_message,
+        )
 
     def render_gericht(
-        self, dish_id: str, *, context: OfficePageContext = _EMPTY_PAGE_CONTEXT
+        self,
+        dish_id: str,
+        *,
+        context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
+        error_message: str | None = None,
     ) -> str | None:
         if self._remote is not None:
             detail = self._remote.catalog_dish_detail(dish_id)
@@ -1280,7 +1415,14 @@ class OfficePanel:
                 return None
             history = service.list_price_history(dish_id)
             detail = api_views.catalog_dish_detail_view(dish, history)
-        return render_gericht_detail(detail, context=context)
+        return render_gericht_detail(
+            detail,
+            context=context,
+            command_fields=self._catalog_update_command_fields(
+                str(detail["updated_at"]), context=context
+            ),
+            error_message=error_message,
+        )
 
     def _catalog_detail_payload(self, dish_id: str) -> dict[str, object] | None:
         if self._remote is not None:
@@ -1337,49 +1479,195 @@ class OfficePanel:
             code for code in ALLERGEN_CODES if form.get(f"allergen_{code}") == "1"
         )
 
+    def _run_catalog_write(self, work: Callable[[], None]) -> None:
+        if self._remote is not None:
+            work()
+        elif self._command_executor is not None:
+            self._command_executor.run(work)
+        else:
+            work()
+
+    @contextmanager
+    def _catalog_write_errors(self) -> Iterator[None]:
+        """CATALOG_ADMIN_PANEL_V1: maps direct-mode domain exceptions and
+        remote-mode RemoteCoreError codes onto the same CatalogCommandError,
+        so both modes produce the same German message *and* the same HTTP
+        status — a missing dish stays 404, a concurrent edit stays 409, a
+        domain rejection stays 422.
+
+        Unavailability is re-raised untouched: "Core nicht erreichbar" is a
+        degradation, not a business rejection, and the HTTP layer renders it
+        through its own 503 path.
+
+        Order matters — RemoteCoreError, CatalogDishStaleError and
+        CatalogDishAlreadyExistsError are all ValueError subclasses, so the
+        catch-all domain branch has to come last, and an already-classified
+        CatalogCommandError has to pass through untouched before it.
+        """
+        from catering_system.ui.remote_core_client import RemoteCoreError
+
+        try:
+            yield
+        except CatalogCommandError:
+            raise
+        except RemoteCoreError as exc:
+            if exc.unavailable:
+                raise
+            mapped = _CATALOG_REMOTE_ERRORS.get(exc.code)
+            if mapped is None:
+                raise
+            raise CatalogCommandError(*mapped) from exc
+        except CatalogDishStaleError as exc:
+            raise CatalogCommandError(*_CATALOG_STALE) from exc
+        except CatalogDishAlreadyExistsError as exc:
+            raise CatalogCommandError(*_CATALOG_EXISTS) from exc
+        except CatalogDishNotFoundError as exc:
+            raise CatalogCommandError(*_CATALOG_NOT_FOUND) from exc
+        except ValueError as exc:
+            raise CatalogCommandError(*_CATALOG_INVALID_DOMAIN) from exc
+
+    def create_catalog_dish(self, form: dict[str, str]) -> str:
+        """CATALOG_ADMIN_PANEL_V1: builds the domain payload from the form and
+        delegates; the dish_id is minted by Core (direct service or Office
+        API), never here, and `active` is not part of the payload at all —
+        a new dish is always created inactive and is activated by the
+        separate Aktivieren command."""
+        created_id = ""
+        with self._catalog_write_errors():
+            price_cents = parse_catalog_price_input(form.get("price_net", ""))
+            vat_raw = form.get("vat_rate_percent", "").strip()
+            if not vat_raw.isdigit():
+                raise CatalogCommandError(*_CATALOG_INVALID_DOMAIN)
+            payload = CatalogDishCreatePayload(
+                name=form.get("name", "").strip(),
+                category=validate_category(form.get("category", "")),
+                pricing_unit=validate_pricing_unit(
+                    form.get("pricing_unit", "").strip()
+                ),
+                current_unit_net_cents=price_cents,
+                vat_rate_percent=int(vat_raw),
+                description=form.get("description", "").strip() or None,
+                composition=form.get("composition", "").strip() or None,
+                notes=form.get("notes", "").strip() or None,
+                allergens=self._catalog_allergens_from_form(form),
+            )
+
+            def work() -> None:
+                nonlocal created_id
+                if self._remote is not None:
+                    created_id = self._remote.catalog_dish_write_service.create_dish(
+                        payload
+                    ).dish_id
+                    return
+                created_id = self.catalog_dish_write_service.create_dish(
+                    payload
+                ).dish_id
+
+            self._run_catalog_write(work)
+        return created_id
+
+    def set_catalog_dish_active(
+        self, dish_id: str, form: dict[str, str], *, active: bool
+    ) -> None:
+        """CATALOG_ADMIN_PANEL_V1: status is its own command in both modes —
+        activate_dish/deactivate_dish, never a field of the edit form — so the
+        optimistic-concurrency token has to travel with it exactly as the
+        update form's does."""
+        expected_raw = form.get("_expect_updated_at", "").strip()
+        if not expected_raw:
+            raise CatalogCommandError(*_CATALOG_INVALID_INPUT)
+        with self._catalog_write_errors():
+            try:
+                expected_updated_at = datetime.fromisoformat(expected_raw)
+            except ValueError as exc:
+                # A malformed precondition is a bad request, not a domain
+                # rejection — it never reached the dish.
+                raise CatalogCommandError(*_CATALOG_INVALID_INPUT) from exc
+
+            def work() -> None:
+                if self._remote is not None:
+                    remote_service = self._remote.catalog_dish_write_service
+                    if active:
+                        remote_service.activate_dish(
+                            dish_id, expected_updated_at=expected_raw
+                        )
+                    else:
+                        remote_service.deactivate_dish(
+                            dish_id, expected_updated_at=expected_raw
+                        )
+                    return
+                if active:
+                    self.catalog_dish_write_service.activate_dish(
+                        dish_id, expected_updated_at=expected_updated_at
+                    )
+                else:
+                    self.catalog_dish_write_service.deactivate_dish(
+                        dish_id, expected_updated_at=expected_updated_at
+                    )
+
+            self._run_catalog_write(work)
+
     def update_catalog_dish(self, dish_id: str, form: dict[str, str]) -> None:
         expected_raw = form.get("_expect_updated_at", "").strip()
         if not expected_raw:
-            raise ValueError("missing catalog updated_at precondition")
-        expected_updated_at = datetime.fromisoformat(expected_raw)
-        current = self._catalog_detail_payload(dish_id)
-        if current is None:
-            raise ValueError(f"no catalog dish with id {dish_id!r}")
-        new_cents = api_views.parse_catalog_price_cents(form.get("price_net", ""))
-        effective_raw = form.get("effective_from", "").strip()
-        effective_from = date.fromisoformat(effective_raw) if effective_raw else None
-        if (
-            new_cents != int(str(current["current_unit_net_cents"]))
-            and effective_from is None
-        ):
-            effective_from = api_views.berlin_today()
-        name = form.get("name", "").strip()
-        description = form.get("description", "").strip() or None
-        composition = form.get("composition", "").strip() or None
-        notes = form.get("notes", "").strip() or None
-        allergens = self._catalog_allergens_from_form(form)
-        active = form.get("active") == "1"
-        args: dict[str, object] = {
-            "name": name,
-            "description": description,
-            "composition": composition,
-            "notes": notes,
-            "current_unit_net_cents": new_cents,
-            "allergens": list(allergens),
-            "active": active,
-        }
-        if effective_from is not None:
-            args["effective_from"] = effective_from.isoformat()
-
-        def work() -> None:
-            if self._remote is not None:
-                self._remote.catalog_dish_write_service.update(
-                    dish_id,
-                    args=args,
-                    expected_updated_at=expected_raw,
-                )
-                return
+            raise CatalogCommandError(*_CATALOG_INVALID_INPUT)
+        with self._catalog_write_errors():
             try:
+                expected_updated_at = datetime.fromisoformat(expected_raw)
+            except ValueError as exc:
+                # A malformed precondition is a bad request, not a domain
+                # rejection — it never reached the dish.
+                raise CatalogCommandError(*_CATALOG_INVALID_INPUT) from exc
+            current = self._catalog_detail_payload(dish_id)
+            if current is None:
+                raise CatalogCommandError(*_CATALOG_NOT_FOUND)
+            # Same price rule as the create form: reject a third decimal
+            # rather than let the shared parser quantize it away.
+            new_cents = parse_catalog_price_input(form.get("price_net", ""))
+            effective_raw = form.get("effective_from", "").strip()
+            try:
+                effective_from = (
+                    date.fromisoformat(effective_raw) if effective_raw else None
+                )
+            except ValueError as exc:
+                raise CatalogCommandError(*_CATALOG_INVALID_INPUT) from exc
+            if (
+                new_cents != int(str(current["current_unit_net_cents"]))
+                and effective_from is None
+            ):
+                effective_from = api_views.berlin_today()
+            name = form.get("name", "").strip()
+            description = form.get("description", "").strip() or None
+            composition = form.get("composition", "").strip() or None
+            notes = form.get("notes", "").strip() or None
+            allergens = self._catalog_allergens_from_form(form)
+            # CATALOG_ADMIN_PANEL_V1: the edit form no longer carries an Aktiv
+            # checkbox (status is its own command now), so `active` must be
+            # read back from the dish's current state. Deriving it from the
+            # form here would silently deactivate every dish on each save,
+            # since a missing checkbox is indistinguishable from an
+            # unchecked one.
+            active = bool(current["active"])
+            args: dict[str, object] = {
+                "name": name,
+                "description": description,
+                "composition": composition,
+                "notes": notes,
+                "current_unit_net_cents": new_cents,
+                "allergens": list(allergens),
+                "active": active,
+            }
+            if effective_from is not None:
+                args["effective_from"] = effective_from.isoformat()
+
+            def work() -> None:
+                if self._remote is not None:
+                    self._remote.catalog_dish_write_service.update(
+                        dish_id,
+                        args=args,
+                        expected_updated_at=expected_raw,
+                    )
+                    return
                 self.catalog_dish_write_service.update_dish(
                     dish_id,
                     update=CatalogDishUpdatePayload(
@@ -1394,18 +1682,8 @@ class OfficePanel:
                     ),
                     expected_updated_at=expected_updated_at,
                 )
-            except CatalogDishStaleError as exc:
-                raise ValueError(
-                    "Das Gericht wurde zwischenzeitlich geändert. "
-                    "Bitte laden Sie die Seite neu."
-                ) from exc
 
-        if self._remote is not None:
-            work()
-        elif self._command_executor is not None:
-            self._command_executor.run(work)
-        else:
-            work()
+            self._run_catalog_write(work)
 
     def _email_list_rows(self) -> list[dict[str, object]]:
         if self._remote is not None:

--- a/src/catering_system/ui/office_panel_catalog_detail.py
+++ b/src/catering_system/ui/office_panel_catalog_detail.py
@@ -1,7 +1,11 @@
-"""Gericht detail — read-only catalog projection (6D-1)."""
+"""Gericht detail — catalog projection and status commands (6D-1)."""
 
 from __future__ import annotations
 
+from catering_system.ui.office_panel_catalog_list import (
+    pricing_unit_label,
+    vat_label,
+)
 from catering_system.ui.office_panel_views import (
     OfficePageContext,
     _e,
@@ -53,21 +57,57 @@ def _price_history_block(history: object) -> str:
     return "<p><strong>Preisänderungen:</strong></p><ul>" + "".join(items) + "</ul>"
 
 
+def _status_command_form(
+    dish_id: str,
+    *,
+    active: bool,
+    command_fields: str,
+) -> str:
+    """CATALOG_ADMIN_PANEL_V1: exactly one status command is offered at a
+    time — the one that would actually change something. Both carry the same
+    optimistic-concurrency token the edit form uses, so a stale page cannot
+    flip a status that somebody else already changed."""
+    action = "deactivate" if active else "activate"
+    label = "Deaktivieren" if active else "Aktivieren"
+    return (
+        f'<form method="post" action="/gerichte/{_e(dish_id)}/{action}">'
+        + command_fields
+        + f'<button type="submit">{_e(label)}</button>'
+        + "</form>"
+    )
+
+
 def render_gericht_detail(
     detail: dict[str, object],
     *,
     context: OfficePageContext,
+    command_fields: str = "",
+    error_message: str | None = None,
 ) -> str:
     name = str(detail.get("name", "Gericht"))
-    status = "Aktiv" if detail.get("active") else "Inaktiv"
+    active = bool(detail.get("active"))
+    status = "Aktiv" if active else "Inaktiv"
+    dish_id = str(detail.get("dish_id", ""))
+    error_html = f'<p class="error">{_e(error_message)}</p>' if error_message else ""
     body = (
-        f'<p class="subtitle">Status: {_e(status)}</p>'
+        error_html
+        + f'<p class="subtitle">Status: {_e(status)}</p>'
+        + _status_command_form(dish_id, active=active, command_fields=command_fields)
         + _text_block("Beschreibung", detail.get("description"))
         + _text_block("Zusammensetzung", detail.get("composition"))
+        + _text_block("Hinweise", detail.get("notes"))
+        # CATALOG_ADMIN_PANEL_V1: read-only in this slice — these are set once
+        # at creation and have no edit path yet.
+        + f"<p><strong>Kategorie:</strong> "
+        f"{_e(str(detail.get('category') or '–'))}</p>"
+        + f"<p><strong>Preiseinheit:</strong> "
+        f"{pricing_unit_label(detail.get('pricing_unit'))}</p>"
+        + f"<p><strong>MwSt:</strong> "
+        f"{vat_label(detail.get('vat_rate_percent'))}</p>"
         + _allergen_block(detail.get("allergen_labels"))
         + f"<p><strong>Preis:</strong> {_e(str(detail.get('price_display', '–')))}</p>"
         + _price_history_block(detail.get("price_history"))
-        + f'<p><a href="/gerichte/{_e(str(detail.get("dish_id", "")))}/edit">Bearbeiten</a></p>'
+        + f'<p><a href="/gerichte/{_e(dish_id)}/edit">Bearbeiten</a></p>'
         + '<p><a href="/gerichte">← Zurück zu Gerichte</a></p>'
     )
     return _page(name, body, active_section="catalog", context=context)

--- a/src/catering_system/ui/office_panel_catalog_edit.py
+++ b/src/catering_system/ui/office_panel_catalog_edit.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from catering_system.domain.catalog import ALLERGEN_CODES, ALLERGEN_LABELS
 from catering_system.ui.office_api_views import catalog_price_input_value
+from catering_system.ui.office_panel_catalog_list import (
+    pricing_unit_label,
+    vat_label,
+)
 from catering_system.ui.office_panel_views import (
     OfficePageContext,
     _e,
@@ -61,6 +65,22 @@ def render_gericht_edit(
     body = (
         error_html
         + f'<p class="subtitle"><a href="/gerichte/{_e(dish_id)}">← Zurück zum Gericht</a></p>'
+        # CATALOG_ADMIN_PANEL_V1: status and the creation-time fields are shown
+        # here for orientation but are not editable on this form — status has
+        # its own Aktivieren/Deaktivieren commands on the detail page, and
+        # Kategorie/Preiseinheit/MwSt have no edit path in this slice. A
+        # checkbox for `active` would additionally be unsafe: an unchecked box
+        # is indistinguishable from an absent one, so a plain save would read
+        # as "deactivate".
+        + '<p class="catalog-readonly"><strong>Status:</strong> '
+        + f"{_e('Aktiv' if active else 'Inaktiv')} — "
+        + f'<a href="/gerichte/{_e(dish_id)}">Status ändern</a></p>'
+        + '<p class="catalog-readonly"><strong>Kategorie:</strong> '
+        + f"{_e(str(detail.get('category') or '–'))}</p>"
+        + '<p class="catalog-readonly"><strong>Preiseinheit:</strong> '
+        + f"{pricing_unit_label(detail.get('pricing_unit'))}</p>"
+        + '<p class="catalog-readonly"><strong>MwSt:</strong> '
+        + f"{vat_label(detail.get('vat_rate_percent'))}</p>"
         + f'<form method="post" action="/gerichte/{_e(dish_id)}/update">'
         + command_fields
         + _text_input("name", "Name", name)
@@ -73,10 +93,6 @@ def render_gericht_edit(
             catalog_price_input_value(cents),
         )
         + _allergen_checkboxes(detail.get("allergens"))
-        + (
-            f'<p><label><input type="checkbox" name="active" value="1"'
-            f"{' checked' if active else ''}> Aktiv</label></p>"
-        )
         + _text_input("effective_from", "Gültig ab (Preis)", effective_default)
         + '<p><button type="submit">Speichern</button></p>'
         + "</form>"

--- a/src/catering_system/ui/office_panel_catalog_list.py
+++ b/src/catering_system/ui/office_panel_catalog_list.py
@@ -1,4 +1,4 @@
-"""Gerichte list — read-only catalog projection (6D-1)."""
+"""Gerichte list — catalog administration surface (6D-1, CATALOG_ADMIN_PANEL_V1)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,32 @@ from catering_system.ui.office_panel_views import (
     _page,
 )
 
+# CATALOG_ADMIN_PANEL_V1: German labels for the closed pricing_unit set. The
+# codes themselves stay the domain's (per_person/stueck/pauschal) — this is
+# presentation only, so an unknown code degrades to the raw value rather than
+# raising, keeping the page rendering even against unexpected data.
+PRICING_UNIT_LABELS = {
+    "per_person": "pro Person",
+    "stueck": "Stück",
+    "pauschal": "Pauschal",
+}
+
+_STATUS_TABS = (
+    ("all", "Alle"),
+    ("active", "Aktiv"),
+    ("inactive", "Inaktiv"),
+)
+
+# CATALOG_ADMIN_PANEL_V1: the read layer caps a page at 100 rows. Filtering
+# now happens in the query, so a full page means "there are more matches",
+# never "the filter silently dropped them" — but the page still must not
+# imply it is showing the whole catalog.
+CATALOG_PAGE_LIMIT = 100
+_LIMIT_NOTICE = (
+    "Die Liste ist auf 100 Gerichte begrenzt. "
+    "Bitte verwenden Sie die Suche, um weitere Gerichte zu finden."
+)
+
 
 def _allergen_cell(labels: object) -> str:
     if isinstance(labels, list) and labels:
@@ -17,9 +43,61 @@ def _allergen_cell(labels: object) -> str:
     return "–"
 
 
+def _optional_cell(value: object) -> str:
+    """Legacy rows predate category/pricing_unit/vat_rate_percent and carry
+    NULL for them (CATALOG_ADMIN_COMPLETION_V1A decision #2/#3) — they render
+    as a dash instead of breaking the page."""
+    if value is None:
+        return "–"
+    text = str(value).strip()
+    return _e(text) if text else "–"
+
+
+def pricing_unit_label(value: object) -> str:
+    if value is None:
+        return "–"
+    return _e(PRICING_UNIT_LABELS.get(str(value), str(value)))
+
+
+def vat_label(value: object) -> str:
+    if value is None:
+        return "–"
+    return f"{_e(str(value))} %"
+
+
+def _status_tabs(search_query: str, status_filter: str) -> str:
+    links = []
+    for value, label in _STATUS_TABS:
+        params = {"status": value}
+        if search_query:
+            params["q"] = search_query
+        query = "&".join(
+            f"{key}={quote(str(param_value), safe='')}"
+            for key, param_value in params.items()
+        )
+        if value == status_filter:
+            links.append(f"<strong>{_e(label)}</strong>")
+        else:
+            links.append(f'<a href="/gerichte?{_e(query)}">{_e(label)}</a>')
+    return '<p class="catalog-filter">' + " | ".join(links) + "</p>"
+
+
+def _search_form(search_query: str, status_filter: str) -> str:
+    return (
+        '<form method="get" action="/gerichte" class="catalog-search">'
+        f'<input type="hidden" name="status" value="{_e(status_filter)}">'
+        '<label for="q">Suche nach Name</label> '
+        f'<input id="q" name="q" value="{_e(search_query)}" size="30">'
+        '<button type="submit">Suchen</button>'
+        "</form>"
+    )
+
+
 def render_gerichte_list(
     payload: dict[str, object],
     *,
+    search_query: str = "",
+    status_filter: str = "all",
     context: OfficePageContext,
 ) -> str:
     rows = payload.get("dishes")
@@ -34,20 +112,37 @@ def render_gerichte_list(
         table_rows.append(
             "<tr>"
             f"<td>{_e(str(row['name']))}</td>"
+            f"<td>{_optional_cell(row.get('category'))}</td>"
+            f"<td>{pricing_unit_label(row.get('pricing_unit'))}</td>"
             '<td class="catalog-price">'
             f"{_e(str(row.get('price_display', '–')))}</td>"
+            f"<td>{vat_label(row.get('vat_rate_percent'))}</td>"
             f"<td>{_allergen_cell(row.get('allergen_labels'))}</td>"
             f"<td>{_e(status)}</td>"
             f'<td><a href="/gerichte/{_e(quote(dish_id, safe=""))}">Öffnen</a></td>'
             "</tr>"
         )
+    empty_text = (
+        "Keine Gerichte gefunden."
+        if search_query or status_filter != "all"
+        else "Keine Gerichte vorhanden."
+    )
+    limit_notice = (
+        f'<p class="catalog-limit">{_e(_LIMIT_NOTICE)}</p>'
+        if len(table_rows) >= CATALOG_PAGE_LIMIT
+        else ""
+    )
     body = (
-        '<p class="subtitle">Stammdaten — nur Lesen. Änderungen folgen in Verwaltung.</p>'
-        "<table><tr><th>Name</th><th>Preis</th><th>Allergene</th>"
+        '<p class="subtitle">Stammdaten — Gerichte anlegen, bearbeiten und '
+        "aktivieren.</p>"
+        '<p><a href="/gerichte/new">Neues Gericht anlegen</a></p>'
+        + _search_form(search_query, status_filter)
+        + _status_tabs(search_query, status_filter)
+        + limit_notice
+        + "<table><tr><th>Name</th><th>Kategorie</th><th>Preiseinheit</th>"
+        "<th>Netto-Preis</th><th>MwSt</th><th>Allergene</th>"
         "<th>Status</th><th></th></tr>"
-        + "".join(
-            table_rows or ['<tr><td colspan="5">Keine Gerichte vorhanden.</td></tr>']
-        )
+        + "".join(table_rows or [f'<tr><td colspan="8">{_e(empty_text)}</td></tr>'])
         + "</table>"
         + '<p><a href="/">← Zurück zur Arbeitszentrale</a></p>'
     )

--- a/src/catering_system/ui/office_panel_catalog_new.py
+++ b/src/catering_system/ui/office_panel_catalog_new.py
@@ -1,0 +1,128 @@
+"""Neues Gericht form — catalog create surface (CATALOG_ADMIN_PANEL_V1)."""
+
+from __future__ import annotations
+
+from catering_system.domain.catalog import (
+    ALLERGEN_CODES,
+    ALLERGEN_LABELS,
+    PRICING_UNITS,
+)
+from catering_system.ui.office_panel_catalog_list import PRICING_UNIT_LABELS
+from catering_system.ui.office_panel_views import (
+    OfficePageContext,
+    _e,
+    _page,
+)
+
+# CATALOG_ADMIN_PANEL_V1: the selectable VAT rates. The domain keeps its own
+# authoritative tuple private and validates every submission through
+# CatalogDishCreatePayload, so this list only decides what the dropdown
+# offers — it can never widen what the domain accepts.
+VAT_RATE_OPTIONS = (7, 19)
+
+_CATEGORY_HINT = (
+    "Kleinbuchstaben, Ziffern und - oder _ als Trenner, z. B. "
+    "„fingerfood“ oder „warme_speisen“."
+)
+
+
+def _text_input(name: str, label: str, value: str, *, hint: str = "") -> str:
+    hint_html = f"<br><small>{_e(hint)}</small>" if hint else ""
+    return (
+        f'<p><label for="{_e(name)}">{_e(label)}</label><br>'
+        f'<input id="{_e(name)}" name="{_e(name)}" value="{_e(value)}" size="60">'
+        f"{hint_html}</p>"
+    )
+
+
+def _textarea(name: str, label: str, value: str) -> str:
+    return (
+        f'<p><label for="{_e(name)}">{_e(label)}</label><br>'
+        f'<textarea id="{_e(name)}" name="{_e(name)}" rows="4" cols="60">'
+        f"{_e(value)}</textarea></p>"
+    )
+
+
+def _pricing_unit_select(selected: str) -> str:
+    options = []
+    for code in PRICING_UNITS:
+        chosen = " selected" if code == selected else ""
+        label = PRICING_UNIT_LABELS.get(code, code)
+        options.append(f'<option value="{_e(code)}"{chosen}>{_e(label)}</option>')
+    return (
+        '<p><label for="pricing_unit">Preiseinheit</label><br>'
+        '<select id="pricing_unit" name="pricing_unit">'
+        + "".join(options)
+        + "</select></p>"
+    )
+
+
+def _vat_select(selected: str) -> str:
+    options = []
+    for rate in VAT_RATE_OPTIONS:
+        chosen = " selected" if str(rate) == selected else ""
+        options.append(f'<option value="{rate}"{chosen}>{rate} %</option>')
+    return (
+        '<p><label for="vat_rate_percent">MwSt</label><br>'
+        '<select id="vat_rate_percent" name="vat_rate_percent">'
+        + "".join(options)
+        + "</select></p>"
+    )
+
+
+def _allergen_checkboxes(form: dict[str, str]) -> str:
+    items = []
+    for code in ALLERGEN_CODES:
+        checked = " checked" if form.get(f"allergen_{code}") == "1" else ""
+        label = ALLERGEN_LABELS[code]
+        items.append(
+            f'<label><input type="checkbox" name="allergen_{_e(code)}" '
+            f'value="1"{checked}> {_e(code)} {_e(label)}</label>'
+        )
+    return (
+        "<p><strong>Allergene</strong></p>"
+        '<div class="allergen-grid">' + "".join(items) + "</div>"
+    )
+
+
+def render_gericht_new(
+    *,
+    command_fields: str,
+    context: OfficePageContext,
+    form: dict[str, str] | None = None,
+    error_message: str | None = None,
+) -> str:
+    """Renders the create form, re-filling every field from `form` so a
+    rejected submission never silently discards what was typed."""
+    values = form or {}
+    error_html = f'<p class="error">{_e(error_message)}</p>' if error_message else ""
+    body = (
+        error_html
+        + '<p class="subtitle">Neues Gericht wird zunächst <strong>inaktiv</strong> '
+        "angelegt und kann danach aktiviert werden.</p>"
+        + '<form method="post" action="/gerichte/new">'
+        + command_fields
+        + _text_input("name", "Name", values.get("name", ""))
+        + _textarea("description", "Beschreibung", values.get("description", ""))
+        + _textarea("composition", "Zusammensetzung", values.get("composition", ""))
+        + _textarea("notes", "Hinweise", values.get("notes", ""))
+        + _text_input(
+            "category",
+            "Kategorie",
+            values.get("category", ""),
+            hint=_CATEGORY_HINT,
+        )
+        + _pricing_unit_select(values.get("pricing_unit", ""))
+        + _text_input("price_net", "Netto-Preis (€)", values.get("price_net", ""))
+        + _vat_select(values.get("vat_rate_percent", ""))
+        + _allergen_checkboxes(values)
+        + '<p><button type="submit">Gericht anlegen</button></p>'
+        + "</form>"
+        + '<p><a href="/gerichte">← Zurück zu Gerichte</a></p>'
+    )
+    return _page(
+        "Neues Gericht",
+        body,
+        active_section="catalog",
+        context=context,
+    )

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -43,6 +43,7 @@ from catering_system.integration.auerswald_sync import (
     resolve_missed_call,
 )
 from catering_system.ui.office_panel import (
+    CatalogCommandError,
     OfferPdfUnavailableError,
     OfficePageContext,
     OfficePanel,
@@ -148,11 +149,42 @@ _OFFER_COMMAND_ERROR_LABELS: dict[str, str] = {
 }
 
 
+# CATALOG_ADMIN_PANEL_V1: catalog-specific keys, deliberately prefixed rather
+# than reusing the raw Office API codes (validation_error/already_exists/
+# stale_state/not_found). Those codes are generic across every command in the
+# API, so a bare "not_found" entry here would put "Das Gericht ..." in front of
+# an unrelated inquiry or order failure. OfficePanel's catalog write methods
+# translate both direct-mode domain exceptions and remote-mode RemoteCoreError
+# codes into these prefixed keys, which is what makes the two modes show the
+# same German text.
+_CATALOG_COMMAND_ERROR_LABELS: dict[str, str] = {
+    "catalog_validation_error": (
+        "Die eingegebenen Gerichtdaten sind ungültig — bitte Name, Kategorie, "
+        "Preiseinheit, Preis und MwSt prüfen."
+    ),
+    "catalog_invalid_price": (
+        "Der Preis ist ungültig. Bitte geben Sie einen Betrag mit höchstens "
+        "zwei Nachkommastellen an, zum Beispiel 12,50."
+    ),
+    "catalog_invalid_input": (
+        "Die Anfrage war unvollständig oder fehlerhaft. "
+        "Bitte laden Sie die Seite neu und versuchen Sie es erneut."
+    ),
+    "catalog_already_exists": "Dieses Gericht existiert bereits.",
+    "catalog_stale_state": (
+        "Das Gericht wurde zwischenzeitlich geändert. Bitte laden Sie die Seite neu."
+    ),
+    "catalog_not_found": "Das Gericht wurde nicht gefunden.",
+}
+
+
 def office_command_error_message(code_or_text: str) -> str:
     if code_or_text in _INQUIRY_COMMAND_ERROR_LABELS:
         return _INQUIRY_COMMAND_ERROR_LABELS[code_or_text]
     if code_or_text in _OFFER_COMMAND_ERROR_LABELS:
         return _OFFER_COMMAND_ERROR_LABELS[code_or_text]
+    if code_or_text in _CATALOG_COMMAND_ERROR_LABELS:
+        return _CATALOG_COMMAND_ERROR_LABELS[code_or_text]
     lowered = code_or_text.lower()
     if "sent evidence already exists" in lowered:
         return _OFFER_COMMAND_ERROR_LABELS["sent_evidence_exists"]
@@ -457,7 +489,16 @@ def make_office_panel_handler(
                     panel.render_kontakte(search_query, status_filter, context=context)
                 )
             elif parts == ["gerichte"]:
-                self._html(panel.render_gerichte(context=context))
+                query = parse_qs(parsed.query)
+                self._html(
+                    panel.render_gerichte(
+                        query.get("q", [""])[0],
+                        query.get("status", ["all"])[0],
+                        context=context,
+                    )
+                )
+            elif parts == ["gerichte", "new"]:
+                self._html(panel.render_gericht_new(context=context))
             elif parts == ["emails"] or parts == ["email"]:
                 self._html(panel.render_email(context=context))
             elif parts == ["aufgaben"]:
@@ -676,6 +717,14 @@ def make_office_panel_handler(
             parts = [part for part in urlparse(self.path).path.split("/") if part]
             try:
                 self._route_post(parts)
+            except CatalogCommandError as exc:
+                # CATALOG_ADMIN_PANEL_V1: carries its own status (404/409/422/
+                # 400) so a catalog rejection keeps its meaning instead of
+                # being flattened into the generic 400 below. Must precede the
+                # ValueError branch — it is a ValueError subclass.
+                self._error_page(
+                    office_command_error_message(exc.code), status=exc.status
+                )
             except RemoteCoreError as exc:
                 self._remote_error_page(exc)
             except (ValueError, KeyError) as exc:
@@ -733,8 +782,21 @@ def make_office_panel_handler(
                     call_id,
                 )
                 self._redirect("/rueckruf")
+            elif parts == ["gerichte", "new"]:
+                self._create_catalog_dish()
             elif len(parts) == 3 and parts[0] == "gerichte" and parts[2] == "update":
                 panel.update_catalog_dish(parts[1], self._form())
+                self._redirect(f"/gerichte/{parts[1]}")
+            elif (
+                len(parts) == 3
+                and parts[0] == "gerichte"
+                and parts[2] in ("activate", "deactivate")
+            ):
+                panel.set_catalog_dish_active(
+                    parts[1],
+                    self._form(),
+                    active=parts[2] == "activate",
+                )
                 self._redirect(f"/gerichte/{parts[1]}")
             elif len(parts) == 3 and parts[0] == "kontakt" and parts[2] == "notizen":
                 contact_key = unquote(parts[1])
@@ -742,6 +804,39 @@ def make_office_panel_handler(
                 self._redirect(f"/kontakt/{quote(contact_key, safe='')}")
             else:
                 self.send_error(404)
+
+        def _create_catalog_dish(self) -> None:
+            """CATALOG_ADMIN_PANEL_V1: a rejected create re-renders the form
+            with the submitted values and the German reason, rather than the
+            generic error page — the operator would otherwise lose everything
+            they typed. Unavailability keeps the shared 503 path."""
+            form = self._form()
+            try:
+                dish_id = panel.create_catalog_dish(form)
+            except CatalogCommandError as exc:
+                self._html(
+                    panel.render_gericht_new(
+                        context=self._fetch_page_context(),
+                        form=form,
+                        error_message=office_command_error_message(exc.code),
+                    ),
+                    exc.status,
+                )
+                return
+            except RemoteCoreError as exc:
+                self._remote_error_page(exc)
+                return
+            except (ValueError, KeyError) as exc:
+                self._html(
+                    panel.render_gericht_new(
+                        context=self._fetch_page_context(),
+                        form=form,
+                        error_message=office_command_error_message(str(exc)),
+                    ),
+                    400,
+                )
+                return
+            self._redirect(f"/gerichte/{quote(dish_id, safe='')}")
 
         def _inquiry_action(self, inquiry_id: str, action: str) -> None:
             if action == "update":

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1808,14 +1808,18 @@ class RemoteCoreClient:
     def list_catalog_dishes(
         self,
         *,
-        active_only: bool = False,
+        active: bool | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> dict[str, object]:
+        """CATALOG_ADMIN_PANEL_V1: sends the status filter as `active`
+        (true/false/omitted) so Core applies it in SQL before LIMIT. Never
+        sends the legacy `active_only` — that alias exists on the API only
+        for callers older than this change."""
         params: dict[str, str] = {}
-        if active_only:
-            params["active_only"] = "true"
+        if active is not None:
+            params["active"] = "true" if active else "false"
         if q:
             params["q"] = q
         if limit != 100:

--- a/tests/unit/test_catalog_dish_service.py
+++ b/tests/unit/test_catalog_dish_service.py
@@ -46,9 +46,44 @@ def test_list_dishes_search_and_active_filter() -> None:
         updated_at=_NOW,
     )
     service = _service(active, inactive)
-    result = service.list_dishes(active_only=True, q="schn")
+    result = service.list_dishes(active=True, q="schn")
     assert result.total_count == 1
     assert result.dishes[0].name == "Schnitzel"
+
+
+def test_list_dishes_inactive_filter_selects_only_inactive() -> None:
+    """CATALOG_ADMIN_PANEL_V1: active=False is a real third state, not the
+    absence of a filter — it must select the inactive rows."""
+    active = CatalogDish(
+        dish_id="11111111-1111-4111-8111-111111111111",
+        name="Schnitzel",
+        description=None,
+        composition=None,
+        notes=None,
+        current_unit_net_cents=850,
+        allergens=("A",),
+        active=True,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    inactive = CatalogDish(
+        dish_id="22222222-2222-4222-8222-222222222222",
+        name="Kartoffelsalat",
+        description=None,
+        composition=None,
+        notes=None,
+        current_unit_net_cents=320,
+        allergens=("J",),
+        active=False,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    service = _service(active, inactive)
+    result = service.list_dishes(active=False)
+    assert result.total_count == 1
+    assert result.dishes[0].name == "Kartoffelsalat"
+    # None keeps both
+    assert service.list_dishes(active=None).total_count == 2
 
 
 def test_list_allergen_codes_returns_dictionary() -> None:

--- a/tests/unit/test_catalog_repository.py
+++ b/tests/unit/test_catalog_repository.py
@@ -61,7 +61,9 @@ def test_sqlite_catalog_price_history_empty_by_default(tmp_path: Path) -> None:
         repo.close()
 
 
-def test_sqlite_catalog_active_only_filter(tmp_path: Path) -> None:
+def test_sqlite_catalog_active_filter(tmp_path: Path) -> None:
+    """CATALOG_ADMIN_PANEL_V1: active is tri-state — True/False select one
+    status in SQL, None applies no status clause at all."""
     db = tmp_path / "core.db"
     repo = SQLiteCatalogRepository(db)
     try:
@@ -70,8 +72,45 @@ def test_sqlite_catalog_active_only_filter(tmp_path: Path) -> None:
         repo.insert_dish_if_absent(
             _dish(dish_id=inactive_id, name="Inaktiv", active=False)
         )
-        active_rows = repo.list_dishes(active_only=True)
-        assert [row.dish_id for row in active_rows] == [_DISH_ID]
+        assert [row.dish_id for row in repo.list_dishes(active=True)] == [_DISH_ID]
+        assert [row.dish_id for row in repo.list_dishes(active=False)] == [inactive_id]
+        assert len(repo.list_dishes(active=None)) == 2
+        assert repo.count_dishes(active=True) == 1
+        assert repo.count_dishes(active=False) == 1
+        assert repo.count_dishes(active=None) == 2
+    finally:
+        repo.close()
+
+
+def test_sqlite_catalog_active_filter_applies_before_limit(tmp_path: Path) -> None:
+    """The regression this contract exists for: with more active dishes than
+    one page holds, the inactive ones must still be found — filtering has to
+    happen in the WHERE clause, not on an already-truncated page."""
+    db = tmp_path / "core.db"
+    repo = SQLiteCatalogRepository(db)
+    try:
+        for index in range(120):
+            repo.insert_dish_if_absent(
+                _dish(
+                    dish_id=f"{index:08d}-1111-4111-8111-111111111111",
+                    name=f"Aktiv {index:03d}",
+                    active=True,
+                )
+            )
+        for index in range(3):
+            repo.insert_dish_if_absent(
+                _dish(
+                    dish_id=f"9999{index:04d}-2222-4222-8222-222222222222",
+                    name=f"Zzz Inaktiv {index}",
+                    active=False,
+                )
+            )
+        inactive = repo.list_dishes(active=False, limit=100)
+        assert len(inactive) == 3
+        assert all(not row.active for row in inactive)
+        assert len(repo.list_dishes(active=True, limit=100)) == 100
+        assert repo.count_dishes(active=True) == 120
+        assert repo.count_dishes(active=False) == 3
     finally:
         repo.close()
 

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3113,6 +3113,99 @@ def test_list_catalog_dishes_rejects_invalid_boolean_query(api) -> None:
     assert (status, body["error"]) == (400, "invalid_request")
 
 
+def _seed_active_and_inactive(db) -> None:
+    _seed_catalog_dish(db)
+    _seed_catalog_dish(
+        db,
+        dish_id=_INACTIVE_CATALOG_DISH_ID,
+        name="Inaktives Gericht",
+        active=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "query,expect_active,expect_inactive",
+    [
+        ("", True, True),
+        ("?active=true", True, False),
+        ("?active=false", False, True),
+        # legacy alias: active_only=true still means "active only", and
+        # active_only=false keeps its original meaning of "no filter"
+        ("?active_only=true", True, False),
+        ("?active_only=false", True, True),
+    ],
+    ids=["no-filter", "active", "inactive", "legacy-true", "legacy-false"],
+)
+def test_list_catalog_dishes_active_filter_contract(
+    api, query: str, expect_active: bool, expect_inactive: bool
+) -> None:
+    """CATALOG_ADMIN_PANEL_V1: `active` is the tri-state contract;
+    `active_only` stays supported for callers older than this change."""
+    base, _ids, db = api
+    _seed_active_and_inactive(db)
+    status, body, _h = _get(f"{base}/office/v1/catalog/dishes{query}")
+    assert status == 200
+    returned = {row["dish_id"] for row in body["dishes"]}
+    assert (_CATALOG_DISH_ID in returned) is expect_active
+    assert (_INACTIVE_CATALOG_DISH_ID in returned) is expect_inactive
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "?active=true&active_only=true",
+        "?active=false&active_only=true",
+        "?active=true&active_only=false",
+    ],
+)
+def test_list_catalog_dishes_rejects_conflicting_active_params(api, query: str) -> None:
+    """Fail closed: `active=false&active_only=true` has no honest answer, so
+    the request is rejected rather than resolved by precedence — including
+    the combinations that happen to agree, which would otherwise make the
+    contract depend on which value the server chose to believe."""
+    base, _ids, db = api
+    _seed_active_and_inactive(db)
+    status, body, _h = _get(f"{base}/office/v1/catalog/dishes{query}")
+    assert (status, body["error"]) == (400, "invalid_request")
+
+
+def test_list_catalog_dishes_rejects_invalid_active_value(api) -> None:
+    base, _ids, _db = api
+    status, body, _h = _get(f"{base}/office/v1/catalog/dishes?active=maybe")
+    assert (status, body["error"]) == (400, "invalid_request")
+
+
+def test_list_catalog_dishes_active_filter_runs_before_limit(api) -> None:
+    """The regression this contract exists for: with more active dishes than
+    a page holds, `active=false` must still return the inactive ones."""
+    base, _ids, db = api
+    for index in range(120):
+        _seed_catalog_dish(
+            db,
+            dish_id=f"{index:08d}-1111-4111-8111-111111111111",
+            name=f"Aktiv {index:03d}",
+            active=True,
+        )
+    for index in range(3):
+        _seed_catalog_dish(
+            db,
+            dish_id=f"9999{index:04d}-2222-4222-8222-222222222222",
+            name=f"Zzz Inaktiv {index}",
+            active=False,
+        )
+    status, body, _h = _get(f"{base}/office/v1/catalog/dishes?active=false")
+    assert status == 200
+    assert len(body["dishes"]) == 3
+    assert body["total_count"] == 3
+    assert all(row["active"] is False for row in body["dishes"])
+
+    status, body, _h = _get(f"{base}/office/v1/catalog/dishes?active=true")
+    assert status == 200
+    assert len(body["dishes"]) == 100
+    assert body["total_count"] == 120
+    assert body["truncated"] is True
+
+
 def test_catalog_dish_detail_schema(api) -> None:
     base, _ids, db = api
     _seed_catalog_dish(db)

--- a/tests/unit/test_office_panel_catalog_admin.py
+++ b/tests/unit/test_office_panel_catalog_admin.py
@@ -1,0 +1,743 @@
+"""CATALOG_ADMIN_PANEL_V1: /gerichte administration surface.
+
+Covers the list's new columns/search/filter, the create form, the separate
+Aktivieren/Deaktivieren commands and their optimistic-concurrency token, and
+the German error handling — all driven through the real HTTP handler so the
+CSRF check and routing are exercised the way a browser would.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+
+import pytest
+
+from catering_system.domain.catalog import CatalogDish
+from catering_system.repositories.in_memory_catalog_repository import (
+    InMemoryCatalogRepository,
+)
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.ui.office_panel import create_office_panel_server
+from catering_system.ui.office_panel_http import csrf_token_for_password
+
+_PASSWORD = "test-pw"
+_CSRF_TOKEN = csrf_token_for_password(_PASSWORD)
+_MODERN_ID = "11111111-1111-4111-8111-111111111111"
+_LEGACY_ID = "22222222-2222-4222-8222-222222222222"
+_NOW = datetime(2026, 7, 16, 8, 0, tzinfo=UTC)
+
+
+def _auth_header() -> str:
+    import base64
+
+    return "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
+
+
+@pytest.fixture()
+def catalog_world():
+    catalog = InMemoryCatalogRepository()
+    catalog.insert_dish_if_absent(
+        CatalogDish(
+            dish_id=_MODERN_ID,
+            name="Bruschetta",
+            description="Beschreibung",
+            composition="Zusammensetzung",
+            notes="Hinweise",
+            current_unit_net_cents=290,
+            allergens=("A",),
+            active=True,
+            created_at=_NOW,
+            updated_at=_NOW,
+            category="fingerfood",
+            pricing_unit="stueck",
+            vat_rate_percent=7,
+        )
+    )
+    # Legacy row: created before CATALOG_ADMIN_COMPLETION_V1A, so all three
+    # new columns are NULL and must not break any page.
+    catalog.insert_dish_if_absent(
+        CatalogDish(
+            dish_id=_LEGACY_ID,
+            name="Altes Gericht",
+            description=None,
+            composition=None,
+            notes=None,
+            current_unit_net_cents=500,
+            allergens=(),
+            active=False,
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        _PASSWORD,
+        host="127.0.0.1",
+        port=0,
+        catalog_repo=catalog,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    yield f"http://{host}:{port}", catalog
+    server.shutdown()
+    server.server_close()
+
+
+def _get(url: str) -> tuple[int, str]:
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", _auth_header())
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _post(url: str, fields: dict[str, str]) -> tuple[int, str]:
+    data = urllib.parse.urlencode(fields).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Authorization", _auth_header())
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def _csrf_from(html: str) -> str:
+    match = re.search(r'name="_csrf_token" value="([^"]*)"', html)
+    assert match, "page is missing the _csrf_token hidden field"
+    return match.group(1)
+
+
+def _expect_updated_at_from(html: str) -> str:
+    match = re.search(r'name="_expect_updated_at" value="([^"]+)"', html)
+    assert match, "page is missing the _expect_updated_at hidden field"
+    return match.group(1)
+
+
+def _valid_create_fields(**overrides: str) -> dict[str, str]:
+    fields = {
+        "_csrf_token": _CSRF_TOKEN,
+        "name": "Neues Gericht",
+        "description": "Beschreibung",
+        "composition": "Zusammensetzung",
+        "notes": "Hinweise",
+        "category": "warme_speisen",
+        "pricing_unit": "per_person",
+        "price_net": "12,50",
+        "vat_rate_percent": "19",
+        "allergen_A": "1",
+    }
+    fields.update(overrides)
+    return fields
+
+
+# --- list: columns, legacy NULLs, search, filter -------------------------
+
+
+def test_list_shows_new_columns(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte")
+    assert status == 200
+    for header in ("Kategorie", "Preiseinheit", "Netto-Preis", "MwSt", "Allergene"):
+        assert header in body
+    assert "fingerfood" in body
+    assert "Stück" in body
+    assert "7 %" in body
+    assert "2,90 €" in body
+    assert "Aktiv" in body
+    assert "Neues Gericht anlegen" in body
+
+
+def test_list_renders_legacy_null_fields_without_failing(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte")
+    assert status == 200
+    assert "Altes Gericht" in body
+    assert "–" in body
+
+
+def test_detail_and_edit_render_legacy_null_fields(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, detail = _get(f"{base}/gerichte/{_LEGACY_ID}")
+    assert status == 200
+    assert "Kategorie" in detail
+    assert "–" in detail
+    status, edit = _get(f"{base}/gerichte/{_LEGACY_ID}/edit")
+    assert status == 200
+    assert "–" in edit
+
+
+def test_list_search_by_name(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte?q=Bruschetta")
+    assert status == 200
+    assert "Bruschetta" in body
+    assert "Altes Gericht" not in body
+
+
+def test_list_search_without_match_shows_empty_notice(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte?q=GibtEsNicht")
+    assert status == 200
+    assert "Keine Gerichte gefunden." in body
+
+
+def test_list_filter_active(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte?status=active")
+    assert status == 200
+    assert "Bruschetta" in body
+    assert "Altes Gericht" not in body
+
+
+def test_list_filter_inactive(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte?status=inactive")
+    assert status == 200
+    assert "Altes Gericht" in body
+    assert "Bruschetta" not in body
+
+
+def test_list_unknown_filter_falls_back_to_all(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte?status=bogus")
+    assert status == 200
+    assert "Bruschetta" in body
+    assert "Altes Gericht" in body
+
+
+# --- create form ---------------------------------------------------------
+
+
+def test_get_create_form(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte/new")
+    assert status == 200
+    for field in (
+        'name="name"',
+        'name="description"',
+        'name="composition"',
+        'name="notes"',
+        'name="category"',
+        'name="pricing_unit"',
+        'name="price_net"',
+        'name="vat_rate_percent"',
+        'name="allergen_A"',
+        'name="allergen_N"',
+    ):
+        assert field in body
+    assert '<option value="7"' in body
+    assert '<option value="19"' in body
+    assert _csrf_from(body) == _CSRF_TOKEN
+
+
+def test_create_success_redirects_to_detail(catalog_world) -> None:
+    base, catalog = catalog_world
+    status, body = _post(
+        f"{base}/gerichte/new", _valid_create_fields(name="Lachstatar")
+    )
+    assert status == 200
+    created = [d for d in catalog.list_dishes() if d.name == "Lachstatar"]
+    assert len(created) == 1
+    dish = created[0]
+    assert dish.category == "warme_speisen"
+    assert dish.pricing_unit == "per_person"
+    assert dish.vat_rate_percent == 19
+    assert dish.allergens == ("A",)
+    # followed the redirect to *this* dish's detail page, not back to the list
+    assert f"/gerichte/{dish.dish_id}/edit" in body
+    assert "Lachstatar" in body
+    assert "Aktivieren" in body
+
+
+def test_created_dish_is_inactive(catalog_world) -> None:
+    base, catalog = catalog_world
+    _status, _body = _post(f"{base}/gerichte/new", _valid_create_fields())
+    dish = next(d for d in catalog.list_dishes() if d.name == "Neues Gericht")
+    assert dish.active is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected_cents",
+    [
+        ("12,50", 1250),
+        ("12.50", 1250),
+        ("12,5", 1250),
+        ("12.5", 1250),
+        ("12", 1200),
+        ("0", 0),
+        ("0,00", 0),
+        ("12,50 €", 1250),
+    ],
+)
+def test_create_accepts_valid_price_formats(
+    catalog_world, raw: str, expected_cents: int
+) -> None:
+    base, catalog = catalog_world
+    _status, _body = _post(
+        f"{base}/gerichte/new",
+        _valid_create_fields(name=f"Preis {raw}", price_net=raw),
+    )
+    dish = next(d for d in catalog.list_dishes() if d.name == f"Preis {raw}")
+    assert dish.current_unit_net_cents == expected_cents
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "1.999",
+        "12,505",
+        "12,999",
+        "-5,00",
+        "-1",
+        "",
+        "   ",
+        "abc",
+        "1e3",
+        "12,5,0",
+        "1.000,50",
+        "12,",
+        "12.",
+        ",50",
+    ],
+)
+def test_create_rejects_imprecise_or_malformed_price(catalog_world, raw: str) -> None:
+    """CATALOG_ADMIN_PANEL_V1 review fix: a third decimal used to be quantized
+    away silently, storing a price nobody typed (1.999 -> 2,00 €). Anything
+    that is not a plain amount with at most two decimals is now refused, and
+    no dish is created."""
+    base, catalog = catalog_world
+    before = len(catalog.list_dishes())
+    status, body = _post(
+        f"{base}/gerichte/new",
+        _valid_create_fields(name="Ungueltiger Preis", price_net=raw),
+    )
+    assert status == 400
+    assert "Nachkommastellen" in body or "ungültig" in body
+    assert len(catalog.list_dishes()) == before
+    assert all(d.name != "Ungueltiger Preis" for d in catalog.list_dishes())
+
+
+@pytest.mark.parametrize("raw", ["1.999", "12,505", "-5,00", "abc", ""])
+def test_edit_rejects_imprecise_price_and_keeps_old_value(
+    catalog_world, raw: str
+) -> None:
+    """The same rule guards the pre-existing edit form — a rejected save must
+    leave the stored price exactly as it was."""
+    base, catalog = catalog_world
+    _status, edit = _get(f"{base}/gerichte/{_MODERN_ID}/edit")
+    before = catalog.get_dish(_MODERN_ID).current_unit_net_cents
+    status, _body = _post(
+        f"{base}/gerichte/{_MODERN_ID}/update",
+        {
+            "_csrf_token": _csrf_from(edit),
+            "_expect_updated_at": _expect_updated_at_from(edit),
+            "name": "Bruschetta",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": raw,
+        },
+    )
+    assert status == 400
+    assert catalog.get_dish(_MODERN_ID).current_unit_net_cents == before
+
+
+@pytest.mark.parametrize(
+    "overrides,expected_status",
+    [
+        # Form/price parsing never reaches the domain -> 400.
+        ({"price_net": "keine-zahl"}, 400),
+        ({"price_net": ""}, 400),
+        # The domain rejected the value -> 422.
+        ({"category": "Fingerfood"}, 422),
+        ({"category": ""}, 422),
+        ({"vat_rate_percent": "5"}, 422),
+        ({"vat_rate_percent": ""}, 422),
+        ({"pricing_unit": "kilogramm"}, 422),
+        ({"name": ""}, 422),
+    ],
+    ids=[
+        "price-not-a-number",
+        "price-empty",
+        "category-uppercase",
+        "category-empty",
+        "vat-not-allowed",
+        "vat-empty",
+        "pricing-unit-unknown",
+        "name-empty",
+    ],
+)
+def test_create_rejects_invalid_input(
+    catalog_world, overrides: dict, expected_status: int
+) -> None:
+    """CATALOG_ADMIN_PANEL_V1 review fix: a malformed price and a value the
+    domain refuses are different failures and must not share a status."""
+    base, catalog = catalog_world
+    before = len(catalog.list_dishes())
+    status, body = _post(f"{base}/gerichte/new", _valid_create_fields(**overrides))
+    assert status == expected_status
+    assert "ungültig" in body
+    assert len(catalog.list_dishes()) == before
+
+
+def test_create_rejected_form_keeps_submitted_values(catalog_world) -> None:
+    base, _catalog = catalog_world
+    _status, body = _post(
+        f"{base}/gerichte/new",
+        _valid_create_fields(name="Behalten", price_net="kaputt"),
+    )
+    assert 'value="Behalten"' in body
+
+
+def test_create_without_csrf_token_is_rejected(catalog_world) -> None:
+    base, catalog = catalog_world
+    before = len(catalog.list_dishes())
+    fields = _valid_create_fields()
+    del fields["_csrf_token"]
+    status, _body = _post(f"{base}/gerichte/new", fields)
+    assert status == 403
+    assert len(catalog.list_dishes()) == before
+
+
+def test_create_with_wrong_csrf_token_is_rejected(catalog_world) -> None:
+    base, catalog = catalog_world
+    before = len(catalog.list_dishes())
+    status, _body = _post(
+        f"{base}/gerichte/new", _valid_create_fields(_csrf_token="falsch")
+    )
+    assert status == 403
+    assert len(catalog.list_dishes()) == before
+
+
+# --- activate / deactivate ----------------------------------------------
+
+
+def test_detail_offers_deactivate_for_active_dish(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte/{_MODERN_ID}")
+    assert status == 200
+    assert "Deaktivieren" in body
+    assert "Aktivieren" not in body
+    assert _csrf_from(body) == _CSRF_TOKEN
+    assert _expect_updated_at_from(body)
+
+
+def test_detail_offers_activate_for_inactive_dish(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte/{_LEGACY_ID}")
+    assert status == 200
+    assert "Aktivieren" in body
+
+
+def test_activate_success(catalog_world) -> None:
+    base, catalog = catalog_world
+    _status, detail = _get(f"{base}/gerichte/{_LEGACY_ID}")
+    status, _body = _post(
+        f"{base}/gerichte/{_LEGACY_ID}/activate",
+        {
+            "_csrf_token": _csrf_from(detail),
+            "_expect_updated_at": _expect_updated_at_from(detail),
+        },
+    )
+    assert status == 200
+    assert catalog.get_dish(_LEGACY_ID).active is True
+
+
+def test_deactivate_success(catalog_world) -> None:
+    base, catalog = catalog_world
+    _status, detail = _get(f"{base}/gerichte/{_MODERN_ID}")
+    status, _body = _post(
+        f"{base}/gerichte/{_MODERN_ID}/deactivate",
+        {
+            "_csrf_token": _csrf_from(detail),
+            "_expect_updated_at": _expect_updated_at_from(detail),
+        },
+    )
+    assert status == 200
+    assert catalog.get_dish(_MODERN_ID).active is False
+
+
+def test_activate_with_stale_updated_at_is_rejected(catalog_world) -> None:
+    base, catalog = catalog_world
+    stale = _NOW.isoformat()
+    _status, detail = _get(f"{base}/gerichte/{_LEGACY_ID}")
+    _post(
+        f"{base}/gerichte/{_LEGACY_ID}/activate",
+        {
+            "_csrf_token": _csrf_from(detail),
+            "_expect_updated_at": _expect_updated_at_from(detail),
+        },
+    )
+    assert catalog.get_dish(_LEGACY_ID).active is True
+    # second command still carries the *original* token
+    status, body = _post(
+        f"{base}/gerichte/{_LEGACY_ID}/deactivate",
+        {"_csrf_token": _CSRF_TOKEN, "_expect_updated_at": stale},
+    )
+    assert status == 409
+    assert "zwischenzeitlich geändert" in body
+    assert catalog.get_dish(_LEGACY_ID).active is True
+
+
+def test_activate_without_csrf_token_leaves_dish_unchanged(catalog_world) -> None:
+    base, catalog = catalog_world
+    status, _body = _post(
+        f"{base}/gerichte/{_LEGACY_ID}/activate",
+        {"_expect_updated_at": _NOW.isoformat()},
+    )
+    assert status == 403
+    assert catalog.get_dish(_LEGACY_ID).active is False
+
+
+def test_status_command_on_missing_dish_reports_not_found(catalog_world) -> None:
+    base, _catalog = catalog_world
+    missing = "33333333-3333-4333-8333-333333333333"
+    status, body = _post(
+        f"{base}/gerichte/{missing}/activate",
+        {"_csrf_token": _CSRF_TOKEN, "_expect_updated_at": _NOW.isoformat()},
+    )
+    assert status == 404
+    assert "nicht gefunden" in body
+
+
+# --- existing edit form keeps working -----------------------------------
+
+
+def test_edit_form_has_no_active_checkbox(catalog_world) -> None:
+    base, _catalog = catalog_world
+    status, body = _get(f"{base}/gerichte/{_MODERN_ID}/edit")
+    assert status == 200
+    assert 'name="active"' not in body
+    # status is still visible, just not editable here
+    assert "Status" in body
+    assert "Status ändern" in body
+
+
+def test_edit_form_shows_creation_fields_read_only(catalog_world) -> None:
+    base, _catalog = catalog_world
+    _status, body = _get(f"{base}/gerichte/{_MODERN_ID}/edit")
+    assert "fingerfood" in body
+    assert "Stück" in body
+    assert "7 %" in body
+    assert 'name="category"' not in body
+    assert 'name="pricing_unit"' not in body
+    assert 'name="vat_rate_percent"' not in body
+
+
+def test_edit_update_still_saves_and_keeps_status(catalog_world) -> None:
+    """The Aktiv checkbox is gone, so `active` is carried forward from the
+    dish's current state — a plain save must never silently deactivate."""
+    base, catalog = catalog_world
+    _status, edit = _get(f"{base}/gerichte/{_MODERN_ID}/edit")
+    status, _body = _post(
+        f"{base}/gerichte/{_MODERN_ID}/update",
+        {
+            "_csrf_token": _csrf_from(edit),
+            "_expect_updated_at": _expect_updated_at_from(edit),
+            "name": "Bruschetta Classica",
+            "description": "Neu",
+            "composition": "Tomaten",
+            "notes": "",
+            "price_net": "3,10",
+            "allergen_A": "1",
+        },
+    )
+    assert status == 200
+    dish = catalog.get_dish(_MODERN_ID)
+    assert dish.name == "Bruschetta Classica"
+    assert dish.current_unit_net_cents == 310
+    assert dish.active is True
+    # creation-time fields survive an edit untouched
+    assert dish.category == "fingerfood"
+    assert dish.pricing_unit == "stueck"
+    assert dish.vat_rate_percent == 7
+
+
+def test_edit_update_on_inactive_dish_keeps_it_inactive(catalog_world) -> None:
+    base, catalog = catalog_world
+    _status, edit = _get(f"{base}/gerichte/{_LEGACY_ID}/edit")
+    status, _body = _post(
+        f"{base}/gerichte/{_LEGACY_ID}/update",
+        {
+            "_csrf_token": _csrf_from(edit),
+            "_expect_updated_at": _expect_updated_at_from(edit),
+            "name": "Altes Gericht",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": "5,00",
+        },
+    )
+    assert status == 200
+    assert catalog.get_dish(_LEGACY_ID).active is False
+
+
+def test_edit_update_with_stale_token_leaves_dish_unchanged(catalog_world) -> None:
+    base, catalog = catalog_world
+    _status, edit = _get(f"{base}/gerichte/{_MODERN_ID}/edit")
+    token = _expect_updated_at_from(edit)
+    _post(
+        f"{base}/gerichte/{_MODERN_ID}/update",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_expect_updated_at": token,
+            "name": "Erste Änderung",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": "2,90",
+        },
+    )
+    status, body = _post(
+        f"{base}/gerichte/{_MODERN_ID}/update",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_expect_updated_at": token,
+            "name": "Darf nicht gespeichert werden",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "price_net": "9,99",
+        },
+    )
+    assert status == 409
+    assert "zwischenzeitlich geändert" in body
+    assert catalog.get_dish(_MODERN_ID).name == "Erste Änderung"
+
+
+# --- server-side status filter (applied before the 100-row limit) --------
+
+
+@pytest.fixture()
+def large_catalog_world():
+    """120 active dishes sorted ahead of 3 inactive ones — the shape that
+    exposed the original bug: a page limit of 100 is filled entirely by
+    active rows, so any filtering done after the read cannot see the
+    inactive ones at all."""
+    catalog = InMemoryCatalogRepository()
+    for index in range(120):
+        catalog.insert_dish_if_absent(
+            CatalogDish(
+                dish_id=f"{index:08d}-1111-4111-8111-111111111111",
+                name=f"Aktiv {index:03d}",
+                description=None,
+                composition=None,
+                notes=None,
+                current_unit_net_cents=100,
+                allergens=(),
+                active=True,
+                created_at=_NOW,
+                updated_at=_NOW,
+            )
+        )
+    for index in range(3):
+        catalog.insert_dish_if_absent(
+            CatalogDish(
+                dish_id=f"9999{index:04d}-2222-4222-8222-222222222222",
+                name=f"Zzz Inaktiv {index}",
+                description=None,
+                composition=None,
+                notes=None,
+                current_unit_net_cents=100,
+                allergens=(),
+                active=False,
+                created_at=_NOW,
+                updated_at=_NOW,
+            )
+        )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        _PASSWORD,
+        host="127.0.0.1",
+        port=0,
+        catalog_repo=catalog,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    yield f"http://{host}:{port}", catalog
+    server.shutdown()
+    server.server_close()
+
+
+def test_inactive_filter_finds_dishes_beyond_the_first_page(
+    large_catalog_world,
+) -> None:
+    """The regression itself: Inaktiv must return the real inactive dishes,
+    not an empty page produced by filtering 100 already-fetched active rows."""
+    base, _catalog = large_catalog_world
+    status, body = _get(f"{base}/gerichte?status=inactive")
+    assert status == 200
+    assert body.count("Zzz Inaktiv") == 3
+    assert "Keine Gerichte gefunden." not in body
+    assert "Aktiv 0" not in body
+
+
+def test_active_filter_returns_only_active_up_to_the_limit(
+    large_catalog_world,
+) -> None:
+    base, body = large_catalog_world[0], None
+    status, body = _get(f"{base}/gerichte?status=active")
+    assert status == 200
+    assert body.count("Öffnen") == 100
+    assert "Zzz Inaktiv" not in body
+
+
+def test_all_filter_applies_no_status_filter(large_catalog_world) -> None:
+    base, _catalog = large_catalog_world
+    status, body = _get(f"{base}/gerichte?status=all")
+    assert status == 200
+    assert body.count("Öffnen") == 100
+
+
+def test_search_combines_with_inactive_filter(large_catalog_world) -> None:
+    base, _catalog = large_catalog_world
+    status, body = _get(f"{base}/gerichte?q=Zzz&status=inactive")
+    assert status == 200
+    assert body.count("Zzz Inaktiv") == 3
+    assert "Aktiv 0" not in body
+
+
+def test_search_combines_with_active_filter(large_catalog_world) -> None:
+    base, _catalog = large_catalog_world
+    status, body = _get(f"{base}/gerichte?q=Zzz&status=active")
+    assert status == 200
+    assert "Keine Gerichte gefunden." in body
+
+
+def test_limit_warning_shown_when_page_is_full(large_catalog_world) -> None:
+    base, _catalog = large_catalog_world
+    _status, body = _get(f"{base}/gerichte?status=active")
+    assert "Die Liste ist auf 100 Gerichte begrenzt." in body
+    assert "Bitte verwenden Sie die Suche" in body
+
+
+def test_limit_warning_absent_below_the_limit(large_catalog_world) -> None:
+    base, _catalog = large_catalog_world
+    _status, body = _get(f"{base}/gerichte?status=inactive")
+    assert "auf 100 Gerichte begrenzt" not in body
+
+
+def test_limit_warning_absent_on_small_catalog(catalog_world) -> None:
+    base, _catalog = catalog_world
+    _status, body = _get(f"{base}/gerichte")
+    assert "auf 100 Gerichte begrenzt" not in body

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -1056,6 +1056,46 @@ def test_gericht_edit_direct_remote_parity(parity_world) -> None:
     assert _strip_remote_fields(d_html) == _strip_remote_fields(r_html)
 
 
+@pytest.mark.parametrize(
+    "query",
+    ["", "?q=Kartoffelsalat", "?status=active", "?status=inactive", "?q=nichts"],
+    ids=["all", "search", "active", "inactive", "no-match"],
+)
+def test_gerichte_search_and_filter_direct_remote_parity(
+    parity_world, query: str
+) -> None:
+    """CATALOG_ADMIN_PANEL_V1: the search is pushed down to each mode's own
+    list call (repository vs query string) while the Aktiv/Inaktiv split is
+    applied in the panel — both have to land on byte-identical HTML."""
+    direct_url, remote_url, _ids = parity_world
+    d_status, d_html = _get(f"{direct_url}/gerichte{query}")
+    r_status, r_html = _get(f"{remote_url}/gerichte{query}")
+    assert d_status == r_status == 200
+    assert d_html == r_html
+
+
+def test_gericht_detail_direct_remote_parity(parity_world) -> None:
+    """The detail page now carries the Aktivieren/Deaktivieren command form,
+    so its hidden precondition fields must match too (modulo the remote-only
+    _command_id, which is minted per render)."""
+    direct_url, remote_url, ids = parity_world
+    dish_id = ids["catalog_dish_id"]
+    d_status, d_html = _get(f"{direct_url}/gerichte/{dish_id}")
+    r_status, r_html = _get(f"{remote_url}/gerichte/{dish_id}")
+    assert d_status == r_status == 200
+    assert "Deaktivieren" in d_html
+    assert _strip_remote_fields(d_html) == _strip_remote_fields(r_html)
+
+
+def test_gericht_new_form_direct_remote_parity(parity_world) -> None:
+    direct_url, remote_url, _ids = parity_world
+    d_status, d_html = _get(f"{direct_url}/gerichte/new")
+    r_status, r_html = _get(f"{remote_url}/gerichte/new")
+    assert d_status == r_status == 200
+    assert "Gericht anlegen" in d_html
+    assert _strip_remote_fields(d_html) == _strip_remote_fields(r_html)
+
+
 def test_rueckruf_stays_local_not_routed_through_core(parity_world) -> None:
     """Rückruf/Auerswald stays outside Core.  On Proxmox, an unconfigured
     local integration must carry the frozen "only on premises" explanation
@@ -1290,6 +1330,261 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
     assert status == 200
     status, order_html = _get(f"{base}/order/{order_id}")
     assert "STORNIERT" in order_html
+
+
+def test_catalog_status_filter_uses_server_side_query_in_remote_mode(
+    remote_world,
+) -> None:
+    """CATALOG_ADMIN_PANEL_V1 review fix: with more active dishes than one
+    page holds, Inaktiv must still find the inactive ones — proving the panel
+    sends `active` to Core rather than filtering an already-truncated page.
+    Driven through the real Office API, so the query string, the SQL WHERE
+    and the LIMIT are all exercised."""
+    base, _api_url = remote_world
+    created_inactive = []
+    for index in range(3):
+        _status, form_html = _get(f"{base}/gerichte/new")
+        _status, detail_html = _post_form(
+            f"{base}/gerichte/new",
+            {
+                "_csrf_token": _CSRF_TOKEN,
+                "_command_id": _extract_hidden(form_html, "_command_id"),
+                "name": f"Zzz Inaktiv {index}",
+                "description": "",
+                "composition": "",
+                "notes": "",
+                "category": "fingerfood",
+                "pricing_unit": "stueck",
+                "price_net": "1,00",
+                "vat_rate_percent": "7",
+            },
+        )
+        created_inactive.append(
+            re.search(r"/gerichte/([0-9a-f-]{36})/edit", detail_html).group(1)
+        )
+
+    status, body = _get(f"{base}/gerichte?status=inactive")
+    assert status == 200
+    assert body.count("Zzz Inaktiv") == 3
+    assert "Keine Gerichte gefunden." not in body
+
+    status, body = _get(f"{base}/gerichte?status=active")
+    assert status == 200
+    assert "Zzz Inaktiv" not in body
+
+    status, body = _get(f"{base}/gerichte?q=Zzz&status=inactive")
+    assert status == 200
+    assert body.count("Zzz Inaktiv") == 3
+
+
+def test_catalog_status_filter_direct_remote_parity_beyond_one_page(
+    parity_world,
+) -> None:
+    """Both modes must answer identically for every filter, including the
+    combinations that only differ once server-side filtering is in play."""
+    direct_url, remote_url, _ids = parity_world
+    for query in ("?status=inactive", "?status=active", "?q=Kartoffel&status=active"):
+        d_status, d_html = _get(f"{direct_url}/gerichte{query}")
+        r_status, r_html = _get(f"{remote_url}/gerichte{query}")
+        assert d_status == r_status == 200
+        assert d_html == r_html
+
+
+def test_catalog_admin_flow_through_remote_panel(remote_world) -> None:
+    """CATALOG_ADMIN_PANEL_V1: create → activate → deactivate driven entirely
+    through the remote panel, so the whole chain (panel → RemoteCoreClient's
+    create_dish/activate_dish/deactivate_dish → the frozen Office API command
+    envelope → Core) is exercised for real rather than mocked."""
+    base, _api_url = remote_world
+
+    _status, form_html = _get(f"{base}/gerichte/new")
+    status, detail_html = _post_form(
+        f"{base}/gerichte/new",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(form_html, "_command_id"),
+            "name": "Ofengemüse",
+            "description": "Saisonal",
+            "composition": "Karotten",
+            "notes": "",
+            "category": "warme_speisen",
+            "pricing_unit": "per_person",
+            "price_net": "7,40",
+            "vat_rate_percent": "19",
+            "allergen_G": "1",
+        },
+    )
+    assert status == 200
+    assert "Ofengemüse" in detail_html
+    # a new dish always lands inactive, so the only status command offered
+    # is Aktivieren
+    assert "Aktivieren" in detail_html
+    assert "Deaktivieren" not in detail_html
+    assert "warme_speisen" in detail_html
+    assert "7,40 €" in detail_html
+    assert "19 %" in detail_html
+
+    dish_id = re.search(r"/gerichte/([0-9a-f-]{36})/edit", detail_html).group(1)
+
+    activate_form = re.search(
+        r'(<form method="post" action="/gerichte/[^"]*/activate".*?</form>)',
+        detail_html,
+        re.DOTALL,
+    ).group(0)
+    status, activated_html = _post_form(
+        f"{base}/gerichte/{dish_id}/activate",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(activate_form, "_command_id"),
+            "_expect_updated_at": _extract_hidden(activate_form, "_expect_updated_at"),
+        },
+    )
+    assert status == 200
+    assert "Deaktivieren" in activated_html
+
+    deactivate_form = re.search(
+        r'(<form method="post" action="/gerichte/[^"]*/deactivate".*?</form>)',
+        activated_html,
+        re.DOTALL,
+    ).group(0)
+    status, deactivated_html = _post_form(
+        f"{base}/gerichte/{dish_id}/deactivate",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(deactivate_form, "_command_id"),
+            "_expect_updated_at": _extract_hidden(
+                deactivate_form, "_expect_updated_at"
+            ),
+        },
+    )
+    assert status == 200
+    assert "Aktivieren" in deactivated_html
+    assert "Deaktivieren" not in deactivated_html
+
+
+def test_catalog_stale_status_command_rejected_through_remote_panel(
+    remote_world,
+) -> None:
+    """A stale optimistic-concurrency token must surface the same German
+    message *and* the same 409 in both modes: remote maps the API's
+    stale_state, direct maps CatalogDishStaleError, and both land on
+    CatalogCommandError, which carries the status through to the response."""
+    base, _api_url = remote_world
+    _status, form_html = _get(f"{base}/gerichte/new")
+    _status, detail_html = _post_form(
+        f"{base}/gerichte/new",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(form_html, "_command_id"),
+            "name": "Stale-Test",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "category": "fingerfood",
+            "pricing_unit": "stueck",
+            "price_net": "1,00",
+            "vat_rate_percent": "7",
+        },
+    )
+    dish_id = re.search(r"/gerichte/([0-9a-f-]{36})/edit", detail_html).group(1)
+    activate_form = re.search(
+        r'(<form method="post" action="/gerichte/[^"]*/activate".*?</form>)',
+        detail_html,
+        re.DOTALL,
+    ).group(0)
+    stale_token = _extract_hidden(activate_form, "_expect_updated_at")
+    status, _body = _post_form(
+        f"{base}/gerichte/{dish_id}/activate",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(activate_form, "_command_id"),
+            "_expect_updated_at": stale_token,
+        },
+    )
+    assert status == 200
+
+    status, error_html = _post_form(
+        f"{base}/gerichte/{dish_id}/deactivate",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": "11111111-1111-4111-8111-aaaaaaaaaaaa",
+            "_expect_updated_at": stale_token,
+        },
+    )
+    assert status == 409
+    assert "zwischenzeitlich geändert" in error_html
+    status, detail_html = _get(f"{base}/gerichte/{dish_id}")
+    assert "Deaktivieren" in detail_html  # still active — nothing changed
+
+
+def test_catalog_missing_dish_status_command_is_404_in_remote_mode(
+    remote_world,
+) -> None:
+    """CATALOG_ADMIN_PANEL_V1 review fix: the remote path must keep the API's
+    404 instead of flattening it into the generic 400."""
+    base, _api_url = remote_world
+    missing = "33333333-3333-4333-8333-333333333333"
+    status, body = _post_form(
+        f"{base}/gerichte/{missing}/activate",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": "11111111-1111-4111-8111-dddddddddddd",
+            "_expect_updated_at": "2026-07-16T08:00:00+00:00",
+        },
+    )
+    assert status == 404
+    assert "nicht gefunden" in body
+
+
+def test_catalog_domain_rejection_is_422_in_remote_mode(remote_world) -> None:
+    """A value the domain refuses (name past its length limit) comes back as
+    the API's validation_error and must surface as 422, distinct from the 400
+    a malformed price gets."""
+    base, _api_url = remote_world
+    _status, form_html = _get(f"{base}/gerichte/new")
+    status, body = _post_form(
+        f"{base}/gerichte/new",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(form_html, "_command_id"),
+            "name": "x" * 600,
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "category": "fingerfood",
+            "pricing_unit": "stueck",
+            "price_net": "1,00",
+            "vat_rate_percent": "7",
+        },
+    )
+    assert status == 422
+    assert "ungültig" in body
+
+
+def test_catalog_malformed_price_is_400_in_remote_mode(remote_world) -> None:
+    """The price is rejected in the panel before any command is sent, so both
+    modes answer 400 without Core ever seeing the request."""
+    base, _api_url = remote_world
+    _status, form_html = _get(f"{base}/gerichte/new")
+    status, body = _post_form(
+        f"{base}/gerichte/new",
+        {
+            "_csrf_token": _CSRF_TOKEN,
+            "_command_id": _extract_hidden(form_html, "_command_id"),
+            "name": "Dreistellig",
+            "description": "",
+            "composition": "",
+            "notes": "",
+            "category": "fingerfood",
+            "pricing_unit": "stueck",
+            "price_net": "1,999",
+            "vat_rate_percent": "7",
+        },
+    )
+    assert status == 400
+    assert "Nachkommastellen" in body
+    status, list_html = _get(f"{base}/gerichte")
+    assert "Dreistellig" not in list_html
 
 
 def test_verify_flow_through_remote_panel(remote_world) -> None:


### PR DESCRIPTION
## Summary
- extend the existing `/gerichte` section into a catalog administration panel
- add search and server-side Aktiv/Inaktiv filtering
- add creation of inactive catalog dishes
- add separate activate/deactivate commands with optimistic concurrency
- preserve correct HTTP statuses in direct and remote mode
- enforce exact EUR price precision without silent rounding
- preserve legacy rows with NULL category, pricing unit, and VAT

## Server-side filtering
- active=true → active dishes
- active=false → inactive dishes
- omitted active → all dishes
- filtering and search happen before LIMIT 100
- legacy active_only=true remains supported
- conflicting active/active_only parameters fail closed

## Price contract
- `12` means 12,00 €
- `12,5` and `12.50` mean 12,50 €
- more than two decimals are rejected
- no float and no silent rounding

## Error status contract
- not_found → 404
- stale_state / already_exists → 409
- validation_error → 422
- invalid form or price → 400
- CSRF → 403
- unavailable Core → 503

## Verification
- 2124 tests passed
- coverage 90.4%
- ruff check passed
- ruff format check passed
- mypy passed
- git diff --check passed

## Deployment note
Office API and Office Panel must be deployed in the same deployment pass because the Panel now sends the new `active=` query parameter.

Also note the intentional input behavior:
a separator-less price such as `12` is interpreted as 12,00 €, not 0,12 €.

## Out of scope
- Offer item editor
- order commercial revisions
- production groups
- full catalog import
- pagination
- production deployment

Do not merge.
Do not deploy.
Do not delete the feature branch or worktree.