### PR TITLE
Show position description and composition on the Offer Detail page

### DIFF
--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -137,6 +137,18 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
             unit_text = (
                 f"{int(unit_cents) / 100:.2f} €" if isinstance(unit_cents, int) else "–"
             )
+            description = position.get("description")
+            description_html = (
+                f"<p>{_e(str(description))}</p>"
+                if isinstance(description, str) and description
+                else ""
+            )
+            composition = position.get("composition")
+            composition_html = (
+                f"<p><strong>Zusammensetzung:</strong> {_e(str(composition))}</p>"
+                if isinstance(composition, str) and composition
+                else ""
+            )
             allergen_html = _allergen_block(
                 position.get("allergen_labels"),
                 unknown=bool(position.get("allergens_unknown")),
@@ -145,6 +157,8 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
                 "<li>"
                 f"<strong>{name}</strong> "
                 f"<span>({_e(unit_text)} netto / Einheit)</span>"
+                f"{description_html}"
+                f"{composition_html}"
                 f"{allergen_html}"
                 "</li>"
             )

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -154,6 +154,8 @@ def _valid_offer_snapshot(
     variant_label: str = "Variante A",
     variant_id: str = _VARIANT_ID,
     position_id: str = _POSITION_ID,
+    position_description: str | None = "Frozen description",
+    position_composition: str | None = "Frozen composition",
 ) -> dict:
     payload: dict[str, object] = {
         "schema_version": "offer_snapshot_v1",
@@ -203,8 +205,8 @@ def _valid_offer_snapshot(
                         "kind": "catalog",
                         "catalog_item_id": "catalog-1",
                         "name": "Fingerfood Paket",
-                        "description": "Frozen description",
-                        "composition": "Frozen composition",
+                        "description": position_description,
+                        "composition": position_composition,
                         "quantity_mode": "total",
                         "quantity": "80",
                         "unit_label": "Stück",
@@ -261,6 +263,8 @@ def _prepare_offer(
     *,
     variant_id: str = _VARIANT_ID,
     position_id: str = _POSITION_ID,
+    position_description: str | None = "Frozen description",
+    position_composition: str | None = "Frozen composition",
 ) -> tuple[str, str]:
     status, body = _api_post(
         f"{api_url}/office/v1/inquiries/{inquiry_id}/prepare-offer",
@@ -269,6 +273,8 @@ def _prepare_offer(
                 inquiry_id=inquiry_id,
                 variant_id=variant_id,
                 position_id=position_id,
+                position_description=position_description,
+                position_composition=position_composition,
             )
         },
     )
@@ -491,6 +497,48 @@ def test_prepared_shows_mark_sent_form_only(direct_world) -> None:
     assert 'action="/offer/' in html and "/mark-sent" in html
     assert "Annahme erfassen" not in html
     assert "In Auftrag umwandeln" not in html
+
+
+def test_offer_detail_shows_position_description_and_composition(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Frozen description" in html
+    assert "Zusammensetzung:</strong> Frozen composition" in html
+
+
+def test_offer_detail_escapes_position_description_and_composition(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(
+        api_url,
+        ids["inquiry_convertible"],
+        position_description="<script>alert('xss')</script>",
+        position_composition="Nüsse & <b>Sesam</b>",
+    )
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "<script>alert('xss')</script>" not in html
+    assert "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;" in html
+    assert "Nüsse &amp; &lt;b&gt;Sesam&lt;/b&gt;" in html
+
+
+def test_offer_detail_omits_description_and_composition_when_absent(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(
+        api_url,
+        ids["inquiry_convertible"],
+        position_description=None,
+        position_composition=None,
+    )
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    assert "Frozen description" not in html
+    assert "Zusammensetzung:" not in html
+    assert "Fingerfood Paket" in html
 
 
 def test_sent_shows_sent_lifecycle_actions(direct_world) -> None:


### PR DESCRIPTION
## Summary

- Renders each position's `description` and `composition` on the Office
  Panel's Offer Detail page (`office_panel_offer_detail._position_rows`).
  Both fields were already returned by the JSON projection
  (`office_api_views._position_detail`, since `a68edf9`) but the HTML
  template never surfaced them, so office staff couldn't actually see this
  content when reviewing an Offer.
- `description` renders as a plain paragraph; `composition` renders as a
  labeled `Zusammensetzung:` paragraph, consistent with the existing
  allergen block styling. Both are `html.escape()`-d via the file's existing
  `_e()` helper, consistent with every other field in this template.
- When either field is null/empty (existing offers, or positions that never
  had this content), nothing renders — no layout change, no stray "None"
  text.

## Explicitly out of scope (per the originating discussion)

- No change to `OrderCommercialSnapshot` creation or persistence.
- No new Offer aggregate reads from Print or Confirmation — verified neither
  imports `Offer`/`OfferRepository` at all, before and after this change.
- No change to the `offer_detail` JSON API projection — it already returned
  these fields correctly.
- Snapshot isolation was already verified separately and is untouched here.

Closes #53

## Test plan

- [x] `tests/unit/test_office_panel_offer_actions.py` — 3 new tests:
      renders both fields, HTML-escapes untrusted content (script tag and
      `&`/`<`/`>` in composition), and omits both cleanly when null.
- [x] Full file (37 tests) and full suite (2255 tests) pass locally.
- [x] `ruff check`/`ruff format --check` clean on `src tests infra`.
- [x] `mypy src/catering_system` clean.
- [x] `coverage report` — 90.7% (≥90% threshold).