### PR TITLE
Align project status documentation with main and production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,30 @@ here. Historical fine-grained execution notes remain in `WORKLOG.md`.
   `08034ba` after successful CI; no service restart was needed because the
   running production modules were unchanged.
 
+### Fixed
+
+- `RemoteCoreClient` accepts declared structured `422` errors
+  (`offer_document_blocked`, `confirmation_document_blocked`,
+  `order_not_ready_to_send`) with validated `reasons`, instead of masking
+  them as a generic `502` (closes #39, PR #40). Deployed to production.
+- Catalog dish detail accepts valid price-history responses instead of
+  rejecting any dish that has price history (closes #37, PR #38). Deployed
+  to production.
+- Office Panel direct mode validates `OFFICE_PDF_*` configuration before
+  opening `core.db`, instead of after already applying migrations and
+  constructing repositories (closes #41, PR #42). **Merged to `main`, not
+  yet deployed to production.**
+- Unreadable or missing `OFFICE_PDF_LOGO_PATH` files now fail startup
+  cleanly with a controlled message instead of an unhandled traceback
+  (PR #42). **Merged to `main`, not yet deployed to production.**
+
+### Documentation
+
+- Documented the full `OFFICE_PDF_*` environment contract (3 required, 8
+  optional variables) in `.env.example` (PR #42).
+- Added PDF configuration preflight, verification, and rollback guidance to
+  the Lenovo production runbook (PR #42).
+
 ## 2026-07-12
 
 ### Staging website

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2768,3 +2768,63 @@ Not included
 	  matching, dashboard queue or accepted-offer handoff
 	•	UI2B working-tree changes were preserved; neither UI2B nor this reminder
 	  slice is pushed or deployed
+
+
+Entry 069
+
+Date: 2026-07-27 — PR #38/#40 merge and deploy, PR #42 merge (not deployed)
+Scope: PR merges on `main`, one production deployment to `a67875d`, and the
+docs-only status-alignment update recorded here. No further production
+change in this entry.
+
+Meaning
+	•	PR #38 (catalog price-history response handling, closes #37) merged.
+	•	PR #40 (structured Offer/PDF error handling, closes #39) merged as a
+	  second commit on the same branch after an independent review found the
+	  `reasons` field was accepted too broadly; restricted to three declared
+	  422 contracts before merge.
+	•	Both PRs deployed to Lenovo production together via one fast-forward
+	  to `a67875d800deff7a954e9c83d42174c41b647326`. Pre-deploy backup taken
+	  and integrity-checked (`core.db.pre-a67875d-deploy.20260727-084522.bak`,
+	  471040 bytes, SHA-256
+	  `82afe9dd5c758279446ce426c49adf3673adfd52f5a45dea6f3f42e99ce1642e`).
+	  Only `catering-office-panel` restarted, per import-graph analysis; the
+	  other three services (`catering-office-api`, `catering-website-intake`,
+	  `catering-kiosk`) were confirmed untouched by PID/start-timestamp
+	  comparison.
+	•	Post-deploy HTTP checks matched contract (Office API `401`, Office
+	  Panel `401`, Kiosk `200`, Website Intake `405`); journals since restart
+	  showed no tracebacks or errors. A separate follow-up read-only
+	  observation pass classified the deployment **HEALTHY**; rollback not
+	  required.
+	•	During review, a startup-order defect was found: direct-mode Office
+	  Panel validated `OFFICE_PDF_*` configuration only after already opening
+	  `core.db` and applying migrations, so an invalid PDF configuration left
+	  a fully-migrated database file behind before failing. The fix was
+	  deliberately split into two independent slices rather than one PR:
+	  `PDF_STARTUP_ORDER_AND_DOCS_V1` (pure code/docs, no production infra
+	  touch) and `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` (systemd interpreter
+	  reconciliation, venv reproducibility, dependency lock strategy — not
+	  implemented yet).
+	•	PR #42 (`PDF_STARTUP_ORDER_AND_DOCS_V1`, closes #41) merged into
+	  `main` as commit `03a3780e699357c30e36049f1293f5a93a214f6f`. **Not
+	  deployed** — production remains on `a67875d` and does not include this
+	  change; it will be deployed via a separate controlled deploy.
+
+Completed
+	•	PR #38: full suite green; APPROVE FOR MERGE verdict; merged.
+	•	PR #40: full suite green after the `reasons`-scope correction;
+	  APPROVE FOR MERGE verdict; merged.
+	•	Production deploy of `a67875d`: backup verified, fast-forward only,
+	  `catering-office-panel` restarted, HTTP/journal/service-state checks
+	  all passed, no rollback required.
+	•	PR #42: 6 new/extended characterization tests (3 failing before the
+	  fix, verified against the pre-fix code in isolation); full suite 2212
+	  passed, coverage 90.7%; independent review APPROVE FOR MERGE; merged.
+
+Not included
+	•	no deployment of PR #42 to production;
+	•	no systemd unit changes, venv changes, lock files, or dependency
+	  tooling — reserved for `PDF_RUNTIME_VENV_AND_SYSTEMD_V1`;
+	•	no service restart or production data/configuration change beyond the
+	  single `a67875d` deploy recorded above.

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,49 +1,107 @@
 # Current status
 
-Operational truth last verified: **2026-07-20T08:30:00Z** (inquiry customer
-reference deploy acceptance on Lenovo `debiancatering`, Tailscale `100.109.6.74`).
+Operational truth last verified: **2026-07-27T11:32:00Z** (PR #42 merge and
+post-merge repository/production alignment check).
 
-This document separates **repository truth** from **production runtime truth**.
-A commit on `origin/main` is not deployed until the relevant services have
-restarted while that commit (or a descendant loaded at restart) is on disk,
-and post-deploy checks are recorded. See
-`docs/runbooks/deployment-truth-checklist.md`.
+This document separates **repository state** (what is on `origin/main`) from
+**production state** (what is actually deployed and running on Lenovo
+`debiancatering`, Tailscale `100.109.6.74`). A commit on `origin/main` is not
+deployed until the relevant services have restarted while that commit (or a
+descendant loaded at restart) is on disk, and post-deploy checks are
+recorded. See `docs/runbooks/deployment-truth-checklist.md`.
 
-## Repository truth
+## Repository state
 
-At deploy verification (**2026-07-20T08:30:00Z**), `git rev-parse origin/main` reported
-`ad810b40722330152133df53452f8ba190ed2cd6`. **Do not treat a SHA printed here
-as permanent:** after this document is committed and pushed, repository HEAD
-advances — query Git for the current value.
-
-| Item | Value (at audit) |
+| Item | Value |
 |---|---|
-| Last verified **application-code** commit deployed (API/Panel) | `ad810b40722330152133df53452f8ba190ed2cd6` (`ad810b4`) |
-| Repository HEAD at verification | `ad810b40722330152133df53452f8ba190ed2cd6` |
-| GitHub Actions `quality` on `ad810b4` | **success** — run [29726086008](https://github.com/VikJo1978/silberloeffel-catering/actions/runs/29726086008) |
-| Canonical checkout (`/home/viktor/projects/silberloeffel-catering`) | `ad810b40722330152133df53452f8ba190ed2cd6` (matches `origin/main` at verification) |
+| `origin/main` HEAD | `03a3780e699357c30e36049f1293f5a93a214f6f` (`03a3780`) |
+| Latest merged PR | [#42 — Fix PDF startup preflight ordering and document configuration contract](https://github.com/VikJo1978/silberloeffel-catering/pull/42) (merge commit `03a3780e699357c30e36049f1293f5a93a214f6f`, parents `a67875d8` + `5f4df5e6`) |
+| CI on the merged commit | `quality` — **pass** (both required checks green at merge time) |
+| Full test suite at this commit (locally verified during review) | **2212 passed**, coverage **90.7%** (≥90% threshold), Ruff/mypy clean |
+
+**Do not treat the SHA above as permanent:** query Git for the current value;
+repository HEAD advances with every merge. Docs-only commits (including this
+update) change repository HEAD but are **not** application deployments —
+production state below remains authoritative until services restart.
+
+## Production state
+
+| Item | Value |
+|---|---|
+| Deployed commit | `a67875d800deff7a954e9c83d42174c41b647326` (`a67875d`) |
+| Relationship to `origin/main` | **one merge behind** — production does not yet include PR #42 |
+| Merged-but-not-yet-deployed changes | **PR #42 only** — [Fix PDF startup preflight ordering and document configuration contract](https://github.com/VikJo1978/silberloeffel-catering/pull/42) (closes issue #41). Not deployed; do not treat it as running in production. |
 | Release discipline (proven) | deployment user can direct-push to `main`; prior pushes were not blocked by required green `quality`; branch protection may be absent or the user may have bypass — exact settings require authenticated owner/admin verification (see `docs/runbooks/release-discipline.md`) |
 
-**Docs-only commits** (including this operational-truth update) change repository
-HEAD but are **not** application deployments. Production runtime truth below
-remains authoritative until services restart.
+## Production services
 
-## Production runtime truth
+Last verified observation: **2026-07-27**, immediately after the `a67875d`
+deploy and its post-deploy observation pass. **These are a point-in-time
+snapshot, not permanent expected values** — re-verify with `systemctl show`
+before relying on them.
 
-Services load Python from `PYTHONPATH=.../src` at **process start**. Disk
-HEAD and in-memory runtime code diverge until each service restarts.
+| Service | PID | Started (CEST) |
+|---|---|---|
+| `catering-office-api` | 427823 | 2026-07-26 22:52:29 |
+| `catering-office-panel` | 435026 | 2026-07-27 08:49:50 |
+| `catering-website-intake` | 362683 | 2026-07-22 22:50:09 |
+| `catering-kiosk` | 332509 | 2026-07-21 00:36:38 |
 
-| Service | Unit | Runtime commit | Last restart (CEST) | MainPID | Notes |
-|---|---|---|---|---|---|
-| Office API | `catering-office-api.service` | `ad810b40722330152133df53452f8ba190ed2cd6` | 2026-07-20 10:22:11 | 322811 | inquiry customer reference **deployed** |
-| Office Panel | `catering-office-panel.service` | `ad810b40722330152133df53452f8ba190ed2cd6` | 2026-07-20 10:22:15 | 322821 | inquiry customer reference **deployed** |
-| Kitchen kiosk | `catering-kiosk.service` | `02b105246f4801e5732c7d13cfc07ac36a7976b6` | 2026-07-19 06:29:42 | 147681 | **unchanged** (not restarted) |
-| Website intake | `catering-website-intake.service` | `68a1cb0d79b538f10326aef17653a3590f4e2c04` | 2026-07-13 16:51:09 | 75898 | **many commits behind** |
+Only `catering-office-panel` was restarted for the `a67875d` deploy (the only
+service whose import graph is affected by that commit's change); the other
+three retained their prior PID/start time, confirming they were not touched.
 
-All four units were **active** at verification. Shared DB:
-`/home/viktor/catering-runtime/core.db`.
+## Deployment verification (`a67875d`)
+
+- HTTP checks: Office API `401`, Office Panel `401`, Kiosk `200`, Website
+  Intake `405` — all matched the expected/documented contract.
+- Database and backup integrity: `PRAGMA integrity_check` = `ok` on both the
+  live database and the pre-deploy backup.
+- Backup: `/home/viktor/catering-runtime/core.db.pre-a67875d-deploy.20260727-084522.bak`
+  — 471040 bytes, SHA-256
+  `82afe9dd5c758279446ce426c49adf3673adfd52f5a45dea6f3f42e99ce1642e`.
+- Rollback: **not required.**
+
+## Current known risk — systemd interpreter mismatch
+
+The tracked unit files (`infra/systemd/catering-office-api.service`,
+`infra/systemd/catering-office-panel.service`) still declare
+`ExecStart=/usr/bin/python3 ...`. Production actually runs
+`.venv/bin/python3 ...` through an **untracked** `systemd` drop-in override
+(`/etc/systemd/system/catering-office-*.service.d/override.conf`) that exists
+only on the host, not in this repository. Do not reinstall the tracked unit
+files as-is before this is resolved — doing so would silently revert
+production to the system interpreter, which lacks `reportlab` and has
+already caused one real crash-loop incident. This is tracked as the next
+slice below (`PDF_RUNTIME_VENV_AND_SYSTEMD_V1`), not fixed yet.
+
+## Next action
+
+1. Review and implement `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` (tracked systemd
+   interpreter alignment, production venv/runtime reproducibility,
+   dependency lock strategy, non-mutating runtime verification tooling —
+   not implemented yet).
+2. Deploy PR #42 to production only through a controlled deploy, either
+   together with or before Slice 2.
+3. Then run the artificial end-to-end pre-launch validation.
 
 ### Deployed and closed
+
+**PR #38 — catalog price-history response handling — DEPLOYED, CLOSED**
+
+- Merged **2026-07-27**; issue #37 closed.
+- Deployed to production as part of the `a67875d` fast-forward (same
+  deployment as PR #40 below).
+- Fixes `RemoteCoreClient.catalog_dish_detail` rejecting any dish that has
+  price history.
+
+**PR #40 — structured Offer/PDF error handling — DEPLOYED, CLOSED**
+
+- Merged **2026-07-27**; issue #39 closed.
+- Deployed to production as part of the `a67875d` fast-forward.
+- Fixes `RemoteCoreClient` masking structured Offer/PDF business errors
+  (`offer_document_blocked`, `confirmation_document_blocked`,
+  `order_not_ready_to_send`) as a generic `502`.
 
 **INQUIRY_CUSTOMER_REFERENCE_AND_SNAPSHOT_DEPLOY_V1 — CLOSED**
 
@@ -110,6 +168,20 @@ All four units were **active** at verification. Shared DB:
 **Auerswald missed-board compatibility — CLOSED** (runtime stable; Office
 Rückruf pull path operational).
 
+### Merged, not yet deployed
+
+**PR #42 — PDF startup preflight ordering and configuration documentation —
+MERGED, NOT DEPLOYED**
+
+- Merged **2026-07-27** into `main` (merge commit `03a3780e699357c30e36049f1293f5a93a214f6f`); issue #41 closed.
+- Fixes direct-mode Office Panel validating `OFFICE_PDF_*` configuration
+  *after* opening `core.db` and applying migrations; hardens
+  `OFFICE_PDF_LOGO_PATH` error handling; documents the full `OFFICE_PDF_*`
+  contract in `.env.example` and the Lenovo runbook.
+- **Production is still on `a67875d` and does not include this change.** Do
+  not deploy without a controlled deploy per the runbook; see "Next action"
+  above.
+
 ## Production database (aggregate)
 
 | Item | Value |
@@ -154,9 +226,9 @@ Core HubSpot intake remains disabled.
 
 ## Quality baseline (repository)
 
-On `cf2edb5` locally and in GitHub Actions: **1376 passed**, coverage **≥90%**,
-Ruff and mypy clean. Documented pre-push gate in
-`docs/runbooks/release-discipline.md`.
+On `03a3780` (current `origin/main`) locally and in GitHub Actions: **2212
+passed**, coverage **90.7%** (≥90% threshold), Ruff and mypy clean.
+Documented pre-push gate in `docs/runbooks/release-discipline.md`.
 
 ## Operational risks (open)
 

--- a/docs/proposals/CATALOG_SNAPSHOT_V2_6D3.md
+++ b/docs/proposals/CATALOG_SNAPSHOT_V2_6D3.md
@@ -1,6 +1,10 @@
 # 6D-3 — Offer Snapshot V2 + Catalog Adapter (design pack)
 
-Status: **design proposal only — no production code authorized until approved**  
+Status: **implemented** — `185e75c Add catalog snapshot v2.` (adds the
+`offer_position_catalog_snapshot_fields` migration on `offer_positions`, i.e.
+`catalog_item_id`/`allergens_json`/`vegan`/`vegetarian`; sub-scope of 6D-3a
+vs 6D-3b and the 6E next slice not independently re-verified in this status
+pass)
 Prerequisite: `CATALOG_SCOPE_V1.md` (6D-0), **6D-1** (`c8662ad`), **6D-2** (`d91c84c Add catalog editing and price history`)  
 Scope owner: **Commercial snapshot boundary** — Catalog → OfferPosition freeze at `prepare-offer`  
 Next slice: **6E** Buffetschilder allergen badges (print reads snapshotted OfferPosition only)


### PR DESCRIPTION
Docs-only status alignment. No application code, tests, dependencies, or
production changes.

## Why

`docs/current-status.md` still recorded `ad810b40722330152133df53452f8ba190ed2cd6`
(2026-07-20) as both repository HEAD and deployed production commit, with no
mention anywhere of PR #38, #40, #42 or issues #37, #39, #41. The distinction
between "merged into `main`" and "deployed to production" was entirely
absent, which is the exact ambiguity that matters right now: PR #42 is
merged but **not deployed**.

## What changed

- **`docs/current-status.md`** — replaced the stale "Repository truth" /
  "Production runtime truth" sections with explicit "Repository state"
  (`origin/main` = `03a3780e699357c30e36049f1293f5a93a214f6f`) and
  "Production state" (deployed = `a67875d800deff7a954e9c83d42174c41b647326`,
  one merge behind `main`, PR #42 the only merged-but-undeployed change)
  sections. Added a "Production services" table using the last verified
  PID/start-timestamp observation, explicitly marked as a point-in-time
  snapshot. Added deployment verification results (HTTP checks, DB/backup
  integrity, no rollback required), a "Current known risk" note on the
  systemd interpreter mismatch (tracked units say `/usr/bin/python3`,
  production actually runs `.venv/bin/python3` via an untracked override —
  do not reinstall the tracked units as-is), and a "Next action" section
  sequencing `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` before/with PR #42's
  deployment. Added closed-PR entries for #38/#40 (deployed) and a
  separate, clearly-labeled "Merged, not yet deployed" entry for #42.
  Updated the stale "1376 passed" quality baseline to the current verified
  2212 passed / 90.7% coverage.
- **`WORKLOG.md`** — appended Entry 069 (2026-07-27) recording the PR
  #38/#40 merge and deploy, the deployment's HEALTHY observation result,
  the PR #42 merge with an explicit not-deployed note, and the decision to
  split the PDF hardening work into `PDF_STARTUP_ORDER_AND_DOCS_V1` (done)
  and `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` (not started). No prior entries
  rewritten.
- **`CHANGELOG.md`** — added `### Fixed` and `### Documentation` entries
  under the existing `## Unreleased` section (the project's established
  convention) for the three fixes and the two documentation additions.
  Each entry states its actual deploy status; PR #42's entries are
  explicitly marked "merged to `main`, not yet deployed to production."
- **`docs/proposals/CATALOG_SNAPSHOT_V2_6D3.md`** — its sibling design
  packs (6D-1, 6D-2) already use a "Status: implemented — `<commit>`"
  convention once done; 6D-3 was still headed "design proposal only — no
  production code authorized" despite the exact migration it specifies
  (`offer_position_catalog_snapshot_fields`, adding `catalog_item_id` /
  `allergens_json` to `offer_positions`) already existing in the codebase,
  introduced by commit `185e75c`. Updated the status line to match the
  sibling convention, explicitly noting that the 6D-3a/6D-3b sub-split and
  the 6E next slice were not independently re-verified in this pass. The
  rest of the design content is untouched.

## Stale statements found (before this change)

- `docs/current-status.md` claimed repository HEAD and deployed production
  were both `ad810b4...` (2026-07-20) — six occurrences of that stale SHA.
- No reference anywhere in `docs/current-status.md`, `WORKLOG.md`, or
  `CHANGELOG.md` to PR #38, #40, #42 or issues #37, #39, #41.
- `docs/current-status.md`'s "Quality baseline" cited 1376 passed tests;
  current verified count is 2212.
- `docs/proposals/CATALOG_SNAPSHOT_V2_6D3.md` was headed "design proposal
  only" despite its core schema change being present in the merged
  codebase.
- No document anywhere conflated merged-vs-deployed state incorrectly —
  the gap was omission, not misstatement (PR #38/#40/#42 simply weren't
  mentioned at all before this change).

## Validation

- `git diff --check` — clean
- `git status --short` — only the four files above
- Stale-SHA sweep: `1b1ead1289bda712009ea672968b3dd0c29da2be` and
  `ed750b2629f7cd55799c1c0798e8ea8c1a78d567` — zero matches in `docs/`,
  `WORKLOG.md`, `CHANGELOG.md` (never present). `a67875d800deff7a954e9c83d42174c41b647326`
  and `03a3780e699357c30e36049f1293f5a93a214f6f` — present only in the
  current-state sections where each is the correct value (production and
  repository HEAD respectively).
- No Markdown linter is configured in this repository (no
  `.markdownlint*` config, no lint step targeting Markdown in CI) — none
  run.

## Explicitly not done

- No application code, test, dependency, systemd, or database change.
- No production deployment, service restart, or production modification.
- PR #42 is **not** marked as deployed anywhere in this change.
