### PR TITLE
Align tracked office-api/office-panel units with the running venv interpreter

### DIFF
--- a/infra/systemd/catering-office-api.service
+++ b/infra/systemd/catering-office-api.service
@@ -15,7 +15,11 @@ Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/src
 # Root-owned, mode 600. Holds OFFICE_API_TOKEN (pack §5) — the token is
 # never an argument and never appears in the process list.
 EnvironmentFile=/etc/catering/office-api.env
-ExecStart=/usr/bin/python3 -m catering_system.ui.office_api --db /home/viktor/catering-runtime/core.db --host 100.109.6.74 --port 8084
+# The project venv, not the system interpreter: this service imports reportlab
+# (offer PDF rendering), which exists only in .venv. /usr/bin/python3 here has
+# already caused one crash-loop. Build the venv with `uv sync --no-dev` before
+# installing this unit — see docs/runbooks/lenovo-production.md.
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m catering_system.ui.office_api --db /home/viktor/catering-runtime/core.db --host 100.109.6.74 --port 8084
 Restart=on-failure
 RestartSec=3
 

--- a/infra/systemd/catering-office-panel.service
+++ b/infra/systemd/catering-office-panel.service
@@ -11,7 +11,11 @@ User=viktor
 WorkingDirectory=/home/viktor/projects/silberloeffel-catering
 Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/src
 EnvironmentFile=/etc/catering/office-panel.env
-ExecStart=/usr/bin/python3 -m catering_system.ui.office_panel --db /home/viktor/catering-runtime/core.db --port 8081
+# The project venv, not the system interpreter: this service imports reportlab
+# (offer PDF rendering), which exists only in .venv. /usr/bin/python3 here has
+# already caused one crash-loop. Build the venv with `uv sync --no-dev` before
+# installing this unit — see docs/runbooks/lenovo-production.md.
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m catering_system.ui.office_panel --db /home/viktor/catering-runtime/core.db --port 8081
 Restart=on-failure
 RestartSec=3
 


### PR DESCRIPTION
Slice B of `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` — `SYSTEMD_RUNTIME_ALIGNMENT_V1`.
Branched from `main` at `b54ee3d` (Slice A already merged).

## Problem

The tracked unit files declare `ExecStart=/usr/bin/python3`, but production
has run both services from `.venv/bin/python3` since the PDF feature landed —
through an **untracked** systemd drop-in override
(`/etc/systemd/system/catering-office-*.service.d/override.conf`) that exists
only on the host, not in this repository. Reinstalling the tracked files as-is
would silently revert production to the system interpreter, which has no
`reportlab` and has already caused one real crash-loop incident.

## Change

Only:
- `infra/systemd/catering-office-api.service`
- `infra/systemd/catering-office-panel.service`

`ExecStart=/usr/bin/python3 -m ...` → `ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m ...`,
with a comment explaining why (reportlab, prior crash-loop, `uv sync --no-dev`
is the documented way to build the venv — Slice A).

## Not in scope (verified — diff touches exactly these 2 files)

- `catering-kiosk.service` / `catering-website-intake.service` — neither
  imports `reportlab`, neither needs the venv;
- Python code, `pyproject.toml`, `uv.lock`, CI, environment files;
- the untracked drop-in override — **not removed by this PR**. It stays in
  place until these units are actually reinstalled on production, which is a
  separate, later slice with its own deploy plan;
- **no production change of any kind.**

## Verification (read-only against the live host, before writing this PR)

- `systemctl show -p ExecStart catering-office-api` / `catering-office-panel`
  on `debiancatering` — the new `ExecStart` line in each unit file is
  **byte-identical** to the `argv[]` currently running in production.
- `.venv/bin/python3` path confirmed to exist and match the project layout
  (`/home/viktor/projects/silberloeffel-catering/.venv/bin/python3`).
- `systemd-analyze verify` run against a **throwaway, uninstalled copy** of
  both files in `/tmp` on the host (removed immediately after) — exit `0`,
  no errors. The live installed units and the running services were not
  touched at any point; `ExecStart` on both was re-checked identical
  before/after.
- `git diff --check` — clean.
- `git status --short` — exactly the two files above.

## Explicitly NOT done

- no `daemon-reload`, no `systemctl restart`, no unit install;
- no removal of the production override;
- no merge — waiting for review, as instructed.

Slice D (production migration: install these units, remove the override,
rebuild `.venv` from `uv.lock`) is a separate PR with its own deploy plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)