### PR TITLE
Increase CI quality job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       # uv provides both the resolver and the Python interpreter, so the


### PR DESCRIPTION
## Summary

- Increase the `quality` job's `timeout-minutes` from `10` to `15` in
  `.github/workflows/ci.yml`. Repeated successful runs have taken
  approximately 7-9 minutes; several otherwise-valid runs were cancelled at
  the existing 10-minute limit.

One-line change; no other workflow configuration (job name, triggers,
permissions, versions, dependency setup, cache, commands, ordering) was
touched. No application code, tests, docs, `pyproject.toml`, `uv.lock`,
or production changed.

Closes #51

## Test plan

- [x] `git diff --check` — clean
- [x] Diff contains exactly one changed line
- [ ] Push and pull-request `quality` runs both succeed