### PR TITLE
Fix Inquiry contact prefill from structured snapshot

### DIFF
--- a/src/catering_system/ui/office_panel_offer_prefill.py
+++ b/src/catering_system/ui/office_panel_offer_prefill.py
@@ -35,9 +35,17 @@ def _clip(value: str | None, limit: int = _MAX_SHORT_TEXT) -> str:
     return (value or "").strip()[:limit]
 
 
+def _contact_prefill_value(
+    structured_value: str | None, labelled_fallback: str | None
+) -> str:
+    """Prefer the Inquiry's structured customer fact; retain legacy intake fallback."""
+    return _clip(structured_value) or _clip(labelled_fallback)
+
+
 def offer_prefill_payload(inquiry: Inquiry) -> dict[str, object]:
     """Build proposal-phase copy only; this performs no Core write."""
     labelled, remaining = labelled_intake_context(inquiry.intake_message)
+    customer = inquiry.customer_snapshot
     context_parts = []
     if inquiry.intake_subject:
         context_parts.append(f"Betreff: {_clip(inquiry.intake_subject, 1000)}")
@@ -64,10 +72,22 @@ def offer_prefill_payload(inquiry: Inquiry) -> dict[str, object]:
                 "serviceStyle": "",
             },
             "orderContextPrefill": {
-                "companyName": _clip(labelled.get("Firma")),
-                "contactPerson": _clip(labelled.get("Name")),
-                "email": _clip(labelled.get("E-Mail")),
-                "phone": _clip(labelled.get("Telefon")),
+                "companyName": _contact_prefill_value(
+                    customer.company_name if customer is not None else None,
+                    labelled.get("Firma"),
+                ),
+                "contactPerson": _contact_prefill_value(
+                    customer.contact_name if customer is not None else None,
+                    labelled.get("Name"),
+                ),
+                "email": _contact_prefill_value(
+                    customer.email if customer is not None else None,
+                    labelled.get("E-Mail"),
+                ),
+                "phone": _contact_prefill_value(
+                    customer.phone if customer is not None else None,
+                    labelled.get("Telefon"),
+                ),
                 "eventDate": inquiry.event_date.isoformat(),
                 "eventTime": _clip(inquiry.time_window_text),
                 "location": _clip(inquiry.location_text),

--- a/tests/unit/test_office_panel_offer_prefill.py
+++ b/tests/unit/test_office_panel_offer_prefill.py
@@ -103,6 +103,66 @@ def test_payload_maps_labelled_context_without_creating_core_records() -> None:
     assert context["eventDate"] == "2026-10-03"
 
 
+def test_fragment_maps_structured_customer_snapshot_and_all_event_fields() -> None:
+    inquiry = replace(
+        _inquiry(),
+        intake_message=(
+            "Veranstaltungsart: Jubiläum\n"
+            "Wunsch: Vegetarisch & glutenfrei\n"
+            "Zusätzlicher Anfragekontext"
+        ),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="Strukturierte Firma GmbH",
+            contact_name="Strukturierter Kontakt",
+            email="structured@example.test",
+            phone="+49 40 98765",
+        ),
+    )
+
+    url = build_offer_prefill_url("https://angebote.example.test", inquiry)
+    request_url, fragment = url.split("#", 1)
+    encoded = fragment.split("=", 1)[1]
+    padded = encoded + "=" * (-len(encoded) % 4)
+    decoded = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+
+    assert request_url == "https://angebote.example.test/"
+    assert decoded["transfer"]["orderContextPrefill"] == {
+        "companyName": "Strukturierte Firma GmbH",
+        "contactPerson": "Strukturierter Kontakt",
+        "email": "structured@example.test",
+        "phone": "+49 40 98765",
+        "eventDate": "2026-10-03",
+        "eventTime": "18:30–23:00",
+        "location": "Große Bleichen 1, Hamburg",
+        "billingAddress": "",
+        "remarks": (
+            "Betreff: Möbel & Mehr GmbH — Jubiläum\n\n"
+            "Wunsch: Vegetarisch & glutenfrei\n\n"
+            "Zusätzlicher Anfragekontext\n\n"
+            "Zusammenfassung: Website-Anfrage — 42 Personen, 2026-10-03"
+        ),
+    }
+
+
+def test_structured_customer_snapshot_precedes_legacy_labelled_contact() -> None:
+    inquiry = replace(
+        _inquiry(),
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="Structured Company",
+            contact_name="Structured Contact",
+            email="structured@example.test",
+            phone="+49 40 98765",
+        ),
+    )
+
+    context = offer_prefill_payload(inquiry)["transfer"]["orderContextPrefill"]
+
+    assert context["companyName"] == "Structured Company"
+    assert context["contactPerson"] == "Structured Contact"
+    assert context["email"] == "structured@example.test"
+    assert context["phone"] == "+49 40 98765"
+
+
 def test_fragment_round_trip_preserves_unicode_and_stays_out_of_request_url() -> None:
     url = build_offer_prefill_url("https://angebote.example.test/app/", _inquiry())
     request_url, fragment = url.split("#", 1)


### PR DESCRIPTION
## Summary

- source Configurator contact prefill from the Inquiry’s structured `customer_snapshot`
- map `company_name` → `companyName`, `contact_name` → `contactPerson`, `email` → `email`, and `phone` → `phone`
- retain labelled intake fields as a compatibility fallback for legacy Inquiries
- leave location, date, time, context composition, fragment encoding, and no-write behavior unchanged

## Root cause

The handoff emitted the correct Configurator keys, but populated all four contact values only from legacy labels in `intake_message`. The affected production Inquiry has all four structured snapshot facts and no corresponding legacy labels, so Core emitted four empty strings. The Configurator parser and form application already accept the emitted key names.

## Tests

- added a snapshot-only Inquiry regression covering all contact and event/context fields through generated-fragment decoding
- added structured-snapshot precedence coverage over legacy labels
- focused prefill tests: 15 passed
- full Core suite: 2,273 passed
- Ruff lint/format check: passed
- mypy: passed
- repository JavaScript tests: 24 passed

No production data was created or modified, and this PR is not merged or deployed.