### PR TITLE
Fix RemoteCoreClient structured error handling

### DIFF
--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -281,15 +281,36 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "invalid_withdrawal_evidence",
             "order_version_not_current_candidate",
             "validation_error",
-            # Issue #39: emitted by POST /offers/.../offer-document when the
-            # snapshot is blocked, together with a `reasons` list. Without
-            # this entry the code was refused by the status whitelist and
-            # surfaced as 502 invalid_response instead of the real 422.
+            # Issue #39: the three document blockers. All are real Office API
+            # business errors that were missing here, so the status whitelist
+            # refused them and they surfaced as 502 invalid_response instead
+            # of the 422 the operator needs to see.
             "offer_document_blocked",
+            "confirmation_document_blocked",
+            "order_not_ready_to_send",
         }
     ),
     500: frozenset({"internal"}),
     503: frozenset({"core_busy"}),
+}
+
+# Issue #39: the error contracts that may carry a `reasons` list, keyed by
+# status. Deliberately narrower than _ERROR_CODES_BY_STATUS — `reasons` is
+# not a general-purpose field, it is part of these three blocker contracts
+# only. Every other status/code pair must still arrive as a bare
+# {"error": ...} body, so an unexpected `reasons` anywhere else is a
+# contract violation rather than something to tolerate.
+#
+# `confirmation_document_blocked` has both reasons-bearing and bare paths in
+# the API, so it appears here *and* must keep working without `reasons`.
+_ERROR_CODES_WITH_REASONS_BY_STATUS: dict[int, frozenset[str]] = {
+    422: frozenset(
+        {
+            "offer_document_blocked",
+            "confirmation_document_blocked",
+            "order_not_ready_to_send",
+        }
+    ),
 }
 
 
@@ -368,24 +389,29 @@ def _exact(data: Mapping[str, object], keys: frozenset[str] | set[str]) -> None:
         _bad_response()
 
 
-def _error_body_code(parsed: Mapping[str, object]) -> str:
+def _error_body_code(parsed: Mapping[str, object], status: int) -> str:
     """Issue #39: read the error code out of an Office API error body.
 
-    The body is `{"error": "<code>"}` plus an optional `reasons` list that
-    some 422s attach (offer/confirmation document blockers). Validating the
-    body with an exact `{"error"}` key set therefore rejected a perfectly
-    valid structured error and turned it into 502 invalid_response.
+    Most errors are a bare `{"error": "<code>"}`. Three 422 blocker
+    contracts also attach a `reasons` list, and validating every body with
+    an exact `{"error"}` key set rejected those valid responses, turning a
+    real business error into 502 invalid_response.
 
-    `error` stays required and must be a string. `reasons`, when present,
-    must be a list of strings — a malformed one still fails closed rather
-    than being carried along as trusted data. Every other key is still
-    refused, so this widens the contract by exactly one declared field.
+    `reasons` is accepted only for the status/code pairs in
+    _ERROR_CODES_WITH_REASONS_BY_STATUS — it is part of those contracts, not
+    a field any error may carry. On any other pair its presence is a
+    contract violation. When it is allowed it must still be a list of
+    strings, so a malformed one fails closed rather than being carried
+    along as trusted data. Unknown keys are refused as before.
     """
     keys = set(parsed)
     if not ({"error"} <= keys <= {"error", "reasons"}):
         _bad_response()
     code = _str(parsed["error"])
     if "reasons" in parsed:
+        allowed = _ERROR_CODES_WITH_REASONS_BY_STATUS.get(status, frozenset())
+        if code not in allowed:
+            _bad_response()
         for reason in _list(parsed["reasons"]):
             _str(reason)
     return code
@@ -1062,7 +1088,7 @@ class RemoteCoreClient:
                 _bad_response()
             try:
                 parsed = _dict(json.loads(raw.decode("utf-8")))
-                code = _error_body_code(parsed)
+                code = _error_body_code(parsed, exc.code)
             except (UnicodeDecodeError, json.JSONDecodeError, RemoteCoreError) as error:
                 raise RemoteCoreError(
                     502, "invalid_response", unavailable=True
@@ -1141,8 +1167,10 @@ class RemoteCoreClient:
             ):
                 try:
                     parsed = _dict(json.loads(raw.decode("utf-8")))
-                    code = _error_body_code(parsed)
+                    code = _error_body_code(parsed, exc.code)
                 except (UnicodeDecodeError, json.JSONDecodeError, RemoteCoreError):
+                    # get_bytes keeps its existing fallback: the real HTTP
+                    # status survives, the code degrades to unexpected_status.
                     pass
             raise RemoteCoreError(exc.code, code) from exc
         except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -281,6 +281,11 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "invalid_withdrawal_evidence",
             "order_version_not_current_candidate",
             "validation_error",
+            # Issue #39: emitted by POST /offers/.../offer-document when the
+            # snapshot is blocked, together with a `reasons` list. Without
+            # this entry the code was refused by the status whitelist and
+            # surfaced as 502 invalid_response instead of the real 422.
+            "offer_document_blocked",
         }
     ),
     500: frozenset({"internal"}),
@@ -361,6 +366,29 @@ def _inquiry_offer_projection(value: object) -> dict[str, object]:
 def _exact(data: Mapping[str, object], keys: frozenset[str] | set[str]) -> None:
     if set(data) != set(keys):
         _bad_response()
+
+
+def _error_body_code(parsed: Mapping[str, object]) -> str:
+    """Issue #39: read the error code out of an Office API error body.
+
+    The body is `{"error": "<code>"}` plus an optional `reasons` list that
+    some 422s attach (offer/confirmation document blockers). Validating the
+    body with an exact `{"error"}` key set therefore rejected a perfectly
+    valid structured error and turned it into 502 invalid_response.
+
+    `error` stays required and must be a string. `reasons`, when present,
+    must be a list of strings — a malformed one still fails closed rather
+    than being carried along as trusted data. Every other key is still
+    refused, so this widens the contract by exactly one declared field.
+    """
+    keys = set(parsed)
+    if not ({"error"} <= keys <= {"error", "reasons"}):
+        _bad_response()
+    code = _str(parsed["error"])
+    if "reasons" in parsed:
+        for reason in _list(parsed["reasons"]):
+            _str(reason)
+    return code
 
 
 def _operational_pause(value: object) -> dict[str, object]:
@@ -1034,8 +1062,7 @@ class RemoteCoreClient:
                 _bad_response()
             try:
                 parsed = _dict(json.loads(raw.decode("utf-8")))
-                _exact(parsed, {"error"})
-                code = _str(parsed["error"])
+                code = _error_body_code(parsed)
             except (UnicodeDecodeError, json.JSONDecodeError, RemoteCoreError) as error:
                 raise RemoteCoreError(
                     502, "invalid_response", unavailable=True
@@ -1114,8 +1141,7 @@ class RemoteCoreClient:
             ):
                 try:
                     parsed = _dict(json.loads(raw.decode("utf-8")))
-                    _exact(parsed, {"error"})
-                    code = _str(parsed["error"])
+                    code = _error_body_code(parsed)
                 except (UnicodeDecodeError, json.JSONDecodeError, RemoteCoreError):
                     pass
             raise RemoteCoreError(exc.code, code) from exc

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -43,6 +43,7 @@ from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
+from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
 
 _SNAPSHOT_ID = "77777777-7777-4777-8777-777777777771"
 _VARIANT_ID = "44444444-4444-4444-8444-444444444441"
@@ -5122,3 +5123,149 @@ def test_offer_document_pdf_static_content_overflow_returns_422(api) -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+# --- issue #39: structured error contracts, client against the real API ------
+#
+# These are contract tests, not schema tests: they drive the actual Office API
+# server through RemoteCoreClient and assert that a reasons-bearing 422 keeps
+# its real business code. The JSON is never hand-written here — it is whatever
+# the endpoint really produces, which is exactly what the unit-level tests in
+# test_remote_core_client.py cannot prove on their own.
+
+
+def _remote_client(base: str) -> RemoteCoreClient:
+    client = RemoteCoreClient(base, _TOKEN)
+    client.begin_request({})
+    return client
+
+
+def test_remote_client_preserves_offer_document_blocked_with_reasons(api) -> None:
+    """Real producer: POST /offers/{id}/offer-document with no invoice
+    address returns 422 offer_document_blocked + reasons."""
+    base, ids, _db = api
+    resolved_inquiry = ids["inquiry_offer_ready"]
+    _ensure_inquiry_fulfillment_mode(base, resolved_inquiry, mode="PICKUP")
+    snapshot = _valid_offer_snapshot(inquiry_id=resolved_inquiry)
+    status, body, _h = _post(
+        _prepare_offer_url(base, resolved_inquiry), args={"snapshot": snapshot}
+    )
+    assert status == 201
+    offer_id = body["offer_id"]
+
+    # the raw endpoint really does emit reasons
+    raw_status, raw_body, _h = _post(
+        _offer_document_url(base, offer_id),
+        args={
+            "offer_version_id": body["offer_version_id"],
+            "offer_variant_id": snapshot["variants"][0]["variant_id"],  # type: ignore[index]
+            "created_by": "office-api-test",
+        },
+    )
+    assert raw_status == 422
+    assert raw_body["error"] == "offer_document_blocked"
+    assert raw_body["reasons"]
+
+    # and the client surfaces it as the business error, not 502
+    client = _remote_client(base)
+    with pytest.raises(RemoteCoreError) as exc:
+        client.command(
+            f"/office/v1/offers/{offer_id}/offer-document",
+            {
+                "offer_version_id": body["offer_version_id"],
+                "offer_variant_id": snapshot["variants"][0]["variant_id"],  # type: ignore[index]
+                "created_by": "office-api-test",
+            },
+            {},
+            expected={201},
+            result_keys={"offer_document_snapshot_id"},
+        )
+    assert (exc.value.status, exc.value.code) == (422, "offer_document_blocked")
+    assert not exc.value.unavailable
+
+
+def test_remote_client_preserves_confirmation_document_blocked_with_reasons(
+    api,
+) -> None:
+    """Real producer: confirmation document creation with no customer contact
+    returns 422 confirmation_document_blocked + reasons."""
+    base, ids, db = api
+    inquiry_id = ids["inquiry_offer_ready"]
+    order_id, order_version_id = _make_effective_offer_order(
+        api, inquiry_id=inquiry_id, ensure_recipient_email=False
+    )
+    _clear_inquiry_recipient_email(db, inquiry_id)
+    inquiries = SQLiteInquiryRepository(db)
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    contact = inquiry.customer_snapshot
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name=contact.company_name if contact else None,
+                contact_name=contact.contact_name if contact else None,
+                phone=None,
+                email=None,
+            ),
+        )
+    )
+    inquiries.close()
+
+    raw_status, raw_body, _h = _post(
+        _confirmation_document_url(base, order_id),
+        args={"created_by": "office-api-test"},
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert raw_status == 422
+    assert raw_body["error"] == "confirmation_document_blocked"
+    assert raw_body.get("reasons")
+
+    client = _remote_client(base)
+    with pytest.raises(RemoteCoreError) as exc:
+        client.command(
+            f"/office/v1/orders/{order_id}/confirmation-document",
+            {"created_by": "office-api-test"},
+            {"current_effective_order_version_id": order_version_id},
+            expected={201},
+            result_keys={"document_snapshot_id"},
+        )
+    assert (exc.value.status, exc.value.code) == (
+        422,
+        "confirmation_document_blocked",
+    )
+    assert not exc.value.unavailable
+
+
+def test_remote_client_preserves_order_not_ready_to_send_with_reasons(api) -> None:
+    """Real producer: confirmation send while the order is paused returns
+    422 order_not_ready_to_send + reasons."""
+    base, _ids, _db = api
+    order_id, order_version_id, snapshot_id = _prepare_confirmation_snapshot(api)
+    _pause_order_via_api(base, order_id)
+
+    raw_status, raw_body, _h = _post(
+        _confirmation_send_url(base, order_id),
+        args={"document_snapshot_id": snapshot_id, "requested_by": "office-api-test"},
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert raw_status == 422
+    assert raw_body == {
+        "error": "order_not_ready_to_send",
+        "reasons": ["operational_pause"],
+    }
+
+    client = _remote_client(base)
+    with pytest.raises(RemoteCoreError) as exc:
+        client.command(
+            f"/office/v1/orders/{order_id}/confirmation-document/send",
+            {
+                "document_snapshot_id": snapshot_id,
+                "requested_by": "office-api-test",
+            },
+            {"current_effective_order_version_id": order_version_id},
+            expected={200},
+            result_keys={"send_attempt_id"},
+        )
+    assert (exc.value.status, exc.value.code) == (422, "order_not_ready_to_send")
+    assert not exc.value.unavailable

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -261,6 +261,119 @@ def test_known_error_code_on_wrong_status_is_invalid_response() -> None:
         server.server_close()
 
 
+# --- structured error bodies (issue #39) -------------------------------------
+#
+# Office API 422s from the document blockers carry an optional `reasons`
+# list next to `error`. Validating the body as an exact {"error"} key set
+# turned those valid responses into 502 invalid_response, and
+# `offer_document_blocked` was additionally missing from the 422 whitelist.
+
+
+def _error_body(**payload: object) -> bytes:
+    return json.dumps(payload).encode()
+
+
+def _expect_error(status: int, body: bytes) -> RemoteCoreError:
+    url, server = _json_server(status, "application/json", body)
+    try:
+        with pytest.raises(RemoteCoreError) as exc:
+            RemoteCoreClient(url, _TOKEN).get("/office/v1/queue")
+        return exc.value
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize("code", ["validation_error", "offer_document_blocked"])
+def test_structured_422_without_reasons_keeps_status_and_code(code: str) -> None:
+    error = _expect_error(422, _error_body(error=code))
+    assert (error.status, error.code) == (422, code)
+    assert not error.unavailable
+
+
+@pytest.mark.parametrize("code", ["validation_error", "offer_document_blocked"])
+def test_structured_422_with_reasons_keeps_status_and_code(code: str) -> None:
+    """The regression: a valid `reasons` list must not become a 502."""
+    error = _expect_error(
+        422, _error_body(error=code, reasons=["missing_address", "no_positions"])
+    )
+    assert (error.status, error.code) == (422, code)
+    assert not error.unavailable
+
+
+def test_structured_422_with_empty_reasons_is_accepted() -> None:
+    error = _expect_error(422, _error_body(error="validation_error", reasons=[]))
+    assert (error.status, error.code) == (422, "validation_error")
+
+
+@pytest.mark.parametrize(
+    "reasons",
+    [
+        "not-a-list",
+        [1, 2],
+        [{"code": "x"}],
+        [None],
+        [["nested"]],
+        None,
+        {"a": "b"},
+    ],
+    ids=["string", "ints", "objects", "null-entry", "nested-list", "null", "object"],
+)
+def test_malformed_reasons_still_fails_closed(reasons: object) -> None:
+    """A malformed `reasons` must never be carried along as trusted data —
+    it is refused exactly like any other contract violation."""
+    error = _expect_error(422, _error_body(error="validation_error", reasons=reasons))
+    assert error.code == "invalid_response"
+    assert error.unavailable
+
+
+def test_unknown_422_code_is_still_rejected() -> None:
+    error = _expect_error(422, _error_body(error="totally_unknown_code"))
+    assert error.code == "invalid_response"
+
+
+def test_unknown_422_code_with_reasons_is_still_rejected() -> None:
+    """Accepting `reasons` must not smuggle an unwhitelisted code through."""
+    error = _expect_error(422, _error_body(error="totally_unknown_code", reasons=["a"]))
+    assert error.code == "invalid_response"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"error": "validation_error", "detail": "extra"},
+        {"error": "validation_error", "reasons": ["a"], "detail": "extra"},
+        {"reasons": ["a"]},
+        {"error": 42},
+        {},
+    ],
+    ids=[
+        "extra-key",
+        "extra-key-with-reasons",
+        "no-error",
+        "error-not-string",
+        "empty",
+    ],
+)
+def test_error_body_schema_stays_strict(body: dict) -> None:
+    """Only `error` (required) and `reasons` (optional) are tolerated — the
+    fix widens the contract by one declared field, not generally."""
+    error = _expect_error(422, json.dumps(body).encode())
+    assert error.code == "invalid_response"
+
+
+def test_reasons_do_not_bypass_the_per_status_whitelist() -> None:
+    """`not_found` is valid for 404, not for 409 — attaching reasons must
+    not change which codes a status accepts."""
+    error = _expect_error(409, _error_body(error="not_found", reasons=["a"]))
+    assert error.code == "invalid_response"
+
+
+def test_other_statuses_still_accept_their_codes_with_reasons() -> None:
+    error = _expect_error(404, _error_body(error="not_found", reasons=["a"]))
+    assert (error.status, error.code) == (404, "not_found")
+
+
 def test_queue_view_rejects_unknown_response_field() -> None:
     body = json.dumps(
         {

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -263,10 +263,19 @@ def test_known_error_code_on_wrong_status_is_invalid_response() -> None:
 
 # --- structured error bodies (issue #39) -------------------------------------
 #
-# Office API 422s from the document blockers carry an optional `reasons`
-# list next to `error`. Validating the body as an exact {"error"} key set
-# turned those valid responses into 502 invalid_response, and
-# `offer_document_blocked` was additionally missing from the 422 whitelist.
+# Three Office API 422 blocker contracts carry a `reasons` list next to
+# `error`. Validating every body as an exact {"error"} key set turned those
+# valid responses into 502 invalid_response, and all three codes were also
+# missing from the 422 whitelist.
+#
+# `reasons` belongs to those three contracts only — it is not a field any
+# error may carry, so its presence anywhere else stays a contract violation.
+
+_REASONS_CONTRACTS_422 = [
+    "offer_document_blocked",
+    "confirmation_document_blocked",
+    "order_not_ready_to_send",
+]
 
 
 def _error_body(**payload: object) -> bytes:
@@ -284,15 +293,18 @@ def _expect_error(status: int, body: bytes) -> RemoteCoreError:
         server.server_close()
 
 
-@pytest.mark.parametrize("code", ["validation_error", "offer_document_blocked"])
-def test_structured_422_without_reasons_keeps_status_and_code(code: str) -> None:
+@pytest.mark.parametrize("code", _REASONS_CONTRACTS_422)
+def test_blocker_422_without_reasons_keeps_status_and_code(code: str) -> None:
+    """All three blockers must survive as their real 422. The API has bare
+    paths for these codes too (notably confirmation_document_blocked), so
+    the absence of `reasons` must stay valid."""
     error = _expect_error(422, _error_body(error=code))
     assert (error.status, error.code) == (422, code)
     assert not error.unavailable
 
 
-@pytest.mark.parametrize("code", ["validation_error", "offer_document_blocked"])
-def test_structured_422_with_reasons_keeps_status_and_code(code: str) -> None:
+@pytest.mark.parametrize("code", _REASONS_CONTRACTS_422)
+def test_blocker_422_with_reasons_keeps_status_and_code(code: str) -> None:
     """The regression: a valid `reasons` list must not become a 502."""
     error = _expect_error(
         422, _error_body(error=code, reasons=["missing_address", "no_positions"])
@@ -301,9 +313,9 @@ def test_structured_422_with_reasons_keeps_status_and_code(code: str) -> None:
     assert not error.unavailable
 
 
-def test_structured_422_with_empty_reasons_is_accepted() -> None:
-    error = _expect_error(422, _error_body(error="validation_error", reasons=[]))
-    assert (error.status, error.code) == (422, "validation_error")
+def test_blocker_422_with_empty_reasons_is_accepted() -> None:
+    error = _expect_error(422, _error_body(error="offer_document_blocked", reasons=[]))
+    assert (error.status, error.code) == (422, "offer_document_blocked")
 
 
 @pytest.mark.parametrize(
@@ -321,10 +333,49 @@ def test_structured_422_with_empty_reasons_is_accepted() -> None:
 )
 def test_malformed_reasons_still_fails_closed(reasons: object) -> None:
     """A malformed `reasons` must never be carried along as trusted data —
-    it is refused exactly like any other contract violation."""
-    error = _expect_error(422, _error_body(error="validation_error", reasons=reasons))
+    it is refused exactly like any other contract violation, even on a
+    contract that is allowed to carry reasons at all."""
+    error = _expect_error(
+        422, _error_body(error="offer_document_blocked", reasons=reasons)
+    )
     assert error.code == "invalid_response"
     assert error.unavailable
+
+
+@pytest.mark.parametrize(
+    "status,code",
+    [
+        (404, "not_found"),
+        (409, "stale_state"),
+        (422, "validation_error"),
+        (400, "invalid_request"),
+    ],
+    ids=["404-not-found", "409-stale", "422-validation-error", "400-invalid-request"],
+)
+def test_reasons_on_an_unsupported_contract_is_rejected(status: int, code: str) -> None:
+    """`reasons` is accepted only for the three declared 422 blockers. On any
+    other status/code pair — including other perfectly valid codes — an
+    unexpected `reasons` is a contract violation, not something to tolerate."""
+    error = _expect_error(status, _error_body(error=code, reasons=["a"]))
+    assert error.code == "invalid_response"
+    assert error.unavailable
+
+
+@pytest.mark.parametrize(
+    "status,code",
+    [
+        (404, "not_found"),
+        (409, "stale_state"),
+        (422, "validation_error"),
+        (400, "invalid_request"),
+    ],
+    ids=["404-not-found", "409-stale", "422-validation-error", "400-invalid-request"],
+)
+def test_same_contracts_without_reasons_are_unaffected(status: int, code: str) -> None:
+    """The counterpart to the test above: without `reasons` these bodies keep
+    behaving exactly as before the fix."""
+    error = _expect_error(status, _error_body(error=code))
+    assert (error.status, error.code) == (status, code)
 
 
 def test_unknown_422_code_is_still_rejected() -> None:
@@ -341,8 +392,8 @@ def test_unknown_422_code_with_reasons_is_still_rejected() -> None:
 @pytest.mark.parametrize(
     "body",
     [
-        {"error": "validation_error", "detail": "extra"},
-        {"error": "validation_error", "reasons": ["a"], "detail": "extra"},
+        {"error": "offer_document_blocked", "detail": "extra"},
+        {"error": "offer_document_blocked", "reasons": ["a"], "detail": "extra"},
         {"reasons": ["a"]},
         {"error": 42},
         {},
@@ -356,22 +407,85 @@ def test_unknown_422_code_with_reasons_is_still_rejected() -> None:
     ],
 )
 def test_error_body_schema_stays_strict(body: dict) -> None:
-    """Only `error` (required) and `reasons` (optional) are tolerated — the
-    fix widens the contract by one declared field, not generally."""
+    """Only `error` (required) and `reasons` (optional, and only for the
+    declared contracts) are tolerated — the fix widens the contract by one
+    field on three codes, not generally."""
     error = _expect_error(422, json.dumps(body).encode())
     assert error.code == "invalid_response"
 
 
 def test_reasons_do_not_bypass_the_per_status_whitelist() -> None:
-    """`not_found` is valid for 404, not for 409 — attaching reasons must
-    not change which codes a status accepts."""
-    error = _expect_error(409, _error_body(error="not_found", reasons=["a"]))
+    """`offer_document_blocked` is declared for 422, not for 409 — attaching
+    reasons must not change which codes a status accepts."""
+    error = _expect_error(
+        409, _error_body(error="offer_document_blocked", reasons=["a"])
+    )
     assert error.code == "invalid_response"
 
 
-def test_other_statuses_still_accept_their_codes_with_reasons() -> None:
-    error = _expect_error(404, _error_body(error="not_found", reasons=["a"]))
+# --- get_bytes shares the same error-body parser (issue #39) -----------------
+#
+# get_bytes (offer-document PDF download) parses error bodies too, and it
+# deliberately degrades instead of raising invalid_response: the real HTTP
+# status always survives, the code falls back to unexpected_status when the
+# body cannot be read. Both halves need pinning.
+
+
+def _expect_bytes_error(status: int, body: bytes) -> RemoteCoreError:
+    url, server = _json_server(status, "application/json", body)
+    try:
+        with pytest.raises(RemoteCoreError) as exc:
+            RemoteCoreClient(url, _TOKEN).get_bytes("/office/v1/offer-document.pdf")
+        return exc.value
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize("code", _REASONS_CONTRACTS_422)
+def test_get_bytes_preserves_supported_structured_error(code: str) -> None:
+    error = _expect_bytes_error(
+        422, _error_body(error=code, reasons=["INVOICE_ADDRESS_REQUIRED"])
+    )
+    assert (error.status, error.code) == (422, code)
+
+
+def test_get_bytes_preserves_a_bare_error_body() -> None:
+    error = _expect_bytes_error(404, _error_body(error="not_found"))
     assert (error.status, error.code) == (404, "not_found")
+
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        # reasons on a contract that does not declare them
+        (422, {"error": "validation_error", "reasons": ["a"]}),
+        (404, {"error": "not_found", "reasons": ["a"]}),
+        # malformed reasons on a contract that does
+        (422, {"error": "offer_document_blocked", "reasons": "not-a-list"}),
+        (422, {"error": "offer_document_blocked", "reasons": [1]}),
+        # unrelated schema violations
+        (422, {"error": "offer_document_blocked", "detail": "x"}),
+        (422, {"error": 42}),
+    ],
+    ids=[
+        "unsupported-contract-422",
+        "unsupported-contract-404",
+        "malformed-reasons-string",
+        "malformed-reasons-ints",
+        "extra-key",
+        "error-not-string",
+    ],
+)
+def test_get_bytes_keeps_its_fallback_for_unusable_bodies(
+    status: int, body: dict
+) -> None:
+    """get_bytes must not start raising invalid_response — its existing
+    contract is that the caller still learns the real HTTP status while the
+    code degrades to unexpected_status."""
+    error = _expect_bytes_error(status, json.dumps(body).encode())
+    assert error.status == status
+    assert error.code == "unexpected_status"
 
 
 def test_queue_view_rejects_unknown_response_field() -> None:


### PR DESCRIPTION
Closes #39

## Summary
- accept the optional `reasons` field, but only for the three 422 blocker contracts that actually emit it
- add all three missing blocker codes to the 422 whitelist
- keep every other error body strict: unknown keys, malformed `reasons`, and `reasons` on an undeclared contract all still fail closed
- cover the real producers with contract tests against the actual Office API server

## Parser contract

An error body is `{"error": "<code>"}` with an optional `reasons` list.

- `error` — required, must be a string
- `reasons` — optional, allowed **only** for the status/code pairs below, and must be a list of strings
- any other key — rejected

```python
_ERROR_CODES_WITH_REASONS_BY_STATUS = {
    422: frozenset(
        {
            "offer_document_blocked",
            "confirmation_document_blocked",
            "order_not_ready_to_send",
        }
    ),
}
```

`reasons` is deliberately **not** globally allowed: it belongs to those contracts, so its presence on any other status/code pair is a contract violation. The parser therefore takes both the HTTP status and the parsed code into account.

## Whitelist additions (HTTP 422)

- `offer_document_blocked`
- `confirmation_document_blocked`
- `order_not_ready_to_send`

All three are current Office API business errors with the same root cause.
`confirmation_document_blocked` has both reasons-bearing and bare paths in the API, so it must work either way — covered by tests.

## Behaviour

| response (HTTP 422 unless noted) | before | after |
|---|---|---|
| `{"error": "offer_document_blocked"}` | 502 invalid_response | **422 offer_document_blocked** |
| `{"error": "offer_document_blocked", "reasons": [...]}` | 502 invalid_response | **422 offer_document_blocked** |
| `{"error": "confirmation_document_blocked"}` ± reasons | 502 invalid_response | **422 confirmation_document_blocked** |
| `{"error": "order_not_ready_to_send"}` ± reasons | 502 invalid_response | **422 order_not_ready_to_send** |
| `{"error": "validation_error", "reasons": [...]}` | 502 invalid_response | 502 invalid_response |
| `404 {"error": "not_found", "reasons": [...]}` | 502 invalid_response | 502 invalid_response |
| `{"error": "validation_error"}` / `404 not_found` | unchanged | unchanged |
| malformed `reasons` on a declared contract | 502 invalid_response | 502 invalid_response |
| unknown key / unknown code | 502 invalid_response | 502 invalid_response |

`reasons` is validated but **not** propagated on `RemoteCoreError`. Surfacing blocker reasons in the panel is a separate contract/UI concern.

## Tests

`tests/unit/test_office_api.py` — contract tests driving `RemoteCoreClient` against the real Office API server, one per real producer. Each first asserts the endpoint genuinely emits `reasons`, then asserts the client surfaces the business 422 rather than 502. No hand-written JSON:

- offer document creation blocked (missing invoice address)
- confirmation document creation blocked (missing customer contact)
- confirmation send blocked as `order_not_ready_to_send` (operational pause)

`tests/unit/test_remote_core_client.py` — schema-level coverage:

- all three blockers, with and without `reasons`
- empty `reasons` accepted
- malformed `reasons` fails closed (7 shapes)
- `reasons` on an undeclared contract rejected (404 not_found, 409 stale_state, 422 validation_error, 400 invalid_request) — and the same bodies without `reasons` still behave exactly as before
- unknown 422 code rejected, with and without `reasons`
- schema strictness (extra key, missing `error`, non-string `error`, empty body)
- `reasons` does not bypass the per-status whitelist
- `get_bytes`: supported structured errors preserved; unsupported/malformed bodies keep the existing fallback (real HTTP status, code degrades to `unexpected_status`)

## Verification

- `ruff check src tests` — passed
- `ruff format --check src tests` — passed
- `mypy src/catering_system` — passed
- `pytest tests/unit/test_remote_core_client.py -q` — 74 passed
- `pytest tests/unit/test_office_api.py -k remote_client_preserves -q` — 3 passed
- `coverage run -m pytest -q` — 2167 passed
- `coverage report` — 90.5%, fail-under met
- `git diff --check` — clean

## Out of scope

- PR #38 (untouched)
- Office API changes
- production deployment
- propagating `reasons` to callers

Do not merge.
Do not deploy.
