### PR TITLE
Add read-only PDF runtime and systemd verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,16 @@ jobs:
         run: uv sync --dev
       - name: Lint
         run: |
-          uv run ruff check src tests
-          uv run ruff format --check src tests
+          uv run ruff check src tests infra
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage
         run: |
           uv run coverage run -m pytest -q
           uv run coverage report
+      - name: Verify PDF runtime and systemd alignment (repository-only)
+        run: uv run python infra/deploy/verify_pdf_runtime.py --repository-only
       - name: Test browser and Worker JavaScript
         run: |
           node --test infra/staging-form/app.test.cjs

--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -196,8 +196,10 @@ alignment without changing anything: no package installation, no `uv sync`, no
 unit installation, no `daemon-reload`, no service restart, no override edit or
 removal, no application code change, no database write. It only reads
 git-tracked files, runs `uv lock --check`, queries systemd with `systemctl
-show`/`systemctl cat`, and reads `/proc/<pid>/cmdline` and `/proc/<pid>/
-environ` (variable **names** only — values are never printed).
+show` (never `systemctl cat` — `show` alone reports the effective,
+drop-in-resolved property values this tool needs), and reads `/proc/<pid>/
+cmdline` and `/proc/<pid>/environ` (variable **names** only — values are
+never printed).
 
 Two modes; one must be given explicitly:
 
@@ -213,26 +215,53 @@ Add `--json` for machine-readable output alongside the human-readable report.
 
 Run `--host-runtime`:
 
-- **before** the Slice D migration below, to confirm the tracked units,
-  the venv, and `reportlab` are actually ready — a successful pre-migration
-  result may legitimately report `READY_WITH_COMPATIBLE_OVERRIDE` (the
-  existing drop-in override still applies and its resulting command matches
-  the tracked target);
+- **before** the Slice D migration below, to see how close the host already
+  is to ready — some individual checks (venv, `reportlab`, the systemd
+  alignment classification) may already pass even though the overall exit
+  code is non-zero (see below), because the git checkout itself hasn't
+  received Slices A/B yet;
 - **after** installing the tracked units and removing the overrides, to
-  confirm the migration landed — a successful post-migration result should
-  report `READY_WITHOUT_OVERRIDE` instead.
+  confirm the migration landed cleanly — a fully successful post-migration
+  run (exit `0`) should report `READY_WITHOUT_OVERRIDE` for both services and
+  no other failures.
 
 `MISMATCHED_OVERRIDE`, `TRACKED_UNIT_MISMATCH`, `RUNTIME_INTERPRETER_MISSING`,
-`REPORTLAB_MISSING`, `REPORTLAB_VERSION_MISMATCH`, `PDF_CONFIG_MISSING`, and
-`LOCK_OUT_OF_DATE` are all failures (non-zero exit) and mean the runtime is
-not ready for that step of the migration — investigate before proceeding, do
-not work around them by installing anything by hand.
+`REPORTLAB_MISSING`, `REPORTLAB_VERSION_MISMATCH`, `PDF_CONFIG_MISSING`,
+`LOCK_MISSING`, and `LOCK_OUT_OF_DATE` are all failures (non-zero exit) and
+mean the runtime is not ready for that step of the migration — investigate
+before proceeding, do not work around them by installing anything by hand.
 
-`uv` is not installed on Lenovo as of this writing, so `--host-runtime` there
-will currently report `LOCK_OUT_OF_DATE` for the repository-state check (it
-cannot verify `uv.lock` without the `uv` binary); this is expected until a
-later slice installs `uv` on the host and is not itself a blocker for reading
-the rest of the report.
+### What `--host-runtime` reports today, before Slices A/B reach the checkout
+
+Lenovo's checkout is still at the commit that predates both `uv.lock` (Slice
+A) and the tracked-unit venv alignment (Slice B). Running `--host-runtime`
+there today is expected to produce a **non-zero exit** with exactly:
+
+```
+LOCK_MISSING           — uv.lock does not exist on this checkout yet
+TRACKED_UNIT_MISMATCH  — catering-office-api.service   (tracked file still says /usr/bin/python3)
+TRACKED_UNIT_MISMATCH  — catering-office-panel.service  (same)
+```
+
+while the runtime-derived checks — which inspect the actually-running system,
+not the stale checkout — may still correctly report `READY_WITH_COMPATIBLE_
+OVERRIDE` for both services, since the existing untracked drop-in override
+already runs them under `.venv/bin/python3`.
+
+**`LOCK_MISSING` occurs first, before `uv` availability is ever tested**,
+because `check_repository_state` requires `uv.lock` to exist before it
+attempts `uv lock --check` at all. `uv` is also not installed on Lenovo as of
+this writing (`uv` is absent from `PATH`); once the checkout is fast-forwarded
+past Slice A so `uv.lock` exists, the failure at that step will shift to
+`LOCK_OUT_OF_DATE` instead (the file exists, but the check can't run without
+the `uv` binary) — that too is expected until a later slice installs `uv` on
+the host, not a script defect.
+
+Do **not** read a `--host-runtime` run against today's checkout as globally
+successful just because some checks pass: the overall exit code stays
+non-zero until the checkout has received Slices A/B and `uv` is installed.
+These specific, expected pre-migration failures prove the checkout hasn't
+received those slices yet — they are not evidence of a defect in this tool.
 
 ## Safe deployment
 

--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -189,6 +189,51 @@ requests:
 > the `pytest` and `mypy` that step 4 of the deployment below currently relies
 > on.
 
+## PDF runtime verification (read-only)
+
+`infra/deploy/verify_pdf_runtime.py` cross-checks the PDF runtime and systemd
+alignment without changing anything: no package installation, no `uv sync`, no
+unit installation, no `daemon-reload`, no service restart, no override edit or
+removal, no application code change, no database write. It only reads
+git-tracked files, runs `uv lock --check`, queries systemd with `systemctl
+show`/`systemctl cat`, and reads `/proc/<pid>/cmdline` and `/proc/<pid>/
+environ` (variable **names** only — values are never printed).
+
+Two modes; one must be given explicitly:
+
+```bash
+# No systemd or production access needed — safe in CI or any checkout.
+uv run python infra/deploy/verify_pdf_runtime.py --repository-only
+
+# Real venv, reportlab, systemd and process checks. Run on Lenovo itself.
+python infra/deploy/verify_pdf_runtime.py --host-runtime
+```
+
+Add `--json` for machine-readable output alongside the human-readable report.
+
+Run `--host-runtime`:
+
+- **before** the Slice D migration below, to confirm the tracked units,
+  the venv, and `reportlab` are actually ready — a successful pre-migration
+  result may legitimately report `READY_WITH_COMPATIBLE_OVERRIDE` (the
+  existing drop-in override still applies and its resulting command matches
+  the tracked target);
+- **after** installing the tracked units and removing the overrides, to
+  confirm the migration landed — a successful post-migration result should
+  report `READY_WITHOUT_OVERRIDE` instead.
+
+`MISMATCHED_OVERRIDE`, `TRACKED_UNIT_MISMATCH`, `RUNTIME_INTERPRETER_MISSING`,
+`REPORTLAB_MISSING`, `REPORTLAB_VERSION_MISMATCH`, `PDF_CONFIG_MISSING`, and
+`LOCK_OUT_OF_DATE` are all failures (non-zero exit) and mean the runtime is
+not ready for that step of the migration — investigate before proceeding, do
+not work around them by installing anything by hand.
+
+`uv` is not installed on Lenovo as of this writing, so `--host-runtime` there
+will currently report `LOCK_OUT_OF_DATE` for the repository-state check (it
+cannot verify `uv.lock` without the `uv` binary); this is expected until a
+later slice installs `uv` on the host and is not itself a blocker for reading
+the rest of the report.
+
 ## Safe deployment
 
 ### 1. Record the starting point

--- a/docs/runbooks/release-discipline.md
+++ b/docs/runbooks/release-discipline.md
@@ -20,10 +20,13 @@ owner/admin verification of GitHub settings.**
 ## What `quality` runs
 
 - `uv lock --check` — fails if `uv.lock` does not match `pyproject.toml`
-- `ruff check src tests`
-- `ruff format --check src tests`
+- `ruff check src tests infra`
+- `ruff format --check src tests infra`
 - `mypy src/catering_system`
 - `coverage run -m pytest -q` + `coverage report`
+- `infra/deploy/verify_pdf_runtime.py --repository-only` — read-only PDF
+  runtime/systemd static checks (`uv.lock` currency, tracked unit
+  `ExecStart` correctness); no systemd or production access required
 - Node tests for staging form and Cloudflare worker
 
 ## Local pre-push gate (documented; not a server substitute)
@@ -32,8 +35,9 @@ owner/admin verification of GitHub settings.**
 cd /home/viktor/projects/silberloeffel-catering
 uv sync --dev
 uv run coverage erase && uv run coverage run -m pytest -q && uv run coverage report
-uv run ruff check src tests && uv run ruff format --check src tests
+uv run ruff check src tests infra && uv run ruff format --check src tests infra
 uv run mypy src/catering_system
+uv run python infra/deploy/verify_pdf_runtime.py --repository-only
 uv lock --check
 git diff --check
 ```

--- a/infra/deploy/verify_pdf_runtime.py
+++ b/infra/deploy/verify_pdf_runtime.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+"""Read-only verification of the PDF runtime and systemd alignment.
+
+PDF_RUNTIME_VERIFICATION_SCRIPT_V1 (Slice C of PDF_RUNTIME_VENV_AND_SYSTEMD_V1).
+
+This tool never mutates anything: no package installation, no `uv sync`, no
+systemd unit installation, no `daemon-reload`, no service restart, no
+override edit/removal, no application code change, no database write. It
+only reads git-tracked files, runs `uv lock --check` (itself read-only),
+queries systemd with `systemctl show`/`systemctl cat`, reads `/proc/<pid>/
+cmdline` and `/proc/<pid>/environ` (variable *names* only — values are never
+printed), and runs the target interpreter with a side-effect-free `-c` probe
+to introspect `sys.prefix` and import `reportlab`.
+
+Why not `/proc/<pid>/exe`: the project venv is a standard stdlib venv, so
+`.venv/bin/python3` is a *symlink* to the system interpreter. `/proc/<pid>/
+exe` resolves through that symlink and reports the system Python for a
+process that is genuinely running inside the venv — a false negative. The
+reliable signals are the argv actually invoked (systemd's own resolved
+`argv[]=`, or `/proc/<pid>/cmdline`) and an independent probe of the same
+interpreter *path* run separately. A live process's own `sys.prefix` cannot
+be read without code injection or a debugger, which this tool does not do —
+see `_HOST_LIMITATIONS` below.
+
+Two modes, one of which must be selected explicitly (no silent default):
+
+    --repository-only   No systemd or production access. Safe for CI and any
+                         checkout. Verifies pyproject.toml/uv.lock, that
+                         `uv lock --check` is clean, and that the tracked
+                         office-api/office-panel units declare the expected
+                         venv interpreter, module and arguments.
+
+    --host-runtime       Adds: the real `.venv` interpreter runs and reports
+                         the expected sys.prefix; `reportlab` is importable,
+                         is version 5.0.0, and lives inside the venv;
+                         required OFFICE_PDF_* variables are present (never
+                         their values) in each service's actual process
+                         environment; the effective (loaded) systemd
+                         ExecStart is compared against the tracked target,
+                         classifying the result as READY_WITHOUT_OVERRIDE or
+                         READY_WITH_COMPATIBLE_OVERRIDE (both are success) or
+                         MISMATCHED_OVERRIDE (failure); each service is
+                         active and its running command line matches.
+
+Exit code 0 only when every check that ran passed. Non-zero otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+# --- constants ----------------------------------------------------------
+
+EXPECTED_REPORTLAB_VERSION = "5.0.0"
+
+# In-scope services only. catering-kiosk and catering-website-intake do not
+# import reportlab and are never inspected by this script.
+SERVICES: tuple[str, ...] = ("catering-office-api", "catering-office-panel")
+
+TRACKED_UNIT_FILES: dict[str, str] = {
+    "catering-office-api": "catering-office-api.service",
+    "catering-office-panel": "catering-office-panel.service",
+}
+
+# The absolute path baked into the tracked unit files. This is a
+# production-host fact (the repository is checked out at exactly this path
+# on the one host the units target), not something --repo-root can move —
+# overriding --repo-root changes where *this script* looks for pyproject.toml
+# / uv.lock / unit files for local testing, it does not change what those
+# unit files are expected to declare.
+EXPECTED_VENV_INTERPRETER = (
+    "/home/viktor/projects/silberloeffel-catering/.venv/bin/python3"
+)
+
+EXPECTED_UNIT_ARGV: dict[str, list[str]] = {
+    "catering-office-api": [
+        EXPECTED_VENV_INTERPRETER,
+        "-m",
+        "catering_system.ui.office_api",
+        "--db",
+        "/home/viktor/catering-runtime/core.db",
+        "--host",
+        "100.109.6.74",
+        "--port",
+        "8084",
+    ],
+    "catering-office-panel": [
+        EXPECTED_VENV_INTERPRETER,
+        "-m",
+        "catering_system.ui.office_panel",
+        "--db",
+        "/home/viktor/catering-runtime/core.db",
+        "--port",
+        "8081",
+    ],
+}
+
+REQUIRED_PDF_ENV_VARS: tuple[str, ...] = (
+    "OFFICE_PDF_COMPANY_LEGAL_NAME",
+    "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+    "OFFICE_PDF_ACCEPTANCE_STATEMENT",
+)
+OPTIONAL_LOGO_PATH_VAR = "OFFICE_PDF_LOGO_PATH"
+
+_SUBPROCESS_TIMEOUT_SECONDS = 10.0
+
+# A live process's own sys.prefix cannot be read without attaching a
+# debugger or injecting code — both out of scope for a read-only tool. This
+# message is surfaced once in host-runtime output rather than silently
+# omitted, per the design brief.
+_HOST_LIMITATIONS = (
+    "Live process sys.prefix cannot be verified without code injection or a "
+    "debugger; relying instead on the effective systemd ExecStart, the "
+    "process command line (/proc/<pid>/cmdline), and an independent probe "
+    "of the same interpreter path run separately. /proc/<pid>/exe is not "
+    "used as evidence of venv use: .venv/bin/python3 is a symlink to the "
+    "system interpreter, so /proc/<pid>/exe resolves to the system path "
+    "even for a process genuinely running inside the venv."
+)
+
+_PROBE_SCRIPT = """
+import json, sys
+result = {
+    "executable": sys.executable,
+    "prefix": sys.prefix,
+    "base_prefix": sys.base_prefix,
+    "version": sys.version.split()[0],
+}
+try:
+    import reportlab
+    result["reportlab_version"] = reportlab.Version
+    result["reportlab_file"] = str(reportlab.__file__)
+except Exception as exc:  # noqa: BLE001 - reported, not raised
+    result["reportlab_error"] = f"{type(exc).__name__}: {exc}"
+print(json.dumps(result))
+"""
+
+
+# --- result model ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    code: str
+    message: str
+
+
+@dataclass
+class Report:
+    mode: str
+    checks: list[CheckResult] = field(default_factory=list)
+
+    def record(self, name: str, ok: bool, code: str, message: str) -> CheckResult:
+        result = CheckResult(name=name, ok=ok, code=code, message=message)
+        self.checks.append(result)
+        return result
+
+    @property
+    def ok(self) -> bool:
+        return all(check.ok for check in self.checks)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "mode": self.mode,
+            "ok": self.ok,
+            "checks": [
+                {
+                    "name": c.name,
+                    "ok": c.ok,
+                    "code": c.code,
+                    "message": c.message,
+                }
+                for c in self.checks
+            ],
+        }
+
+    def render_human(self) -> str:
+        lines = [f"PDF runtime verification — mode: {self.mode}", ""]
+        for check in self.checks:
+            marker = "PASS" if check.ok else "FAIL"
+            lines.append(f"[{marker}] {check.code}: {check.message}")
+        lines.append("")
+        lines.append("OVERALL: " + ("OK" if self.ok else "FAILED"))
+        return "\n".join(lines)
+
+
+# --- subprocess plumbing (isolated for testability) ------------------------
+
+
+def _run(cmd: Sequence[str], timeout: float = _SUBPROCESS_TIMEOUT_SECONDS):
+    """The only place that shells out. No shell=True, explicit timeout.
+
+    Tests replace this function (module-level monkeypatch) to supply canned
+    output instead of requiring a real systemd host or a real venv.
+    """
+    return subprocess.run(
+        list(cmd), check=False, capture_output=True, text=True, timeout=timeout
+    )
+
+
+class CommandUnavailable(RuntimeError):
+    """Raised when the target binary does not exist on PATH."""
+
+
+def _run_or_raise(cmd: Sequence[str], timeout: float = _SUBPROCESS_TIMEOUT_SECONDS):
+    try:
+        return _run(cmd, timeout=timeout)
+    except FileNotFoundError as exc:
+        raise CommandUnavailable(str(exc)) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CommandUnavailable(f"timed out after {timeout}s: {exc}") from exc
+
+
+# --- repository-state checks (safe in both modes) ---------------------------
+
+
+def check_repository_state(report: Report, repo_root: Path) -> None:
+    if not repo_root.is_dir():
+        report.record(
+            "repository_root",
+            False,
+            "REPO_ROOT_NOT_FOUND",
+            f"repository root does not exist: {repo_root}",
+        )
+        return
+    report.record("repository_root", True, "OK", f"repository root: {repo_root}")
+
+    pyproject = repo_root / "pyproject.toml"
+    if pyproject.is_file():
+        report.record("pyproject_exists", True, "OK", f"found {pyproject}")
+    else:
+        report.record(
+            "pyproject_exists",
+            False,
+            "PYPROJECT_MISSING",
+            f"pyproject.toml not found at {pyproject}",
+        )
+        return
+
+    lock = repo_root / "uv.lock"
+    if lock.is_file():
+        report.record("uv_lock_exists", True, "OK", f"found {lock}")
+    else:
+        report.record(
+            "uv_lock_exists",
+            False,
+            "LOCK_MISSING",
+            f"uv.lock not found at {lock}",
+        )
+        return
+
+    try:
+        result = _run_or_raise(["uv", "lock", "--check"], timeout=60.0)
+    except CommandUnavailable as exc:
+        report.record(
+            "uv_lock_check",
+            False,
+            "LOCK_OUT_OF_DATE",
+            f"could not run `uv lock --check` (uv unavailable): {exc}",
+        )
+        return
+    if result.returncode == 0:
+        report.record("uv_lock_check", True, "OK", "uv.lock matches pyproject.toml")
+    else:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        tail = detail[-1] if detail else "uv lock --check failed"
+        report.record(
+            "uv_lock_check",
+            False,
+            "LOCK_OUT_OF_DATE",
+            f"uv.lock does not match pyproject.toml: {tail}",
+        )
+
+
+# --- tracked systemd unit checks (safe in both modes) -----------------------
+
+
+def _parse_exec_start(unit_text: str) -> list[str] | None:
+    for line in unit_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ExecStart="):
+            value = stripped[len("ExecStart=") :].strip()
+            if not value:
+                return None
+            return shlex.split(value)
+    return None
+
+
+def check_tracked_units(report: Report, repo_root: Path) -> None:
+    for service, filename in TRACKED_UNIT_FILES.items():
+        unit_path = repo_root / "infra" / "systemd" / filename
+        name = f"tracked_unit[{service}]"
+        if not unit_path.is_file():
+            report.record(
+                name,
+                False,
+                "TRACKED_UNIT_MISSING",
+                f"{unit_path} not found",
+            )
+            continue
+        argv = _parse_exec_start(unit_path.read_text(encoding="utf-8"))
+        expected = EXPECTED_UNIT_ARGV[service]
+        if argv == expected:
+            report.record(
+                name,
+                True,
+                "OK",
+                f"{filename} declares the expected venv interpreter, "
+                "module and arguments",
+            )
+        else:
+            report.record(
+                name,
+                False,
+                "TRACKED_UNIT_MISMATCH",
+                f"{filename} ExecStart is {argv!r}, expected {expected!r}",
+            )
+
+
+# --- host-runtime: python interpreter + reportlab ---------------------------
+
+
+@dataclass(frozen=True)
+class InterpreterProbe:
+    ok: bool
+    executable: str | None = None
+    prefix: str | None = None
+    base_prefix: str | None = None
+    version: str | None = None
+    reportlab_version: str | None = None
+    reportlab_file: str | None = None
+    reportlab_error: str | None = None
+    error: str | None = None
+
+
+def probe_interpreter(python_path: Path) -> InterpreterProbe:
+    try:
+        result = _run_or_raise([str(python_path), "-c", _PROBE_SCRIPT], timeout=30.0)
+    except CommandUnavailable as exc:
+        return InterpreterProbe(ok=False, error=str(exc))
+    if result.returncode != 0:
+        stderr_tail = (result.stderr or "").strip().splitlines()
+        tail = stderr_tail[-1] if stderr_tail else f"exit code {result.returncode}"
+        return InterpreterProbe(ok=False, error=tail)
+    try:
+        data = json.loads(result.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError) as exc:
+        return InterpreterProbe(ok=False, error=f"unparseable probe output: {exc}")
+    return InterpreterProbe(
+        ok=True,
+        executable=data.get("executable"),
+        prefix=data.get("prefix"),
+        base_prefix=data.get("base_prefix"),
+        version=data.get("version"),
+        reportlab_version=data.get("reportlab_version"),
+        reportlab_file=data.get("reportlab_file"),
+        reportlab_error=data.get("reportlab_error"),
+    )
+
+
+def check_python_runtime(report: Report, venv_path: Path) -> InterpreterProbe | None:
+    python_path = venv_path / "bin" / "python3"
+    if not python_path.exists():
+        report.record(
+            "runtime_interpreter_present",
+            False,
+            "RUNTIME_INTERPRETER_MISSING",
+            f"{python_path} does not exist",
+        )
+        return None
+    if not (python_path.is_file() or python_path.is_symlink()):
+        report.record(
+            "runtime_interpreter_present",
+            False,
+            "RUNTIME_INTERPRETER_MISSING",
+            f"{python_path} is not a regular file or symlink",
+        )
+        return None
+    report.record("runtime_interpreter_present", True, "OK", f"{python_path} exists")
+
+    probe = probe_interpreter(python_path)
+    if not probe.ok:
+        report.record(
+            "runtime_interpreter_runs",
+            False,
+            "RUNTIME_INTERPRETER_MISSING",
+            f"{python_path} did not run successfully: {probe.error}",
+        )
+        return probe
+    report.record(
+        "runtime_interpreter_runs",
+        True,
+        "OK",
+        f"{python_path} runs (Python {probe.version})",
+    )
+
+    expected_prefix = str(venv_path)
+    prefix_matches = probe.prefix == expected_prefix
+    base_differs = probe.base_prefix is not None and probe.base_prefix != probe.prefix
+    if prefix_matches and base_differs:
+        report.record(
+            "venv_prefix",
+            True,
+            "OK",
+            f"sys.prefix={probe.prefix} (base_prefix differs, venv active)",
+        )
+    else:
+        report.record(
+            "venv_prefix",
+            False,
+            "VENV_PREFIX_MISMATCH",
+            f"sys.prefix={probe.prefix!r} base_prefix={probe.base_prefix!r}, "
+            f"expected prefix {expected_prefix!r} with base_prefix differing",
+        )
+
+    if probe.reportlab_version is not None:
+        report.record(
+            "reportlab_importable",
+            True,
+            "OK",
+            f"reportlab {probe.reportlab_version} importable",
+        )
+        if probe.reportlab_version == EXPECTED_REPORTLAB_VERSION:
+            report.record(
+                "reportlab_version",
+                True,
+                "OK",
+                f"reportlab version {probe.reportlab_version} matches expected "
+                f"{EXPECTED_REPORTLAB_VERSION}",
+            )
+        else:
+            report.record(
+                "reportlab_version",
+                False,
+                "REPORTLAB_VERSION_MISMATCH",
+                f"reportlab version {probe.reportlab_version!r} != expected "
+                f"{EXPECTED_REPORTLAB_VERSION!r}",
+            )
+        reportlab_file = probe.reportlab_file
+        located_in_venv = bool(
+            reportlab_file
+            and Path(reportlab_file).resolve().is_relative_to(venv_path.resolve())
+        )
+        report.record(
+            "reportlab_location",
+            located_in_venv,
+            "OK" if located_in_venv else "REPORTLAB_LOCATION_OUTSIDE_VENV",
+            (
+                f"reportlab installed inside {venv_path}"
+                if located_in_venv
+                else f"reportlab location is outside {venv_path}"
+            ),
+        )
+    else:
+        report.record(
+            "reportlab_importable",
+            False,
+            "REPORTLAB_MISSING",
+            f"import reportlab failed: {probe.reportlab_error}",
+        )
+    return probe
+
+
+# --- host-runtime: systemd effective configuration --------------------------
+
+
+def _systemctl_show(service: str, *properties: str) -> dict[str, str] | None:
+    args = ["systemctl", "show", service]
+    for prop in properties:
+        args += ["-p", prop]
+    try:
+        result = _run_or_raise(args, timeout=15.0)
+    except CommandUnavailable:
+        return None
+    if result.returncode != 0:
+        return None
+    # `systemctl show -p A -p B` prints exactly one "Key=Value" line per
+    # requested property (confirmed against the real production output for
+    # ExecStart/FragmentPath/DropInPaths/ActiveState/MainPID) — no
+    # multi-line values to reassemble here.
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep and key in properties:
+            values[key] = value
+    return values
+
+
+def _extract_effective_argv(exec_start_value: str) -> list[str] | None:
+    marker = "argv[]="
+    start = exec_start_value.find(marker)
+    if start == -1:
+        return None
+    start += len(marker)
+    end = exec_start_value.find(" ;", start)
+    segment = exec_start_value[start:end] if end != -1 else exec_start_value[start:]
+    return shlex.split(segment.strip())
+
+
+def check_effective_systemd(report: Report, service: str) -> dict[str, str] | None:
+    props = _systemctl_show(
+        service, "ExecStart", "FragmentPath", "DropInPaths", "ActiveState", "MainPID"
+    )
+    name = f"effective_systemd[{service}]"
+    if props is None:
+        report.record(
+            name,
+            False,
+            "TRACKED_UNIT_MISMATCH",
+            f"could not query systemctl for {service} (systemctl unavailable "
+            "or command failed)",
+        )
+        return None
+
+    exec_start = props.get("ExecStart", "")
+    effective_argv = _extract_effective_argv(exec_start)
+    expected_argv = EXPECTED_UNIT_ARGV.get(service)
+    drop_in_paths = props.get("DropInPaths", "").strip()
+    override_present = bool(drop_in_paths)
+
+    if effective_argv is None:
+        report.record(
+            name,
+            False,
+            "TRACKED_UNIT_MISMATCH",
+            f"{service}: could not parse effective ExecStart",
+        )
+        return props
+
+    if effective_argv != expected_argv:
+        code = "MISMATCHED_OVERRIDE" if override_present else "TRACKED_UNIT_MISMATCH"
+        report.record(
+            name,
+            False,
+            code,
+            f"{service}: effective command {effective_argv!r} does not match "
+            f"expected {expected_argv!r}"
+            + (f" (override: {drop_in_paths})" if override_present else ""),
+        )
+        return props
+
+    if override_present:
+        report.record(
+            name,
+            True,
+            "READY_WITH_COMPATIBLE_OVERRIDE",
+            f"{service}: effective command matches the tracked target via a "
+            f"compatible override ({drop_in_paths})",
+        )
+    else:
+        report.record(
+            name,
+            True,
+            "READY_WITHOUT_OVERRIDE",
+            f"{service}: effective command matches the tracked target with "
+            "no override present",
+        )
+    return props
+
+
+# --- host-runtime: PDF configuration presence --------------------------------
+
+
+def _read_environ_names(pid: str) -> set[str] | None:
+    environ_path = Path(f"/proc/{pid}/environ")
+    try:
+        raw = environ_path.read_bytes()
+    except OSError:
+        return None
+    names = set()
+    for entry in raw.split(b"\0"):
+        if not entry:
+            continue
+        key, _, _value = entry.partition(b"=")
+        names.add(key.decode("utf-8", errors="replace"))
+    return names
+
+
+def _read_cmdline(pid: str) -> list[str] | None:
+    cmdline_path = Path(f"/proc/{pid}/cmdline")
+    try:
+        raw = cmdline_path.read_bytes()
+    except OSError:
+        return None
+    parts = [p.decode("utf-8", errors="replace") for p in raw.split(b"\0") if p]
+    return parts or None
+
+
+def check_pdf_config_and_process(
+    report: Report, service: str, main_pid: str | None
+) -> None:
+    active_name = f"service_active[{service}]"
+    if not main_pid or main_pid in ("0", ""):
+        report.record(
+            active_name,
+            False,
+            "SERVICE_INACTIVE",
+            f"{service}: no running MainPID",
+        )
+        report.record(
+            f"pdf_config[{service}]",
+            False,
+            "PDF_CONFIG_MISSING",
+            f"{service}: cannot inspect environment, service is not active",
+        )
+        return
+    report.record(active_name, True, "OK", f"{service}: active, MainPID={main_pid}")
+
+    names = _read_environ_names(main_pid)
+    if names is None:
+        report.record(
+            f"pdf_config[{service}]",
+            False,
+            "PDF_CONFIG_MISSING",
+            f"{service}: /proc/{main_pid}/environ not readable",
+        )
+    else:
+        missing = [v for v in REQUIRED_PDF_ENV_VARS if v not in names]
+        if missing:
+            report.record(
+                f"pdf_config[{service}]",
+                False,
+                "PDF_CONFIG_MISSING",
+                f"{service}: missing required variable(s): "
+                + ", ".join(sorted(missing))
+                + " (values never inspected or printed)",
+            )
+        else:
+            report.record(
+                f"pdf_config[{service}]",
+                True,
+                "OK",
+                f"{service}: all required OFFICE_PDF_* variables are present "
+                "(values not inspected)",
+            )
+        if OPTIONAL_LOGO_PATH_VAR in names:
+            # The variable's own value is a file path, not a secret, but per
+            # the read-only contract for this tool it is never printed here
+            # either — only whether it resolves to a readable regular file.
+            logo_ok = _check_logo_path_readable(main_pid, OPTIONAL_LOGO_PATH_VAR)
+            report.record(
+                f"pdf_logo_path[{service}]",
+                logo_ok,
+                "OK" if logo_ok else "PDF_CONFIG_MISSING",
+                f"{service}: {OPTIONAL_LOGO_PATH_VAR} is "
+                + (
+                    "a readable regular file"
+                    if logo_ok
+                    else "set but not a readable regular file"
+                ),
+            )
+        else:
+            report.record(
+                f"pdf_logo_path[{service}]",
+                True,
+                "OK",
+                f"{service}: {OPTIONAL_LOGO_PATH_VAR} not set (optional)",
+            )
+
+    cmdline = _read_cmdline(main_pid)
+    expected_argv = EXPECTED_UNIT_ARGV.get(service)
+    if cmdline is None:
+        report.record(
+            f"process_cmdline[{service}]",
+            False,
+            "TRACKED_UNIT_MISMATCH",
+            f"{service}: /proc/{main_pid}/cmdline not readable",
+        )
+    elif cmdline == expected_argv:
+        report.record(
+            f"process_cmdline[{service}]",
+            True,
+            "OK",
+            f"{service}: running command line matches the expected target",
+        )
+    else:
+        report.record(
+            f"process_cmdline[{service}]",
+            False,
+            "TRACKED_UNIT_MISMATCH",
+            f"{service}: running command line {cmdline!r} does not match "
+            f"expected {expected_argv!r}",
+        )
+
+
+def _check_logo_path_readable(pid: str, var_name: str) -> bool:
+    """Reads the variable's own value only to test file readability — the
+    value itself (a filesystem path) is never printed or stored."""
+    names = _read_environ_names(pid)
+    if names is None or var_name not in names:
+        return False
+    environ_path = Path(f"/proc/{pid}/environ")
+    try:
+        raw = environ_path.read_bytes()
+    except OSError:
+        return False
+    for entry in raw.split(b"\0"):
+        if not entry:
+            continue
+        key, sep, value = entry.partition(b"=")
+        if sep and key.decode("utf-8", errors="replace") == var_name:
+            candidate = Path(value.decode("utf-8", errors="replace"))
+            return candidate.is_file()
+    return False
+
+
+# --- mode assembly ------------------------------------------------------
+
+
+def run_repository_only(repo_root: Path) -> Report:
+    report = Report(mode="repository-only")
+    check_repository_state(report, repo_root)
+    check_tracked_units(report, repo_root)
+    return report
+
+
+def run_host_runtime(repo_root: Path, venv_path: Path) -> Report:
+    report = Report(mode="host-runtime")
+    check_repository_state(report, repo_root)
+    check_tracked_units(report, repo_root)
+    check_python_runtime(report, venv_path)
+
+    report.checks.append(
+        CheckResult(
+            name="process_prefix_limitation",
+            ok=True,
+            code="OK",
+            message=_HOST_LIMITATIONS,
+        )
+    )
+
+    for service in SERVICES:
+        props = check_effective_systemd(report, service)
+        main_pid = props.get("MainPID") if props else None
+        check_pdf_config_and_process(report, service, main_pid)
+
+    return report
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def _default_repo_root() -> Path:
+    # infra/deploy/verify_pdf_runtime.py -> repo root is two parents up.
+    return Path(__file__).resolve().parents[2]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only verification of the PDF runtime and systemd "
+            "alignment. Never mutates anything — see module docstring."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--repository-only",
+        action="store_true",
+        help="Checks that need no systemd or production access (CI-safe).",
+    )
+    mode.add_argument(
+        "--host-runtime",
+        action="store_true",
+        help="Adds real venv/reportlab/systemd/process checks. Run on the "
+        "target host only.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Override the repository root (defaults to the checkout this "
+        "script lives in). Use for local/test runs.",
+    )
+    parser.add_argument(
+        "--venv-path",
+        type=Path,
+        default=None,
+        help="Override the expected venv path for --host-runtime (defaults "
+        "to <repo-root>/.venv). Use for local/test runs.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON in addition to the human-readable report.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root or _default_repo_root()
+
+    if args.repository_only:
+        report = run_repository_only(repo_root)
+    else:
+        venv_path = args.venv_path or (repo_root / ".venv")
+        report = run_host_runtime(repo_root, venv_path)
+
+    if args.json:
+        print(json.dumps(report.to_json(), indent=2, sort_keys=True))
+    else:
+        print(report.render_human())
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/deploy/verify_pdf_runtime.py
+++ b/infra/deploy/verify_pdf_runtime.py
@@ -7,10 +7,12 @@ This tool never mutates anything: no package installation, no `uv sync`, no
 systemd unit installation, no `daemon-reload`, no service restart, no
 override edit/removal, no application code change, no database write. It
 only reads git-tracked files, runs `uv lock --check` (itself read-only),
-queries systemd with `systemctl show`/`systemctl cat`, reads `/proc/<pid>/
-cmdline` and `/proc/<pid>/environ` (variable *names* only — values are never
-printed), and runs the target interpreter with a side-effect-free `-c` probe
-to introspect `sys.prefix` and import `reportlab`.
+queries systemd with `systemctl show` (never `systemctl cat` — `show` alone
+is sufficient, since it already reports the effective, drop-in-resolved
+property values this tool needs), reads `/proc/<pid>/cmdline` and
+`/proc/<pid>/environ` (variable *names* only — values are never printed),
+and runs the target interpreter with a side-effect-free `-c` probe to
+introspect `sys.prefix` and import `reportlab`.
 
 Why not `/proc/<pid>/exe`: the project venv is a standard stdlib venv, so
 `.venv/bin/python3` is a *symlink* to the system interpreter. `/proc/<pid>/
@@ -49,6 +51,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shlex
 import subprocess
 from dataclasses import dataclass, field
@@ -195,28 +198,53 @@ class Report:
 # --- subprocess plumbing (isolated for testability) ------------------------
 
 
-def _run(cmd: Sequence[str], timeout: float = _SUBPROCESS_TIMEOUT_SECONDS):
+def _run(
+    cmd: Sequence[str],
+    timeout: float = _SUBPROCESS_TIMEOUT_SECONDS,
+    cwd: Path | None = None,
+):
     """The only place that shells out. No shell=True, explicit timeout.
 
     Tests replace this function (module-level monkeypatch) to supply canned
     output instead of requiring a real systemd host or a real venv.
     """
     return subprocess.run(
-        list(cmd), check=False, capture_output=True, text=True, timeout=timeout
+        list(cmd),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
     )
 
 
 class CommandUnavailable(RuntimeError):
-    """Raised when the target binary does not exist on PATH."""
+    """Raised when the target command could not be launched at all — the
+    binary is missing, not executable, or the launch otherwise failed at the
+    OS level (covers FileNotFoundError, PermissionError, NotADirectoryError,
+    and similar subprocess-launch OSErrors uniformly)."""
 
 
-def _run_or_raise(cmd: Sequence[str], timeout: float = _SUBPROCESS_TIMEOUT_SECONDS):
+class ExecStartParseError(ValueError):
+    """Raised when an ExecStart value cannot be tokenized (e.g. unbalanced
+    quoting). Callers convert this into a clean failed CheckResult instead of
+    letting shlex's ValueError propagate as an uncaught traceback."""
+
+
+def _run_or_raise(
+    cmd: Sequence[str],
+    timeout: float = _SUBPROCESS_TIMEOUT_SECONDS,
+    cwd: Path | None = None,
+):
     try:
-        return _run(cmd, timeout=timeout)
-    except FileNotFoundError as exc:
-        raise CommandUnavailable(str(exc)) from exc
+        return _run(cmd, timeout=timeout, cwd=cwd)
     except subprocess.TimeoutExpired as exc:
         raise CommandUnavailable(f"timed out after {timeout}s: {exc}") from exc
+    except OSError as exc:
+        # FileNotFoundError (binary missing) is an OSError subclass, so this
+        # also covers PermissionError (exists but not executable) and other
+        # exec-time failures without needing a separate except clause.
+        raise CommandUnavailable(f"{type(exc).__name__}: {exc}") from exc
 
 
 # --- repository-state checks (safe in both modes) ---------------------------
@@ -258,7 +286,7 @@ def check_repository_state(report: Report, repo_root: Path) -> None:
         return
 
     try:
-        result = _run_or_raise(["uv", "lock", "--check"], timeout=60.0)
+        result = _run_or_raise(["uv", "lock", "--check"], timeout=60.0, cwd=repo_root)
     except CommandUnavailable as exc:
         report.record(
             "uv_lock_check",
@@ -284,13 +312,21 @@ def check_repository_state(report: Report, repo_root: Path) -> None:
 
 
 def _parse_exec_start(unit_text: str) -> list[str] | None:
+    """Returns None when no ExecStart line is present (or it's empty).
+    Raises ExecStartParseError — never a bare shlex ValueError — when a line
+    is present but its syntax can't be tokenized (e.g. unbalanced quoting)."""
     for line in unit_text.splitlines():
         stripped = line.strip()
         if stripped.startswith("ExecStart="):
             value = stripped[len("ExecStart=") :].strip()
             if not value:
                 return None
-            return shlex.split(value)
+            try:
+                return shlex.split(value)
+            except ValueError as exc:
+                raise ExecStartParseError(
+                    f"ExecStart has malformed syntax: {exc}"
+                ) from exc
     return None
 
 
@@ -306,7 +342,16 @@ def check_tracked_units(report: Report, repo_root: Path) -> None:
                 f"{unit_path} not found",
             )
             continue
-        argv = _parse_exec_start(unit_path.read_text(encoding="utf-8"))
+        try:
+            argv = _parse_exec_start(unit_path.read_text(encoding="utf-8"))
+        except ExecStartParseError as exc:
+            report.record(
+                name,
+                False,
+                "TRACKED_UNIT_MISMATCH",
+                f"{filename}: {exc}",
+            )
+            continue
         expected = EXPECTED_UNIT_ARGV[service]
         if argv == expected:
             report.record(
@@ -384,7 +429,20 @@ def check_python_runtime(report: Report, venv_path: Path) -> InterpreterProbe | 
             f"{python_path} is not a regular file or symlink",
         )
         return None
-    report.record("runtime_interpreter_present", True, "OK", f"{python_path} exists")
+    if not os.access(python_path, os.X_OK):
+        report.record(
+            "runtime_interpreter_present",
+            False,
+            "RUNTIME_INTERPRETER_MISSING",
+            f"{python_path} exists but is not executable",
+        )
+        return None
+    report.record(
+        "runtime_interpreter_present",
+        True,
+        "OK",
+        f"{python_path} exists and is executable",
+    )
 
     probe = probe_interpreter(python_path)
     if not probe.ok:
@@ -495,6 +553,9 @@ def _systemctl_show(service: str, *properties: str) -> dict[str, str] | None:
 
 
 def _extract_effective_argv(exec_start_value: str) -> list[str] | None:
+    """Returns None when no argv[]= segment is present. Raises
+    ExecStartParseError — never a bare shlex ValueError — when a segment is
+    present but its syntax can't be tokenized (e.g. unbalanced quoting)."""
     marker = "argv[]="
     start = exec_start_value.find(marker)
     if start == -1:
@@ -502,7 +563,12 @@ def _extract_effective_argv(exec_start_value: str) -> list[str] | None:
     start += len(marker)
     end = exec_start_value.find(" ;", start)
     segment = exec_start_value[start:end] if end != -1 else exec_start_value[start:]
-    return shlex.split(segment.strip())
+    try:
+        return shlex.split(segment.strip())
+    except ValueError as exc:
+        raise ExecStartParseError(
+            f"effective ExecStart has malformed syntax: {exc}"
+        ) from exc
 
 
 def check_effective_systemd(report: Report, service: str) -> dict[str, str] | None:
@@ -521,10 +587,16 @@ def check_effective_systemd(report: Report, service: str) -> dict[str, str] | No
         return None
 
     exec_start = props.get("ExecStart", "")
-    effective_argv = _extract_effective_argv(exec_start)
     expected_argv = EXPECTED_UNIT_ARGV.get(service)
     drop_in_paths = props.get("DropInPaths", "").strip()
     override_present = bool(drop_in_paths)
+
+    try:
+        effective_argv = _extract_effective_argv(exec_start)
+    except ExecStartParseError as exc:
+        code = "MISMATCHED_OVERRIDE" if override_present else "TRACKED_UNIT_MISMATCH"
+        report.record(name, False, code, f"{service}: {exc}")
+        return props
 
     if effective_argv is None:
         report.record(
@@ -595,15 +667,25 @@ def _read_cmdline(pid: str) -> list[str] | None:
 
 
 def check_pdf_config_and_process(
-    report: Report, service: str, main_pid: str | None
+    report: Report, service: str, props: dict[str, str] | None
 ) -> None:
+    """`props` is the dict returned by check_effective_systemd — this reuses
+    the already-fetched ActiveState/MainPID rather than re-querying. Both
+    ActiveState == 'active' and a non-zero MainPID are required: MainPID
+    alone is not sufficient evidence (a unit mid-'activating' can already
+    have a forked-but-not-yet-active MainPID), and ActiveState alone doesn't
+    tell us which PID to inspect."""
     active_name = f"service_active[{service}]"
-    if not main_pid or main_pid in ("0", ""):
+    active_state = props.get("ActiveState") if props else None
+    main_pid = props.get("MainPID") if props else None
+    has_pid = bool(main_pid) and main_pid not in ("0", "")
+    if active_state != "active" or not has_pid:
         report.record(
             active_name,
             False,
             "SERVICE_INACTIVE",
-            f"{service}: no running MainPID",
+            f"{service}: not active (ActiveState={active_state!r}, "
+            f"MainPID={main_pid!r})",
         )
         report.record(
             f"pdf_config[{service}]",
@@ -612,6 +694,7 @@ def check_pdf_config_and_process(
             f"{service}: cannot inspect environment, service is not active",
         )
         return
+    assert main_pid is not None  # narrowed by has_pid above
     report.record(active_name, True, "OK", f"{service}: active, MainPID={main_pid}")
 
     names = _read_environ_names(main_pid)
@@ -739,8 +822,7 @@ def run_host_runtime(repo_root: Path, venv_path: Path) -> Report:
 
     for service in SERVICES:
         props = check_effective_systemd(report, service)
-        main_pid = props.get("MainPID") if props else None
-        check_pdf_config_and_process(report, service, main_pid)
+        check_pdf_config_and_process(report, service, props)
 
     return report
 

--- a/tests/unit/test_verify_pdf_runtime.py
+++ b/tests/unit/test_verify_pdf_runtime.py
@@ -1,0 +1,574 @@
+"""PDF_RUNTIME_VERIFICATION_SCRIPT_V1 — infra/deploy/verify_pdf_runtime.py.
+
+No real systemd host and no real venv are required: every subprocess call
+goes through the module's single `_run` seam, which these tests monkeypatch
+with canned CompletedProcess-shaped output. Filesystem-backed checks (unit
+files, /proc/<pid>/{cmdline,environ}) use tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_INFRA_DEPLOY = Path(__file__).resolve().parents[2] / "infra" / "deploy"
+if str(_INFRA_DEPLOY) not in sys.path:
+    sys.path.insert(0, str(_INFRA_DEPLOY))
+
+import verify_pdf_runtime as vpr  # noqa: E402
+
+_API_ARGV = vpr.EXPECTED_UNIT_ARGV["catering-office-api"]
+_PANEL_ARGV = vpr.EXPECTED_UNIT_ARGV["catering-office-panel"]
+_VENV_PY = vpr.EXPECTED_VENV_INTERPRETER
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    """Shaped like subprocess.CompletedProcess for the parts this module reads."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_unit(repo_root: Path, service: str, argv: list[str]) -> Path:
+    unit_dir = repo_root / "infra" / "systemd"
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    exec_line = "ExecStart=" + " ".join(argv)
+    text = (
+        "[Unit]\nDescription=test\n\n[Service]\nUser=viktor\n"
+        f"{exec_line}\nRestart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n"
+    )
+    path = unit_dir / vpr.TRACKED_UNIT_FILES[service]
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_valid_units(repo_root: Path) -> None:
+    _write_unit(repo_root, "catering-office-api", _API_ARGV)
+    _write_unit(repo_root, "catering-office-panel", _PANEL_ARGV)
+
+
+def _base_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    (root / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    _write_valid_units(root)
+    return root
+
+
+def _find(report: vpr.Report, code: str) -> vpr.CheckResult:
+    matches = [c for c in report.checks if c.code == code]
+    assert matches, (
+        f"no check with code {code!r} among {[c.code for c in report.checks]}"
+    )
+    return matches[0]
+
+
+def _has_failure(report: vpr.Report, code: str) -> bool:
+    return any((not c.ok) and c.code == code for c in report.checks)
+
+
+# --- 1/2/3: tracked unit checks ---------------------------------------------
+
+
+def test_tracked_unit_correct_interpreter_passes(tmp_path: Path) -> None:
+    repo = _base_repo(tmp_path)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_tracked_units(report, repo)
+    assert report.ok
+    for service in vpr.SERVICES:
+        assert any(c.name == f"tracked_unit[{service}]" and c.ok for c in report.checks)
+
+
+def test_tracked_unit_system_python_fails(tmp_path: Path) -> None:
+    repo = _base_repo(tmp_path)
+    _write_unit(
+        repo,
+        "catering-office-api",
+        ["/usr/bin/python3"] + _API_ARGV[1:],
+    )
+    report = vpr.Report(mode="repository-only")
+    vpr.check_tracked_units(report, repo)
+    assert not report.ok
+    assert _has_failure(report, "TRACKED_UNIT_MISMATCH")
+
+
+def test_tracked_unit_argument_mismatch_fails(tmp_path: Path) -> None:
+    repo = _base_repo(tmp_path)
+    wrong = _API_ARGV[:-1] + ["9999"]  # wrong port
+    _write_unit(repo, "catering-office-api", wrong)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_tracked_units(report, repo)
+    assert not report.ok
+    assert _has_failure(report, "TRACKED_UNIT_MISMATCH")
+
+
+# --- 4/5: uv.lock presence and currency -------------------------------------
+
+
+def test_uv_lock_absent_fails(tmp_path: Path) -> None:
+    repo = _base_repo(tmp_path)
+    (repo / "uv.lock").unlink()
+    report = vpr.Report(mode="repository-only")
+    vpr.check_repository_state(report, repo)
+    assert not report.ok
+    assert _has_failure(report, "LOCK_MISSING")
+
+
+def test_uv_lock_check_failure_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        assert cmd[:2] == ["uv", "lock"]
+        return _proc(returncode=1, stderr="error: lock file is not up to date\n")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_repository_state(report, repo)
+    assert not report.ok
+    assert _has_failure(report, "LOCK_OUT_OF_DATE")
+
+
+def test_uv_binary_missing_reports_lock_out_of_date_not_crash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        raise FileNotFoundError("uv")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_repository_state(report, repo)  # must not raise
+    assert not report.ok
+    assert _has_failure(report, "LOCK_OUT_OF_DATE")
+
+
+# --- 6: interpreter missing --------------------------------------------------
+
+
+def test_venv_interpreter_missing_fails(tmp_path: Path) -> None:
+    venv = tmp_path / "no-such-venv"
+    report = vpr.Report(mode="host-runtime")
+    probe = vpr.check_python_runtime(report, venv)
+    assert probe is None
+    assert not report.ok
+    assert _has_failure(report, "RUNTIME_INTERPRETER_MISSING")
+
+
+# --- 7/8/9: reportlab + prefix checks, via a fake venv python --------------
+
+
+def _make_fake_python(tmp_path: Path, payload: dict) -> Path:
+    """A real, executable script standing in for .venv/bin/python3 — this is
+    the 'fake command output' the task asks for, without needing a real venv
+    or monkeypatching subprocess for these particular checks."""
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    script = bin_dir / "python3"
+    script.write_text(
+        f"#!/usr/bin/env python3\nimport json, sys\nprint(json.dumps({payload!r}))\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return venv
+
+
+def test_reportlab_missing_fails(tmp_path: Path) -> None:
+    venv = _make_fake_python(
+        tmp_path,
+        {
+            "executable": "x",
+            "prefix": str(tmp_path / "venv"),
+            "base_prefix": "/usr",
+            "version": "3.12.0",
+            "reportlab_error": "ModuleNotFoundError: No module named 'reportlab'",
+        },
+    )
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_python_runtime(report, venv)
+    assert not report.ok
+    assert _has_failure(report, "REPORTLAB_MISSING")
+
+
+def test_reportlab_wrong_version_fails(tmp_path: Path) -> None:
+    venv = _make_fake_python(
+        tmp_path,
+        {
+            "executable": "x",
+            "prefix": str(tmp_path / "venv"),
+            "base_prefix": "/usr",
+            "version": "3.12.0",
+            "reportlab_version": "4.0.0",
+            "reportlab_file": str(
+                tmp_path / "venv" / "lib" / "reportlab" / "__init__.py"
+            ),
+        },
+    )
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_python_runtime(report, venv)
+    assert not report.ok
+    assert _has_failure(report, "REPORTLAB_VERSION_MISMATCH")
+
+
+def test_sys_prefix_outside_venv_fails(tmp_path: Path) -> None:
+    venv = _make_fake_python(
+        tmp_path,
+        {
+            "executable": "x",
+            "prefix": "/usr",  # wrong: equals base_prefix, not the venv
+            "base_prefix": "/usr",
+            "version": "3.12.0",
+            "reportlab_version": "5.0.0",
+            "reportlab_file": str(
+                tmp_path / "venv" / "lib" / "reportlab" / "__init__.py"
+            ),
+        },
+    )
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_python_runtime(report, venv)
+    assert not report.ok
+    assert _has_failure(report, "VENV_PREFIX_MISMATCH")
+
+
+def test_reportlab_correct_and_in_venv_passes(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    reportlab_file = (
+        venv_dir / "lib" / "python3.12" / "site-packages" / "reportlab" / "__init__.py"
+    )
+    venv = _make_fake_python(
+        tmp_path,
+        {
+            "executable": str(venv_dir / "bin" / "python3"),
+            "prefix": str(venv_dir),
+            "base_prefix": "/usr",
+            "version": "3.12.0",
+            "reportlab_version": "5.0.0",
+            "reportlab_file": str(reportlab_file),
+        },
+    )
+    assert venv == venv_dir
+    report = vpr.Report(mode="host-runtime")
+    probe = vpr.check_python_runtime(report, venv)
+    assert probe is not None and probe.ok
+    assert report.ok
+    assert _find(report, "OK")  # at least one passing OK-coded check exists
+
+
+# --- 10: required PDF variable absent, values never exposed ----------------
+
+
+def _write_proc_pid(
+    tmp_path: Path, pid: str, *, environ_pairs: list[tuple[str, str]], argv: list[str]
+):
+    proc_dir = tmp_path / "proc" / pid
+    proc_dir.mkdir(parents=True)
+    environ_blob = "".join(f"{k}={v}\0" for k, v in environ_pairs)
+    (proc_dir / "environ").write_bytes(environ_blob.encode("utf-8"))
+    cmdline_blob = "".join(f"{a}\0" for a in argv)
+    (proc_dir / "cmdline").write_bytes(cmdline_blob.encode("utf-8"))
+    return proc_dir
+
+
+def test_missing_pdf_variable_fails_without_exposing_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pid = "4242"
+    secret_value = "s3cr3t-legal-name-should-never-appear"
+    proc_dir = _write_proc_pid(
+        tmp_path,
+        pid,
+        environ_pairs=[
+            ("HOME", "/home/viktor"),
+            ("OFFICE_PDF_COMPANY_LEGAL_NAME", secret_value),
+            # OFFICE_PDF_COMPANY_ADDRESS_LINES and OFFICE_PDF_ACCEPTANCE_STATEMENT
+            # are intentionally absent.
+        ],
+        argv=_API_ARGV,
+    )
+    monkeypatch.setattr(
+        vpr,
+        "_read_environ_names",
+        lambda p: (
+            {k for k, _v in [("HOME", ""), ("OFFICE_PDF_COMPANY_LEGAL_NAME", "")]}
+            if p == pid
+            else None
+        ),
+    )
+    monkeypatch.setattr(vpr, "_read_cmdline", lambda p: _API_ARGV if p == pid else None)
+
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_pdf_config_and_process(report, "catering-office-api", pid)
+
+    assert not report.ok
+    failure = _find(report, "PDF_CONFIG_MISSING")
+    assert "OFFICE_PDF_COMPANY_ADDRESS_LINES" in failure.message
+    assert "OFFICE_PDF_ACCEPTANCE_STATEMENT" in failure.message
+    for check in report.checks:
+        assert secret_value not in check.message
+    rendered = report.render_human()
+    assert secret_value not in rendered
+    _ = proc_dir  # written for documentation of the real /proc shape; reads are monkeypatched
+
+
+# --- 11/12/13: effective vs tracked systemd classification -----------------
+
+
+def _systemctl_show_output(
+    *,
+    argv: list[str],
+    active: bool = True,
+    pid: str = "111",
+    override: str | None = None,
+) -> str:
+    exec_start = (
+        "{ path=" + argv[0] + " ; argv[]=" + " ".join(argv) + " ; ignore_errors=no }"
+    )
+    lines = [
+        f"ExecStart={exec_start}",
+        "FragmentPath=/etc/systemd/system/catering-office-api.service",
+        f"DropInPaths={override or ''}",
+        f"ActiveState={'active' if active else 'inactive'}",
+        f"MainPID={pid if active else '0'}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def test_effective_matches_tracked_no_override_ready_without_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        assert cmd[0] == "systemctl"
+        return _proc(
+            returncode=0, stdout=_systemctl_show_output(argv=_API_ARGV, override=None)
+        )
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="host-runtime")
+    props = vpr.check_effective_systemd(report, "catering-office-api")
+    assert props is not None
+    assert report.ok
+    match = _find(report, "READY_WITHOUT_OVERRIDE")
+    assert match.ok
+
+
+def test_compatible_override_ready_with_compatible_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    override_path = "/etc/systemd/system/catering-office-api.service.d/override.conf"
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        return _proc(
+            returncode=0,
+            stdout=_systemctl_show_output(argv=_API_ARGV, override=override_path),
+        )
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_effective_systemd(report, "catering-office-api")
+    assert report.ok
+    match = _find(report, "READY_WITH_COMPATIBLE_OVERRIDE")
+    assert match.ok
+    assert override_path in match.message
+
+
+def test_override_changes_command_mismatched_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    override_path = "/etc/systemd/system/catering-office-api.service.d/override.conf"
+    wrong_argv = ["/usr/bin/python3"] + _API_ARGV[1:]
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        return _proc(
+            returncode=0,
+            stdout=_systemctl_show_output(argv=wrong_argv, override=override_path),
+        )
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_effective_systemd(report, "catering-office-api")
+    assert not report.ok
+    assert _has_failure(report, "MISMATCHED_OVERRIDE")
+
+
+# --- 14: inactive service ----------------------------------------------------
+
+
+def test_inactive_service_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_pdf_config_and_process(report, "catering-office-api", None)
+    assert not report.ok
+    assert _has_failure(report, "SERVICE_INACTIVE")
+
+
+# --- 15: /proc/<pid>/exe must never be consulted ----------------------------
+
+
+def test_proc_pid_exe_never_used_for_venv_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misleading /proc/<pid>/exe (resolving to the system interpreter, as
+    it always does for a stdlib venv symlink) must not cause a false
+    failure, because this module never reads it at all."""
+    import os
+
+    real_readlink = os.readlink
+
+    def exploding_readlink(path, *a, **kw):  # noqa: ANN001
+        if "/exe" in str(path):
+            raise AssertionError(
+                "verify_pdf_runtime must never consult /proc/<pid>/exe"
+            )
+        return real_readlink(path, *a, **kw)
+
+    monkeypatch.setattr(os, "readlink", exploding_readlink)
+
+    pid = "555"
+    monkeypatch.setattr(
+        vpr,
+        "_read_environ_names",
+        lambda p: (
+            {
+                "OFFICE_PDF_COMPANY_LEGAL_NAME",
+                "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+                "OFFICE_PDF_ACCEPTANCE_STATEMENT",
+            }
+            if p == pid
+            else None
+        ),
+    )
+    monkeypatch.setattr(vpr, "_read_cmdline", lambda p: _API_ARGV if p == pid else None)
+
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_pdf_config_and_process(report, "catering-office-api", pid)
+    assert report.ok  # would only fail if something wrongly touched /proc/pid/exe
+
+
+# --- 16: repository-only mode needs no systemd ------------------------------
+
+
+def test_repository_only_mode_never_calls_systemctl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        if cmd[0] == "systemctl":
+            raise AssertionError("repository-only mode must not call systemctl")
+        assert cmd[:2] == ["uv", "lock"]
+        return _proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.run_repository_only(repo)
+    assert report.ok
+    assert report.mode == "repository-only"
+
+
+# --- 17: subprocess timeouts are explicit and fail clearly ------------------
+
+
+def test_subprocess_timeout_fails_clearly_not_crash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        assert timeout is not None and timeout > 0
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_repository_state(report, repo)  # must not raise
+    assert not report.ok
+    failure = _find(report, "LOCK_OUT_OF_DATE")
+    assert "timed out" in failure.message
+
+
+def test_all_run_call_sites_pass_an_explicit_timeout() -> None:
+    """Static guard: every _run(...) call site in the module supplies an
+    explicit timeout, either via the caller's default parameter or a literal
+    — subprocess.run must never be called with an unbounded wait."""
+    import ast
+
+    source = (_INFRA_DEPLOY / "verify_pdf_runtime.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    run_def_default = None
+    call_sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_run":
+            run_def_default = node
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("_run", "_run_or_raise")
+        ):
+            call_sites.append(node)
+    assert run_def_default is not None
+    assert run_def_default.args.defaults, "_run must default its timeout parameter"
+    assert call_sites, "expected at least one _run/_run_or_raise call site"
+    for call in call_sites:
+        has_explicit = any(kw.arg == "timeout" for kw in call.keywords)
+        assert has_explicit or run_def_default.args.defaults, (
+            f"call at line {call.lineno} has no explicit timeout and no default"
+        )
+
+
+# --- CLI-level smoke: mode is required, mutually exclusive ------------------
+
+
+def test_cli_requires_explicit_mode() -> None:
+    parser = vpr.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_cli_modes_are_mutually_exclusive() -> None:
+    parser = vpr.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--repository-only", "--host-runtime"])
+
+
+def test_main_returns_zero_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        assert cmd[:2] == ["uv", "lock"]
+        return _proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    code = vpr.main(["--repository-only", "--repo-root", str(repo)])
+    assert code == 0
+
+
+def test_main_returns_nonzero_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _base_repo(tmp_path)
+    (repo / "uv.lock").unlink()
+    code = vpr.main(["--repository-only", "--repo-root", str(repo)])
+    assert code == 1
+
+
+def test_main_json_output_is_valid_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _base_repo(tmp_path)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+        return _proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    code = vpr.main(["--repository-only", "--repo-root", str(repo), "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "repository-only"
+    assert payload["ok"] is True
+    assert isinstance(payload["checks"], list) and payload["checks"]

--- a/tests/unit/test_verify_pdf_runtime.py
+++ b/tests/unit/test_verify_pdf_runtime.py
@@ -106,6 +106,45 @@ def test_tracked_unit_argument_mismatch_fails(tmp_path: Path) -> None:
     assert _has_failure(report, "TRACKED_UNIT_MISMATCH")
 
 
+def test_malformed_tracked_exec_start_fails_clean_not_crash(tmp_path: Path) -> None:
+    """Unbalanced quoting in a tracked unit's ExecStart must not let shlex's
+    ValueError escape as an uncaught traceback."""
+    repo = _base_repo(tmp_path)
+    unit_dir = repo / "infra" / "systemd"
+    malformed = (
+        "[Unit]\nDescription=test\n\n[Service]\nUser=viktor\n"
+        'ExecStart=/usr/bin/python3 -m foo --arg "unterminated\n'
+        "Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n"
+    )
+    (unit_dir / vpr.TRACKED_UNIT_FILES["catering-office-api"]).write_text(
+        malformed, encoding="utf-8"
+    )
+
+    report = vpr.Report(mode="repository-only")
+    vpr.check_tracked_units(report, repo)  # must not raise
+
+    assert not report.ok
+    failure = _find(report, "TRACKED_UNIT_MISMATCH")
+    assert "catering-office-api.service" in failure.message
+    assert "malformed" in failure.message.lower()
+
+
+def test_extract_effective_argv_malformed_raises_parse_error() -> None:
+    """Unit-level: malformed argv[]= syntax raises the dedicated
+    ExecStartParseError, never a bare shlex ValueError."""
+    malformed = (
+        "{ path=/usr/bin/python3 ; argv[]=/usr/bin/python3 -m foo "
+        '--arg "unterminated ; ignore_errors=no }'
+    )
+    with pytest.raises(vpr.ExecStartParseError):
+        vpr._extract_effective_argv(malformed)
+
+
+def test_parse_exec_start_malformed_raises_parse_error() -> None:
+    with pytest.raises(vpr.ExecStartParseError):
+        vpr._parse_exec_start('ExecStart=/usr/bin/python3 --arg "unterminated')
+
+
 # --- 4/5: uv.lock presence and currency -------------------------------------
 
 
@@ -123,7 +162,7 @@ def test_uv_lock_check_failure_fails(
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         assert cmd[:2] == ["uv", "lock"]
         return _proc(returncode=1, stderr="error: lock file is not up to date\n")
 
@@ -139,7 +178,7 @@ def test_uv_binary_missing_reports_lock_out_of_date_not_crash(
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         raise FileNotFoundError("uv")
 
     monkeypatch.setattr(vpr, "_run", fake_run)
@@ -147,6 +186,29 @@ def test_uv_binary_missing_reports_lock_out_of_date_not_crash(
     vpr.check_repository_state(report, repo)  # must not raise
     assert not report.ok
     assert _has_failure(report, "LOCK_OUT_OF_DATE")
+
+
+def test_uv_lock_check_runs_with_repo_root_as_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: `uv lock --check` must run with repo_root as its cwd, not
+    whatever directory the verifier process itself happens to be started
+    from — otherwise --repo-root would silently validate the wrong project
+    (caught empirically via a real, unmocked CLI run against a --repo-root
+    that differed from the shell's cwd)."""
+    repo = _base_repo(tmp_path)
+    seen_cwd: list[object] = []
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, cwd=None, **_kw):
+        if cmd[:2] == ["uv", "lock"]:
+            seen_cwd.append(cwd)
+        return _proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="repository-only")
+    vpr.check_repository_state(report, repo)
+    assert report.ok
+    assert seen_cwd == [repo]
 
 
 # --- 6: interpreter missing --------------------------------------------------
@@ -159,6 +221,80 @@ def test_venv_interpreter_missing_fails(tmp_path: Path) -> None:
     assert probe is None
     assert not report.ok
     assert _has_failure(report, "RUNTIME_INTERPRETER_MISSING")
+
+
+def test_venv_interpreter_exists_but_not_executable_fails_clean(
+    tmp_path: Path,
+) -> None:
+    """Existence alone is not enough — the file must also be executable.
+    Caught by the explicit os.access(X_OK) check before any subprocess
+    launch is even attempted, so the message can say 'not executable'
+    distinctly from 'does not exist'."""
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    python_path = bin_dir / "python3"
+    python_path.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    python_path.chmod(0o644)  # deliberately not executable
+
+    report = vpr.Report(mode="host-runtime")
+    probe = vpr.check_python_runtime(report, venv)  # must not raise
+
+    assert probe is None
+    assert not report.ok
+    failure = _find(report, "RUNTIME_INTERPRETER_MISSING")
+    assert "not executable" in failure.message
+    assert "does not exist" not in failure.message
+
+
+def test_subprocess_launch_permission_error_fails_clean_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even if the os.access(X_OK) pre-check somehow passes (e.g. a TOCTOU
+    race, or a filesystem where the bit lies), a PermissionError raised by
+    the actual subprocess launch must be converted to a clean failure by
+    _run_or_raise's broadened OSError handling — never an uncaught
+    traceback. Exercised directly against probe_interpreter, the function
+    that performs the launch, with a real executable-looking (but
+    PermissionError-raising) target."""
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    probe = vpr.probe_interpreter(Path("/some/venv/bin/python3"))  # must not raise
+
+    assert probe.ok is False
+    assert probe.error is not None
+    assert "PermissionError" in probe.error
+
+
+def test_run_or_raise_wraps_permission_error_as_command_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unit-level: PermissionError (an OSError subclass) is caught uniformly
+    alongside FileNotFoundError, not just the latter specifically."""
+
+    def raising_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(vpr, "_run", raising_run)
+    with pytest.raises(vpr.CommandUnavailable, match="PermissionError"):
+        vpr._run_or_raise(["x"])
+
+
+def test_run_or_raise_still_wraps_file_not_found_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: broadening the except clause to OSError must not
+    lose the pre-existing FileNotFoundError ('uv' binary missing) coverage."""
+
+    def raising_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(vpr, "_run", raising_run)
+    with pytest.raises(vpr.CommandUnavailable, match="FileNotFoundError"):
+        vpr._run_or_raise(["x"])
 
 
 # --- 7/8/9: reportlab + prefix checks, via a fake venv python --------------
@@ -304,7 +440,8 @@ def test_missing_pdf_variable_fails_without_exposing_values(
     monkeypatch.setattr(vpr, "_read_cmdline", lambda p: _API_ARGV if p == pid else None)
 
     report = vpr.Report(mode="host-runtime")
-    vpr.check_pdf_config_and_process(report, "catering-office-api", pid)
+    props = {"ActiveState": "active", "MainPID": pid}
+    vpr.check_pdf_config_and_process(report, "catering-office-api", props)
 
     assert not report.ok
     failure = _find(report, "PDF_CONFIG_MISSING")
@@ -343,7 +480,7 @@ def _systemctl_show_output(
 def test_effective_matches_tracked_no_override_ready_without_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         assert cmd[0] == "systemctl"
         return _proc(
             returncode=0, stdout=_systemctl_show_output(argv=_API_ARGV, override=None)
@@ -363,7 +500,7 @@ def test_compatible_override_ready_with_compatible_override(
 ) -> None:
     override_path = "/etc/systemd/system/catering-office-api.service.d/override.conf"
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         return _proc(
             returncode=0,
             stdout=_systemctl_show_output(argv=_API_ARGV, override=override_path),
@@ -378,13 +515,73 @@ def test_compatible_override_ready_with_compatible_override(
     assert override_path in match.message
 
 
+def test_malformed_effective_exec_start_no_override_fails_clean_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unbalanced quoting in systemctl's reported ExecStart must not crash
+    check_effective_systemd — no override present, so the closest explicit
+    host-runtime mismatch classification is TRACKED_UNIT_MISMATCH."""
+    malformed = (
+        "{ path=/usr/bin/python3 ; argv[]=/usr/bin/python3 -m foo "
+        '--arg "unterminated ; ignore_errors=no }'
+    )
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        lines = [
+            f"ExecStart={malformed}",
+            "FragmentPath=/etc/systemd/system/catering-office-api.service",
+            "DropInPaths=",
+            "ActiveState=active",
+            "MainPID=111",
+        ]
+        return _proc(returncode=0, stdout="\n".join(lines) + "\n")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="host-runtime")
+    props = vpr.check_effective_systemd(report, "catering-office-api")  # must not raise
+
+    assert props is not None
+    assert not report.ok
+    assert _has_failure(report, "TRACKED_UNIT_MISMATCH")
+
+
+def test_malformed_effective_exec_start_with_override_fails_clean_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same malformed syntax, but with an override present — the failure
+    classification should be MISMATCHED_OVERRIDE, consistent with how a
+    parseable-but-wrong effective command is classified two lines below."""
+    override_path = "/etc/systemd/system/catering-office-api.service.d/override.conf"
+    malformed = (
+        "{ path=/usr/bin/python3 ; argv[]=/usr/bin/python3 -m foo "
+        '--arg "unterminated ; ignore_errors=no }'
+    )
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        lines = [
+            f"ExecStart={malformed}",
+            "FragmentPath=/etc/systemd/system/catering-office-api.service",
+            f"DropInPaths={override_path}",
+            "ActiveState=active",
+            "MainPID=111",
+        ]
+        return _proc(returncode=0, stdout="\n".join(lines) + "\n")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    report = vpr.Report(mode="host-runtime")
+    vpr.check_effective_systemd(report, "catering-office-api")  # must not raise
+
+    assert not report.ok
+    assert _has_failure(report, "MISMATCHED_OVERRIDE")
+
+
 def test_override_changes_command_mismatched_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     override_path = "/etc/systemd/system/catering-office-api.service.d/override.conf"
     wrong_argv = ["/usr/bin/python3"] + _API_ARGV[1:]
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         return _proc(
             returncode=0,
             stdout=_systemctl_show_output(argv=wrong_argv, override=override_path),
@@ -405,6 +602,92 @@ def test_inactive_service_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     vpr.check_pdf_config_and_process(report, "catering-office-api", None)
     assert not report.ok
     assert _has_failure(report, "SERVICE_INACTIVE")
+
+
+def test_active_state_inactive_with_nonzero_pid_fails_closed() -> None:
+    """MainPID alone is not sufficient evidence of activity: a unit that
+    reports ActiveState=inactive must fail SERVICE_INACTIVE even if MainPID
+    is non-zero (or outright malformed) — both properties are required."""
+    report = vpr.Report(mode="host-runtime")
+    props = {"ActiveState": "inactive", "MainPID": "4242"}
+    vpr.check_pdf_config_and_process(report, "catering-office-api", props)
+    assert not report.ok
+    assert _has_failure(report, "SERVICE_INACTIVE")
+
+    report2 = vpr.Report(mode="host-runtime")
+    malformed_props = {"ActiveState": "inactive", "MainPID": "not-a-pid"}
+    vpr.check_pdf_config_and_process(report2, "catering-office-api", malformed_props)
+    assert not report2.ok
+    assert _has_failure(report2, "SERVICE_INACTIVE")
+
+
+def test_active_state_active_but_zero_pid_fails_closed() -> None:
+    """The reverse combination must also fail: ActiveState=active alone,
+    without a real MainPID, is not sufficient either."""
+    report = vpr.Report(mode="host-runtime")
+    props = {"ActiveState": "active", "MainPID": "0"}
+    vpr.check_pdf_config_and_process(report, "catering-office-api", props)
+    assert not report.ok
+    assert _has_failure(report, "SERVICE_INACTIVE")
+
+
+def test_run_host_runtime_wires_effective_systemd_props_into_process_checks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Confirms the actual call-site wiring in run_host_runtime: the props
+    dict returned by check_effective_systemd (including ActiveState and
+    MainPID) is what check_pdf_config_and_process receives — not just each
+    function tested in isolation, which is what the earlier signature change
+    (main_pid str -> props dict) actually touched."""
+    repo = _base_repo(tmp_path)
+    venv_dir = tmp_path / "venv"
+    interpreter_payload = {
+        "executable": str(venv_dir / "bin" / "python3"),
+        "prefix": str(venv_dir),
+        "base_prefix": "/usr",
+        "version": "3.12.0",
+        "reportlab_version": "5.0.0",
+        "reportlab_file": str(venv_dir / "lib" / "reportlab" / "__init__.py"),
+    }
+    venv = _make_fake_python(tmp_path, interpreter_payload)
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        if cmd[0] == "uv":
+            return _proc(returncode=0, stdout="")
+        if cmd[0] == str(venv / "bin" / "python3"):
+            # _make_fake_python's script is real and executable, but _run is
+            # fully monkeypatched here, so its own execution is bypassed too
+            # — return exactly what it would have printed.
+            return _proc(returncode=0, stdout=json.dumps(interpreter_payload))
+        assert cmd[0] == "systemctl"
+        service = cmd[2]
+        argv = vpr.EXPECTED_UNIT_ARGV[service]
+        return _proc(returncode=0, stdout=_systemctl_show_output(argv=argv, pid="777"))
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    monkeypatch.setattr(
+        vpr,
+        "_read_environ_names",
+        lambda p: (
+            {
+                "OFFICE_PDF_COMPANY_LEGAL_NAME",
+                "OFFICE_PDF_COMPANY_ADDRESS_LINES",
+                "OFFICE_PDF_ACCEPTANCE_STATEMENT",
+            }
+            if p == "777"
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        vpr,
+        "_read_cmdline",
+        lambda p: _API_ARGV if p == "777" else None,
+    )
+
+    report = vpr.run_host_runtime(repo, venv)
+    active_checks = [c for c in report.checks if c.name.startswith("service_active[")]
+    assert active_checks and all(c.ok for c in active_checks)
+    assert not _has_failure(report, "SERVICE_INACTIVE")
 
 
 # --- 15: /proc/<pid>/exe must never be consulted ----------------------------
@@ -446,7 +729,8 @@ def test_proc_pid_exe_never_used_for_venv_evidence(
     monkeypatch.setattr(vpr, "_read_cmdline", lambda p: _API_ARGV if p == pid else None)
 
     report = vpr.Report(mode="host-runtime")
-    vpr.check_pdf_config_and_process(report, "catering-office-api", pid)
+    props = {"ActiveState": "active", "MainPID": pid}
+    vpr.check_pdf_config_and_process(report, "catering-office-api", props)
     assert report.ok  # would only fail if something wrongly touched /proc/pid/exe
 
 
@@ -458,7 +742,7 @@ def test_repository_only_mode_never_calls_systemctl(
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         if cmd[0] == "systemctl":
             raise AssertionError("repository-only mode must not call systemctl")
         assert cmd[:2] == ["uv", "lock"]
@@ -478,7 +762,7 @@ def test_subprocess_timeout_fails_clearly_not_crash(
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         assert timeout is not None and timeout > 0
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
 
@@ -539,7 +823,7 @@ def test_main_returns_zero_on_success(
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         assert cmd[:2] == ["uv", "lock"]
         return _proc(returncode=0, stdout="")
 
@@ -557,12 +841,67 @@ def test_main_returns_nonzero_on_failure(
     assert code == 1
 
 
+def test_main_host_runtime_non_executable_interpreter_no_crash_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through main(): a non-executable interpreter must produce
+    a clean non-zero exit, not an uncaught traceback bubbling out of the CLI
+    entry point."""
+    repo = _base_repo(tmp_path)
+    venv = tmp_path / "venv"
+    bin_dir = venv / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python3").write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+    (bin_dir / "python3").chmod(0o644)  # not executable
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        if cmd[0] == "uv":
+            return _proc(returncode=0, stdout="")
+        return _proc(returncode=1, stdout="", stderr="unit not found")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    code = vpr.main(
+        [
+            "--host-runtime",
+            "--repo-root",
+            str(repo),
+            "--venv-path",
+            str(venv),
+        ]
+    )  # must not raise
+    assert code == 1
+
+
+def test_main_repository_only_malformed_tracked_unit_no_crash_nonzero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through main(): malformed ExecStart quoting in a tracked
+    unit must produce a clean non-zero exit, not a traceback."""
+    repo = _base_repo(tmp_path)
+    malformed = (
+        "[Unit]\nDescription=test\n\n[Service]\nUser=viktor\n"
+        'ExecStart=/usr/bin/python3 -m foo --arg "unterminated\n'
+        "Restart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n"
+    )
+    (
+        repo / "infra" / "systemd" / vpr.TRACKED_UNIT_FILES["catering-office-api"]
+    ).write_text(malformed, encoding="utf-8")
+
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
+        assert cmd[:2] == ["uv", "lock"]
+        return _proc(returncode=0, stdout="")
+
+    monkeypatch.setattr(vpr, "_run", fake_run)
+    code = vpr.main(["--repository-only", "--repo-root", str(repo)])  # must not raise
+    assert code == 1
+
+
 def test_main_json_output_is_valid_json(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     repo = _base_repo(tmp_path)
 
-    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS):
+    def fake_run(cmd, timeout=vpr._SUBPROCESS_TIMEOUT_SECONDS, **_kw):
         return _proc(returncode=0, stdout="")
 
     monkeypatch.setattr(vpr, "_run", fake_run)


### PR DESCRIPTION
Slice C of `PDF_RUNTIME_VENV_AND_SYSTEMD_V1` — `PDF_RUNTIME_VERIFICATION_SCRIPT_V1`.
Branched from `main` at `a14a96349f62c01a3c57d8c4fa6cdc6b4a1bfa53`.
Closes #47.

**Updated after review** (commit `518995b`) — see "Hardening follow-up" below for what changed since the original commit `8e5cf82`.

## Root cause

Slices A and B landed `uv.lock` and aligned the *tracked* systemd units to
`.venv/bin/python3`, but production hasn't been migrated: it still runs under
an untracked drop-in override, and its checkout hasn't been fast-forwarded
past those slices yet. Before a production migration (a later, separately
authorized slice) can be attempted safely, there needs to be a read-only way
to prove the runtime and systemd configuration actually agree — including
catching the specific failure mode that a naive check would miss.

**Why `/proc/<pid>/exe` doesn't work**: `.venv/bin/python3` is a symlink to
the system interpreter (standard stdlib venv). `/proc/<pid>/exe` resolves
through that symlink and reports the system Python for a process genuinely
running inside the venv — confirmed manually during the PR #46 review. This
tool never reads it. It relies instead on the argv actually invoked
(systemd's own resolved `argv[]=`, and `/proc/<pid>/cmdline`) plus an
independent probe of the same interpreter *path* run separately.

## Modes

| Mode | Access needed | Checks |
|---|---|---|
| `--repository-only` | none — CI-safe | `pyproject.toml`/`uv.lock` present, `uv lock --check` clean, tracked `office-api`/`office-panel` units declare the expected venv interpreter, module and arguments |
| `--host-runtime` | the target host | everything above, plus: real `.venv` interpreter runs and reports the expected `sys.prefix`; `reportlab` importable, version `5.0.0`, installed inside the venv; required `OFFICE_PDF_*` variables present (names only) in each service's actual process environment; effective (loaded) `ExecStart` compared to the tracked target; each service's `ActiveState == "active"` **and** a non-zero `MainPID`, with a matching command line |

`--json` adds machine-readable output alongside the mandatory human-readable
report. Mode is required explicitly — there is no default that silently
guesses which checks are safe.

## Status classifications

Success: `READY_WITHOUT_OVERRIDE`, `READY_WITH_COMPATIBLE_OVERRIDE` (both
acceptable pre-migration outcomes — systemd's own drop-in resolution via
`systemctl show -p ExecStart` is used directly, not a reimplementation of the
override clear-and-replace semantics).

Failure: `MISMATCHED_OVERRIDE`, `TRACKED_UNIT_MISMATCH`,
`RUNTIME_INTERPRETER_MISSING`, `REPORTLAB_MISSING`,
`REPORTLAB_VERSION_MISMATCH`, `PDF_CONFIG_MISSING`, `LOCK_OUT_OF_DATE`, plus
a few additional codes for conditions not explicitly named in the brief
(`REPO_ROOT_NOT_FOUND`, `PYPROJECT_MISSING`, `LOCK_MISSING`,
`VENV_PREFIX_MISMATCH`, `REPORTLAB_LOCATION_OUTSIDE_VENV`,
`SERVICE_INACTIVE`).

Exit code `0` only when every check that ran passed.

## Hardening follow-up (commit `518995b`, after review)

The review found two robustness properties it explicitly asked to confirm
did not hold, plus a related bug surfaced while demonstrating the fix:

1. **Malformed `ExecStart` no longer crashes.** Both `shlex.split` call
   sites (`_parse_exec_start` for tracked units, `_extract_effective_argv`
   for systemd's reported effective command) let an unbalanced-quoting
   `ValueError` escape as an uncaught traceback. Both now raise a dedicated
   `ExecStartParseError` that callers convert into a clean failed
   `CheckResult`: `TRACKED_UNIT_MISMATCH` in repository-only mode, and
   `MISMATCHED_OVERRIDE` or `TRACKED_UNIT_MISMATCH` in host-runtime mode
   depending on whether an override is present — reusing the exact
   classification logic already used two lines below for a
   parseable-but-wrong effective command.
2. **Non-executable interpreter no longer crashes.** `check_python_runtime`
   only checked existence, not the executable bit; a present-but-not-
   executable `.venv/bin/python3` reached `subprocess.run` and raised an
   uncaught `PermissionError`. Added an explicit `os.access(path, os.X_OK)`
   check (`RUNTIME_INTERPRETER_MISSING`, message distinguishes "does not
   exist" from "exists but is not executable") before ever attempting to
   launch it, and broadened `_run_or_raise`'s except clause from
   `FileNotFoundError` to `OSError` as defense-in-depth (this still covers
   the original `FileNotFoundError` case too, since it's an `OSError`
   subclass).
3. **`ActiveState` is now actually checked, not just fetched.** Previously
   "active" was inferred from `MainPID` alone even though `ActiveState` was
   already being queried and simply never read. `check_pdf_config_and_process`
   now takes the full effective-systemd props dict and requires
   `ActiveState == "active"` **together with** a non-zero `MainPID`.
4. **Found while producing the required negative CLI demonstrations, not
   named in the original review**: `uv lock --check` never passed `cwd`, so
   it silently validated whatever directory the verifier process happened
   to be started from instead of `--repo-root`'s target — invisible
   whenever `repo_root` equals the caller's cwd (the common case), but a
   real correctness bug for the documented "override `--repo-root` for
   local tests" use case. `_run`/`_run_or_raise` now accept an explicit
   `cwd`, and the `uv lock --check` call passes `repo_root`.
5. **Corrected two documentation claims.** The module docstring and runbook
   both said the tool queries systemd with "`systemctl show`/`systemctl
   cat`" — it only ever calls `systemctl show`. The runbook's description
   of today's expected `--host-runtime` result against Lenovo's
   still-pre-Slice-A/B checkout also didn't match reality: it anticipated
   only a `uv`-unavailable → `LOCK_OUT_OF_DATE` failure, when the
   actually-reproducible result is `LOCK_MISSING` (checkout predates Slice
   A entirely) plus two `TRACKED_UNIT_MISMATCH` (predates Slice B) — and is
   now explicit that a pre-migration run against today's checkout is not
   globally successful even when individual runtime-derived checks pass.

## Test coverage

`tests/unit/test_verify_pdf_runtime.py` — **40 tests** (25 → 40 in this
follow-up), all 17 originally-required scenarios plus CLI/JSON smoke checks
plus the hardening above:

1–17: unchanged from the original PR (correct venv interpreter; `/usr/bin/
python3` tracked; argument mismatch; `uv.lock` absent/check-failure; missing
interpreter; `reportlab` missing/wrong-version/outside-venv; `sys.prefix`
mismatch; required PDF variable absent without leaking values; `READY_
WITHOUT_OVERRIDE`/`READY_WITH_COMPATIBLE_OVERRIDE`/`MISMATCHED_OVERRIDE`;
inactive service; a faked `/proc/<pid>/exe` must not cause a false failure;
`--repository-only` never calls `systemctl`; explicit timeouts; `Timeout
Expired` converted cleanly.

New in this follow-up:
- malformed `ExecStart` in both parser paths, unit-level (`Exec
  StartParseError` raised) and through `check_tracked_units`/`check_
  effective_systemd` (with and without an override present) — clean
  failure, no traceback;
- non-executable interpreter, unit-level and through `check_python_runtime`;
- `PermissionError` handling in `_run_or_raise`, with a `FileNotFoundError`
  regression guard alongside it;
- `ActiveState`/`MainPID` combinations: inactive with a non-zero-or-
  malformed pid, active with a zero pid — both fail `SERVICE_INACTIVE`;
- an end-to-end `run_host_runtime` wiring test confirming the props dict
  actually flows from `check_effective_systemd` into `check_pdf_config_and_
  process`;
- the `cwd` regression (asserts `uv lock --check` is invoked with
  `repo_root` as its working directory);
- two `main()`-level CLI smoke tests confirming a clean non-zero exit with
  no traceback for both crash scenarios.

No real systemd host or real venv is required for any test.

## Negative CLI demonstrations (not just unit tests)

Ran directly against the built CLI, with a fake `systemctl` and a fake
interpreter script on `PATH` (not mocks inside the test process):

```
1. Malformed tracked ExecStart, --repository-only:
   [FAIL] TRACKED_UNIT_MISMATCH: catering-office-api.service: ExecStart has
          malformed syntax: No closing quotation
   exit=1, no traceback

2. Malformed effective ExecStart (via fake systemctl), --host-runtime:
   [FAIL] TRACKED_UNIT_MISMATCH: catering-office-api: effective ExecStart
          has malformed syntax: No closing quotation
   exit=1, no traceback

3. Non-executable interpreter, --host-runtime:
   [FAIL] RUNTIME_INTERPRETER_MISSING: …/.venv/bin/python3 exists but is
          not executable
   exit=1, no traceback (grep-confirmed: no "Traceback"/"File \"" in output)
```

## Production read-only validation

Ran `--host-runtime` against `debiancatering` before opening the original
PR (script copied to `/tmp`, not the repo checkout; removed immediately
after) — result unaffected by this follow-up, since the hardening changes
don't alter behavior against well-formed input:

```
[FAIL] LOCK_MISSING: uv.lock not found …
[FAIL] TRACKED_UNIT_MISMATCH: catering-office-api.service ExecStart is
       ['/usr/bin/python3', …], expected ['…/.venv/bin/python3', …]
[FAIL] TRACKED_UNIT_MISMATCH: catering-office-panel.service (same)
[PASS] … venv runs, reportlab 5.0.0 importable and inside .venv
[PASS] READY_WITH_COMPATIBLE_OVERRIDE (both services)
[PASS] … service active, PDF config present, command line matches
```

Both failures are expected and correct: production's git checkout is still
at the pre-Slice-A/B commit (`a67875d800deff7a954e9c83d42174c41b647326`).
Confirmed after: production `git rev-parse HEAD` unchanged, working tree
clean, both services' `ActiveEnterTimestamp` unchanged (no restart), both
`override.conf` files still present.

## Validation (local, full suite)

- `uv lock --check` — clean
- `uv sync --dev` — clean
- `uv run ruff check src tests infra` / `uv run ruff format --check src tests infra` — clean
- `uv run mypy src/catering_system` — no issues, 183 files
- `uv run pytest tests/unit/test_verify_pdf_runtime.py -q` — **40 passed**
- `uv run pytest -q` — **2252 passed** (2212 pre-existing + 40)
- `uv run coverage run -m pytest -q` + `coverage report` — **90.7%** (gate 90)
- `uv run python infra/deploy/verify_pdf_runtime.py --repository-only` — OK
- `git diff --check` — clean

## Explicitly out of scope

```
Not included:
- dependency installation
- systemd unit installation
- override removal
- daemon-reload
- service restart
- production deployment
```

Slice D (installing the tracked units, removing the overrides, restarting
`catering-office-api`/`catering-office-panel`) remains separately authorized
and is not started here.

Do not merge — waiting for re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)