### PR TITLE
Fix PDF startup preflight ordering and document configuration contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,27 @@ OFFICE_API_TOKEN=
 # CLI flag.
 CORE_OFFICE_API_URL=
 CORE_OFFICE_API_TOKEN=
+
+# Offer/Confirmation PDF static content (issue #41): required in direct mode
+# for both the Core Office API and the Office Panel — validated before
+# core.db is ever opened; refuses to start if any required value is missing
+# or blank. Free-text format unless noted; never invent production wording
+# here, these are placeholders only.
+
+# Required.
+OFFICE_PDF_COMPANY_LEGAL_NAME=Musterfirma GmbH
+# Pipe-separated address lines, e.g. "Straße 1|20095 Hamburg".
+OFFICE_PDF_COMPANY_ADDRESS_LINES=Musterstraße 1|20095 Hamburg
+OFFICE_PDF_ACCEPTANCE_STATEMENT=Mit der Bestätigung dieses Angebots kommt der Auftrag zustande.
+
+# Optional.
+# Absolute path to a readable logo image file; unset skips the logo. A
+# missing or unreadable path refuses to start rather than skipping silently.
+OFFICE_PDF_LOGO_PATH=
+OFFICE_PDF_COMPANY_PHONE=
+OFFICE_PDF_COMPANY_EMAIL=
+OFFICE_PDF_COMPANY_WEB=
+OFFICE_PDF_COMPANY_REGISTER_TEXT=
+OFFICE_PDF_COMPANY_VAT_ID_TEXT=
+OFFICE_PDF_FOOTER_NOTE=
+OFFICE_PDF_BANK_DETAILS_TEXT=

--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -220,6 +220,59 @@ journalctl -u catering-office-panel -u catering-kiosk \
 
 The intake smoke request should return `405`, not `200`.
 
+## PDF configuration (Offer/Confirmation documents)
+
+Office API and direct-mode Office Panel both require the `OFFICE_PDF_*`
+environment contract (issue #41) — see `.env.example` for the full list of
+required and optional variables. On Lenovo these live in the root-owned,
+mode-`600` `/etc/catering/office-api.env` and `/etc/catering/office-panel.env`
+— never print, paste, or `cat` those files. Both services validate this
+configuration before opening `core.db`: a missing or blank required variable,
+or an unreadable `OFFICE_PDF_LOGO_PATH`, refuses to start with no database
+side effect.
+
+**Verify presence without printing values** — list variable *names* only,
+never their contents:
+
+```bash
+sudo grep -o '^OFFICE_PDF_[A-Z_]*=' /etc/catering/office-panel.env
+```
+
+**Preflight verification** — proves the configuration actually loads,
+without ever echoing a value. A missing/blank required variable prints the
+variable name and exits non-zero; success prints nothing and exits `0`:
+
+```bash
+cd /home/viktor/projects/silberloeffel-catering
+sudo -u viktor env -i $(sudo grep -v '^#' /etc/catering/office-panel.env) \
+  PYTHONPATH=src python3 -c \
+  'from catering_system.ui.offer_pdf_static_content_env import offer_pdf_static_content_from_env as f; f()'
+echo "exit code: $?"
+```
+
+**PDF smoke test without emailing a customer** — download the PDF for an
+already-existing offer/confirmation via the authenticated, read-only Office
+Panel/API endpoint (a `GET`, never a "send" endpoint) and confirm it is a
+well-formed PDF, without composing or sending anything:
+
+```bash
+curl -s -u office:$OFFICE_PANEL_PASSWORD \
+  http://127.0.0.1:8081/offers/<offer_id>/document.pdf -o /tmp/pdf-smoke.pdf
+file /tmp/pdf-smoke.pdf   # expect: PDF document
+rm -f /tmp/pdf-smoke.pdf
+```
+
+**Rollback for this slice** — this is a pure code change: no schema change,
+no change to the `OFFICE_PDF_*` values already configured on production.
+Rollback is the standard [code-only rollback](#code-only-rollback) below
+(revert the commit, restart `catering-office-panel` only, re-run the smoke
+checks) — no database restore and no environment-file change is ever needed
+for this slice.
+
+Systemd `ExecStart`/interpreter and dependency-installation changes are
+tracked separately (`PDF_RUNTIME_VENV_AND_SYSTEMD_V1`) and are not part of
+this procedure.
+
 ## Unit files
 
 The live units are in `/etc/systemd/system/`. Always inspect the effective unit

--- a/src/catering_system/ui/offer_pdf_static_content_env.py
+++ b/src/catering_system/ui/offer_pdf_static_content_env.py
@@ -39,8 +39,15 @@ def offer_pdf_static_content_from_env() -> OfferPdfStaticContent:
     logo_path = os.environ.get("OFFICE_PDF_LOGO_PATH", "").strip()
     logo_bytes = None
     if logo_path:
-        with open(logo_path, "rb") as logo_file:
-            logo_bytes = logo_file.read()
+        try:
+            with open(logo_path, "rb") as logo_file:
+                logo_bytes = logo_file.read()
+        except OSError as exc:
+            raise SystemExit(
+                "OFFICE_PDF_LOGO_PATH is set but the file could not be read: "
+                f"{logo_path} ({exc.strerror or 'unreadable'}) — refusing to "
+                "start with an unusable logo asset."
+            ) from exc
     return OfferPdfStaticContent(
         company_legal_name=legal_name,
         company_address_lines=address_lines,

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3967,6 +3967,15 @@ def main() -> None:
                 "--db is required in direct mode (or set CORE_OFFICE_API_URL "
                 "and CORE_OFFICE_API_TOKEN for remote mode)"
             )
+        from catering_system.ui.offer_pdf_static_content_env import (
+            offer_pdf_static_content_from_env,
+        )
+
+        # Validated before core.db is ever opened (issue #41): an invalid
+        # PDF configuration must fail closed with no database side effect —
+        # no file created, no migration applied, no repository constructed.
+        offer_pdf_static_content = offer_pdf_static_content_from_env()
+
         from catering_system.repositories.core_transaction import (
             CoreCommandExecutor,
             open_core_connection,
@@ -4010,9 +4019,6 @@ def main() -> None:
         from catering_system.repositories.bootstrap_customer_identity_schema import (
             bootstrap_customer_identity_schema,
         )
-        from catering_system.ui.offer_pdf_static_content_env import (
-            offer_pdf_static_content_from_env,
-        )
 
         connection = open_core_connection(args.db)
         inquiry_repo = SQLiteInquiryRepository.from_connection(connection)
@@ -4026,7 +4032,6 @@ def main() -> None:
         offer_document_repo = SQLiteOfferDocumentSnapshotRepository.from_connection(
             connection
         )
-        offer_pdf_static_content = offer_pdf_static_content_from_env()
         payment_reminder_repo = SQLitePaymentReminderRepository.from_connection(
             connection
         )

--- a/tests/unit/test_offer_pdf_static_content_env.py
+++ b/tests/unit/test_offer_pdf_static_content_env.py
@@ -115,3 +115,79 @@ def test_optional_vars_populate_when_set(monkeypatch: pytest.MonkeyPatch) -> Non
     content = offer_pdf_static_content_from_env()
     assert content.company_phone == "+49 40 1234567"
     assert content.footer_note == "Vielen Dank für Ihr Vertrauen."
+
+
+# --- OFFICE_PDF_LOGO_PATH: fail closed, never a raw traceback (issue #41) ---
+
+
+def test_logo_path_pointing_at_missing_file_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    missing = tmp_path / "does-not-exist.png"
+    monkeypatch.setenv("OFFICE_PDF_LOGO_PATH", str(missing))
+    with pytest.raises(SystemExit) as exc_info:
+        offer_pdf_static_content_from_env()
+    message = str(exc_info.value)
+    assert "OFFICE_PDF_LOGO_PATH" in message
+    assert str(missing) in message
+
+
+def test_logo_path_pointing_at_unreadable_file_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    unreadable = tmp_path / "no-permission.png"
+    unreadable.write_bytes(b"\x89PNG\r\n")
+    unreadable.chmod(0o000)
+    monkeypatch.setenv("OFFICE_PDF_LOGO_PATH", str(unreadable))
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            offer_pdf_static_content_from_env()
+        message = str(exc_info.value)
+        assert "OFFICE_PDF_LOGO_PATH" in message
+        assert str(unreadable) in message
+    finally:
+        unreadable.chmod(0o644)
+
+
+def test_logo_path_pointing_at_a_directory_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    monkeypatch.setenv("OFFICE_PDF_LOGO_PATH", str(tmp_path))
+    with pytest.raises(SystemExit) as exc_info:
+        offer_pdf_static_content_from_env()
+    message = str(exc_info.value)
+    assert "OFFICE_PDF_LOGO_PATH" in message
+    assert str(tmp_path) in message
+
+
+def test_logo_path_error_never_carries_a_raw_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The failure must be a clean SystemExit, not an unhandled OSError —
+    proven by asserting the raised type directly rather than only its
+    message."""
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    monkeypatch.setenv("OFFICE_PDF_LOGO_PATH", str(tmp_path / "missing.png"))
+    with pytest.raises(SystemExit):
+        offer_pdf_static_content_from_env()
+    # If this were still the unhandled-OSError bug, pytest.raises(SystemExit)
+    # above would itself fail with an unexpected exception type.
+
+
+def test_valid_logo_path_still_loads_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _clear_all(monkeypatch)
+    _set_required(monkeypatch)
+    logo = tmp_path / "logo.png"
+    logo.write_bytes(b"\x89PNG\r\n\x1a\n")
+    monkeypatch.setenv("OFFICE_PDF_LOGO_PATH", str(logo))
+    content = offer_pdf_static_content_from_env()
+    assert content.logo_png_bytes == b"\x89PNG\r\n\x1a\n"

--- a/tests/unit/test_pdf_config_startup_order.py
+++ b/tests/unit/test_pdf_config_startup_order.py
@@ -1,0 +1,290 @@
+"""PDF_STARTUP_ORDER_AND_DOCS_V1 (issue #41) — Office Panel direct-mode
+startup must validate PDF configuration before opening core.db: an invalid
+OFFICE_PDF_* configuration must never create a database file, run a
+migration, or construct a repository. Office API already gets this right;
+its tests here are a regression guard, not new behavior."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import select
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.offer_pdf_static_content import TEST_ACCEPTANCE_STATEMENT
+
+_VALID_PDF_ENV = {
+    "OFFICE_PDF_COMPANY_LEGAL_NAME": "TEST GmbH [PLATZHALTER]",
+    "OFFICE_PDF_COMPANY_ADDRESS_LINES": "Teststraße 1|20095 Hamburg",
+    "OFFICE_PDF_ACCEPTANCE_STATEMENT": TEST_ACCEPTANCE_STATEMENT,
+}
+
+_ALL_OFFICE_PDF_VARS = (
+    "OFFICE_PDF_COMPANY_LEGAL_NAME",
+    "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+    "OFFICE_PDF_ACCEPTANCE_STATEMENT",
+    "OFFICE_PDF_LOGO_PATH",
+    "OFFICE_PDF_COMPANY_PHONE",
+    "OFFICE_PDF_COMPANY_EMAIL",
+    "OFFICE_PDF_COMPANY_WEB",
+    "OFFICE_PDF_COMPANY_REGISTER_TEXT",
+    "OFFICE_PDF_COMPANY_VAT_ID_TEXT",
+    "OFFICE_PDF_FOOTER_NOTE",
+    "OFFICE_PDF_BANK_DETAILS_TEXT",
+)
+
+
+def _base_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "src"
+    for name in (*_ALL_OFFICE_PDF_VARS, "CORE_OFFICE_API_URL", "CORE_OFFICE_API_TOKEN"):
+        env.pop(name, None)
+    return env
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+# --- Office Panel direct mode: invalid PDF config has no DB side effect -----
+
+
+def test_direct_mode_invalid_pdf_config_creates_no_db_file(tmp_path: Path) -> None:
+    db = tmp_path / "does-not-exist-yet.db"
+    env = _base_env()
+    env["OFFICE_PANEL_PASSWORD"] = "test-password-local-only"
+    env["OFFICE_PDF_COMPANY_LEGAL_NAME"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_LEGAL_NAME"
+    ]
+    env["OFFICE_PDF_COMPANY_ADDRESS_LINES"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_ADDRESS_LINES"
+    ]
+    # OFFICE_PDF_ACCEPTANCE_STATEMENT deliberately left unset.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "catering_system.ui.office_panel",
+            "--db",
+            str(db),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "OFFICE_PDF_ACCEPTANCE_STATEMENT" in result.stderr
+    assert not db.exists(), "invalid PDF config must not create the database file"
+    assert "Office panel on http" not in result.stdout
+
+
+def test_direct_mode_invalid_pdf_config_leaves_existing_db_byte_identical(
+    tmp_path: Path,
+) -> None:
+    """A pre-existing, already-migrated database must be untouched when
+    startup later fails on PDF configuration."""
+    from catering_system.repositories.bootstrap_customer_identity_schema import (
+        bootstrap_customer_identity_schema,
+    )
+    from catering_system.repositories.core_transaction import open_core_connection
+    from catering_system.repositories.sqlite_inquiry_repository import (
+        SQLiteInquiryRepository,
+    )
+
+    db = tmp_path / "pre-existing.db"
+    connection = open_core_connection(str(db))
+    SQLiteInquiryRepository.from_connection(connection)
+    bootstrap_customer_identity_schema(connection)
+    connection.close()
+    before_hash = hashlib.sha256(db.read_bytes()).hexdigest()
+
+    env = _base_env()
+    env["OFFICE_PANEL_PASSWORD"] = "test-password-local-only"
+    env["OFFICE_PDF_COMPANY_LEGAL_NAME"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_LEGAL_NAME"
+    ]
+    env["OFFICE_PDF_COMPANY_ADDRESS_LINES"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_ADDRESS_LINES"
+    ]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "catering_system.ui.office_panel",
+            "--db",
+            str(db),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    after_hash = hashlib.sha256(db.read_bytes()).hexdigest()
+    assert after_hash == before_hash
+
+
+def test_direct_mode_invalid_pdf_config_never_opens_connection_or_builds_repos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """White-box companion to the black-box DB-file tests above: every
+    repository construction in direct mode requires the connection object
+    that only ``open_core_connection`` produces, so a tripwire on that one
+    call proves no migration and no repository construction was even
+    attempted — not merely that they left no observable trace."""
+    import catering_system.ui.office_panel as office_panel_module
+    from catering_system.repositories import core_transaction
+
+    calls: list[str] = []
+
+    def _tripwire(db_path: object) -> None:
+        calls.append("open_core_connection")
+        raise AssertionError("open_core_connection must not be called")
+
+    monkeypatch.setattr(core_transaction, "open_core_connection", _tripwire)
+    monkeypatch.setenv("OFFICE_PANEL_PASSWORD", "test-password-local-only")
+    monkeypatch.setenv(
+        "OFFICE_PDF_COMPANY_LEGAL_NAME", _VALID_PDF_ENV["OFFICE_PDF_COMPANY_LEGAL_NAME"]
+    )
+    monkeypatch.setenv(
+        "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+        _VALID_PDF_ENV["OFFICE_PDF_COMPANY_ADDRESS_LINES"],
+    )
+    monkeypatch.delenv("OFFICE_PDF_ACCEPTANCE_STATEMENT", raising=False)
+    monkeypatch.delenv("CORE_OFFICE_API_URL", raising=False)
+    monkeypatch.delenv("CORE_OFFICE_API_TOKEN", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["office_panel", "--db", str(tmp_path / "tripwire.db"), "--port", "0"],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        office_panel_module.main()
+    assert "OFFICE_PDF_ACCEPTANCE_STATEMENT" in str(exc_info.value)
+    assert calls == []
+
+
+def test_direct_mode_valid_pdf_config_still_starts_normally(tmp_path: Path) -> None:
+    """Regression guard: moving the preflight earlier must not change the
+    valid-configuration startup path."""
+    db = tmp_path / "valid-startup.db"
+    env = _base_env()
+    env["OFFICE_PANEL_PASSWORD"] = "test-password-local-only"
+    env.update(_VALID_PDF_ENV)
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-u",  # unbuffered stdout, so readline() below sees it promptly
+            "-m",
+            "catering_system.ui.office_panel",
+            "--db",
+            str(db),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        ready, _, _ = select.select([proc.stdout], [], [], 10)
+        assert ready, "office panel printed no startup banner within 10s"
+        line = proc.stdout.readline()
+        assert "Office panel on http" in line
+        assert proc.poll() is None  # still running, didn't crash on startup
+        assert db.exists()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+# --- Office API: regression guard (already correct before this slice) -------
+
+
+def test_office_api_invalid_pdf_config_creates_no_db_file(tmp_path: Path) -> None:
+    db = tmp_path / "api-does-not-exist-yet.db"
+    env = _base_env()
+    env["OFFICE_API_TOKEN"] = "test-token-local-only"
+    env["OFFICE_PDF_COMPANY_LEGAL_NAME"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_LEGAL_NAME"
+    ]
+    env["OFFICE_PDF_COMPANY_ADDRESS_LINES"] = _VALID_PDF_ENV[
+        "OFFICE_PDF_COMPANY_ADDRESS_LINES"
+    ]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "catering_system.ui.office_api",
+            "--db",
+            str(db),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "OFFICE_PDF_ACCEPTANCE_STATEMENT" in result.stderr
+    assert not db.exists()
+    assert "Core Office API on http" not in result.stdout
+
+
+def test_office_api_valid_pdf_config_still_starts_normally(tmp_path: Path) -> None:
+    db = tmp_path / "api-valid-startup.db"
+    env = _base_env()
+    env["OFFICE_API_TOKEN"] = "test-token-local-only"
+    env.update(_VALID_PDF_ENV)
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-u",
+            "-m",
+            "catering_system.ui.office_api",
+            "--db",
+            str(db),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        ready, _, _ = select.select([proc.stdout], [], [], 10)
+        assert ready, "office api printed no startup banner within 10s"
+        line = proc.stdout.readline()
+        assert "Core Office API on http" in line
+        assert proc.poll() is None
+        assert db.exists()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)


### PR DESCRIPTION
Fixes #41

## Root cause

Direct-mode Office Panel (`office_panel.py` `main()`) opened `core.db`,
applied migrations, and constructed five repositories *before* validating
`OFFICE_PDF_*` environment configuration. An invalid PDF config would leave
a fully-migrated database file behind before the process exited. Office
API's `main()` already validated PDF config before touching the database —
only Office Panel's ordering was wrong.

Separately, `offer_pdf_static_content_env.py` left `OFFICE_PDF_LOGO_PATH`
file access unguarded: a missing or unreadable logo file produced a raw,
unhandled `FileNotFoundError`/`OSError` traceback instead of a clean,
fail-closed message.

## Implementation

- `src/catering_system/ui/office_panel.py`: moved the existing
  `offer_pdf_static_content_from_env()` call (and its import) to run
  immediately after the `--db`/dual-mode checks, before
  `open_core_connection()` and all repository construction. No other logic
  changed; the shared loader is reused as-is, not duplicated.
- `src/catering_system/ui/offer_pdf_static_content_env.py`: wrapped the
  `OFFICE_PDF_LOGO_PATH` file read in `try/except OSError`, raising a clean
  `SystemExit` naming the variable and the offending path (not a secret —
  no company/legal text values are ever included) instead of propagating a
  raw traceback. Successful logo loading is unchanged.
- `.env.example`: documented all 11 `OFFICE_PDF_*` variables (3 required, 8
  optional) with harmless placeholders.
- `docs/runbooks/lenovo-production.md`: added a "PDF configuration" section
  — presence verification without printing secrets, a non-mutating
  preflight check, a PDF smoke test that never sends a customer email, and
  a rollback note. Explicitly excludes venv/systemd instructions (tracked
  separately).

## Tests

New `tests/unit/test_pdf_config_startup_order.py` (6 tests):
- direct-mode invalid PDF config creates no DB file
- direct-mode invalid PDF config leaves a pre-existing DB byte-for-byte
  unchanged
- white-box tripwire proving `open_core_connection` is never even called
  when PDF config is invalid (so no migration/repository construction was
  attempted, not merely that none left a trace)
- direct-mode valid config still starts and binds normally (regression
  guard)
- Office API invalid config still creates no DB file, valid config still
  starts normally (regression guard for already-correct behavior)

Extended `tests/unit/test_offer_pdf_static_content_env.py` (+5 tests) for
the logo-path hardening: missing file, unreadable file, path-is-a-directory,
proof the failure is a clean `SystemExit` (not a raw exception type), and a
regression test that valid logo loading is unchanged.

**Before the fix:** 3 startup-order tests + 4 logo-path tests failed
(verified by running them against the pre-fix code in isolation).
**After the fix:** all 2212 tests pass.

## Verification

- `ruff check src tests` — pass
- `ruff format --check src tests` — pass
- `mypy src/catering_system` — pass (183 files)
- `coverage run -m pytest -q` — 2212 passed
- `coverage report` — 90.7% (≥90% threshold)
- `git diff --check` — clean

## Risk

Valid PDF configuration (production's current state) is unaffected — the
same function is called with the same inputs, only earlier. Invalid
configuration now fails before any database file is created, migration
applied, or repository constructed, for both entry points.

## Not included

```
Not included:
- systemd runtime migration
- venv migration
- dependency lock strategy
- deployment tooling
```

These are tracked separately as `PDF_RUNTIME_VENV_AND_SYSTEMD_V1`. No
production deployment is part of this PR.
