### PR TITLE
Update current status repository head after docs merge

### DIFF
--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -14,15 +14,17 @@ recorded. See `docs/runbooks/deployment-truth-checklist.md`.
 
 | Item | Value |
 |---|---|
-| `origin/main` HEAD | `03a3780e699357c30e36049f1293f5a93a214f6f` (`03a3780`) |
-| Latest merged PR | [#42 — Fix PDF startup preflight ordering and document configuration contract](https://github.com/VikJo1978/silberloeffel-catering/pull/42) (merge commit `03a3780e699357c30e36049f1293f5a93a214f6f`, parents `a67875d8` + `5f4df5e6`) |
-| CI on the merged commit | `quality` — **pass** (both required checks green at merge time) |
-| Full test suite at this commit (locally verified during review) | **2212 passed**, coverage **90.7%** (≥90% threshold), Ruff/mypy clean |
+| `origin/main` HEAD | `8abb9b5ea3350ec71c66e87f0481be0b0823ccf7` (`8abb9b5`) |
+| Latest merged functional PR | [#42 — Fix PDF startup preflight ordering and document configuration contract](https://github.com/VikJo1978/silberloeffel-catering/pull/42) (merge commit `03a3780e699357c30e36049f1293f5a93a214f6f`, parents `a67875d8` + `5f4df5e6`) |
+| Latest merged PR (docs-only) | [#43 — Align project status documentation with main and production](https://github.com/VikJo1978/silberloeffel-catering/pull/43) (merge commit `8abb9b5ea3350ec71c66e87f0481be0b0823ccf7`) — this and the current follow-up correction are documentation-only; they do not change PR #42's merged/not-deployed status below |
+| CI on the latest functional merge (`03a3780`) | `quality` — **pass** (both required checks green at merge time) |
+| Full test suite at `03a3780` (locally verified during review) | **2212 passed**, coverage **90.7%** (≥90% threshold), Ruff/mypy clean |
 
 **Do not treat the SHA above as permanent:** query Git for the current value;
-repository HEAD advances with every merge. Docs-only commits (including this
-update) change repository HEAD but are **not** application deployments —
-production state below remains authoritative until services restart.
+repository HEAD advances with every merge. Docs-only commits (including PR
+#43 and this update) change repository HEAD but are **not** application
+deployments — production state below remains authoritative until services
+restart.
 
 ## Production state
 


### PR DESCRIPTION
Minimal documentation-only follow-up. Docs PR #43 documented its own
`origin/main` HEAD as `03a3780e699357c30e36049f1293f5a93a214f6f` — the
commit immediately before its own merge. Once #43 merged, `origin/main`
naturally advanced to its merge commit `8abb9b5ea3350ec71c66e87f0481be0b0823ccf7`,
making that one self-referential line stale again. This is the expected,
unavoidable one-step lag any doc commit has in describing its own resulting
HEAD, corrected here rather than left to compound.

## Change

`docs/current-status.md` only:

- `origin/main` HEAD: `03a3780e699357c30e36049f1293f5a93a214f6f` → `8abb9b5ea3350ec71c66e87f0481be0b0823ccf7`
- Split the single "Latest merged PR" row into "Latest merged functional PR"
  (still #42, unchanged) and "Latest merged PR (docs-only)" (#43, new),
  with a note that both #43 and this follow-up are documentation-only and
  do not change PR #42's merged/not-deployed status.
- Reworded the two lines referencing "the merged commit" to name `03a3780`
  explicitly, since "origin/main HEAD" and "the last functional merge" are
  no longer the same commit.

## Unchanged (verified)

- Production commit: still `a67875d800deff7a954e9c83d42174c41b647326`
- PR #42: still recorded as merged, **not deployed**
- PR #38 / #40: still recorded as deployed
- Production services table, deployment verification, backup details: untouched

## Validation

- `git diff --check` — clean
- `git status --short` — only `docs/current-status.md`
- No source, test, dependency, systemd, or configuration files changed

No production action taken.
