### PR TITLE
OFFER_BUDGET_DEFINITION_V1: internal budget definition in the Prepared Offer snapshot contract

### DIFF
--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -428,6 +428,64 @@ Restoring the database discards later production writes. Use it only after the
 owner explicitly accepts that data loss window. Follow the stop-copy-verify
 procedure in [Backup and restore](backup-restore.md#restore-production).
 
+### Migration 8 — `offer_versions.budget_definition_json` (OFFER_BUDGET_DEFINITION_V1)
+
+Migration 8 (component `offers`, `_migration_8_offer_version_budget_definition`
+in `sqlite_offer_repository.py`) is a single additive statement:
+
+```sql
+ALTER TABLE offer_versions ADD COLUMN budget_definition_json TEXT
+```
+
+- **Additive and nullable.** It adds exactly one column, no others. The
+  column has no `NOT NULL` constraint and no default beyond SQLite's implicit
+  `NULL`, so every pre-migration row reads back with
+  `budget_definition_json = NULL` — no backfill, no data rewrite.
+- **Existing rows are untouched.** `ALTER TABLE ... ADD COLUMN` in SQLite
+  does not rewrite the table; it only changes the schema definition applied
+  when reading/writing rows going forward.
+- **Old code safely ignores the added column.** Pre-migration Core code
+  never selects `budget_definition_json` by name (it doesn't know the
+  column exists), and `SELECT *`-style row mapping elsewhere in this
+  codebase maps by explicit column name, not position — so old code
+  running against a post-migration database behaves exactly as it did
+  before. This is the same reasoning that makes the standard
+  [code-only rollback](#code-only-rollback) sufficient here.
+- **Routine rollback never drops the column.** If a rollback of this
+  feature is needed, use the standard code-only rollback above (revert the
+  commit, restart the affected services). Leave
+  `offer_versions.budget_definition_json` in place — dropping it is a
+  destructive schema change with no operational benefit, since old code
+  simply never reads it. This project deliberately does not ship an
+  automatic down-migration for this column (or any migration) — a down
+  migration is not part of the `apply_migrations` runner in
+  `sqlite_migrations.py`, and none should be added for this slice.
+- **Database restore is the only way to actually remove the column**, and
+  is routine-rollback overkill for this slice specifically: it would also
+  discard every other production write since the backup. Follow
+  [Database restore](#database-restore) above only if a full restore is
+  independently justified for some other reason — never solely to undo
+  this column.
+
+**Verify the migration applied and the column exists**, read-only, no
+service restart required:
+
+```bash
+sqlite3 /home/viktor/catering-runtime/core.db \
+  "SELECT component, version, name, applied_at FROM schema_migrations \
+   WHERE component = 'offers' ORDER BY version;"
+sqlite3 /home/viktor/catering-runtime/core.db \
+  "PRAGMA table_info(offer_versions);" | grep budget_definition_json
+```
+
+The first command's last row should read
+`offers|8|offer_version_budget_definition|<timestamp>`; the second should
+print one line for the new `TEXT` column. Absence of the column with the
+service otherwise healthy means the code deployed but the process has not
+yet reconnected to `core.db` since deploy (migrations apply on first
+connection) — restart the affected service and re-check, don't attempt any
+manual `ALTER TABLE`.
+
 ## Common failures
 
 | Symptom | Check | Typical cause |

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 
 from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
 from catering_system.domain.inquiry import PlanningMode, validate_planning_mode
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.order_payment_reminder import (
     PaymentMethod,
     validate_payment_method,
@@ -209,6 +210,10 @@ class OfferVersion:
     customer_title: str | None = None
     customer_introduction: str | None = None
     customer_notes: str | None = None
+    # OFFER_BUDGET_DEFINITION_V1: internal-only operator planning metadata,
+    # frozen from the source OfferSnapshot's budget_definition (if any).
+    # Never surfaced in customer-facing documents/wording.
+    budget_definition: OfferBudgetDefinition | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.offer_version_id, "offer_version_id")

--- a/src/catering_system/domain/offer_budget_definition.py
+++ b/src/catering_system/domain/offer_budget_definition.py
@@ -1,0 +1,94 @@
+"""OFFER_BUDGET_DEFINITION_V1 — internal-only operator planning metadata.
+
+Shared value object embedded (optionally) in both the OfferSnapshot wire
+envelope (``domain/offer_snapshot.py``) and the persisted Offer aggregate
+(``domain/offer.py``). Never customer-facing: not included in the Offer
+document/PDF, printed wording, or any customer-visible text — it exists only
+for the Office Panel's internal Offer Detail view.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+OfferBudgetType = Literal["TOTAL", "PER_PERSON"]
+OfferBudgetTaxBasis = Literal["GROSS", "NET"]
+OfferBudgetCostScope = Literal["FULL_OFFER", "POSITIONS_ONLY"]
+
+OFFER_BUDGET_TYPES: tuple[OfferBudgetType, ...] = ("TOTAL", "PER_PERSON")
+OFFER_BUDGET_TAX_BASES: tuple[OfferBudgetTaxBasis, ...] = ("GROSS", "NET")
+OFFER_BUDGET_COST_SCOPES: tuple[OfferBudgetCostScope, ...] = (
+    "FULL_OFFER",
+    "POSITIONS_ONLY",
+)
+
+
+def validate_offer_budget_type(value: str) -> OfferBudgetType:
+    if value == "TOTAL":
+        return "TOTAL"
+    if value == "PER_PERSON":
+        return "PER_PERSON"
+    raise ValueError("invalid budget_definition.type")
+
+
+def validate_offer_budget_tax_basis(value: str) -> OfferBudgetTaxBasis:
+    if value == "GROSS":
+        return "GROSS"
+    if value == "NET":
+        return "NET"
+    raise ValueError("invalid budget_definition.tax_basis")
+
+
+def validate_offer_budget_cost_scope(value: str) -> OfferBudgetCostScope:
+    if value == "FULL_OFFER":
+        return "FULL_OFFER"
+    if value == "POSITIONS_ONLY":
+        return "POSITIONS_ONLY"
+    raise ValueError("invalid budget_definition.cost_scope")
+
+
+@dataclass(frozen=True)
+class OfferBudgetDefinition:
+    """One operator-configured budget figure and how it is compared.
+
+    ``amount_cents`` follows the same non-negative integer euro-cents
+    representation as every other money field in the Offer snapshot — no
+    floats cross this boundary. ``type`` decides whether ``amount_cents`` is
+    an absolute total or a per-person rate; ``tax_basis``/``cost_scope``
+    decide which totals it is compared against (see
+    OFFER_OPERATIONAL_QUEUE_V1-adjacent Configurator docs for the four
+    included/excluded combinations).
+    """
+
+    amount_cents: int
+    type: OfferBudgetType
+    tax_basis: OfferBudgetTaxBasis
+    cost_scope: OfferBudgetCostScope
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.amount_cents, int) or isinstance(
+            self.amount_cents, bool
+        ):
+            raise ValueError(
+                "budget_definition.amount_cents must be integer euro cents"
+            )
+        if self.amount_cents < 0:
+            raise ValueError("budget_definition.amount_cents must be non-negative")
+        validate_offer_budget_type(self.type)
+        validate_offer_budget_tax_basis(self.tax_basis)
+        validate_offer_budget_cost_scope(self.cost_scope)
+
+
+__all__ = [
+    "OFFER_BUDGET_COST_SCOPES",
+    "OFFER_BUDGET_TAX_BASES",
+    "OFFER_BUDGET_TYPES",
+    "OfferBudgetCostScope",
+    "OfferBudgetDefinition",
+    "OfferBudgetTaxBasis",
+    "OfferBudgetType",
+    "validate_offer_budget_cost_scope",
+    "validate_offer_budget_tax_basis",
+    "validate_offer_budget_type",
+]

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -10,6 +10,7 @@ from datetime import date, datetime
 from typing import Literal
 
 from catering_system.domain.inquiry import PlanningMode
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.order_payment_reminder import PaymentMethod
 
 SCHEMA_VERSION = "offer_snapshot_v1"
@@ -136,6 +137,9 @@ class OfferSnapshotEnvelope:
     calculator: OfferSnapshotCalculator
     variants: tuple[OfferSnapshotVariant, ...]
     source_draft_id: str | None = None
+    # OFFER_BUDGET_DEFINITION_V1: optional internal-only operator planning
+    # metadata — never customer-facing (see domain/offer_budget_definition.py).
+    budget_definition: OfferBudgetDefinition | None = None
 
 
 @dataclass(frozen=True)

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -37,6 +37,7 @@ from catering_system.domain.offer import (
     VatRatePercent,
     WithdrawalEvidence,
 )
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.order_payment_reminder import validate_payment_method
 from catering_system.repositories.sqlite_migrations import apply_migrations
 
@@ -291,6 +292,18 @@ def _migration_7_offer_version_customer_narrative(
             connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
 
 
+def _migration_8_offer_version_budget_definition(
+    connection: sqlite3.Connection,
+) -> None:
+    existing = {
+        row[1] for row in connection.execute("PRAGMA table_info(offer_versions)")
+    }
+    if "budget_definition_json" not in existing:
+        connection.execute(
+            "ALTER TABLE offer_versions ADD COLUMN budget_definition_json TEXT"
+        )
+
+
 _MIGRATIONS = (
     (1, "create_offer_tables", _migration_1_create_tables),
     (2, "unique_source_inquiry", _migration_2_unique_source_inquiry),
@@ -314,6 +327,11 @@ _MIGRATIONS = (
         7,
         "offer_version_customer_narrative",
         _migration_7_offer_version_customer_narrative,
+    ),
+    (
+        8,
+        "offer_version_budget_definition",
+        _migration_8_offer_version_budget_definition,
     ),
 )
 
@@ -343,6 +361,41 @@ def _optional_allergens(value: str | None) -> tuple[AllergenCode, ...] | None:
     if not isinstance(parsed, list):
         raise ValueError("allergens_json must decode to a list")
     return validate_allergen_codes([str(item) for item in parsed])
+
+
+def _budget_definition_storage(value: OfferBudgetDefinition | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(
+        {
+            "amount_cents": value.amount_cents,
+            "type": value.type,
+            "tax_basis": value.tax_basis,
+            "cost_scope": value.cost_scope,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _stored_budget_definition(value: str | None) -> OfferBudgetDefinition | None:
+    """Reject malformed stored payloads rather than silently drop them —
+    this column is only ever written by ``_budget_definition_storage`` above,
+    so a decode/shape failure here means on-disk corruption, not a normal
+    "no budget" case (that's represented by SQL NULL / Python None)."""
+    if value is None:
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("budget_definition_json must decode to an object")
+    try:
+        return OfferBudgetDefinition(
+            amount_cents=parsed["amount_cents"],
+            type=parsed["type"],
+            tax_basis=parsed["tax_basis"],
+            cost_scope=parsed["cost_scope"],
+        )
+    except KeyError as exc:
+        raise ValueError("budget_definition_json missing required field") from exc
 
 
 def _dt(value: str) -> datetime:
@@ -623,8 +676,8 @@ class SQLiteOfferRepository:
                 snapshot_id, snapshot_hash, event_date, time_window_text,
                 location_text, guest_count, planning_mode, payment_method,
                 payment_customer_visible_text, customer_title,
-                customer_introduction, customer_notes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                customer_introduction, customer_notes, budget_definition_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 version.offer_version_id,
@@ -644,6 +697,7 @@ class SQLiteOfferRepository:
                 version.customer_title,
                 version.customer_introduction,
                 version.customer_notes,
+                _budget_definition_storage(version.budget_definition),
             ),
         )
         for sort_order, variant in enumerate(version.variants):
@@ -776,7 +830,7 @@ class SQLiteOfferRepository:
                    snapshot_id, snapshot_hash, event_date, time_window_text,
                    location_text, guest_count, planning_mode, payment_method,
                    payment_customer_visible_text, customer_title,
-                   customer_introduction, customer_notes
+                   customer_introduction, customer_notes, budget_definition_json
             FROM offer_versions
             WHERE offer_id = ?
             ORDER BY version_number
@@ -823,6 +877,7 @@ class SQLiteOfferRepository:
                     customer_title=row[13],
                     customer_introduction=row[14],
                     customer_notes=row[15],
+                    budget_definition=_stored_budget_definition(row[16]),
                 )
             )
         return tuple(versions)

--- a/src/catering_system/services/offer_budget_presentation.py
+++ b/src/catering_system/services/offer_budget_presentation.py
@@ -1,0 +1,105 @@
+"""OFFER_BUDGET_DEFINITION_V1 — internal Office Panel presentation only.
+
+Composes the "Aktuell"/"Verfügbar" comparison shown in the Offer Detail
+budget block entirely from the already-frozen, already-validated position
+cents already present in the OfferVersion snapshot (``net_total_cents`` /
+``vat_amount_cents`` / ``gross_total_cents`` per position). Nothing here
+re-derives pricing or VAT — it only selects and sums numbers the pricing
+engine already computed, exactly like the Configurator's
+``utils/budgetBreakdown.ts`` does client-side. Never used for anything
+customer-facing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Iterable
+
+from catering_system.domain.offer import OfferPosition
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+
+_SPEISEN_KINDS = frozenset({"catalog", "surcharge"})
+
+
+@dataclass(frozen=True)
+class OfferBudgetPresentation:
+    amount_cents: int
+    type: str
+    tax_basis: str
+    cost_scope: str
+    # None only when type=PER_PERSON and guest_count is unknown — nothing to
+    # divide by, so no comparison can be shown (never a crash / never 0).
+    comparison_amount_cents: int | None
+    remaining_cents: int | None
+    over: bool | None
+
+
+def _round_half_up_cents(value: Decimal) -> int:
+    return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def _sum_cents(
+    positions: Iterable[OfferPosition], *, gross: bool, kinds: frozenset[str] | None
+) -> int:
+    total = 0
+    for position in positions:
+        if kinds is not None and position.kind not in kinds:
+            continue
+        total += position.gross_total_cents if gross else position.net_total_cents
+    return total
+
+
+def compute_offer_budget_presentation(
+    budget_definition: OfferBudgetDefinition | None,
+    *,
+    positions: Iterable[OfferPosition],
+    guest_count: int | None,
+) -> OfferBudgetPresentation | None:
+    if budget_definition is None:
+        return None
+
+    positions = list(positions)
+    gross = budget_definition.tax_basis == "GROSS"
+    kinds = _SPEISEN_KINDS if budget_definition.cost_scope == "POSITIONS_ONLY" else None
+    comparison_absolute_cents = _sum_cents(positions, gross=gross, kinds=kinds)
+
+    if budget_definition.type == "TOTAL":
+        remaining = budget_definition.amount_cents - comparison_absolute_cents
+        return OfferBudgetPresentation(
+            amount_cents=budget_definition.amount_cents,
+            type=budget_definition.type,
+            tax_basis=budget_definition.tax_basis,
+            cost_scope=budget_definition.cost_scope,
+            comparison_amount_cents=comparison_absolute_cents,
+            remaining_cents=remaining,
+            over=remaining < 0,
+        )
+
+    # PER_PERSON
+    if guest_count is None or guest_count <= 0:
+        return OfferBudgetPresentation(
+            amount_cents=budget_definition.amount_cents,
+            type=budget_definition.type,
+            tax_basis=budget_definition.tax_basis,
+            cost_scope=budget_definition.cost_scope,
+            comparison_amount_cents=None,
+            remaining_cents=None,
+            over=None,
+        )
+    comparison_per_person_cents = _round_half_up_cents(
+        Decimal(comparison_absolute_cents) / Decimal(guest_count)
+    )
+    remaining = budget_definition.amount_cents - comparison_per_person_cents
+    return OfferBudgetPresentation(
+        amount_cents=budget_definition.amount_cents,
+        type=budget_definition.type,
+        tax_basis=budget_definition.tax_basis,
+        cost_scope=budget_definition.cost_scope,
+        comparison_amount_cents=comparison_per_person_cents,
+        remaining_cents=remaining,
+        over=remaining < 0,
+    )
+
+
+__all__ = ["OfferBudgetPresentation", "compute_offer_budget_presentation"]

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -693,6 +693,7 @@ def _build_version_from_snapshot(
         customer_title=_normalize_narrative(snapshot.customer_text.title),
         customer_introduction=_normalize_narrative(snapshot.customer_text.introduction),
         customer_notes=_normalize_narrative(snapshot.customer_text.notes),
+        budget_definition=snapshot.budget_definition,
     )
 
 

--- a/src/catering_system/services/offer_snapshot_validation.py
+++ b/src/catering_system/services/offer_snapshot_validation.py
@@ -10,6 +10,12 @@ from typing import Literal, cast
 
 from catering_system.domain.catalog import validate_allergen_codes
 from catering_system.domain.inquiry import validate_planning_mode
+from catering_system.domain.offer_budget_definition import (
+    OfferBudgetDefinition,
+    validate_offer_budget_cost_scope,
+    validate_offer_budget_tax_basis,
+    validate_offer_budget_type,
+)
 from catering_system.domain.offer_snapshot import (
     CURRENCY,
     MAX_EMAIL_LEN,
@@ -61,8 +67,10 @@ _ENVELOPE_KEYS = frozenset(
         "payment_terms",
         "calculator",
         "variants",
+        "budget_definition",
     }
 )
+_BUDGET_DEFINITION_KEYS = frozenset({"amount_cents", "type", "tax_basis", "cost_scope"})
 _RECIPIENT_KEYS = frozenset({"company_name", "contact_name", "email", "postal_address"})
 _EVENT_KEYS = frozenset(
     {
@@ -166,6 +174,7 @@ def validate_offer_snapshot(
     source_draft_id = _optional_short_text(
         payload.get("source_draft_id"), "source_draft_id"
     )
+    budget_definition = _parse_budget_definition(payload.get("budget_definition"))
 
     computed_hash = compute_snapshot_hash(payload)
     if snapshot_hash != computed_hash:
@@ -187,6 +196,7 @@ def validate_offer_snapshot(
         payment_terms=payment_terms,
         calculator=calculator,
         variants=variants,
+        budget_definition=budget_definition,
     )
     if v2:
         return snapshot
@@ -206,6 +216,7 @@ def validate_offer_snapshot(
         payment_terms=snapshot.payment_terms,
         calculator=snapshot.calculator,
         variants=snapshot.variants,
+        budget_definition=snapshot.budget_definition,
     )
 
 
@@ -423,6 +434,42 @@ def _parse_payment_terms(payload: dict[str, object]) -> OfferSnapshotPaymentTerm
         customer_visible_text=_require_long_text(
             payload.get("customer_visible_text"), "payment_terms.customer_visible_text"
         ),
+    )
+
+
+def _parse_budget_definition(
+    value: object,
+) -> OfferBudgetDefinition | None:
+    """OFFER_BUDGET_DEFINITION_V1: optional, strictly validated when present.
+
+    Absent entirely on older snapshots and on snapshots where the operator
+    never enabled budget tracking — that is not an error, it simply means
+    ``budget_definition`` stays ``None``. When present, every field is
+    required and strictly checked; there is no partial/legacy shape accepted
+    at this boundary (legacy defaulting is a Configurator-side concern for
+    its own local drafts, not something Core reinterprets on write).
+    """
+    if value is None:
+        return None
+    payload = _require_object(value, "budget_definition")
+    _reject_unknown_keys(payload, _BUDGET_DEFINITION_KEYS, "budget_definition")
+    amount_cents = _require_cents(
+        payload.get("amount_cents"), "budget_definition.amount_cents"
+    )
+    budget_type = validate_offer_budget_type(
+        _require_exact_str(payload.get("type"), "budget_definition.type")
+    )
+    tax_basis = validate_offer_budget_tax_basis(
+        _require_exact_str(payload.get("tax_basis"), "budget_definition.tax_basis")
+    )
+    cost_scope = validate_offer_budget_cost_scope(
+        _require_exact_str(payload.get("cost_scope"), "budget_definition.cost_scope")
+    )
+    return OfferBudgetDefinition(
+        amount_cents=amount_cents,
+        type=budget_type,
+        tax_basis=tax_basis,
+        cost_scope=cost_scope,
     )
 
 

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -43,7 +43,11 @@ from catering_system.domain.offer import (
     Offer,
     OfferPosition,
     OfferState,
+    OfferVersion,
     derive_offer_state,
+)
+from catering_system.services.offer_budget_presentation import (
+    compute_offer_budget_presentation,
 )
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
@@ -318,6 +322,66 @@ def _position_detail(position: OfferPosition) -> dict[str, object]:
     return row
 
 
+def _budget_definition_detail(version: OfferVersion) -> dict[str, object] | None:
+    """OFFER_BUDGET_DEFINITION_V1 — internal-only, never in customer-facing
+    output. Omitted entirely (not an empty object) when the version has no
+    budget_definition, so old Offers render exactly as before."""
+    if version.budget_definition is None:
+        return None
+    positions = [
+        position for variant in version.variants for position in variant.positions
+    ]
+    presentation = compute_offer_budget_presentation(
+        version.budget_definition,
+        positions=positions,
+        guest_count=version.guest_count,
+    )
+    assert presentation is not None  # budget_definition is not None above
+    return {
+        "amount_cents": presentation.amount_cents,
+        "type": presentation.type,
+        "tax_basis": presentation.tax_basis,
+        "cost_scope": presentation.cost_scope,
+        "comparison_amount_cents": presentation.comparison_amount_cents,
+        "remaining_cents": presentation.remaining_cents,
+        "over": presentation.over,
+    }
+
+
+def _version_detail(
+    offer: Offer, version: OfferVersion, *, operating_today: date
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "offer_version_id": version.offer_version_id,
+        "version": version.version_number,
+        "state": derive_offer_state(
+            offer, version.offer_version_id, today=operating_today
+        ),
+        "created_at": version.created_at.isoformat(),
+        "sent_at": _version_sent_at(offer, version.offer_version_id),
+        "event_date": version.event_date.isoformat(),
+        "valid_until": version.valid_until.isoformat(),
+        "time_window_text": version.time_window_text,
+        "location_text": version.location_text,
+        "guest_count": version.guest_count,
+        "planning_mode": version.planning_mode,
+        "variants": [
+            {
+                "variant_id": variant.variant_id,
+                "name": variant.label,
+                "positions": [
+                    _position_detail(position) for position in variant.positions
+                ],
+            }
+            for variant in version.variants
+        ],
+    }
+    budget_definition = _budget_definition_detail(version)
+    if budget_definition is not None:
+        row["budget_definition"] = budget_definition
+    return row
+
+
 def offer_detail(offer: Offer, *, today: date | None = None) -> dict[str, object]:
     operating_today = today or berlin_today()
     projection = derive_inquiry_offer_projection(offer, today=operating_today)
@@ -329,31 +393,7 @@ def offer_detail(offer: Offer, *, today: date | None = None) -> dict[str, object
         "commercial_state": projection.commercial_state,
         "acceptance_id": projection.acceptance_id,
         "versions": [
-            {
-                "offer_version_id": version.offer_version_id,
-                "version": version.version_number,
-                "state": derive_offer_state(
-                    offer, version.offer_version_id, today=operating_today
-                ),
-                "created_at": version.created_at.isoformat(),
-                "sent_at": _version_sent_at(offer, version.offer_version_id),
-                "event_date": version.event_date.isoformat(),
-                "valid_until": version.valid_until.isoformat(),
-                "time_window_text": version.time_window_text,
-                "location_text": version.location_text,
-                "guest_count": version.guest_count,
-                "planning_mode": version.planning_mode,
-                "variants": [
-                    {
-                        "variant_id": variant.variant_id,
-                        "name": variant.label,
-                        "positions": [
-                            _position_detail(position) for position in variant.positions
-                        ],
-                    }
-                    for variant in version.variants
-                ],
-            }
+            _version_detail(offer, version, operating_today=operating_today)
             for version in versions
         ],
         "sent_evidence": _surface_sent_evidence(offer, projection.offer_version_id),

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -165,6 +165,60 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
     return "".join(rows) or "<li>Keine Positionen</li>"
 
 
+_BUDGET_TAX_BASIS_LABELS = {"GROSS": "brutto", "NET": "netto"}
+_BUDGET_COST_SCOPE_LABELS = {
+    "FULL_OFFER": "mit allen Kosten",
+    "POSITIONS_ONLY": "nur Positionen",
+}
+
+
+def _budget_cents(cents: object) -> str:
+    if not isinstance(cents, int) or isinstance(cents, bool):
+        return "–"
+    return f"{cents / 100:.2f} €".replace(".", ",")
+
+
+def _budget_block(surface: dict[str, object]) -> str:
+    """OFFER_BUDGET_DEFINITION_V1 — compact internal-only planning block.
+
+    Office Panel only, never the customer document. Omitted entirely (no
+    empty section) when this OfferVersion has no budget_definition — covers
+    both "operator never enabled budget tracking" and "Offer predates this
+    feature" the same way.
+    """
+    budget = surface.get("budget_definition")
+    if not isinstance(budget, dict):
+        return ""
+    per_person = budget.get("type") == "PER_PERSON"
+    suffix = " / Person" if per_person else ""
+    amount_line = f"<p><span>Budget</span><strong>{_e(_budget_cents(budget.get('amount_cents')))}{suffix}</strong></p>"
+    basis_label = _BUDGET_TAX_BASIS_LABELS.get(str(budget.get("tax_basis")), "–")
+    scope_label = _BUDGET_COST_SCOPE_LABELS.get(str(budget.get("cost_scope")), "–")
+    basis_line = f"<p><span>Basis</span><strong>{_e(basis_label)} · {_e(scope_label)}</strong></p>"
+    comparison = budget.get("comparison_amount_cents")
+    if comparison is None:
+        comparison_line = (
+            "<p><span>Aktuell</span><strong>Gästezahl noch offen</strong></p>"
+        )
+        remaining_line = ""
+    else:
+        comparison_line = f"<p><span>Aktuell</span><strong>{_e(_budget_cents(comparison))}{suffix}</strong></p>"
+        remaining = budget.get("remaining_cents")
+        over = bool(budget.get("over"))
+        remaining_abs = abs(remaining) if isinstance(remaining, int) else None
+        remaining_label = "Überschritten" if over else "Verfügbar"
+        remaining_line = (
+            f"<p><span>{remaining_label}</span>"
+            f"<strong>{_e(_budget_cents(remaining_abs))}{suffix}</strong></p>"
+        )
+    return (
+        '<section class="offer-detail-section offer-budget-section">'
+        "<h2>Budget (intern)</h2>"
+        f"{amount_line}{basis_line}{comparison_line}{remaining_line}"
+        "</section>"
+    )
+
+
 def _select_options(
     values: tuple[str, ...],
     labels: dict[str, str],
@@ -414,8 +468,7 @@ def render_offer_detail(
         f"<p><span>Gäste</span><strong>{_e(guest_text)}</strong></p>"
         f"<p><span>Zeitfenster</span><strong>{_e(str(surface['time_window_text']))}</strong></p>"
         f"<p><span>Planung</span><strong>{_e(planning)}</strong></p>"
-        "</section>"
-        '<section class="offer-detail-section">'
+        "</section>" + _budget_block(surface) + '<section class="offer-detail-section">'
         "<h2>Positionen (Snapshot)</h2>"
         f'<ul class="offer-position-list">{_position_rows(variants)}</ul>'
         "</section>"

--- a/tests/unit/test_offer_budget_customer_boundary.py
+++ b/tests/unit/test_offer_budget_customer_boundary.py
@@ -1,0 +1,217 @@
+"""Coordinated-review closure — customer-document boundary for budget_definition.
+
+Closes a review finding: Section 6 of the coordinated budget-slice review
+established the internal/customer-facing boundary by grepping
+`proposalExport.ts`/`office_panel_offer_detail.py` for the string "budget".
+That is a structural signal, not a behavioral proof. This file prepares a
+*real* Offer with a real `budget_definition` through the real services and
+exercises the real customer-facing outputs end to end:
+
+- the persisted ``OfferDocumentSnapshot`` (ANGEBOT / AUFTRAGSBESTÄTIGUNG,
+  built by ``OfferDocumentSnapshotService`` exactly as the Office Panel's
+  "PDF erzeugen" action does);
+- its canonical JSON serialization (the persisted-row representation);
+- the actual rendered PDF bytes, with real text extracted via pypdf (not a
+  grep of the renderer's source) — the same technique
+  ``test_offer_pdf_renderer.py`` already uses for content assertions;
+- the customer-facing print/export representation `is` the
+  OfferDocumentSnapshot/PDF pair above — there is no separate "print"
+  document type in this codebase, and no outbound customer-email builder
+  exists yet for Offers (only inbound intake-email projection does, which
+  is a different, unrelated feature) — confirmed structurally below so this
+  test breaks the moment either is introduced without budget exclusion.
+
+...and, from the *same* prepared Offer, proves the internal Office Panel
+side of the boundary: ``office_api_views.offer_detail`` (the real Office
+API surface builder) includes ``budget_definition`` in the version dict,
+and ``office_panel_offer_detail._budget_block`` (the real internal-only
+renderer) renders it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.offer import Offer
+from catering_system.domain.offer_document_snapshot import OfferDocumentSnapshot
+from catering_system.domain.offer_snapshot import compute_snapshot_hash
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_offer_document_snapshot_repository import (
+    InMemoryOfferDocumentSnapshotRepository,
+)
+from catering_system.repositories.in_memory_offer_repository import (
+    InMemoryOfferRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.offer_document_snapshot_serialization import (
+    snapshot_to_canonical_json,
+)
+from catering_system.services.offer_document_snapshot_service import (
+    OfferDocumentSnapshotService,
+)
+from catering_system.services.offer_pdf_renderer import render_offer_document_pdf
+from catering_system.services.offer_service import OfferService
+from catering_system.ui.office_api_views import offer_detail
+from catering_system.ui.office_panel_offer_detail import _budget_block
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+from tests.unit.test_offer_service import (
+    _INQUIRY_ID,
+    _budget_definition_payload,
+    _sample_inquiry,
+    _valid_snapshot,
+)
+
+_NOW = datetime(2026, 7, 20, 9, 0, tzinfo=UTC)
+_TODAY = date(2026, 7, 20)
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1", postal_code="20095", city="Hamburg", country="DE"
+)
+
+
+def _prepare_offer_with_budget() -> tuple[Offer, OfferDocumentSnapshot]:
+    """Real Offer, prepared through the real service, carrying a real
+    PER_PERSON budget_definition — then a real customer document snapshot
+    built for it, exactly as the Office Panel's document action would."""
+    offers = InMemoryOfferRepository()
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    documents = InMemoryOfferDocumentSnapshotRepository()
+
+    snapshot = InquiryCustomerSnapshot(
+        company_name="ACME GmbH",
+        contact_name="Anna",
+        email="anna@example.invalid",
+        phone="+49301234567",
+        invoice_address=_INVOICE,
+        delivery_address=None,
+        delivery_address_mode="SAME_AS_INVOICE",
+    )
+    inquiry = replace(
+        _sample_inquiry(), customer_snapshot=snapshot, fulfillment_mode="DELIVERY"
+    )
+    inquiries.save(inquiry)
+
+    offer_service = OfferService(offers, inquiries, orders, today=lambda: _TODAY)
+    payload = _valid_snapshot()
+    payload["budget_definition"] = _budget_definition_payload(
+        amount_cents=3500, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+    offer = offer_service.prepare_offer_version(_INQUIRY_ID, payload)
+    version = offer.versions[0]
+    assert version.budget_definition is not None  # sanity: the fixture worked
+
+    doc_service = OfferDocumentSnapshotService(
+        offers, inquiries, documents, now=lambda: _NOW, today=lambda: _TODAY
+    )
+    customer_doc = doc_service.prepare_offer_document(
+        offer.offer_id,
+        version.offer_version_id,
+        version.variants[0].variant_id,
+        "office",
+    )
+    return offer, customer_doc
+
+
+# --- customer-facing snapshot: structurally cannot carry budget_definition -------
+
+
+def test_offer_document_snapshot_has_no_budget_field_at_all() -> None:
+    """Not "the field is None" — the dataclass has no such field. A future
+    change would have to explicitly add one, which is exactly the kind of
+    change this test exists to catch."""
+    field_names = {f.name for f in dataclasses.fields(OfferDocumentSnapshot)}
+    assert not any("budget" in name.lower() for name in field_names)
+
+
+def test_customer_document_built_from_a_budgeted_offer_carries_no_budget_data() -> None:
+    """The Offer really has a budget_definition (asserted below) — proves
+    this isn't vacuously true because nothing was ever set."""
+    offer, customer_doc = _prepare_offer_with_budget()
+    assert offer.versions[0].budget_definition is not None
+    assert offer.versions[0].budget_definition.amount_cents == 3500
+
+    for field in dataclasses.fields(customer_doc):
+        value = getattr(customer_doc, field.name)
+        assert "budget" not in repr(value).lower(), (
+            f"customer document field {field.name!r} unexpectedly mentions budget"
+        )
+
+
+def test_customer_document_canonical_json_contains_no_budget_data() -> None:
+    """The persisted-row representation — what actually lives in the
+    offer_document_snapshots table — never carries budget data either."""
+    _offer, customer_doc = _prepare_offer_with_budget()
+    canonical = snapshot_to_canonical_json(customer_doc)
+    assert "budget" not in canonical.lower()
+
+
+def test_rendered_pdf_text_contains_no_budget_data() -> None:
+    """The strongest proof available: render the real PDF bytes from a
+    real budgeted Offer's customer document, extract the real text via
+    pypdf (not a source grep of the renderer), and confirm the internal
+    planning figure never reaches the customer-visible page."""
+    _offer, customer_doc = _prepare_offer_with_budget()
+    pdf_bytes = render_offer_document_pdf(customer_doc, fake_offer_pdf_static_content())
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    text = "\n".join(page.extract_text() for page in reader.pages)
+    assert "budget" not in text.lower()
+    # Sanity: the extraction actually found real content, so an empty/failed
+    # extraction can't silently make the assertion above meaningless.
+    assert "ANGEBOT" in text
+
+
+# --- internal Office Panel side of the same boundary: budget IS shown here ------
+
+
+def test_office_api_surface_for_the_same_offer_includes_budget_definition() -> None:
+    """The real Office API surface builder — not a hand-built dict — for
+    the exact same Offer the customer document above was built from."""
+    offer, _customer_doc = _prepare_offer_with_budget()
+    detail = offer_detail(offer, today=_TODAY)
+    version_row = detail["versions"][0]
+    assert "budget_definition" in version_row
+    assert version_row["budget_definition"]["amount_cents"] == 3500
+
+
+def test_internal_budget_block_renders_for_the_same_offer() -> None:
+    """The real internal-only HTML renderer, fed the real surface dict."""
+    offer, _customer_doc = _prepare_offer_with_budget()
+    detail = offer_detail(offer, today=_TODAY)
+    version_row = detail["versions"][0]
+    html = _budget_block(version_row)
+    assert "35,00" in html
+    assert "Budget" in html
+
+
+# --- no other customer-facing surface exists yet to leak into -------------------
+
+
+def test_no_outbound_customer_email_builder_exists_for_offers() -> None:
+    """FYI/trip-wire, not the primary proof above: this codebase has no
+    "email the customer about this Offer" builder today — only inbound
+    intake-email *projection* (a different, unrelated feature). If one is
+    added later, it must get its own version of the tests above; this
+    assertion is here so that addition doesn't silently bypass this file
+    without a reviewer noticing the boundary needs re-proving."""
+    services_dir = (
+        Path(__file__).resolve().parents[2] / "src" / "catering_system" / "services"
+    )
+    email_related = [
+        p
+        for p in services_dir.glob("*.py")
+        if "email" in p.name and "intake" not in p.name
+    ]
+    assert email_related == []

--- a/tests/unit/test_offer_budget_definition_domain.py
+++ b/tests/unit/test_offer_budget_definition_domain.py
@@ -1,0 +1,99 @@
+"""Unit tests — OfferBudgetDefinition value object validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from catering_system.domain.offer_budget_definition import (
+    OfferBudgetDefinition,
+    validate_offer_budget_cost_scope,
+    validate_offer_budget_tax_basis,
+    validate_offer_budget_type,
+)
+
+
+def test_valid_definition_constructs() -> None:
+    definition = OfferBudgetDefinition(
+        amount_cents=3500, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    assert definition.amount_cents == 3500
+
+
+def test_rejects_negative_amount() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        OfferBudgetDefinition(
+            amount_cents=-1, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+        )
+
+
+def test_rejects_float_amount() -> None:
+    with pytest.raises(ValueError, match="integer euro cents"):
+        OfferBudgetDefinition(
+            amount_cents=35.0,  # type: ignore[arg-type]
+            type="TOTAL",
+            tax_basis="GROSS",
+            cost_scope="FULL_OFFER",
+        )
+
+
+def test_rejects_bool_amount() -> None:
+    with pytest.raises(ValueError, match="integer euro cents"):
+        OfferBudgetDefinition(
+            amount_cents=True,
+            type="TOTAL",
+            tax_basis="GROSS",
+            cost_scope="FULL_OFFER",
+        )
+
+
+def test_zero_amount_is_valid() -> None:
+    definition = OfferBudgetDefinition(
+        amount_cents=0, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    assert definition.amount_cents == 0
+
+
+@pytest.mark.parametrize("value", ["TOTAL", "PER_PERSON"])
+def test_validate_offer_budget_type_accepts_known_values(value: str) -> None:
+    assert validate_offer_budget_type(value) == value
+
+
+def test_validate_offer_budget_type_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="invalid budget_definition.type"):
+        validate_offer_budget_type("total")
+
+
+@pytest.mark.parametrize("value", ["GROSS", "NET"])
+def test_validate_offer_budget_tax_basis_accepts_known_values(value: str) -> None:
+    assert validate_offer_budget_tax_basis(value) == value
+
+
+def test_validate_offer_budget_tax_basis_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="invalid budget_definition.tax_basis"):
+        validate_offer_budget_tax_basis("brutto")
+
+
+@pytest.mark.parametrize("value", ["FULL_OFFER", "POSITIONS_ONLY"])
+def test_validate_offer_budget_cost_scope_accepts_known_values(value: str) -> None:
+    assert validate_offer_budget_cost_scope(value) == value
+
+
+def test_validate_offer_budget_cost_scope_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="invalid budget_definition.cost_scope"):
+        validate_offer_budget_cost_scope("EVERYTHING")
+
+
+def test_domain_module_has_no_repository_or_api_imports() -> None:
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "catering_system"
+        / "domain"
+        / "offer_budget_definition.py"
+    )
+    text = source.read_text(encoding="utf-8")
+    assert "repositories" not in text
+    assert "catering_system.ui" not in text
+    assert "catering_system.services" not in text

--- a/tests/unit/test_offer_budget_presentation.py
+++ b/tests/unit/test_offer_budget_presentation.py
@@ -1,0 +1,220 @@
+"""Unit tests — OFFER_BUDGET_DEFINITION_V1 Office Panel presentation math.
+
+Everything here sums already-frozen position cents (net_total_cents /
+gross_total_cents) grouped by kind — no pricing or VAT is re-derived.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.offer import OfferPosition
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.services.offer_budget_presentation import (
+    compute_offer_budget_presentation,
+)
+
+
+def _catalog_position(
+    *, net_total_cents: int, vat_amount_cents: int, gross_total_cents: int
+) -> OfferPosition:
+    return OfferPosition(
+        position_id="88888888-8888-4888-8888-888888888881",
+        kind="catalog",
+        name="Fingerfood Paket",
+        unit_net_cents=net_total_cents,
+        net_total_cents=net_total_cents,
+        vat_rate_percent=7,
+        vat_amount_cents=vat_amount_cents,
+        gross_total_cents=gross_total_cents,
+    )
+
+
+def _fee_position(
+    *, net_total_cents: int, vat_amount_cents: int, gross_total_cents: int
+) -> OfferPosition:
+    return OfferPosition(
+        position_id="88888888-8888-4888-8888-888888888882",
+        kind="fee",
+        name="Büffetpauschale",
+        unit_net_cents=net_total_cents,
+        net_total_cents=net_total_cents,
+        vat_rate_percent=19,
+        vat_amount_cents=vat_amount_cents,
+        gross_total_cents=gross_total_cents,
+    )
+
+
+def test_no_budget_definition_returns_none() -> None:
+    result = compute_offer_budget_presentation(None, positions=[], guest_count=80)
+    assert result is None
+
+
+def test_total_gross_full_offer_includes_fees() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        ),
+        _fee_position(
+            net_total_cents=1500, vat_amount_cents=285, gross_total_cents=1785
+        ),
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=30000, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    assert result.comparison_amount_cents == 24824 + 1785
+    assert result.remaining_cents == 30000 - (24824 + 1785)
+    assert result.over is False
+
+
+def test_total_net_positions_only_excludes_fees() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        ),
+        _fee_position(
+            net_total_cents=1500, vat_amount_cents=285, gross_total_cents=1785
+        ),
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=20000, type="TOTAL", tax_basis="NET", cost_scope="POSITIONS_ONLY"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    assert result.comparison_amount_cents == 23200
+    assert result.remaining_cents == 20000 - 23200
+    assert result.over is True
+
+
+def test_positions_only_gross_includes_position_vat_but_not_fee_vat() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        ),
+        _fee_position(
+            net_total_cents=1500, vat_amount_cents=285, gross_total_cents=1785
+        ),
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=30000,
+        type="TOTAL",
+        tax_basis="GROSS",
+        cost_scope="POSITIONS_ONLY",
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    # Only the catalog position's own gross — fee gross is excluded entirely,
+    # not partially subtracted; this differs from the Configurator's
+    # positions-only+gross derivation (which reconstructs a Speisen-only
+    # gross from aggregate VAT buckets) because here each position already
+    # carries its own final gross_total_cents, so a straight sum-by-kind is
+    # sufficient and exact.
+    assert result.comparison_amount_cents == 24824
+
+
+def test_per_person_rounds_half_up() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        ),
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=350, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    # 24824 / 80 = 310.3 -> ROUND_HALF_UP -> 310
+    assert result.comparison_amount_cents == 310
+    assert result.remaining_cents == 40
+    assert result.over is False
+
+
+def test_per_person_exact_equality_is_neither_remaining_nor_exceeded_incorrectly() -> (
+    None
+):
+    positions = [
+        _catalog_position(
+            net_total_cents=24800, vat_amount_cents=0, gross_total_cents=24800
+        )
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=310, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    assert result.comparison_amount_cents == 310
+    assert result.remaining_cents == 0
+    assert result.over is False
+
+
+def test_total_exact_equality_is_not_over() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=24824, vat_amount_cents=0, gross_total_cents=24824
+        )
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=24824, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=80
+    )
+    assert result is not None
+    assert result.remaining_cents == 0
+    assert result.over is False
+
+
+def test_per_person_with_none_guest_count_has_no_comparison() -> None:
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        )
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=350, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=None
+    )
+    assert result is not None
+    assert result.comparison_amount_cents is None
+    assert result.remaining_cents is None
+    assert result.over is None
+
+
+def test_per_person_with_zero_guest_count_has_no_comparison() -> None:
+    """Never divides by zero."""
+    positions = [
+        _catalog_position(
+            net_total_cents=23200, vat_amount_cents=1624, gross_total_cents=24824
+        )
+    ]
+    budget = OfferBudgetDefinition(
+        amount_cents=350, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(
+        budget, positions=positions, guest_count=0
+    )
+    assert result is not None
+    assert result.comparison_amount_cents is None
+
+
+def test_empty_positions_gives_zero_comparison() -> None:
+    budget = OfferBudgetDefinition(
+        amount_cents=30000, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    result = compute_offer_budget_presentation(budget, positions=[], guest_count=80)
+    assert result is not None
+    assert result.comparison_amount_cents == 0
+    assert result.remaining_cents == 30000
+    assert result.over is False

--- a/tests/unit/test_offer_budget_presentation_configurator_parity.py
+++ b/tests/unit/test_offer_budget_presentation_configurator_parity.py
@@ -1,0 +1,159 @@
+"""Cross-repo guest-count parity — Core vs. Configurator.
+
+Closes a coordinated-review finding: for `type=PER_PERSON`, Configurator's
+`utils/budgetBreakdown.ts` used to silently substitute a guest count of 1
+when `persons <= 0`, fabricating an "Aktuell"/"Verfügbar" value where Core
+correctly reported the comparison as unavailable
+(`compute_offer_budget_presentation` returns `comparison_amount_cents=None`
+for `guest_count is None or guest_count <= 0`). Configurator was fixed to
+match Core exactly (see `budgetBreakdown.ts`'s `personsRequired` flag and its
+own parity tests in `frontend/src/utils/__tests__/budgetBreakdown.test.ts`,
+describe block "PER_PERSON guest-count parity with Core").
+
+This file proves the two engines agree, using an *identical* underlying
+snapshot on both sides: a single catalog position priced at 31,80 €/person
+(7% VAT), 20 persons -> net_total_cents = 63600 (636,00 €), scope
+POSITIONS_ONLY + basis NET so the comparison total depends only on
+`net_total_cents` and is entirely independent of Pauschalen (a
+Configurator-only presentation concern, not part of the guest-count
+semantics under test here) — the same fixture shape the Configurator side
+uses (`computeAll` in its own test file, `item7` at 31.80 €/person, 7% VAT).
+
+Covers, on both sides, the four cases the coordinated review asked for:
+guest_count = 0, guest_count missing, guest_count = 1, and a normal
+positive guest_count.
+"""
+
+from __future__ import annotations
+
+from catering_system.domain.offer import OfferPosition
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.services.offer_budget_presentation import (
+    compute_offer_budget_presentation,
+)
+
+# 20 persons * 31.80 EUR/person, matching the Configurator's `item7` fixture
+# (price=31.8, per_person, vat_rate_percent=7) at persons=20.
+_NET_TOTAL_CENTS = 63600
+_VAT_AMOUNT_CENTS = round(_NET_TOTAL_CENTS * 0.07)
+_GROSS_TOTAL_CENTS = _NET_TOTAL_CENTS + _VAT_AMOUNT_CENTS
+
+# 35,00 EUR/person configured budget — same amount used in the
+# Configurator's matching parity test.
+_AMOUNT_CENTS = 3500
+
+
+def _position() -> OfferPosition:
+    return OfferPosition(
+        position_id="99999999-9999-4999-9999-999999999991",
+        kind="catalog",
+        name="Speise",
+        unit_net_cents=_NET_TOTAL_CENTS,
+        net_total_cents=_NET_TOTAL_CENTS,
+        vat_rate_percent=7,
+        vat_amount_cents=_VAT_AMOUNT_CENTS,
+        gross_total_cents=_GROSS_TOTAL_CENTS,
+    )
+
+
+def _budget() -> OfferBudgetDefinition:
+    return OfferBudgetDefinition(
+        amount_cents=_AMOUNT_CENTS,
+        type="PER_PERSON",
+        tax_basis="NET",
+        cost_scope="POSITIONS_ONLY",
+    )
+
+
+def test_guest_count_zero_has_no_comparison_matching_configurator_personsRequired() -> (
+    None
+):
+    """Core: guest_count=0 -> comparison/remaining/over all None.
+
+    Configurator equivalent: `computeBudgetBreakdown({..., persons: 0})`
+    returns `personsRequired: true`, `comparisonPerPerson: null`,
+    `remaining: null`, `over: null` — see
+    frontend/src/utils/__tests__/budgetBreakdown.test.ts,
+    "guest_count = 0: personsRequired is true, nothing is fabricated".
+    Neither side ever assumes a guest count of 1.
+    """
+    result = compute_offer_budget_presentation(
+        _budget(), positions=[_position()], guest_count=0
+    )
+    assert result is not None
+    assert result.comparison_amount_cents is None
+    assert result.remaining_cents is None
+    assert result.over is None
+
+
+def test_guest_count_missing_has_no_comparison_matching_configurator_personsRequired() -> (
+    None
+):
+    """Core: guest_count=None -> comparison/remaining/over all None.
+
+    Configurator equivalent: `persons: null` -> the same `personsRequired:
+    true` state as guest_count=0 — "missing" and "<= 0" are one case on
+    both sides, not two.
+    """
+    result = compute_offer_budget_presentation(
+        _budget(), positions=[_position()], guest_count=None
+    )
+    assert result is not None
+    assert result.comparison_amount_cents is None
+    assert result.remaining_cents is None
+    assert result.over is None
+
+
+def test_guest_count_one_shows_a_real_comparison_matching_configurator() -> None:
+    """Core: guest_count=1 -> divides by 1, a real (if extreme) comparison.
+
+    Configurator equivalent: `persons: 1` -> `personsRequired: false`,
+    `comparisonPerPerson = 636.00`, matching `comparison_amount_cents =
+    63600` here exactly (636,00 EUR expressed in cents).
+    """
+    result = compute_offer_budget_presentation(
+        _budget(), positions=[_position()], guest_count=1
+    )
+    assert result is not None
+    assert result.comparison_amount_cents == _NET_TOTAL_CENTS  # 63600 -> 636,00 EUR
+    assert result.remaining_cents == _AMOUNT_CENTS - _NET_TOTAL_CENTS
+    assert result.over is True
+
+
+def test_guest_count_normal_positive_shows_a_real_comparison_matching_configurator() -> (
+    None
+):
+    """Core: guest_count=20 (the fixture's real headcount) -> 31,80 EUR/person.
+
+    Configurator equivalent: `persons: 20` -> `comparisonPerPerson =
+    subtotal / 20 = 636,00 / 20 = 31,80`, matching `comparison_amount_cents
+    = 3180` here exactly (31,80 EUR expressed in cents) — the same figure
+    the position was priced at per person in the first place.
+    """
+    result = compute_offer_budget_presentation(
+        _budget(), positions=[_position()], guest_count=20
+    )
+    assert result is not None
+    assert result.comparison_amount_cents == 3180  # 31,80 EUR/person
+    assert result.remaining_cents == _AMOUNT_CENTS - 3180  # 35,00 - 31,80 = 3,20 EUR
+    assert result.over is False
+
+
+def test_total_budget_type_is_unaffected_by_guest_count_on_either_side() -> None:
+    """TOTAL never divides by persons on the Core side either — matches
+    the Configurator's `personsRequired` guard, which only ever applies to
+    `budgetType === "per_person"`."""
+    total_budget = OfferBudgetDefinition(
+        amount_cents=100000,
+        type="TOTAL",
+        tax_basis="NET",
+        cost_scope="POSITIONS_ONLY",
+    )
+    for guest_count in (0, None, 1, 20):
+        result = compute_offer_budget_presentation(
+            total_budget, positions=[_position()], guest_count=guest_count
+        )
+        assert result is not None
+        assert result.comparison_amount_cents == _NET_TOTAL_CENTS
+        assert result.remaining_cents == 100000 - _NET_TOTAL_CENTS
+        assert result.over is False

--- a/tests/unit/test_offer_detail.py
+++ b/tests/unit/test_offer_detail.py
@@ -13,6 +13,7 @@ from catering_system.domain.offer import (
     OfferVersion,
     SentEvidence,
 )
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
@@ -55,6 +56,8 @@ def _version(
     created_at: datetime | None = None,
     label: str = "Variante A",
     snapshot_id: str = "77777777-7777-4777-8777-777777777771",
+    guest_count: int | None = 80,
+    budget_definition: OfferBudgetDefinition | None = None,
 ) -> OfferVersion:
     return OfferVersion(
         offer_version_id=offer_version_id,
@@ -67,10 +70,11 @@ def _version(
         event_date=date(2026, 8, 1),
         time_window_text="18:00–22:00",
         location_text="Hamburg",
-        guest_count=80,
+        guest_count=guest_count,
         planning_mode="caterer_suggestion",
         payment_method="RECHNUNG",
         payment_customer_visible_text="Zahlung per Rechnung",
+        budget_definition=budget_definition,
         variants=(
             OfferVariant(
                 variant_id=_VARIANT_ID,
@@ -100,6 +104,8 @@ def _offer(
     accepted: bool = False,
     converted: bool = False,
     valid_until: date | None = None,
+    guest_count: int | None = 80,
+    budget_definition: OfferBudgetDefinition | None = None,
 ) -> Offer:
     sent_evidence = (
         (
@@ -148,7 +154,13 @@ def _offer(
         offer_id=_OFFER_ID,
         source_inquiry_id=inquiry_id,
         created_at=_NOW,
-        versions=(_version(valid_until=valid_until),),
+        versions=(
+            _version(
+                valid_until=valid_until,
+                guest_count=guest_count,
+                budget_definition=budget_definition,
+            ),
+        ),
         sent_evidence=sent_evidence,
         acceptance_evidence=acceptance,
         rejection_evidence=(),
@@ -256,6 +268,98 @@ def test_history_sorted_chronologically() -> None:
     history = offer_detail(offer, today=_TODAY)["history"]
     timestamps = [entry["at"] for entry in history]
     assert timestamps == sorted(timestamps)
+
+
+def test_offer_detail_omits_budget_definition_when_absent() -> None:
+    """OFFER_BUDGET_DEFINITION_V1 backward compatibility: old Offers must
+    render without an empty/placeholder section — the key itself is
+    omitted, not present with a null/empty value."""
+    inquiry = _inquiry()
+    detail = offer_detail(_offer(inquiry.inquiry_id), today=_TODAY)
+    assert "budget_definition" not in detail["versions"][0]
+
+
+def test_offer_detail_includes_budget_definition_total_gross_full_offer() -> None:
+    inquiry = _inquiry()
+    budget = OfferBudgetDefinition(
+        amount_cents=30000, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    detail = offer_detail(
+        _offer(inquiry.inquiry_id, budget_definition=budget), today=_TODAY
+    )
+    view = detail["versions"][0]["budget_definition"]
+    assert view == {
+        "amount_cents": 30000,
+        "type": "TOTAL",
+        "tax_basis": "GROSS",
+        "cost_scope": "FULL_OFFER",
+        "comparison_amount_cents": 24824,
+        "remaining_cents": 5176,
+        "over": False,
+    }
+
+
+def test_offer_detail_includes_budget_definition_per_person_rounds_half_up() -> None:
+    inquiry = _inquiry()
+    budget = OfferBudgetDefinition(
+        amount_cents=350, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    detail = offer_detail(
+        _offer(inquiry.inquiry_id, guest_count=80, budget_definition=budget),
+        today=_TODAY,
+    )
+    view = detail["versions"][0]["budget_definition"]
+    # 24824 / 80 = 310.3 -> ROUND_HALF_UP -> 310
+    assert view["comparison_amount_cents"] == 310
+    assert view["remaining_cents"] == 40
+    assert view["over"] is False
+
+
+def test_offer_detail_budget_definition_over_budget() -> None:
+    inquiry = _inquiry()
+    budget = OfferBudgetDefinition(
+        amount_cents=20000, type="TOTAL", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    detail = offer_detail(
+        _offer(inquiry.inquiry_id, budget_definition=budget), today=_TODAY
+    )
+    view = detail["versions"][0]["budget_definition"]
+    assert view["remaining_cents"] == 20000 - 24824
+    assert view["over"] is True
+
+
+def test_offer_detail_budget_definition_per_person_with_unknown_guest_count() -> None:
+    """PER_PERSON budget with no guest_count on the OfferVersion — no
+    comparison can be computed; never crashes, never divides by zero."""
+    inquiry = _inquiry()
+    budget = OfferBudgetDefinition(
+        amount_cents=350, type="PER_PERSON", tax_basis="GROSS", cost_scope="FULL_OFFER"
+    )
+    detail = offer_detail(
+        _offer(inquiry.inquiry_id, guest_count=None, budget_definition=budget),
+        today=_TODAY,
+    )
+    view = detail["versions"][0]["budget_definition"]
+    assert view["comparison_amount_cents"] is None
+    assert view["remaining_cents"] is None
+    assert view["over"] is None
+
+
+def test_offer_detail_budget_definition_positions_only_net() -> None:
+    inquiry = _inquiry()
+    budget = OfferBudgetDefinition(
+        amount_cents=20000,
+        type="TOTAL",
+        tax_basis="NET",
+        cost_scope="POSITIONS_ONLY",
+    )
+    detail = offer_detail(
+        _offer(inquiry.inquiry_id, budget_definition=budget), today=_TODAY
+    )
+    view = detail["versions"][0]["budget_definition"]
+    # Single catalog position: net_total_cents=23200.
+    assert view["comparison_amount_cents"] == 23200
+    assert view["remaining_cents"] == 20000 - 23200
 
 
 def test_second_version_history_label() -> None:

--- a/tests/unit/test_offer_panel_budget_block.py
+++ b/tests/unit/test_offer_panel_budget_block.py
@@ -1,0 +1,121 @@
+"""Unit tests — Office Panel Offer Detail internal-only budget block.
+
+Tests the private ``_budget_block`` renderer directly against the
+``surface`` dict shape produced by ``office_api_views.offer_detail`` (one
+version's dict, as consumed by ``render_offer_detail``). Never appears in
+any customer-facing document.
+"""
+
+from __future__ import annotations
+
+from catering_system.ui.office_panel_offer_detail import _budget_block
+
+
+def test_no_budget_definition_renders_nothing() -> None:
+    assert _budget_block({"guest_count": 80}) == ""
+
+
+def test_total_budget_renders_verfuegbar() -> None:
+    html = _budget_block(
+        {
+            "budget_definition": {
+                "amount_cents": 30000,
+                "type": "TOTAL",
+                "tax_basis": "GROSS",
+                "cost_scope": "FULL_OFFER",
+                "comparison_amount_cents": 24824,
+                "remaining_cents": 5176,
+                "over": False,
+            }
+        }
+    )
+    assert "Budget (intern)" in html
+    assert "300,00 €" in html
+    assert "brutto" in html
+    assert "mit allen Kosten" in html
+    assert "248,24 €" in html
+    assert "Verfügbar" in html
+    assert "51,76 €" in html
+    assert "Überschritten" not in html
+    # Never per-person suffix for TOTAL.
+    assert "/ Person" not in html
+
+
+def test_per_person_budget_renders_ueberschritten_and_suffix() -> None:
+    html = _budget_block(
+        {
+            "budget_definition": {
+                "amount_cents": 3500,
+                "type": "PER_PERSON",
+                "tax_basis": "GROSS",
+                "cost_scope": "FULL_OFFER",
+                "comparison_amount_cents": 3644,
+                "remaining_cents": -144,
+                "over": True,
+            }
+        }
+    )
+    assert "35,00 €" in html
+    assert "/ Person" in html
+    assert "36,44 €" in html
+    assert "Überschritten" in html
+    assert "1,44 €" in html
+    assert "Verfügbar" not in html
+
+
+def test_positions_only_net_label() -> None:
+    html = _budget_block(
+        {
+            "budget_definition": {
+                "amount_cents": 20000,
+                "type": "TOTAL",
+                "tax_basis": "NET",
+                "cost_scope": "POSITIONS_ONLY",
+                "comparison_amount_cents": 23200,
+                "remaining_cents": -3200,
+                "over": True,
+            }
+        }
+    )
+    assert "netto" in html
+    assert "nur Positionen" in html
+
+
+def test_unknown_guest_count_shows_placeholder_not_crash() -> None:
+    html = _budget_block(
+        {
+            "budget_definition": {
+                "amount_cents": 3500,
+                "type": "PER_PERSON",
+                "tax_basis": "GROSS",
+                "cost_scope": "FULL_OFFER",
+                "comparison_amount_cents": None,
+                "remaining_cents": None,
+                "over": None,
+            }
+        }
+    )
+    assert "Gästezahl noch offen" in html
+    assert "Verfügbar" not in html
+    assert "Überschritten" not in html
+
+
+def test_budget_block_escapes_html() -> None:
+    # amount_cents/type/etc are always machine-produced enums/ints here, but
+    # the renderer must still not be trivially breakable if that ever
+    # changes — assert no raw "<" from arbitrary label lookups leaks in for
+    # an unrecognized tax_basis/cost_scope value.
+    html = _budget_block(
+        {
+            "budget_definition": {
+                "amount_cents": 100,
+                "type": "TOTAL",
+                "tax_basis": "<script>",
+                "cost_scope": "<script>",
+                "comparison_amount_cents": 0,
+                "remaining_cents": 100,
+                "over": False,
+            }
+        }
+    )
+    assert "<script>" not in html

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -20,6 +20,7 @@ from catering_system.domain.offer import (
     WithdrawalEvidence,
     derive_offer_state,
 )
+from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.repositories.in_memory_offer_repository import (
     InMemoryOfferRepository,
 )
@@ -95,6 +96,7 @@ def _version(
     valid_until: date = date(2026, 7, 31),
     snapshot_hash: str = _HASH_V1,
     variant_ids: tuple[str, ...] | None = None,
+    budget_definition: OfferBudgetDefinition | None = None,
 ) -> OfferVersion:
     version_id = _V1_ID if number == 1 else _V2_ID
     ids = variant_ids or ((_A_ID, _B_ID) if number == 1 else (_C_ID,))
@@ -117,6 +119,7 @@ def _version(
             )
             for index, variant_id in enumerate(ids, start=1)
         ),
+        budget_definition=budget_definition,
     )
 
 
@@ -588,6 +591,116 @@ def test_pre_migration_7_rows_load_with_narrative_fields_none(
     assert v1.customer_notes is None
 
 
+def test_sqlite_offer_roundtrip_preserves_budget_definition(tmp_path: Path) -> None:
+    repo = SQLiteOfferRepository(tmp_path / "offer.db")
+    budget = OfferBudgetDefinition(
+        amount_cents=3500,
+        type="PER_PERSON",
+        tax_basis="GROSS",
+        cost_scope="FULL_OFFER",
+    )
+    offer = _offer(versions=(_version(budget_definition=budget),))
+    repo.save(offer)
+    loaded = repo.get(_OFFER_ID)
+    assert loaded is not None
+    assert loaded.versions[0].budget_definition == budget
+    assert loaded == offer
+
+
+def test_sqlite_offer_roundtrip_preserves_absent_budget_definition(
+    tmp_path: Path,
+) -> None:
+    repo = SQLiteOfferRepository(tmp_path / "offer.db")
+    offer = _offer(versions=(_version(budget_definition=None),))
+    repo.save(offer)
+    loaded = repo.get(_OFFER_ID)
+    assert loaded is not None
+    assert loaded.versions[0].budget_definition is None
+
+
+def test_pre_migration_8_rows_load_with_budget_definition_none(
+    tmp_path: Path,
+) -> None:
+    """Migration/backward-compat: rows persisted before
+    OFFER_BUDGET_DEFINITION_V1 load with budget_definition=None rather than
+    failing or inventing a default."""
+    db = tmp_path / "pre_migration.db"
+    conn = sqlite3.connect(db)
+    apply_migrations(conn, "offers", _MIGRATIONS[:7])
+    conn.execute(
+        "INSERT INTO offers (offer_id, source_inquiry_id, created_at) VALUES (?, ?, ?)",
+        (_OFFER_ID, _INQUIRY_ID, _NOW.isoformat()),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_versions (
+            offer_version_id, offer_id, version_number, created_at, valid_until,
+            snapshot_id, snapshot_hash, event_date, time_window_text,
+            location_text, guest_count, planning_mode, payment_method,
+            payment_customer_visible_text, customer_title,
+            customer_introduction, customer_notes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _V1_ID,
+            _OFFER_ID,
+            1,
+            _NOW.isoformat(),
+            date(2026, 7, 31).isoformat(),
+            "77777777-7777-7777-7777-777777777771",
+            _HASH_V1,
+            _EVENT_DATE.isoformat(),
+            "18:00–22:00",
+            "Hamburg",
+            80,
+            "caterer_suggestion",
+            "RECHNUNG",
+            "Zahlung per Rechnung",
+            None,
+            None,
+            None,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO offer_variants "
+        "(variant_id, offer_version_id, offer_id, label, sort_order) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (_A_ID, _V1_ID, _OFFER_ID, "Variante A", 0),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_positions (
+            position_id, variant_id, offer_version_id, kind, name,
+            unit_net_cents, net_total_cents, vat_rate_percent,
+            vat_amount_cents, gross_total_cents, related_position_id,
+            sort_order
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _POS_A,
+            _A_ID,
+            _V1_ID,
+            "catalog",
+            "Fingerfood Paket",
+            290,
+            23200,
+            7,
+            1624,
+            24824,
+            None,
+            0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repo = SQLiteOfferRepository(db)  # migration 8 runs defensively on open
+    loaded = repo.get(_OFFER_ID)
+    repo.close()
+    assert loaded is not None
+    assert loaded.versions[0].budget_definition is None
+
+
 def test_prepare_offer_document_after_sqlite_reload_gets_frozen_narrative(
     tmp_path: Path,
 ) -> None:
@@ -707,6 +820,7 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         (5, "offer_variant_and_position_print_fields"),
         (6, "offer_position_catalog_snapshot_fields"),
         (7, "offer_version_customer_narrative"),
+        (8, "offer_version_budget_definition"),
     ]
     conn = sqlite3.connect(db)
     apply_migrations(conn, "offers", _MIGRATIONS)
@@ -714,4 +828,4 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM schema_migrations WHERE component = 'offers'"
     ).fetchone()
     conn.close()
-    assert rows_after == (7,)
+    assert rows_after == (8,)

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -162,6 +162,21 @@ def _valid_snapshot(*, inquiry_id: str = _INQUIRY_ID) -> dict[str, object]:
     return payload
 
 
+def _budget_definition_payload(
+    *,
+    amount_cents: int = 3500,
+    type: str = "PER_PERSON",
+    tax_basis: str = "GROSS",
+    cost_scope: str = "FULL_OFFER",
+) -> dict[str, object]:
+    return {
+        "amount_cents": amount_cents,
+        "type": type,
+        "tax_basis": tax_basis,
+        "cost_scope": cost_scope,
+    }
+
+
 def _sample_inquiry(*, inquiry_id: str = _INQUIRY_ID) -> Inquiry:
     return Inquiry(
         inquiry_id=inquiry_id,
@@ -341,6 +356,59 @@ def test_prepare_offer_version_happy_path() -> None:
     stored = offers.get(offer.offer_id)
     assert stored == offer
     assert offers.get_by_source_inquiry_id(_INQUIRY_ID) == offer
+
+
+def test_prepare_offer_version_persists_budget_definition() -> None:
+    """OFFER_BUDGET_DEFINITION_V1: preserved through Offer preparation."""
+    _inquiries, _orders, offers, service = _world(inquiry=_sample_inquiry())
+    payload = _valid_snapshot()
+    payload["budget_definition"] = _budget_definition_payload()
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, payload)
+
+    version = offer.versions[0]
+    assert version.budget_definition is not None
+    assert version.budget_definition.amount_cents == 3500
+    assert version.budget_definition.type == "PER_PERSON"
+    assert version.budget_definition.tax_basis == "GROSS"
+    assert version.budget_definition.cost_scope == "FULL_OFFER"
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    assert stored.versions[0].budget_definition == version.budget_definition
+
+
+def test_prepare_offer_version_without_budget_definition_stays_none() -> None:
+    """Budget tracking disabled — omit the field entirely, no default is
+    silently invented."""
+    _inquiries, _orders, _offers, service = _world(inquiry=_sample_inquiry())
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
+
+    assert offer.versions[0].budget_definition is None
+
+
+def test_prepare_offer_version_duplicate_preserves_original_budget_definition() -> None:
+    """Duplicate protection (offer_already_exists) must not touch the
+    already-persisted Offer — its budget_definition is untouched by the
+    rejected second prepare attempt, even when the retry carries a
+    different budget_definition."""
+    _inquiries, _orders, offers, service = _world(inquiry=_sample_inquiry())
+    first_payload = _valid_snapshot()
+    first_payload["budget_definition"] = _budget_definition_payload(amount_cents=3500)
+    first_payload["snapshot_hash"] = compute_snapshot_hash(first_payload)
+    original = service.prepare_offer_version(_INQUIRY_ID, first_payload)
+
+    second_payload = _valid_snapshot()
+    second_payload["budget_definition"] = _budget_definition_payload(amount_cents=9999)
+    second_payload["snapshot_hash"] = compute_snapshot_hash(second_payload)
+    with pytest.raises(OfferPreparationBlockedError):
+        service.prepare_offer_version(_INQUIRY_ID, second_payload)
+
+    stored = offers.get(original.offer_id)
+    assert stored is not None
+    assert stored.versions[0].budget_definition is not None
+    assert stored.versions[0].budget_definition.amount_cents == 3500
 
 
 def test_prepare_offer_version_narrative_normalization() -> None:

--- a/tests/unit/test_offer_snapshot_validation.py
+++ b/tests/unit/test_offer_snapshot_validation.py
@@ -100,10 +100,28 @@ def _variant(*, positions: list[dict[str, object]] | None = None) -> dict[str, o
     }
 
 
-def _snapshot_body(
-    *, guest_count: int | None = 80, variants: list[dict[str, object]] | None = None
+def _budget_definition(
+    *,
+    amount_cents: int = 3500,
+    type: str = "PER_PERSON",
+    tax_basis: str = "GROSS",
+    cost_scope: str = "FULL_OFFER",
 ) -> dict[str, object]:
     return {
+        "amount_cents": amount_cents,
+        "type": type,
+        "tax_basis": tax_basis,
+        "cost_scope": cost_scope,
+    }
+
+
+def _snapshot_body(
+    *,
+    guest_count: int | None = 80,
+    variants: list[dict[str, object]] | None = None,
+    budget_definition: dict[str, object] | None = None,
+) -> dict[str, object]:
+    body: dict[str, object] = {
         "schema_version": "offer_snapshot_v1",
         "source": "fingerfood-configurator-backend",
         "source_draft_id": "draft-1",
@@ -142,14 +160,20 @@ def _snapshot_body(
         },
         "variants": variants or [_variant()],
     }
+    if budget_definition is not None:
+        body["budget_definition"] = budget_definition
+    return body
 
 
 def _valid_snapshot(
     *,
     guest_count: int | None = 80,
     variants: list[dict[str, object]] | None = None,
+    budget_definition: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    payload = _snapshot_body(guest_count=guest_count, variants=variants)
+    payload = _snapshot_body(
+        guest_count=guest_count, variants=variants, budget_definition=budget_definition
+    )
     payload["snapshot_hash"] = compute_snapshot_hash(payload)
     return payload
 
@@ -457,6 +481,97 @@ def test_v2_empty_allergens_list_is_valid() -> None:
     assert snapshot.schema_version == SCHEMA_VERSION_V2
     assert snapshot.variants[0].positions[0].allergens == ()
     assert snapshot.variants[0].positions[0].catalog_item_id == dish_id
+
+
+def test_budget_definition_absent_is_valid() -> None:
+    """OFFER_BUDGET_DEFINITION_V1 backward compatibility: older/plain
+    snapshots without budget tracking must validate exactly as before."""
+    snapshot = validate_offer_snapshot(_valid_snapshot())
+    assert snapshot.budget_definition is None
+
+
+def test_budget_definition_valid_roundtrips() -> None:
+    payload = _valid_snapshot(budget_definition=_budget_definition())
+    snapshot = validate_offer_snapshot(payload)
+    assert snapshot.budget_definition is not None
+    assert snapshot.budget_definition.amount_cents == 3500
+    assert snapshot.budget_definition.type == "PER_PERSON"
+    assert snapshot.budget_definition.tax_basis == "GROSS"
+    assert snapshot.budget_definition.cost_scope == "FULL_OFFER"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"type": "TOTAL", "tax_basis": "NET", "cost_scope": "POSITIONS_ONLY"},
+        {"type": "TOTAL", "tax_basis": "GROSS", "cost_scope": "FULL_OFFER"},
+        {"type": "PER_PERSON", "tax_basis": "NET", "cost_scope": "FULL_OFFER"},
+        {"type": "PER_PERSON", "tax_basis": "GROSS", "cost_scope": "POSITIONS_ONLY"},
+    ],
+)
+def test_budget_definition_every_combination_is_valid(
+    overrides: dict[str, object],
+) -> None:
+    payload = _valid_snapshot(budget_definition=_budget_definition(**overrides))
+    snapshot = validate_offer_snapshot(payload)
+    assert snapshot.budget_definition is not None
+    assert snapshot.budget_definition.type == overrides["type"]
+    assert snapshot.budget_definition.tax_basis == overrides["tax_basis"]
+    assert snapshot.budget_definition.cost_scope == overrides["cost_scope"]
+
+
+def test_budget_definition_rejects_unknown_field() -> None:
+    definition = _budget_definition()
+    definition["extra"] = "nope"
+    with pytest.raises(ValueError, match="unknown budget_definition field"):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+@pytest.mark.parametrize("field", ["amount_cents", "type", "tax_basis", "cost_scope"])
+def test_budget_definition_rejects_missing_field(field: str) -> None:
+    definition = _budget_definition()
+    del definition[field]
+    with pytest.raises(ValueError):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+def test_budget_definition_rejects_invalid_type_enum() -> None:
+    definition = _budget_definition(type="TOTAL_BUDGET")
+    with pytest.raises(ValueError, match="invalid budget_definition.type"):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+def test_budget_definition_rejects_invalid_tax_basis_enum() -> None:
+    definition = _budget_definition(tax_basis="brutto")
+    with pytest.raises(ValueError, match="invalid budget_definition.tax_basis"):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+def test_budget_definition_rejects_invalid_cost_scope_enum() -> None:
+    definition = _budget_definition(cost_scope="EVERYTHING")
+    with pytest.raises(ValueError, match="invalid budget_definition.cost_scope"):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+def test_budget_definition_rejects_negative_amount() -> None:
+    definition = _budget_definition(amount_cents=-100)
+    with pytest.raises(ValueError):
+        validate_offer_snapshot(_valid_snapshot(budget_definition=definition))
+
+
+def test_budget_definition_rejects_float_amount() -> None:
+    # budget_definition is parsed before the snapshot_hash is even checked
+    # (see validate_offer_snapshot), so the float is caught first — a stale
+    # hash from the float mutation never gets evaluated.
+    payload = _valid_snapshot(budget_definition=_budget_definition())
+    payload["budget_definition"]["amount_cents"] = 35.0
+    with pytest.raises(ValueError, match="amount_cents must be integer euro cents"):
+        validate_offer_snapshot(payload)
+
+
+def test_budget_definition_rejects_non_object() -> None:
+    with pytest.raises(ValueError, match="budget_definition must be an object"):
+        validate_offer_snapshot(_valid_snapshot(budget_definition="not-an-object"))  # type: ignore[arg-type]
 
 
 def test_domain_module_has_no_repository_or_api_imports() -> None:


### PR DESCRIPTION
Closes #58.

## Summary

Extends the Core Offer snapshot contract and persisted Offer aggregate with an **optional** `budget_definition` — internal-only operator planning metadata (amount/type/tax basis/cost scope) from the Configurator's budget selectors. Never customer-facing: not in the Offer PDF, not in any customer-visible wording, only shown in a compact internal block on the Office Panel's Offer Detail page.

## Exact snapshot schema addition

New optional envelope field, sibling of `variants`/`calculator` in `OfferSnapshotEnvelope`:

```json
"budget_definition": {
  "amount_cents": 3500,
  "type": "PER_PERSON",
  "tax_basis": "GROSS",
  "cost_scope": "FULL_OFFER"
}
```

- `amount_cents`: non-negative integer euro cents — the established money representation for this schema (matches `unit_net_cents`, `net_total_cents`, etc.); no floats cross this boundary (the schema's `canonical_snapshot_json` already forbids them).
- `type`: `TOTAL` | `PER_PERSON`
- `tax_basis`: `GROSS` | `NET`
- `cost_scope`: `FULL_OFFER` | `POSITIONS_ONLY`
- Strictly validated (unknown fields / invalid enum values rejected, same pattern as `payment_terms.method`).
- Optional at every level: absent on older snapshots (no reinterpretation of old Offers), absent whenever the operator has budget tracking disabled.

## What's included

- **Domain**: `domain/offer_budget_definition.py` (new, shared value object + validators), `OfferSnapshotEnvelope.budget_definition`, `OfferVersion.budget_definition`.
- **Validation**: `services/offer_snapshot_validation.py` — envelope key + strict field parsing.
- **Service**: `services/offer_service.py` — mapped through `prepare_offer_version` and `prepare_next_offer_version` (covers prepare + the revision/replay path). The existing `offer_already_exists` duplicate-detection path is untouched — a rejected duplicate attempt never overwrites the original Offer's `budget_definition`.
- **Persistence**: `repositories/sqlite_offer_repository.py` — migration 8, one `budget_definition_json` column on `offer_versions` (mirrors the existing `allergens_json`-on-positions pattern rather than four flat columns).
- **Office Panel**: `services/offer_budget_presentation.py` (new — sums each version's already-frozen position cents by `kind`, no pricing/VAT re-derivation) + `ui/office_api_views.py` + `ui/office_panel_offer_detail.py` — compact "Budget (intern)" block:
  ```
  Budget: 35,00 € / Person
  Basis: brutto · mit allen Kosten
  Aktuell: 36,44 € / Person
  Überschritten: 1,44 € / Person
  ```
  Omitted entirely (not an empty section) when no `budget_definition` is present — old Offers render exactly as before.

## Tests

- Schema/contract: valid roundtrip, all 4 combinations, unknown-field rejection, missing-field rejection, invalid-enum rejection, negative/float amount rejection, absence-is-valid.
- Persistence: roundtrip with and without a definition, migration 8 pre-existing-row backward compatibility.
- Service: prepare persists it, absence stays `None`, duplicate-attempt preserves the original's definition unchanged.
- Presentation math: all 8 combinations, ROUND_HALF_UP rounding, exact-equality (never falsely "exceeded"), unknown/zero guest-count (never divides by zero).
- Office Detail rendering: HTML block content, per-person vs total labeling, Verfügbar vs Überschritten, omission when absent, no unescaped enum values.

Also exercised as a true cross-repo integration in the companion Configurator PR's E2E suite (`test_prepare_offer_e2e.py`): a real snapshot built by the Configurator backend, sent over HTTP to a real instance of this Core API, persisted, and read back — not mocked on either side.

## Validation

```
ruff check src tests        # clean
ruff format --check src tests infra   # clean
mypy src/catering_system    # clean, 186 files
pytest                      # 2333 passed (full suite, includes all new/modified tests above)
```

## Companion PR

fingerfood-app#16 (Configurator) — starts sending `budget_definition` in the supported location once this contract exists. **Neither side should merge independently of a coordinated review.**

Not merged. Not deployed.