### PR TITLE
CONFIGURABLE_OFFER_CHARGES_V1 (Stage 2A): Core contract, persistence and migration

### DIFF
--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -486,6 +486,65 @@ yet reconnected to `core.db` since deploy (migrations apply on first
 connection) — restart the affected service and re-check, don't attempt any
 manual `ALTER TABLE`.
 
+### Migration 9 — `offer_versions.charges_definition_json` (CONFIGURABLE_OFFER_CHARGES_V1)
+
+Migration 9 (component `offers`, `_migration_9_offer_version_charges_definition`
+in `sqlite_offer_repository.py`) is the same additive pattern as migration 8,
+one statement:
+
+```sql
+ALTER TABLE offer_versions ADD COLUMN charges_definition_json TEXT
+```
+
+- **Additive and nullable.** Adds exactly one column, no `NOT NULL`
+  constraint, no default beyond SQLite's implicit `NULL`. Every
+  pre-migration row reads back with `charges_definition_json = NULL` — no
+  backfill, no data rewrite.
+- **Existing rows are untouched**, for the same reason as migration 8:
+  `ALTER TABLE ... ADD COLUMN` in SQLite only changes the schema definition
+  applied going forward, it does not rewrite existing rows.
+- **Old code safely ignores the added column** — same reasoning as
+  migration 8: pre-migration Core code never selects
+  `charges_definition_json` by name, and row mapping elsewhere maps by
+  explicit column name, not position. This is what makes the standard
+  [code-only rollback](#code-only-rollback) sufficient here too.
+- **Absence of `charges_definition` does not change existing behaviour.**
+  `delivery`/`dishware`/`buffet_fee` positions were already being
+  materialized as `kind="fee"` positions by the Configurator before this
+  slice, and already rendered normally in the Office Panel and customer
+  PDF (both are, and remain, kind-agnostic — see
+  `tests/unit/test_offer_charges_rendering.py`). This migration only adds
+  a place to persist the *structured, editable* charges definition
+  alongside those positions; it does not change what gets billed or
+  printed for any Offer that doesn't send one.
+- **Routine rollback never drops the column** — same reasoning and same
+  process as migration 8: revert the commit, restart the affected
+  services, leave `offer_versions.charges_definition_json` in place. No
+  down-migration is provided for this column, consistent with every other
+  migration in this runner.
+- **Database restore is the only way to actually remove the column**, and
+  is routine-rollback overkill for this slice specifically, exactly as
+  documented for migration 8 above — only use it if a full restore is
+  independently justified for some other reason.
+
+**Verify the migration applied and the column exists**, read-only, no
+service restart required:
+
+```bash
+sqlite3 /home/viktor/catering-runtime/core.db \
+  "SELECT component, version, name, applied_at FROM schema_migrations \
+   WHERE component = 'offers' ORDER BY version;"
+sqlite3 /home/viktor/catering-runtime/core.db \
+  "PRAGMA table_info(offer_versions);" | grep charges_definition_json
+```
+
+The first command's last row should read
+`offers|9|offer_version_charges_definition|<timestamp>`; the second should
+print one line for the new `TEXT` column. Absence of the column with the
+service otherwise healthy means the code deployed but the process has not
+yet reconnected to `core.db` since deploy — restart the affected service
+and re-check, don't attempt any manual `ALTER TABLE`.
+
 ## Common failures
 
 | Symptom | Check | Typical cause |

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
 from catering_system.domain.inquiry import PlanningMode, validate_planning_mode
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.domain.offer_charges import OfferChargesDefinition
 from catering_system.domain.order_payment_reminder import (
     PaymentMethod,
     validate_payment_method,
@@ -31,12 +32,28 @@ OfferState = Literal[
     "Superseded",
     "Expired",
 ]
-PositionKind = Literal["catalog", "surcharge", "fee", "custom"]
+PositionKind = Literal[
+    "catalog", "surcharge", "fee", "custom", "delivery", "dishware", "buffet_fee"
+]
 PositionQuantityMode = Literal["total", "per_person"]
 VatRatePercent = Literal[7, 19]
 SentChannel = Literal["email", "postal", "in_person", "other"]
 AcceptanceChannel = Literal["email", "phone", "signed_document", "in_person", "other"]
-POSITION_KINDS: tuple[PositionKind, ...] = ("catalog", "surcharge", "fee", "custom")
+# CONFIGURABLE_OFFER_CHARGES_V1: "delivery"/"dishware"/"buffet_fee" are new,
+# explicit kinds for the structured charges this slice introduces. Legacy
+# snapshots keep using "fee" for the same conceptual charges (Anlieferung/
+# Geschirrpauschale/Büffetpauschale materialized unconditionally by the
+# pre-this-slice Configurator) — "fee" is not removed or reinterpreted, it
+# simply stops being what *new* charges_definition-bearing snapshots use.
+POSITION_KINDS: tuple[PositionKind, ...] = (
+    "catalog",
+    "surcharge",
+    "fee",
+    "custom",
+    "delivery",
+    "dishware",
+    "buffet_fee",
+)
 POSITION_QUANTITY_MODES: tuple[PositionQuantityMode, ...] = ("total", "per_person")
 VAT_RATES: tuple[VatRatePercent, ...] = (7, 19)
 SENT_CHANNELS: tuple[SentChannel, ...] = ("email", "postal", "in_person", "other")
@@ -214,6 +231,16 @@ class OfferVersion:
     # frozen from the source OfferSnapshot's budget_definition (if any).
     # Never surfaced in customer-facing documents/wording.
     budget_definition: OfferBudgetDefinition | None = None
+    # CONFIGURABLE_OFFER_CHARGES_V1: the structured delivery/dishware/buffet
+    # definition this version's charges were derived from, frozen from the
+    # source OfferSnapshot (if any). Unlike budget_definition, this *is*
+    # customer-facing in effect — it's the input behind real delivery/
+    # dishware/buffet_fee positions already in variants[].positions — but the
+    # definition object itself is only ever surfaced in internal views
+    # (Office Panel), never printed verbatim into a customer document. None
+    # on legacy snapshots that never sent one; their positions (historically
+    # always kind="fee") are untouched and not reinterpreted.
+    charges_definition: OfferChargesDefinition | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.offer_version_id, "offer_version_id")

--- a/src/catering_system/domain/offer_charges.py
+++ b/src/catering_system/domain/offer_charges.py
@@ -15,6 +15,13 @@ backend) are trusted as-is, never reinterpreted or synthesized from this
 module. See ``services/offer_snapshot_validation.py`` for the consistency
 check that only ever applies when a ``charges_definition`` is actually
 present on the incoming snapshot.
+
+Default posture for new Offers (binding on Stage 2B, the Configurator side
+that will build these definitions): ``dishware.base_mode`` and
+``buffet.base_mode`` both default to ``"NONE"``. Neither Geschirrpauschale
+nor Büffetpauschale is added automatically — both must be explicitly
+selected by the office user. This replaces the pre-this-slice behaviour
+where both were always-on, unconditional fee positions.
 """
 
 from __future__ import annotations
@@ -121,7 +128,11 @@ class DishwareChargeDefinition:
 @dataclass(frozen=True)
 class BuffetChargeDefinition:
     """Büffetpauschale charge — same NONE/PAUSCHALE shape as dishware's base
-    mode, no additional lines. Existing canonical rate: 50 cents/person."""
+    mode, no additional lines. Existing canonical rate: 50 cents/person.
+
+    New Offers default to ``base_mode="NONE"`` — Büffetpauschale must be
+    explicitly selected by the office user, it is never added automatically
+    (this replaces the pre-this-slice unconditional behaviour)."""
 
     base_mode: ChargeBaseMode
     pauschale_per_person_cents: int

--- a/src/catering_system/domain/offer_charges.py
+++ b/src/catering_system/domain/offer_charges.py
@@ -1,0 +1,160 @@
+"""CONFIGURABLE_OFFER_CHARGES_V1 — delivery/dishware/buffet charge definitions.
+
+Shared value objects embedded (optionally) in both the OfferSnapshot wire
+envelope (``domain/offer_snapshot.py``) and the persisted Offer aggregate
+(``domain/offer.py``). Unlike ``OfferBudgetDefinition``, these *are*
+customer-facing: they describe real offer-level charges that materialize as
+``delivery``/``dishware``/``buffet_fee`` positions, appear in totals, and
+render in the customer document/PDF exactly like any other position.
+
+Absent (``None``) on the envelope means "legacy snapshot" — no charges
+definition was ever sent, and the snapshot's already-materialized positions
+(historically always ``kind="fee"`` Büffetpauschale/Geschirrpauschale/
+Anlieferung, added unconditionally by the pre-this-slice Configurator
+backend) are trusted as-is, never reinterpreted or synthesized from this
+module. See ``services/offer_snapshot_validation.py`` for the consistency
+check that only ever applies when a ``charges_definition`` is actually
+present on the incoming snapshot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ChargeBaseMode = Literal["NONE", "PAUSCHALE"]
+
+CHARGE_BASE_MODES: tuple[ChargeBaseMode, ...] = ("NONE", "PAUSCHALE")
+
+
+def validate_charge_base_mode(value: str) -> ChargeBaseMode:
+    if value == "NONE":
+        return "NONE"
+    if value == "PAUSCHALE":
+        return "PAUSCHALE"
+    raise ValueError("invalid charge base_mode")
+
+
+def _require_non_negative_cents(value: object, field_name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} must be integer euro cents")
+    if value < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return value
+
+
+@dataclass(frozen=True)
+class DeliveryChargeDefinition:
+    """One operator-configured delivery amount.
+
+    ``amount_cents`` is the complete, standalone charge — 0 is explicitly
+    valid (collection / free delivery), not a sentinel for "no delivery".
+    Every ``charges_definition`` that specifies delivery at all carries this
+    object; there is no separate on/off toggle for delivery the way
+    dishware/buffet have ``base_mode``.
+    """
+
+    amount_cents: int
+
+    def __post_init__(self) -> None:
+        _require_non_negative_cents(self.amount_cents, "delivery.amount_cents")
+
+
+@dataclass(frozen=True)
+class DishwareAdditionalLineDefinition:
+    """One operator-entered additional dishware line.
+
+    Deliberately carries no calculated total — ``net_total_cents`` is never
+    accepted from the wire and never stored here (binding decision: the
+    server always derives ``quantity * unit_net_cents`` itself, at whatever
+    point it is needed, rather than trusting or persisting a client-supplied
+    figure that could drift from the inputs that produced it).
+    """
+
+    description: str
+    quantity: int
+    unit_net_cents: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.description, str):
+            raise ValueError("dishware line description must be a string")
+        if self.description != self.description.strip():
+            raise ValueError("dishware line description must be trimmed")
+        if not self.description:
+            raise ValueError("dishware line description is required")
+        if not isinstance(self.quantity, int) or isinstance(self.quantity, bool):
+            raise ValueError("dishware line quantity must be a whole number")
+        if self.quantity < 1:
+            raise ValueError("dishware line quantity must be a positive integer")
+        _require_non_negative_cents(self.unit_net_cents, "dishware line unit_net_cents")
+
+    @property
+    def net_total_cents(self) -> int:
+        """Derived on demand — never a stored/persisted field (see class docstring)."""
+        return self.quantity * self.unit_net_cents
+
+
+@dataclass(frozen=True)
+class DishwareChargeDefinition:
+    """Dishware charge: an independent Pauschale toggle plus an independent
+    list of additional lines. The two are orthogonal — all four
+    combinations (NONE/no lines, NONE/lines, PAUSCHALE/no lines,
+    PAUSCHALE/lines) are valid and meaningful; a non-empty ``additional_lines``
+    does not imply or require ``base_mode == "PAUSCHALE"``.
+
+    ``pauschale_per_person_cents`` is always present and validated even when
+    ``base_mode == "NONE"`` — the configured rate survives being toggled
+    off, so switching back to PAUSCHALE later does not lose it.
+    """
+
+    base_mode: ChargeBaseMode
+    pauschale_per_person_cents: int
+    additional_lines: tuple[DishwareAdditionalLineDefinition, ...] = ()
+
+    def __post_init__(self) -> None:
+        validate_charge_base_mode(self.base_mode)
+        _require_non_negative_cents(
+            self.pauschale_per_person_cents, "dishware.pauschale_per_person_cents"
+        )
+
+
+@dataclass(frozen=True)
+class BuffetChargeDefinition:
+    """Büffetpauschale charge — same NONE/PAUSCHALE shape as dishware's base
+    mode, no additional lines. Existing canonical rate: 50 cents/person."""
+
+    base_mode: ChargeBaseMode
+    pauschale_per_person_cents: int
+
+    def __post_init__(self) -> None:
+        validate_charge_base_mode(self.base_mode)
+        _require_non_negative_cents(
+            self.pauschale_per_person_cents, "buffet.pauschale_per_person_cents"
+        )
+
+
+@dataclass(frozen=True)
+class OfferChargesDefinition:
+    """Complete operator-configured charges for one Offer snapshot.
+
+    All three fields are required whenever ``charges_definition`` is present
+    on the envelope at all — there is no partial shape; a snapshot either
+    carries the complete, explicit charge configuration or none of it
+    (``charges_definition`` itself is ``None`` on the envelope/version).
+    """
+
+    delivery: DeliveryChargeDefinition
+    dishware: DishwareChargeDefinition
+    buffet: BuffetChargeDefinition
+
+
+__all__ = [
+    "CHARGE_BASE_MODES",
+    "BuffetChargeDefinition",
+    "ChargeBaseMode",
+    "DeliveryChargeDefinition",
+    "DishwareAdditionalLineDefinition",
+    "DishwareChargeDefinition",
+    "OfferChargesDefinition",
+    "validate_charge_base_mode",
+]

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -11,6 +11,7 @@ from typing import Literal
 
 from catering_system.domain.inquiry import PlanningMode
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.domain.offer_charges import OfferChargesDefinition
 from catering_system.domain.order_payment_reminder import PaymentMethod
 
 SCHEMA_VERSION = "offer_snapshot_v1"
@@ -28,10 +29,17 @@ MAX_EMAIL_LEN = 320
 MAX_SHORT_TEXT_LEN = 500
 MAX_LONG_TEXT_LEN = 20_000
 
-SnapshotPositionKind = Literal["catalog", "surcharge", "fee", "custom"]
+SnapshotPositionKind = Literal[
+    "catalog", "surcharge", "fee", "custom", "delivery", "dishware", "buffet_fee"
+]
 SnapshotQuantityMode = Literal["total", "per_person"]
 
-_POSITION_KINDS: frozenset[str] = frozenset({"catalog", "surcharge", "fee", "custom"})
+# CONFIGURABLE_OFFER_CHARGES_V1: "delivery"/"dishware"/"buffet_fee" are new,
+# explicit kinds; legacy "fee" positions keep working unchanged (see
+# domain/offer.py PositionKind for the full rationale).
+_POSITION_KINDS: frozenset[str] = frozenset(
+    {"catalog", "surcharge", "fee", "custom", "delivery", "dishware", "buffet_fee"}
+)
 _QUANTITY_MODES: frozenset[str] = frozenset({"total", "per_person"})
 _VAT_RATES: frozenset[int] = frozenset({7, 19})
 _QUANTITY_RE = re.compile(r"^(?:0|[1-9]\d*)(?:\.\d{1,3})?\Z")
@@ -140,6 +148,11 @@ class OfferSnapshotEnvelope:
     # OFFER_BUDGET_DEFINITION_V1: optional internal-only operator planning
     # metadata — never customer-facing (see domain/offer_budget_definition.py).
     budget_definition: OfferBudgetDefinition | None = None
+    # CONFIGURABLE_OFFER_CHARGES_V1: optional structured delivery/dishware/
+    # buffet definition (see domain/offer_charges.py). Absent means legacy —
+    # the snapshot's positions (historically kind="fee") are trusted as-is,
+    # never reinterpreted from this field.
+    charges_definition: OfferChargesDefinition | None = None
 
 
 @dataclass(frozen=True)

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -38,6 +38,13 @@ from catering_system.domain.offer import (
     WithdrawalEvidence,
 )
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.domain.offer_charges import (
+    BuffetChargeDefinition,
+    DeliveryChargeDefinition,
+    DishwareAdditionalLineDefinition,
+    DishwareChargeDefinition,
+    OfferChargesDefinition,
+)
 from catering_system.domain.order_payment_reminder import validate_payment_method
 from catering_system.repositories.sqlite_migrations import apply_migrations
 
@@ -304,6 +311,18 @@ def _migration_8_offer_version_budget_definition(
         )
 
 
+def _migration_9_offer_version_charges_definition(
+    connection: sqlite3.Connection,
+) -> None:
+    existing = {
+        row[1] for row in connection.execute("PRAGMA table_info(offer_versions)")
+    }
+    if "charges_definition_json" not in existing:
+        connection.execute(
+            "ALTER TABLE offer_versions ADD COLUMN charges_definition_json TEXT"
+        )
+
+
 _MIGRATIONS = (
     (1, "create_offer_tables", _migration_1_create_tables),
     (2, "unique_source_inquiry", _migration_2_unique_source_inquiry),
@@ -332,6 +351,11 @@ _MIGRATIONS = (
         8,
         "offer_version_budget_definition",
         _migration_8_offer_version_budget_definition,
+    ),
+    (
+        9,
+        "offer_version_charges_definition",
+        _migration_9_offer_version_charges_definition,
     ),
 )
 
@@ -396,6 +420,73 @@ def _stored_budget_definition(value: str | None) -> OfferBudgetDefinition | None
         )
     except KeyError as exc:
         raise ValueError("budget_definition_json missing required field") from exc
+
+
+def _charges_definition_storage(value: OfferChargesDefinition | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(
+        {
+            "delivery": {"amount_cents": value.delivery.amount_cents},
+            "dishware": {
+                "base_mode": value.dishware.base_mode,
+                "pauschale_per_person_cents": value.dishware.pauschale_per_person_cents,
+                "additional_lines": [
+                    {
+                        "description": line.description,
+                        "quantity": line.quantity,
+                        "unit_net_cents": line.unit_net_cents,
+                    }
+                    for line in value.dishware.additional_lines
+                ],
+            },
+            "buffet": {
+                "base_mode": value.buffet.base_mode,
+                "pauschale_per_person_cents": value.buffet.pauschale_per_person_cents,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _stored_charges_definition(value: str | None) -> OfferChargesDefinition | None:
+    """Reject malformed stored payloads rather than silently drop them —
+    this column is only ever written by ``_charges_definition_storage`` above,
+    so a decode/shape failure here means on-disk corruption, not a normal
+    "no charges" case (that's represented by SQL NULL / Python None)."""
+    if value is None:
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError("charges_definition_json must decode to an object")
+    try:
+        delivery_raw = parsed["delivery"]
+        dishware_raw = parsed["dishware"]
+        buffet_raw = parsed["buffet"]
+        additional_lines = tuple(
+            DishwareAdditionalLineDefinition(
+                description=line["description"],
+                quantity=line["quantity"],
+                unit_net_cents=line["unit_net_cents"],
+            )
+            for line in dishware_raw["additional_lines"]
+        )
+        return OfferChargesDefinition(
+            delivery=DeliveryChargeDefinition(
+                amount_cents=delivery_raw["amount_cents"]
+            ),
+            dishware=DishwareChargeDefinition(
+                base_mode=dishware_raw["base_mode"],
+                pauschale_per_person_cents=dishware_raw["pauschale_per_person_cents"],
+                additional_lines=additional_lines,
+            ),
+            buffet=BuffetChargeDefinition(
+                base_mode=buffet_raw["base_mode"],
+                pauschale_per_person_cents=buffet_raw["pauschale_per_person_cents"],
+            ),
+        )
+    except (KeyError, TypeError) as exc:
+        raise ValueError("charges_definition_json missing required field") from exc
 
 
 def _dt(value: str) -> datetime:
@@ -676,8 +767,9 @@ class SQLiteOfferRepository:
                 snapshot_id, snapshot_hash, event_date, time_window_text,
                 location_text, guest_count, planning_mode, payment_method,
                 payment_customer_visible_text, customer_title,
-                customer_introduction, customer_notes, budget_definition_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                customer_introduction, customer_notes, budget_definition_json,
+                charges_definition_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 version.offer_version_id,
@@ -698,6 +790,7 @@ class SQLiteOfferRepository:
                 version.customer_introduction,
                 version.customer_notes,
                 _budget_definition_storage(version.budget_definition),
+                _charges_definition_storage(version.charges_definition),
             ),
         )
         for sort_order, variant in enumerate(version.variants):
@@ -830,7 +923,8 @@ class SQLiteOfferRepository:
                    snapshot_id, snapshot_hash, event_date, time_window_text,
                    location_text, guest_count, planning_mode, payment_method,
                    payment_customer_visible_text, customer_title,
-                   customer_introduction, customer_notes, budget_definition_json
+                   customer_introduction, customer_notes, budget_definition_json,
+                   charges_definition_json
             FROM offer_versions
             WHERE offer_id = ?
             ORDER BY version_number
@@ -878,6 +972,7 @@ class SQLiteOfferRepository:
                     customer_introduction=row[14],
                     customer_notes=row[15],
                     budget_definition=_stored_budget_definition(row[16]),
+                    charges_definition=_stored_charges_definition(row[17]),
                 )
             )
         return tuple(versions)

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -694,6 +694,7 @@ def _build_version_from_snapshot(
         customer_introduction=_normalize_narrative(snapshot.customer_text.introduction),
         customer_notes=_normalize_narrative(snapshot.customer_text.notes),
         budget_definition=snapshot.budget_definition,
+        charges_definition=snapshot.charges_definition,
     )
 
 

--- a/src/catering_system/services/offer_snapshot_validation.py
+++ b/src/catering_system/services/offer_snapshot_validation.py
@@ -16,6 +16,14 @@ from catering_system.domain.offer_budget_definition import (
     validate_offer_budget_tax_basis,
     validate_offer_budget_type,
 )
+from catering_system.domain.offer_charges import (
+    BuffetChargeDefinition,
+    DeliveryChargeDefinition,
+    DishwareAdditionalLineDefinition,
+    DishwareChargeDefinition,
+    OfferChargesDefinition,
+    validate_charge_base_mode,
+)
 from catering_system.domain.offer_snapshot import (
     CURRENCY,
     MAX_EMAIL_LEN,
@@ -68,9 +76,17 @@ _ENVELOPE_KEYS = frozenset(
         "calculator",
         "variants",
         "budget_definition",
+        "charges_definition",
     }
 )
 _BUDGET_DEFINITION_KEYS = frozenset({"amount_cents", "type", "tax_basis", "cost_scope"})
+_CHARGES_DEFINITION_KEYS = frozenset({"delivery", "dishware", "buffet"})
+_DELIVERY_CHARGE_KEYS = frozenset({"amount_cents"})
+_DISHWARE_CHARGE_KEYS = frozenset(
+    {"base_mode", "pauschale_per_person_cents", "additional_lines"}
+)
+_DISHWARE_LINE_KEYS = frozenset({"description", "quantity", "unit_net_cents"})
+_BUFFET_CHARGE_KEYS = frozenset({"base_mode", "pauschale_per_person_cents"})
 _RECIPIENT_KEYS = frozenset({"company_name", "contact_name", "email", "postal_address"})
 _EVENT_KEYS = frozenset(
     {
@@ -175,6 +191,8 @@ def validate_offer_snapshot(
         payload.get("source_draft_id"), "source_draft_id"
     )
     budget_definition = _parse_budget_definition(payload.get("budget_definition"))
+    charges_definition = _parse_charges_definition(payload.get("charges_definition"))
+    _validate_charges_consistency(charges_definition, variants, event)
 
     computed_hash = compute_snapshot_hash(payload)
     if snapshot_hash != computed_hash:
@@ -197,6 +215,7 @@ def validate_offer_snapshot(
         calculator=calculator,
         variants=variants,
         budget_definition=budget_definition,
+        charges_definition=charges_definition,
     )
     if v2:
         return snapshot
@@ -217,6 +236,7 @@ def validate_offer_snapshot(
         calculator=snapshot.calculator,
         variants=snapshot.variants,
         budget_definition=snapshot.budget_definition,
+        charges_definition=snapshot.charges_definition,
     )
 
 
@@ -473,6 +493,118 @@ def _parse_budget_definition(
     )
 
 
+def _require_positive_int(value: object, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field} must be a whole number")
+    if value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _parse_delivery_charge(payload: dict[str, object]) -> DeliveryChargeDefinition:
+    _reject_unknown_keys(payload, _DELIVERY_CHARGE_KEYS, "charges_definition.delivery")
+    return DeliveryChargeDefinition(
+        amount_cents=_require_cents(
+            payload.get("amount_cents"), "charges_definition.delivery.amount_cents"
+        )
+    )
+
+
+def _parse_dishware_line(
+    value: object, *, label: str
+) -> DishwareAdditionalLineDefinition:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    payload = value
+    _reject_unknown_keys(payload, _DISHWARE_LINE_KEYS, label)
+    # Deliberately not `_require_short_text` — that helper trims before
+    # returning, which would silently swallow untrimmed input instead of
+    # rejecting it. Only the length cap is enforced here; trim/non-empty
+    # rejection is delegated to DishwareAdditionalLineDefinition itself
+    # (the single source of truth for that rule, already covered by
+    # tests/unit/test_offer_charges_domain.py).
+    description = _require_exact_str(payload.get("description"), f"{label}.description")
+    if len(description) > MAX_SHORT_TEXT_LEN:
+        raise ValueError(f"{label}.description exceeds length limit")
+    return DishwareAdditionalLineDefinition(
+        description=description,
+        quantity=_require_positive_int(payload.get("quantity"), f"{label}.quantity"),
+        unit_net_cents=_require_cents(
+            payload.get("unit_net_cents"), f"{label}.unit_net_cents"
+        ),
+    )
+
+
+def _parse_dishware_charge(payload: dict[str, object]) -> DishwareChargeDefinition:
+    _reject_unknown_keys(payload, _DISHWARE_CHARGE_KEYS, "charges_definition.dishware")
+    base_mode = validate_charge_base_mode(
+        _require_exact_str(
+            payload.get("base_mode"), "charges_definition.dishware.base_mode"
+        )
+    )
+    pauschale_per_person_cents = _require_cents(
+        payload.get("pauschale_per_person_cents"),
+        "charges_definition.dishware.pauschale_per_person_cents",
+    )
+    lines_raw = payload.get("additional_lines", [])
+    lines_list = _require_list(
+        lines_raw, "charges_definition.dishware.additional_lines"
+    )
+    if len(lines_list) > MAX_POSITIONS_PER_VARIANT:
+        raise ValueError("charges_definition.dishware.additional_lines exceeds limit")
+    additional_lines = tuple(
+        _parse_dishware_line(
+            item, label=f"charges_definition.dishware.additional_lines[{index}]"
+        )
+        for index, item in enumerate(lines_list)
+    )
+    return DishwareChargeDefinition(
+        base_mode=base_mode,
+        pauschale_per_person_cents=pauschale_per_person_cents,
+        additional_lines=additional_lines,
+    )
+
+
+def _parse_buffet_charge(payload: dict[str, object]) -> BuffetChargeDefinition:
+    _reject_unknown_keys(payload, _BUFFET_CHARGE_KEYS, "charges_definition.buffet")
+    base_mode = validate_charge_base_mode(
+        _require_exact_str(
+            payload.get("base_mode"), "charges_definition.buffet.base_mode"
+        )
+    )
+    pauschale_per_person_cents = _require_cents(
+        payload.get("pauschale_per_person_cents"),
+        "charges_definition.buffet.pauschale_per_person_cents",
+    )
+    return BuffetChargeDefinition(
+        base_mode=base_mode, pauschale_per_person_cents=pauschale_per_person_cents
+    )
+
+
+def _parse_charges_definition(value: object) -> OfferChargesDefinition | None:
+    """CONFIGURABLE_OFFER_CHARGES_V1: optional, strictly validated when present.
+
+    Absent entirely means legacy — the snapshot's already-materialized
+    positions (historically ``kind="fee"``) are trusted as-is, never
+    reinterpreted from this field. When present, delivery/dishware/buffet
+    are all required — there is no partial shape.
+    """
+    if value is None:
+        return None
+    payload = _require_object(value, "charges_definition")
+    _reject_unknown_keys(payload, _CHARGES_DEFINITION_KEYS, "charges_definition")
+    delivery = _parse_delivery_charge(
+        _require_object(payload.get("delivery"), "charges_definition.delivery")
+    )
+    dishware = _parse_dishware_charge(
+        _require_object(payload.get("dishware"), "charges_definition.dishware")
+    )
+    buffet = _parse_buffet_charge(
+        _require_object(payload.get("buffet"), "charges_definition.buffet")
+    )
+    return OfferChargesDefinition(delivery=delivery, dishware=dishware, buffet=buffet)
+
+
 def _parse_calculator(payload: dict[str, object]) -> OfferSnapshotCalculator:
     _reject_unknown_keys(payload, _CALCULATOR_KEYS, "calculator")
     return OfferSnapshotCalculator(
@@ -665,6 +797,137 @@ def _validate_variant_arithmetic(
         != totals.net_cents + totals.vat_7_amount_cents + totals.vat_19_amount_cents
     ):
         raise ValueError("offer snapshot gross arithmetic mismatch")
+
+
+def _validate_charges_consistency(
+    charges_definition: OfferChargesDefinition | None,
+    variants: tuple[OfferSnapshotVariant, ...],
+    event: OfferSnapshotEvent,
+) -> None:
+    """CONFIGURABLE_OFFER_CHARGES_V1: cross-check the declared charges
+    definition against the positions actually materialized in every variant.
+
+    Only runs when ``charges_definition`` is present on the incoming
+    snapshot — legacy snapshots (no ``charges_definition``) are never
+    subject to this check; their fee positions are trusted as-is (see
+    ``domain/offer_charges.py`` module docstring).
+
+    Basic per-position/per-variant net/VAT/gross arithmetic is already
+    enforced unconditionally by ``_validate_position_arithmetic`` and
+    ``_validate_variant_arithmetic`` above for every position regardless of
+    ``kind`` — this function only checks that delivery/dishware/buffet_fee
+    positions *correspond* to what ``charges_definition`` declares, not the
+    arithmetic itself.
+
+    Assumption (undocumented by the spec, made explicit here): every
+    variant is checked independently against the same, single
+    ``charges_definition`` — a snapshot has one delivery/dishware/buffet
+    configuration shared across all its variants.
+    """
+    if charges_definition is None:
+        return
+    for index, variant in enumerate(variants):
+        _validate_variant_charges_consistency(
+            charges_definition, variant, event, label=f"variants[{index}]"
+        )
+
+
+def _validate_variant_charges_consistency(
+    charges: OfferChargesDefinition,
+    variant: OfferSnapshotVariant,
+    event: OfferSnapshotEvent,
+    *,
+    label: str,
+) -> None:
+    _validate_delivery_consistency(charges.delivery, variant, label=label)
+    _validate_dishware_consistency(charges.dishware, variant, event, label=label)
+    _validate_buffet_consistency(charges.buffet, variant, event, label=label)
+
+
+def _validate_delivery_consistency(
+    delivery: DeliveryChargeDefinition, variant: OfferSnapshotVariant, *, label: str
+) -> None:
+    positions = [p for p in variant.positions if p.kind == "delivery"]
+    if len(positions) != 1:
+        raise ValueError(
+            f"{label}: charges_definition.delivery requires exactly one "
+            'kind="delivery" position'
+        )
+    if positions[0].net_total_cents != delivery.amount_cents:
+        raise ValueError(
+            f"{label}: delivery position does not match charges_definition"
+        )
+
+
+def _validate_dishware_consistency(
+    dishware: DishwareChargeDefinition,
+    variant: OfferSnapshotVariant,
+    event: OfferSnapshotEvent,
+    *,
+    label: str,
+) -> None:
+    """Correspondence contract for additional lines: each ``additional_lines``
+    entry matches exactly one ``kind="dishware"`` position whose ``name``
+    equals the line's ``description`` and whose ``net_total_cents`` equals
+    the line's derived ``quantity * unit_net_cents``. Any ``kind="dishware"``
+    position left over after matching all lines is treated as the Pauschale
+    row (there may be at most one).
+    """
+    remaining = [p for p in variant.positions if p.kind == "dishware"]
+    for line_index, line in enumerate(dishware.additional_lines):
+        match = next(
+            (
+                position
+                for position in remaining
+                if position.name == line.description
+                and position.net_total_cents == line.net_total_cents
+            ),
+            None,
+        )
+        if match is None:
+            raise ValueError(
+                f"{label}: charges_definition.dishware.additional_lines[{line_index}]"
+                " has no matching dishware position"
+            )
+        remaining.remove(match)
+    if dishware.base_mode == "PAUSCHALE":
+        if event.guest_count is None:
+            raise ValueError(
+                f"{label}: dishware base_mode=PAUSCHALE requires event.guest_count"
+            )
+        expected = event.guest_count * dishware.pauschale_per_person_cents
+        if len(remaining) != 1:
+            raise ValueError(f"{label}: dishware Pauschale position not found")
+        if remaining[0].net_total_cents != expected:
+            raise ValueError(f"{label}: dishware Pauschale position amount mismatch")
+    elif remaining:
+        raise ValueError(
+            f"{label}: unexplained dishware position present for base_mode=NONE"
+        )
+
+
+def _validate_buffet_consistency(
+    buffet: BuffetChargeDefinition,
+    variant: OfferSnapshotVariant,
+    event: OfferSnapshotEvent,
+    *,
+    label: str,
+) -> None:
+    positions = [p for p in variant.positions if p.kind == "buffet_fee"]
+    if buffet.base_mode == "PAUSCHALE":
+        if event.guest_count is None:
+            raise ValueError(
+                f"{label}: buffet base_mode=PAUSCHALE requires event.guest_count"
+            )
+        expected = event.guest_count * buffet.pauschale_per_person_cents
+        if len(positions) != 1:
+            raise ValueError(f"{label}: buffet_fee position not found")
+        if positions[0].net_total_cents != expected:
+            raise ValueError(f"{label}: buffet_fee position amount mismatch")
+    elif positions:
+        raise ValueError(
+            f"{label}: unexplained buffet_fee position present for base_mode=NONE"
+        )
 
 
 def _parse_position(

--- a/src/catering_system/services/offer_snapshot_validation.py
+++ b/src/catering_system/services/offer_snapshot_validation.py
@@ -859,6 +859,30 @@ def _validate_delivery_consistency(
         )
 
 
+def _verify_matched_position_vat_arithmetic(
+    position: OfferSnapshotPosition, *, label: str
+) -> None:
+    """Re-verify VAT/gross arithmetic explicitly, scoped to this consistency
+    check, rather than relying solely on the earlier, separate
+    ``_validate_position_arithmetic`` pass (already unconditionally run for
+    every position — see that function's docstring). Defense in depth: a
+    matched dishware position's ``vat_amount_cents``/``gross_total_cents``
+    must be self-consistent no matter how this function is later refactored
+    or reordered relative to the generic arithmetic pass."""
+    expected_vat = _round_half_up(
+        Decimal(position.net_total_cents)
+        * Decimal(position.vat_rate_percent)
+        / Decimal(100)
+    )
+    if position.vat_amount_cents != expected_vat:
+        raise ValueError(f"{label}: matched dishware position VAT amount mismatch")
+    if (
+        position.gross_total_cents
+        != position.net_total_cents + position.vat_amount_cents
+    ):
+        raise ValueError(f"{label}: matched dishware position gross total mismatch")
+
+
 def _validate_dishware_consistency(
     dishware: DishwareChargeDefinition,
     variant: OfferSnapshotVariant,
@@ -866,41 +890,92 @@ def _validate_dishware_consistency(
     *,
     label: str,
 ) -> None:
-    """Correspondence contract for additional lines: each ``additional_lines``
-    entry matches exactly one ``kind="dishware"`` position whose ``name``
-    equals the line's ``description`` and whose ``net_total_cents`` equals
-    the line's derived ``quantity * unit_net_cents``. Any ``kind="dishware"``
-    position left over after matching all lines is treated as the Pauschale
-    row (there may be at most one).
+    """Deterministic correspondence contract — the Pauschale position is
+    never inferred as "whatever is left over".
+
+    Canonical identity, by construction (this is the wire contract Stage 2B
+    must produce, not an inference over ambiguous data):
+
+    - an ``additional_lines`` entry corresponds to a ``kind="dishware"``
+      position with ``quantity_mode="total"`` — a fixed, non-guest-count
+      quantity, matching the line's own fixed integer quantity;
+    - the Pauschale row is the ``kind="dishware"`` position with
+      ``quantity_mode="per_person"`` — the guest-count-based quantity
+      semantics that distinguish it structurally from every line, not by
+      elimination.
+
+    Each line is matched against its position on the full field set
+    (description/name, quantity, unit_net_cents, derived net_total_cents,
+    vat_rate_percent-derived vat_amount_cents/gross_total_cents) so a
+    position with the same total but a different quantity/unit price is
+    rejected rather than silently accepted. Ambiguous matches (more than
+    one candidate position satisfying a single line) are rejected, as is a
+    single position satisfying more than one line (structurally impossible
+    here since a matched position is removed from the candidate pool, but
+    the ambiguity check below still catches the case where two lines could
+    each independently claim the same still-unconsumed position).
     """
-    remaining = [p for p in variant.positions if p.kind == "dishware"]
+    dishware_positions = [p for p in variant.positions if p.kind == "dishware"]
+    pauschale_candidates = [
+        p for p in dishware_positions if p.quantity_mode == "per_person"
+    ]
+    remaining_lines = [p for p in dishware_positions if p.quantity_mode == "total"]
+
     for line_index, line in enumerate(dishware.additional_lines):
-        match = next(
-            (
-                position
-                for position in remaining
-                if position.name == line.description
-                and position.net_total_cents == line.net_total_cents
-            ),
-            None,
+        line_label = (
+            f"{label}: charges_definition.dishware.additional_lines[{line_index}]"
         )
-        if match is None:
-            raise ValueError(
-                f"{label}: charges_definition.dishware.additional_lines[{line_index}]"
-                " has no matching dishware position"
-            )
-        remaining.remove(match)
+        matches = [
+            position
+            for position in remaining_lines
+            if position.name == line.description
+            and position.quantity == str(line.quantity)
+            and position.unit_net_cents == line.unit_net_cents
+            and position.net_total_cents == line.net_total_cents
+        ]
+        if not matches:
+            raise ValueError(f"{line_label} has no matching dishware position")
+        if len(matches) > 1:
+            raise ValueError(f"{line_label} matches multiple dishware positions")
+        match = matches[0]
+        _verify_matched_position_vat_arithmetic(match, label=line_label)
+        remaining_lines.remove(match)
+
+    if remaining_lines:
+        raise ValueError(
+            f"{label}: unexplained dishware position present for additional_lines"
+        )
+
     if dishware.base_mode == "PAUSCHALE":
         if event.guest_count is None:
             raise ValueError(
                 f"{label}: dishware base_mode=PAUSCHALE requires event.guest_count"
             )
-        expected = event.guest_count * dishware.pauschale_per_person_cents
-        if len(remaining) != 1:
+        if not pauschale_candidates:
             raise ValueError(f"{label}: dishware Pauschale position not found")
-        if remaining[0].net_total_cents != expected:
+        if len(pauschale_candidates) > 1:
+            raise ValueError(f"{label}: multiple dishware Pauschale positions present")
+        pauschale = pauschale_candidates[0]
+        if pauschale.quantity != "1":
+            raise ValueError(
+                f"{label}: dishware Pauschale position quantity must be 1 (per person)"
+            )
+        if pauschale.unit_net_cents != dishware.pauschale_per_person_cents:
+            raise ValueError(
+                f"{label}: dishware Pauschale position unit_net_cents mismatch"
+            )
+        # Given quantity=="1" and unit_net_cents==pauschale_per_person_cents
+        # (both just checked above) plus the unconditional generic
+        # per-position arithmetic pass that already ran for every position
+        # (net_total_cents == unit_net_cents * effective_quantity), this is
+        # mathematically implied — kept as an explicit, self-contained
+        # check anyway (defense in depth against reordering/refactoring),
+        # not because it can independently fail today.
+        expected_net = event.guest_count * dishware.pauschale_per_person_cents
+        if pauschale.net_total_cents != expected_net:
             raise ValueError(f"{label}: dishware Pauschale position amount mismatch")
-    elif remaining:
+        _verify_matched_position_vat_arithmetic(pauschale, label=label)
+    elif pauschale_candidates:
         raise ValueError(
             f"{label}: unexplained dishware position present for base_mode=NONE"
         )

--- a/tests/unit/test_offer_charges_domain.py
+++ b/tests/unit/test_offer_charges_domain.py
@@ -1,0 +1,249 @@
+"""Unit tests — CONFIGURABLE_OFFER_CHARGES_V1 value object validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from catering_system.domain.offer_charges import (
+    BuffetChargeDefinition,
+    DeliveryChargeDefinition,
+    DishwareAdditionalLineDefinition,
+    DishwareChargeDefinition,
+    OfferChargesDefinition,
+    validate_charge_base_mode,
+)
+
+
+# --- DeliveryChargeDefinition -----------------------------------------------------
+
+
+def test_delivery_valid_amount_constructs() -> None:
+    assert DeliveryChargeDefinition(amount_cents=3500).amount_cents == 3500
+
+
+def test_delivery_zero_is_valid() -> None:
+    assert DeliveryChargeDefinition(amount_cents=0).amount_cents == 0
+
+
+def test_delivery_rejects_negative_amount() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        DeliveryChargeDefinition(amount_cents=-1)
+
+
+def test_delivery_rejects_bool_amount() -> None:
+    with pytest.raises(ValueError, match="integer euro cents"):
+        DeliveryChargeDefinition(amount_cents=True)  # type: ignore[arg-type]
+
+
+def test_delivery_rejects_float_amount() -> None:
+    with pytest.raises(ValueError, match="integer euro cents"):
+        DeliveryChargeDefinition(amount_cents=35.0)  # type: ignore[arg-type]
+
+
+# --- DishwareAdditionalLineDefinition ---------------------------------------------
+
+
+def test_dishware_line_valid_constructs() -> None:
+    line = DishwareAdditionalLineDefinition(
+        description="Weinglas", quantity=20, unit_net_cents=80
+    )
+    assert line.quantity == 20
+    assert line.unit_net_cents == 80
+
+
+def test_dishware_line_derives_net_total_and_never_stores_it() -> None:
+    line = DishwareAdditionalLineDefinition(
+        description="Weinglas", quantity=20, unit_net_cents=80
+    )
+    assert line.net_total_cents == 1600
+    assert not hasattr(line, "_net_total_cents")
+    assert "net_total_cents" not in line.__dataclass_fields__
+
+
+def test_dishware_line_rejects_empty_description() -> None:
+    with pytest.raises(ValueError, match="description is required"):
+        DishwareAdditionalLineDefinition(description="", quantity=1, unit_net_cents=100)
+
+
+def test_dishware_line_rejects_untrimmed_description() -> None:
+    with pytest.raises(ValueError, match="must be trimmed"):
+        DishwareAdditionalLineDefinition(
+            description=" Weinglas ", quantity=1, unit_net_cents=100
+        )
+
+
+def test_dishware_line_rejects_zero_quantity() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        DishwareAdditionalLineDefinition(
+            description="Weinglas", quantity=0, unit_net_cents=100
+        )
+
+
+def test_dishware_line_rejects_negative_quantity() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        DishwareAdditionalLineDefinition(
+            description="Weinglas", quantity=-1, unit_net_cents=100
+        )
+
+
+def test_dishware_line_rejects_fractional_quantity() -> None:
+    with pytest.raises(ValueError, match="whole number"):
+        DishwareAdditionalLineDefinition(
+            description="Weinglas",
+            quantity=1.5,
+            unit_net_cents=100,  # type: ignore[arg-type]
+        )
+
+
+def test_dishware_line_rejects_bool_quantity() -> None:
+    with pytest.raises(ValueError, match="whole number"):
+        DishwareAdditionalLineDefinition(
+            description="Weinglas",
+            quantity=True,
+            unit_net_cents=100,  # type: ignore[arg-type]
+        )
+
+
+def test_dishware_line_rejects_negative_unit_net_cents() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        DishwareAdditionalLineDefinition(
+            description="Weinglas", quantity=1, unit_net_cents=-1
+        )
+
+
+def test_dishware_line_zero_unit_net_cents_is_valid() -> None:
+    line = DishwareAdditionalLineDefinition(
+        description="Weinglas", quantity=1, unit_net_cents=0
+    )
+    assert line.net_total_cents == 0
+
+
+# --- DishwareChargeDefinition ------------------------------------------------------
+
+
+def test_dishware_charge_none_with_no_lines() -> None:
+    charge = DishwareChargeDefinition(base_mode="NONE", pauschale_per_person_cents=200)
+    assert charge.base_mode == "NONE"
+    assert charge.additional_lines == ()
+
+
+def test_dishware_charge_pauschale_with_no_lines() -> None:
+    charge = DishwareChargeDefinition(
+        base_mode="PAUSCHALE", pauschale_per_person_cents=200
+    )
+    assert charge.base_mode == "PAUSCHALE"
+
+
+def test_dishware_charge_none_with_lines() -> None:
+    """Explicitly supported: additional lines are independent of base_mode."""
+    line = DishwareAdditionalLineDefinition(
+        description="Weinglas", quantity=20, unit_net_cents=80
+    )
+    charge = DishwareChargeDefinition(
+        base_mode="NONE", pauschale_per_person_cents=200, additional_lines=(line,)
+    )
+    assert charge.base_mode == "NONE"
+    assert charge.additional_lines == (line,)
+
+
+def test_dishware_charge_pauschale_with_lines() -> None:
+    line = DishwareAdditionalLineDefinition(
+        description="Weinglas", quantity=20, unit_net_cents=80
+    )
+    charge = DishwareChargeDefinition(
+        base_mode="PAUSCHALE",
+        pauschale_per_person_cents=200,
+        additional_lines=(line,),
+    )
+    assert charge.base_mode == "PAUSCHALE"
+    assert charge.additional_lines == (line,)
+
+
+def test_dishware_charge_pauschale_rate_required_even_when_none() -> None:
+    """The rate survives being toggled off — still validated/required."""
+    with pytest.raises(ValueError, match="non-negative"):
+        DishwareChargeDefinition(base_mode="NONE", pauschale_per_person_cents=-1)
+
+
+def test_dishware_charge_rejects_invalid_base_mode() -> None:
+    with pytest.raises(ValueError, match="invalid charge base_mode"):
+        DishwareChargeDefinition(
+            base_mode="SOMETHING_ELSE",  # type: ignore[arg-type]
+            pauschale_per_person_cents=200,
+        )
+
+
+# --- BuffetChargeDefinition ---------------------------------------------------------
+
+
+def test_buffet_charge_none() -> None:
+    charge = BuffetChargeDefinition(base_mode="NONE", pauschale_per_person_cents=50)
+    assert charge.base_mode == "NONE"
+
+
+def test_buffet_charge_pauschale() -> None:
+    charge = BuffetChargeDefinition(
+        base_mode="PAUSCHALE", pauschale_per_person_cents=50
+    )
+    assert charge.base_mode == "PAUSCHALE"
+
+
+def test_buffet_charge_rejects_invalid_base_mode() -> None:
+    with pytest.raises(ValueError, match="invalid charge base_mode"):
+        BuffetChargeDefinition(
+            base_mode="MAYBE",  # type: ignore[arg-type]
+            pauschale_per_person_cents=50,
+        )
+
+
+def test_buffet_charge_rejects_negative_rate() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        BuffetChargeDefinition(base_mode="NONE", pauschale_per_person_cents=-1)
+
+
+# --- OfferChargesDefinition ----------------------------------------------------------
+
+
+def test_offer_charges_definition_constructs_with_all_three_required() -> None:
+    definition = OfferChargesDefinition(
+        delivery=DeliveryChargeDefinition(amount_cents=3500),
+        dishware=DishwareChargeDefinition(
+            base_mode="NONE", pauschale_per_person_cents=200
+        ),
+        buffet=BuffetChargeDefinition(base_mode="NONE", pauschale_per_person_cents=50),
+    )
+    assert definition.delivery.amount_cents == 3500
+    assert definition.dishware.base_mode == "NONE"
+    assert definition.buffet.base_mode == "NONE"
+
+
+# --- validate_charge_base_mode -------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["NONE", "PAUSCHALE"])
+def test_validate_charge_base_mode_accepts_known_values(value: str) -> None:
+    assert validate_charge_base_mode(value) == value
+
+
+def test_validate_charge_base_mode_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="invalid charge base_mode"):
+        validate_charge_base_mode("none")  # lowercase — strict, uppercase-only
+
+
+# --- boundary --------------------------------------------------------------------------
+
+
+def test_domain_module_has_no_repository_or_api_imports() -> None:
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "catering_system"
+        / "domain"
+        / "offer_charges.py"
+    )
+    text = source.read_text(encoding="utf-8")
+    assert "repositories" not in text
+    assert "catering_system.ui" not in text
+    assert "catering_system.services" not in text

--- a/tests/unit/test_offer_charges_rendering.py
+++ b/tests/unit/test_offer_charges_rendering.py
@@ -1,0 +1,331 @@
+"""CONFIGURABLE_OFFER_CHARGES_V1 — rendering boundary regression tests.
+
+Deliberately zero source changes to the Office Panel or PDF renderer in
+this slice (per the binding decision that existing kind-agnostic rendering
+"may continue to render the new position kinds as normal charge rows").
+These tests prove that claim rather than assume it:
+
+- ``delivery``/``dishware``/``buffet_fee`` positions render exactly like
+  any other position (Office Panel row list + customer PDF);
+- legacy ``kind="fee"`` positions still render unchanged;
+- absence of ``charges_definition`` does not alter old documents;
+- ``charges_definition`` itself is never exposed by the Office API detail
+  view or printed into the customer PDF — it stays internal-only, unlike
+  its materialized positions which are fully customer-facing.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from dataclasses import replace
+from datetime import UTC, date, datetime
+
+from pypdf import PdfReader
+
+from catering_system.domain.offer import (
+    Offer,
+    OfferPosition,
+    OfferVariant,
+    OfferVersion,
+)
+from catering_system.domain.offer_charges import (
+    BuffetChargeDefinition,
+    DeliveryChargeDefinition,
+    DishwareAdditionalLineDefinition,
+    DishwareChargeDefinition,
+    OfferChargesDefinition,
+)
+from catering_system.domain.offer_document_snapshot import OfferDocumentPosition
+from catering_system.domain.offer_pdf import OfferPdfStaticContent
+from catering_system.services.offer_document_snapshot_hash import compute_document_hash
+from catering_system.services.offer_pdf_renderer import render_offer_document_pdf
+from catering_system.ui.office_api_views import offer_detail
+from catering_system.ui.office_panel_offer_detail import _position_rows
+from tests.unit.test_offer_document_snapshot import _valid_snapshot
+
+_OFFER_ID = "11111111-1111-1111-1111-111111111111"
+_INQUIRY_ID = "22222222-2222-2222-2222-222222222222"
+_V1_ID = "33333333-3333-3333-3333-333333333331"
+_VARIANT_ID = "44444444-4444-4444-4444-444444444441"
+_NOW = datetime(2026, 7, 15, 10, 0, tzinfo=UTC)
+_HASH = "sha256:" + ("a" * 64)
+
+
+def _static() -> OfferPdfStaticContent:
+    return OfferPdfStaticContent(
+        company_legal_name="TEST Catering GmbH [PLATZHALTER]",
+        company_address_lines=("Teststraße 1", "20095 Hamburg", "Deutschland"),
+        acceptance_statement="[TEST PLACEHOLDER — NOT APPROVED CUSTOMER WORDING]",
+        footer_note="TEST FOOTER — Silberlöffel Event Catering Service",
+    )
+
+
+def _text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() for page in reader.pages)
+
+
+# --- Office Panel: _position_rows is kind-agnostic ----------------------------------
+
+
+def test_position_rows_renders_new_charge_kinds_like_any_other_position() -> None:
+    variants = [
+        {
+            "positions": [
+                {"name": "Fingerfood Paket", "unit_net_cents": 290, "kind": "catalog"},
+                {"name": "Anlieferung", "unit_net_cents": 3500, "kind": "delivery"},
+                {
+                    "name": "Geschirrpauschale",
+                    "unit_net_cents": 200,
+                    "kind": "dishware",
+                },
+                {
+                    "name": "Büffetpauschale",
+                    "unit_net_cents": 50,
+                    "kind": "buffet_fee",
+                },
+            ]
+        }
+    ]
+    html = _position_rows(variants)
+    assert "Fingerfood Paket" in html
+    assert "Anlieferung" in html
+    assert "Geschirrpauschale" in html
+    assert "Büffetpauschale" in html
+    assert html.count("<li>") == 4
+
+
+def test_position_rows_renders_legacy_fee_kind_unchanged() -> None:
+    variants = [
+        {
+            "positions": [
+                {
+                    "name": "Büffetpauschale (Altbestand)",
+                    "unit_net_cents": 50,
+                    "kind": "fee",
+                },
+            ]
+        }
+    ]
+    html = _position_rows(variants)
+    assert "Büffetpauschale (Altbestand)" in html
+    assert "<li>" in html
+
+
+# --- Office API detail view: charges_definition stays internal-only ----------------
+
+
+def _position(position_id: str, kind: str, name: str, cents: int) -> OfferPosition:
+    return OfferPosition(
+        position_id=position_id,
+        kind=kind,  # type: ignore[arg-type]
+        name=name,
+        unit_net_cents=cents,
+        net_total_cents=cents,
+        vat_rate_percent=19,
+        vat_amount_cents=round(cents * 0.19),
+        gross_total_cents=cents + round(cents * 0.19),
+    )
+
+
+def _offer_with_charges_definition() -> Offer:
+    charges = OfferChargesDefinition(
+        delivery=DeliveryChargeDefinition(amount_cents=3500),
+        dishware=DishwareChargeDefinition(
+            base_mode="PAUSCHALE",
+            pauschale_per_person_cents=200,
+            additional_lines=(
+                DishwareAdditionalLineDefinition(
+                    description="Weinglas", quantity=20, unit_net_cents=80
+                ),
+            ),
+        ),
+        buffet=BuffetChargeDefinition(
+            base_mode="PAUSCHALE", pauschale_per_person_cents=50
+        ),
+    )
+    variant = OfferVariant(
+        variant_id=_VARIANT_ID,
+        offer_version_id=_V1_ID,
+        label="Variante A",
+        positions=(
+            _position(str(uuid.uuid4()), "catalog", "Fingerfood Paket", 23200),
+            _position(str(uuid.uuid4()), "delivery", "Anlieferung", 3500),
+            _position(str(uuid.uuid4()), "dishware", "Geschirrpauschale", 16000),
+            _position(str(uuid.uuid4()), "dishware", "Weinglas", 1600),
+            _position(str(uuid.uuid4()), "buffet_fee", "Büffetpauschale", 4000),
+        ),
+    )
+    version = OfferVersion(
+        offer_version_id=_V1_ID,
+        offer_id=_OFFER_ID,
+        version_number=1,
+        created_at=_NOW,
+        valid_until=date(2026, 7, 31),
+        snapshot_id=str(uuid.uuid4()),
+        snapshot_hash=_HASH,
+        event_date=date(2026, 8, 20),
+        time_window_text="18:00–22:00",
+        location_text="Hamburg",
+        guest_count=80,
+        planning_mode="caterer_suggestion",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        variants=(variant,),
+        charges_definition=charges,
+    )
+    return Offer(
+        offer_id=_OFFER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        versions=(version,),
+    )
+
+
+def _contains_key_or_value(node: object, needle: str) -> bool:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(key, str) and needle in key:
+                return True
+            if _contains_key_or_value(value, needle):
+                return True
+        return False
+    if isinstance(node, list):
+        return any(_contains_key_or_value(item, needle) for item in node)
+    if isinstance(node, str):
+        return needle in node
+    return False
+
+
+def test_offer_detail_never_exposes_charges_definition() -> None:
+    """The definition itself stays internal-only; only its materialized
+    positions (already asserted to render normally above) are
+    customer-facing. Positive control: position names/kinds ARE present."""
+    detail = offer_detail(_offer_with_charges_definition(), today=date(2026, 7, 20))
+    assert not _contains_key_or_value(detail, "charges_definition")
+    variant = detail["versions"][0]["variants"][0]  # type: ignore[index]
+    names = {position["name"] for position in variant["positions"]}  # type: ignore[index]
+    assert names == {
+        "Fingerfood Paket",
+        "Anlieferung",
+        "Geschirrpauschale",
+        "Weinglas",
+        "Büffetpauschale",
+    }
+
+
+# --- Customer PDF: kind-agnostic renderer, charges_definition never printed --------
+
+
+def test_pdf_renders_new_charge_kinds_and_never_prints_charges_definition() -> None:
+    positions = (
+        OfferDocumentPosition(
+            position_id="pos-1",
+            kind="catalog",
+            name="Fingerfood Paket",
+            unit_net_cents=290,
+            net_total_cents=23200,
+            vat_rate_percent=7,
+            vat_cents=1624,
+            gross_cents=24824,
+            quantity="80",
+            unit_label="Stück",
+        ),
+        OfferDocumentPosition(
+            position_id="pos-2",
+            kind="delivery",
+            name="Anlieferung",
+            unit_net_cents=3500,
+            net_total_cents=3500,
+            vat_rate_percent=19,
+            vat_cents=665,
+            gross_cents=4165,
+            quantity="1",
+            unit_label="Pauschale",
+        ),
+        OfferDocumentPosition(
+            position_id="pos-3",
+            kind="dishware",
+            name="Geschirrpauschale",
+            unit_net_cents=200,
+            net_total_cents=16000,
+            vat_rate_percent=19,
+            vat_cents=3040,
+            gross_cents=19040,
+            quantity="80",
+            unit_label="Person",
+        ),
+        OfferDocumentPosition(
+            position_id="pos-4",
+            kind="buffet_fee",
+            name="Büffetpauschale",
+            unit_net_cents=50,
+            net_total_cents=4000,
+            vat_rate_percent=19,
+            vat_cents=760,
+            gross_cents=4760,
+            quantity="80",
+            unit_label="Person",
+        ),
+    )
+    snapshot = _valid_snapshot(
+        positions=positions,
+        net_total_cents=23200 + 3500 + 16000 + 4000,
+        vat_total_cents=1624 + 665 + 3040 + 760,
+        gross_total_cents=24824 + 4165 + 19040 + 4760,
+    )
+    snapshot = replace(snapshot, document_hash=compute_document_hash(snapshot))
+    pdf_bytes = render_offer_document_pdf(snapshot, _static())
+    text = _text(pdf_bytes)
+
+    assert "Fingerfood Paket" in text
+    assert "Anlieferung" in text
+    assert "Geschirrpauschale" in text
+    assert "Büffetpauschale" in text
+    assert "charges_definition" not in text
+
+
+def test_pdf_renders_legacy_fee_positions_unchanged_when_no_charges_definition() -> (
+    None
+):
+    """Absence of ``charges_definition`` (this snapshot type has no such
+    field at all) does not alter old documents — pre-existing kind="fee"
+    Pauschale positions render exactly as before this slice."""
+    positions = (
+        OfferDocumentPosition(
+            position_id="pos-1",
+            kind="catalog",
+            name="Fingerfood Paket",
+            unit_net_cents=290,
+            net_total_cents=23200,
+            vat_rate_percent=7,
+            vat_cents=1624,
+            gross_cents=24824,
+            quantity="80",
+            unit_label="Stück",
+        ),
+        OfferDocumentPosition(
+            position_id="pos-2",
+            kind="fee",
+            name="Büffetpauschale",
+            unit_net_cents=50,
+            net_total_cents=4000,
+            vat_rate_percent=19,
+            vat_cents=760,
+            gross_cents=4760,
+            quantity="80",
+            unit_label="Person",
+        ),
+    )
+    snapshot = _valid_snapshot(
+        positions=positions,
+        net_total_cents=23200 + 4000,
+        vat_total_cents=1624 + 760,
+        gross_total_cents=24824 + 4760,
+    )
+    snapshot = replace(snapshot, document_hash=compute_document_hash(snapshot))
+    pdf_bytes = render_offer_document_pdf(snapshot, _static())
+    text = _text(pdf_bytes)
+    assert "Fingerfood Paket" in text
+    assert "Büffetpauschale" in text

--- a/tests/unit/test_offer_charges_validation.py
+++ b/tests/unit/test_offer_charges_validation.py
@@ -1,0 +1,642 @@
+"""Unit tests — CONFIGURABLE_OFFER_CHARGES_V1 envelope validation.
+
+Covers: schema parsing (required/optional shape, unknown-key rejection,
+bool-as-int rejection, quantity/description rules) and the new
+charges-vs-positions consistency cross-check. Basic per-position/per-variant
+net/VAT/gross arithmetic is exercised generically by
+``test_offer_snapshot_validation.py`` already and is not re-tested here.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import cast
+
+import pytest
+
+from catering_system.domain.offer_snapshot import compute_snapshot_hash
+from catering_system.services.offer_snapshot_validation import validate_offer_snapshot
+
+_INQUIRY_ID = "22222222-2222-4222-8222-222222222222"
+_SNAPSHOT_ID = "77777777-7777-4777-8777-777777777771"
+_VARIANT_ID = "44444444-4444-4444-8444-444444444441"
+_GUEST_COUNT = 80
+
+_DELIVERY_AMOUNT_CENTS = 3500
+_DISHWARE_PAUSCHALE_PER_PERSON_CENTS = 200
+_BUFFET_PAUSCHALE_PER_PERSON_CENTS = 50
+_DISHWARE_LINE_QUANTITY = 20
+_DISHWARE_LINE_UNIT_NET_CENTS = 80
+
+
+def _catalog_position() -> dict[str, object]:
+    return {
+        "position_id": "88888888-8888-4888-8888-888888888881",
+        "kind": "catalog",
+        "catalog_item_id": "catalog-1",
+        "name": "Fingerfood Paket",
+        "description": None,
+        "composition": None,
+        "quantity_mode": "total",
+        "quantity": "80",
+        "unit_label": "Stück",
+        "unit_net_cents": 290,
+        "net_total_cents": 23200,
+        "vat_rate_percent": 7,
+        "vat_amount_cents": 1624,
+        "gross_total_cents": 24824,
+        "notes": None,
+        "related_position_id": None,
+    }
+
+
+def _charge_position(
+    *,
+    position_id: str,
+    kind: str,
+    name: str,
+    quantity_mode: str,
+    quantity: str,
+    unit_net_cents: int,
+    net_total_cents: int,
+    vat_rate_percent: int = 19,
+) -> dict[str, object]:
+    vat_amount_cents = round(net_total_cents * vat_rate_percent / 100)
+    return {
+        "position_id": position_id,
+        "kind": kind,
+        "catalog_item_id": None,
+        "name": name,
+        "description": None,
+        "composition": None,
+        "quantity_mode": quantity_mode,
+        "quantity": quantity,
+        "unit_label": "Pauschale",
+        "unit_net_cents": unit_net_cents,
+        "net_total_cents": net_total_cents,
+        "vat_rate_percent": vat_rate_percent,
+        "vat_amount_cents": vat_amount_cents,
+        "gross_total_cents": net_total_cents + vat_amount_cents,
+        "notes": None,
+        "related_position_id": None,
+    }
+
+
+def _delivery_position(
+    position_id: str = "88888888-8888-4888-8888-888888888891",
+    amount_cents: int = _DELIVERY_AMOUNT_CENTS,
+) -> dict[str, object]:
+    return _charge_position(
+        position_id=position_id,
+        kind="delivery",
+        name="Anlieferung",
+        quantity_mode="total",
+        quantity="1",
+        unit_net_cents=amount_cents,
+        net_total_cents=amount_cents,
+    )
+
+
+def _dishware_pauschale_position(
+    position_id: str = "88888888-8888-4888-8888-888888888892",
+    per_person_cents: int = _DISHWARE_PAUSCHALE_PER_PERSON_CENTS,
+    guest_count: int = _GUEST_COUNT,
+) -> dict[str, object]:
+    return _charge_position(
+        position_id=position_id,
+        kind="dishware",
+        name="Geschirrpauschale",
+        quantity_mode="per_person",
+        quantity="1",
+        unit_net_cents=per_person_cents,
+        net_total_cents=per_person_cents * guest_count,
+    )
+
+
+def _dishware_line_position(
+    position_id: str = "88888888-8888-4888-8888-888888888893",
+    description: str = "Weinglas",
+    quantity: int = _DISHWARE_LINE_QUANTITY,
+    unit_net_cents: int = _DISHWARE_LINE_UNIT_NET_CENTS,
+) -> dict[str, object]:
+    return _charge_position(
+        position_id=position_id,
+        kind="dishware",
+        name=description,
+        quantity_mode="total",
+        quantity=str(quantity),
+        unit_net_cents=unit_net_cents,
+        net_total_cents=quantity * unit_net_cents,
+    )
+
+
+def _buffet_position(
+    position_id: str = "88888888-8888-4888-8888-888888888894",
+    per_person_cents: int = _BUFFET_PAUSCHALE_PER_PERSON_CENTS,
+    guest_count: int = _GUEST_COUNT,
+) -> dict[str, object]:
+    return _charge_position(
+        position_id=position_id,
+        kind="buffet_fee",
+        name="Büffetpauschale",
+        quantity_mode="per_person",
+        quantity="1",
+        unit_net_cents=per_person_cents,
+        net_total_cents=per_person_cents * guest_count,
+    )
+
+
+def _dishware_line_def(
+    description: str = "Weinglas",
+    quantity: int = _DISHWARE_LINE_QUANTITY,
+    unit_net_cents: int = _DISHWARE_LINE_UNIT_NET_CENTS,
+) -> dict[str, object]:
+    return {
+        "description": description,
+        "quantity": quantity,
+        "unit_net_cents": unit_net_cents,
+    }
+
+
+def _charges_definition(
+    *,
+    delivery_amount_cents: int = _DELIVERY_AMOUNT_CENTS,
+    dishware_base_mode: str = "PAUSCHALE",
+    dishware_per_person_cents: int = _DISHWARE_PAUSCHALE_PER_PERSON_CENTS,
+    dishware_lines: list[dict[str, object]] | None = None,
+    buffet_base_mode: str = "PAUSCHALE",
+    buffet_per_person_cents: int = _BUFFET_PAUSCHALE_PER_PERSON_CENTS,
+) -> dict[str, object]:
+    return {
+        "delivery": {"amount_cents": delivery_amount_cents},
+        "dishware": {
+            "base_mode": dishware_base_mode,
+            "pauschale_per_person_cents": dishware_per_person_cents,
+            "additional_lines": dishware_lines if dishware_lines is not None else [],
+        },
+        "buffet": {
+            "base_mode": buffet_base_mode,
+            "pauschale_per_person_cents": buffet_per_person_cents,
+        },
+    }
+
+
+def _variant(positions: list[dict[str, object]]) -> dict[str, object]:
+    net_cents = sum(cast(int, item["net_total_cents"]) for item in positions)
+    vat_7_base_cents = sum(
+        cast(int, item["net_total_cents"])
+        for item in positions
+        if item["vat_rate_percent"] == 7
+    )
+    vat_7_amount_cents = sum(
+        cast(int, item["vat_amount_cents"])
+        for item in positions
+        if item["vat_rate_percent"] == 7
+    )
+    vat_19_base_cents = sum(
+        cast(int, item["net_total_cents"])
+        for item in positions
+        if item["vat_rate_percent"] == 19
+    )
+    vat_19_amount_cents = sum(
+        cast(int, item["vat_amount_cents"])
+        for item in positions
+        if item["vat_rate_percent"] == 19
+    )
+    gross_cents = sum(cast(int, item["gross_total_cents"]) for item in positions)
+    return {
+        "variant_id": _VARIANT_ID,
+        "label": "Variante A",
+        "description": "Customer-visible alternative",
+        "positions": positions,
+        "totals": {
+            "net_cents": net_cents,
+            "vat_7_base_cents": vat_7_base_cents,
+            "vat_7_amount_cents": vat_7_amount_cents,
+            "vat_19_base_cents": vat_19_base_cents,
+            "vat_19_amount_cents": vat_19_amount_cents,
+            "gross_cents": gross_cents,
+        },
+    }
+
+
+def _default_positions() -> list[dict[str, object]]:
+    return [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+        _dishware_line_position(),
+        _buffet_position(),
+    ]
+
+
+def _snapshot(
+    *,
+    guest_count: int | None = _GUEST_COUNT,
+    positions: list[dict[str, object]] | None = None,
+    charges_definition: dict[str, object] | None | object = "__default__",
+) -> dict[str, object]:
+    variant = _variant(positions if positions is not None else _default_positions())
+    body: dict[str, object] = {
+        "schema_version": "offer_snapshot_v1",
+        "source": "fingerfood-configurator-backend",
+        "source_draft_id": "draft-1",
+        "inquiry_id": _INQUIRY_ID,
+        "snapshot_id": _SNAPSHOT_ID,
+        "snapshot_created_at": "2026-07-15T08:30:00+00:00",
+        "valid_until": "2026-07-29",
+        "currency": "EUR",
+        "recipient": {
+            "company_name": "Example company",
+            "contact_name": "Example contact",
+            "email": "customer@example.invalid",
+            "postal_address": "Customer-visible recipient address",
+        },
+        "event": {
+            "event_date": "2026-08-20",
+            "time_window_text": "18:00–22:00",
+            "location_text": "Hamburg",
+            "guest_count": guest_count,
+            "planning_mode": "caterer_suggestion",
+        },
+        "customer_text": {
+            "title": "Sommerfest",
+            "introduction": "Customer-visible introduction",
+            "notes": "Customer-visible conditions and notes",
+        },
+        "payment_terms": {
+            "method": "RECHNUNG",
+            "customer_visible_text": "Zahlung per Rechnung",
+        },
+        "calculator": {
+            "name": "fingerfood-backend",
+            "calculator_revision": "future-revision",
+            "catalog_revision": "future-revision",
+            "tax_revision": "future-revision",
+        },
+        "variants": [variant],
+    }
+    if charges_definition == "__default__":
+        body["charges_definition"] = _charges_definition(
+            dishware_lines=[_dishware_line_def()]
+        )
+    elif charges_definition is not None:
+        body["charges_definition"] = charges_definition
+    payload = deepcopy(body)
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+    return payload
+
+
+# --- happy paths -------------------------------------------------------------------
+
+
+def test_full_schema_with_all_charge_kinds_is_accepted() -> None:
+    snapshot = validate_offer_snapshot(_snapshot())
+    assert snapshot.charges_definition is not None
+    assert snapshot.charges_definition.delivery.amount_cents == _DELIVERY_AMOUNT_CENTS
+    assert snapshot.charges_definition.dishware.base_mode == "PAUSCHALE"
+    assert len(snapshot.charges_definition.dishware.additional_lines) == 1
+    assert snapshot.charges_definition.buffet.base_mode == "PAUSCHALE"
+
+
+def test_legacy_snapshot_without_charges_definition_is_unaffected() -> None:
+    positions = [_catalog_position()]
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=None)
+    )
+    assert snapshot.charges_definition is None
+
+
+def test_dishware_none_mode_no_lines_no_materialized_position() -> None:
+    positions = [_catalog_position(), _delivery_position(), _buffet_position()]
+    charges = _charges_definition(dishware_base_mode="NONE", dishware_lines=[])
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=charges)
+    )
+    assert snapshot.charges_definition is not None
+    assert snapshot.charges_definition.dishware.base_mode == "NONE"
+
+
+def test_dishware_none_mode_with_lines_only() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_line_position(),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(
+        dishware_base_mode="NONE", dishware_lines=[_dishware_line_def()]
+    )
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=charges)
+    )
+    assert snapshot.charges_definition is not None
+    assert snapshot.charges_definition.dishware.base_mode == "NONE"
+
+
+def test_dishware_pauschale_mode_no_lines() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=charges)
+    )
+    assert snapshot.charges_definition is not None
+
+
+def test_buffet_none_mode_no_materialized_position() -> None:
+    positions = [_catalog_position(), _delivery_position()]
+    charges = _charges_definition(
+        dishware_base_mode="NONE", dishware_lines=[], buffet_base_mode="NONE"
+    )
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=charges)
+    )
+    assert snapshot.charges_definition is not None
+
+
+# --- envelope / schema shape ---------------------------------------------------------
+
+
+def test_charges_definition_rejects_unknown_top_level_key() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    charges["extra"] = 1
+    with pytest.raises(ValueError, match="unknown charges_definition field"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_charges_definition_requires_delivery() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    del charges["delivery"]
+    with pytest.raises(ValueError, match="delivery must be an object"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_charges_definition_requires_dishware() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    del charges["dishware"]
+    with pytest.raises(ValueError, match="dishware must be an object"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_charges_definition_requires_buffet() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    del charges["buffet"]
+    with pytest.raises(ValueError, match="buffet must be an object"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_delivery_rejects_unknown_key() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["delivery"])["extra"] = 1
+    with pytest.raises(ValueError, match="unknown charges_definition.delivery field"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_delivery_rejects_bool_amount() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["delivery"])["amount_cents"] = True
+    with pytest.raises(ValueError, match="integer euro cents"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_rejects_unknown_key() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["dishware"])["extra"] = 1
+    with pytest.raises(ValueError, match="unknown charges_definition.dishware field"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_rejects_invalid_base_mode() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["dishware"])["base_mode"] = "MAYBE"
+    with pytest.raises(ValueError, match="invalid charge base_mode"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_unknown_key() -> None:
+    line = _dishware_line_def()
+    line["extra"] = 1
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(
+        ValueError,
+        match="unknown charges_definition.dishware.additional_lines\\[0\\] field",
+    ):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_empty_description() -> None:
+    line = _dishware_line_def(description="")
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(ValueError, match="description is required"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_untrimmed_description() -> None:
+    line = _dishware_line_def(description=" Weinglas ")
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(ValueError, match="must be trimmed"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_zero_quantity() -> None:
+    line = _dishware_line_def(quantity=0)
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(ValueError, match="positive integer"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_fractional_quantity() -> None:
+    """Floats are rejected even earlier, by canonical-hash serialization
+    (see domain/offer_snapshot.py `_serialize_json_value`) — a stronger,
+    pre-existing, envelope-wide protection that fires before this field's
+    own whole-number check ever runs (that check is exercised directly
+    against the domain object in test_offer_charges_domain.py instead)."""
+    line = _dishware_line_def()
+    line["quantity"] = 1.5
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(ValueError, match="floating-point values are forbidden"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_dishware_line_rejects_bool_quantity() -> None:
+    line = _dishware_line_def()
+    line["quantity"] = True
+    charges = _charges_definition(dishware_lines=[line])
+    with pytest.raises(ValueError, match="whole number"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_buffet_rejects_unknown_key() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["buffet"])["extra"] = 1
+    with pytest.raises(ValueError, match="unknown charges_definition.buffet field"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+def test_buffet_rejects_negative_rate() -> None:
+    charges = _charges_definition(dishware_lines=[])
+    cast(dict[str, object], charges["buffet"])["pauschale_per_person_cents"] = -1
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_offer_snapshot(_snapshot(charges_definition=charges))
+
+
+# --- consistency: delivery -----------------------------------------------------------
+
+
+def test_consistency_rejects_missing_delivery_position() -> None:
+    positions = [
+        _catalog_position(),
+        _dishware_pauschale_position(),
+        _dishware_line_position(),
+        _buffet_position(),
+    ]
+    with pytest.raises(ValueError, match="requires exactly one"):
+        validate_offer_snapshot(_snapshot(positions=positions))
+
+
+def test_consistency_rejects_delivery_amount_mismatch() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(amount_cents=4000),
+        _dishware_pauschale_position(),
+        _dishware_line_position(),
+        _buffet_position(),
+    ]
+    with pytest.raises(ValueError, match="delivery position does not match"):
+        validate_offer_snapshot(_snapshot(positions=positions))
+
+
+def test_consistency_rejects_duplicate_delivery_position() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _delivery_position(position_id="88888888-8888-4888-8888-888888888895"),
+        _dishware_pauschale_position(),
+        _dishware_line_position(),
+        _buffet_position(),
+    ]
+    with pytest.raises(ValueError, match="requires exactly one"):
+        validate_offer_snapshot(_snapshot(positions=positions))
+
+
+# --- consistency: dishware -----------------------------------------------------------
+
+
+def test_consistency_rejects_unexplained_dishware_position_when_none() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="NONE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="unexplained dishware position present for base_mode=NONE"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_missing_pauschale_position_when_enabled() -> None:
+    positions = [_catalog_position(), _delivery_position(), _buffet_position()]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(ValueError, match="dishware Pauschale position not found"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_pauschale_amount_mismatch() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(per_person_cents=250),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(ValueError, match="dishware Pauschale position amount mismatch"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_unmatched_additional_line() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_line_position(description="Teller"),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(
+        dishware_base_mode="NONE",
+        dishware_lines=[_dishware_line_def(description="Weinglas")],
+    )
+    with pytest.raises(ValueError, match="has no matching dishware position"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_dishware_pauschale_requires_guest_count() -> None:
+    positions = [_catalog_position(), _delivery_position()]
+    charges = _charges_definition(
+        dishware_base_mode="PAUSCHALE", dishware_lines=[], buffet_base_mode="NONE"
+    )
+    with pytest.raises(
+        ValueError, match="dishware base_mode=PAUSCHALE requires event.guest_count"
+    ):
+        validate_offer_snapshot(
+            _snapshot(guest_count=None, positions=positions, charges_definition=charges)
+        )
+
+
+# --- consistency: buffet --------------------------------------------------------------
+
+
+def test_consistency_rejects_unexplained_buffet_position_when_none() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+        _buffet_position(),
+    ]
+    charges = _charges_definition(buffet_base_mode="NONE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="unexplained buffet_fee position present for base_mode=NONE"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_missing_buffet_position_when_enabled() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+    ]
+    charges = _charges_definition(buffet_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(ValueError, match="buffet_fee position not found"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_buffet_amount_mismatch() -> None:
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+        _buffet_position(per_person_cents=99),
+    ]
+    charges = _charges_definition(buffet_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(ValueError, match="buffet_fee position amount mismatch"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )

--- a/tests/unit/test_offer_charges_validation.py
+++ b/tests/unit/test_offer_charges_validation.py
@@ -552,20 +552,6 @@ def test_consistency_rejects_missing_pauschale_position_when_enabled() -> None:
         )
 
 
-def test_consistency_rejects_pauschale_amount_mismatch() -> None:
-    positions = [
-        _catalog_position(),
-        _delivery_position(),
-        _dishware_pauschale_position(per_person_cents=250),
-        _buffet_position(),
-    ]
-    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
-    with pytest.raises(ValueError, match="dishware Pauschale position amount mismatch"):
-        validate_offer_snapshot(
-            _snapshot(positions=positions, charges_definition=charges)
-        )
-
-
 def test_consistency_rejects_unmatched_additional_line() -> None:
     positions = [
         _catalog_position(),
@@ -593,6 +579,153 @@ def test_consistency_dishware_pauschale_requires_guest_count() -> None:
     ):
         validate_offer_snapshot(
             _snapshot(guest_count=None, positions=positions, charges_definition=charges)
+        )
+
+
+# --- consistency: dishware — stricter deterministic matching -------------------------
+
+
+def test_consistency_rejects_line_position_with_same_total_but_different_quantity() -> (
+    None
+):
+    """A position with the same net total but a different quantity/unit
+    price must not be accepted as a match — the composite key requires
+    quantity and unit_net_cents to match too, not just the derived total."""
+    decoy = _charge_position(
+        position_id="88888888-8888-4888-8888-888888888895",
+        kind="dishware",
+        name="Weinglas",
+        quantity_mode="total",
+        quantity="40",
+        unit_net_cents=40,
+        net_total_cents=1600,  # same total as the real line (20 * 80), different shape
+    )
+    positions = [_catalog_position(), _delivery_position(), decoy, _buffet_position()]
+    charges = _charges_definition(
+        dishware_base_mode="NONE", dishware_lines=[_dishware_line_def()]
+    )
+    with pytest.raises(ValueError, match="has no matching dishware position"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_duplicate_matching_positions_for_one_line() -> None:
+    line_pos_1 = _dishware_line_position(
+        position_id="88888888-8888-4888-8888-888888888893"
+    )
+    line_pos_2 = _dishware_line_position(
+        position_id="88888888-8888-4888-8888-888888888895"
+    )
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        line_pos_1,
+        line_pos_2,
+        _buffet_position(),
+    ]
+    charges = _charges_definition(
+        dishware_base_mode="NONE", dishware_lines=[_dishware_line_def()]
+    )
+    with pytest.raises(ValueError, match="matches multiple dishware positions"):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_does_not_treat_total_mode_position_as_pauschale() -> None:
+    """The Pauschale is identified by quantity_mode="per_person", never by
+    elimination — a quantity_mode="total" position whose amount happens to
+    equal guest_count * pauschale_per_person_cents is not the Pauschale."""
+    decoy = _charge_position(
+        position_id="88888888-8888-4888-8888-888888888895",
+        kind="dishware",
+        name="Zufällig gleicher Betrag",
+        quantity_mode="total",
+        quantity="1",
+        unit_net_cents=16000,
+        net_total_cents=16000,  # == 80 guests * 200 cents/person, by coincidence
+    )
+    positions = [_catalog_position(), _delivery_position(), decoy, _buffet_position()]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="unexplained dishware position present for additional_lines"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_multiple_pauschale_candidates() -> None:
+    pauschale_1 = _dishware_pauschale_position(
+        position_id="88888888-8888-4888-8888-888888888892"
+    )
+    pauschale_2 = _dishware_pauschale_position(
+        position_id="88888888-8888-4888-8888-888888888895"
+    )
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        pauschale_1,
+        pauschale_2,
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="multiple dishware Pauschale positions present"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_pauschale_position_with_wrong_quantity() -> None:
+    bad_pauschale = _charge_position(
+        position_id="88888888-8888-4888-8888-888888888892",
+        kind="dishware",
+        name="Geschirrpauschale",
+        quantity_mode="per_person",
+        quantity="2",
+        unit_net_cents=200,
+        net_total_cents=200 * 2 * _GUEST_COUNT,
+    )
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        bad_pauschale,
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="dishware Pauschale position quantity must be 1"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
+        )
+
+
+def test_consistency_rejects_pauschale_position_unit_net_cents_mismatch() -> None:
+    bad_pauschale = _charge_position(
+        position_id="88888888-8888-4888-8888-888888888892",
+        kind="dishware",
+        name="Geschirrpauschale",
+        quantity_mode="per_person",
+        quantity="1",
+        unit_net_cents=250,
+        net_total_cents=250 * _GUEST_COUNT,
+    )
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        bad_pauschale,
+        _buffet_position(),
+    ]
+    charges = _charges_definition(dishware_base_mode="PAUSCHALE", dishware_lines=[])
+    with pytest.raises(
+        ValueError, match="dishware Pauschale position unit_net_cents mismatch"
+    ):
+        validate_offer_snapshot(
+            _snapshot(positions=positions, charges_definition=charges)
         )
 
 
@@ -640,3 +773,41 @@ def test_consistency_rejects_buffet_amount_mismatch() -> None:
         validate_offer_snapshot(
             _snapshot(positions=positions, charges_definition=charges)
         )
+
+
+def test_buffet_default_none_never_auto_materializes_a_fee_position() -> None:
+    """Operator confirmation: Büffetpauschale must be explicitly selected by
+    the office user. A charges_definition with buffet.base_mode="NONE"
+    (the default for new Offers) requires — and permits — zero buffet_fee
+    positions; nothing is added automatically."""
+    positions = [
+        _catalog_position(),
+        _delivery_position(),
+        _dishware_pauschale_position(),
+    ]
+    charges = _charges_definition(buffet_base_mode="NONE", dishware_lines=[])
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=positions, charges_definition=charges)
+    )
+    assert snapshot.charges_definition is not None
+    assert snapshot.charges_definition.buffet.base_mode == "NONE"
+    kinds = {
+        position.kind for variant in snapshot.variants for position in variant.positions
+    }
+    assert "buffet_fee" not in kinds
+
+
+def test_legacy_snapshot_without_charges_definition_never_synthesizes_buffet_fee() -> (
+    None
+):
+    """Absence of charges_definition is the legacy path — Core trusts
+    whatever positions arrived and never invents a Büffetpauschale on its
+    own, regardless of whether the operator's snapshot includes one."""
+    snapshot = validate_offer_snapshot(
+        _snapshot(positions=[_catalog_position()], charges_definition=None)
+    )
+    kinds = {
+        position.kind for variant in snapshot.variants for position in variant.positions
+    }
+    assert "buffet_fee" not in kinds
+    assert snapshot.charges_definition is None

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -21,6 +21,13 @@ from catering_system.domain.offer import (
     derive_offer_state,
 )
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
+from catering_system.domain.offer_charges import (
+    BuffetChargeDefinition,
+    DeliveryChargeDefinition,
+    DishwareAdditionalLineDefinition,
+    DishwareChargeDefinition,
+    OfferChargesDefinition,
+)
 from catering_system.repositories.in_memory_offer_repository import (
     InMemoryOfferRepository,
 )
@@ -97,6 +104,7 @@ def _version(
     snapshot_hash: str = _HASH_V1,
     variant_ids: tuple[str, ...] | None = None,
     budget_definition: OfferBudgetDefinition | None = None,
+    charges_definition: OfferChargesDefinition | None = None,
 ) -> OfferVersion:
     version_id = _V1_ID if number == 1 else _V2_ID
     ids = variant_ids or ((_A_ID, _B_ID) if number == 1 else (_C_ID,))
@@ -120,6 +128,7 @@ def _version(
             for index, variant_id in enumerate(ids, start=1)
         ),
         budget_definition=budget_definition,
+        charges_definition=charges_definition,
     )
 
 
@@ -701,6 +710,124 @@ def test_pre_migration_8_rows_load_with_budget_definition_none(
     assert loaded.versions[0].budget_definition is None
 
 
+def test_sqlite_offer_roundtrip_preserves_charges_definition(tmp_path: Path) -> None:
+    repo = SQLiteOfferRepository(tmp_path / "offer.db")
+    charges = OfferChargesDefinition(
+        delivery=DeliveryChargeDefinition(amount_cents=3500),
+        dishware=DishwareChargeDefinition(
+            base_mode="PAUSCHALE",
+            pauschale_per_person_cents=200,
+            additional_lines=(
+                DishwareAdditionalLineDefinition(
+                    description="Weinglas", quantity=20, unit_net_cents=80
+                ),
+            ),
+        ),
+        buffet=BuffetChargeDefinition(base_mode="NONE", pauschale_per_person_cents=50),
+    )
+    offer = _offer(versions=(_version(charges_definition=charges),))
+    repo.save(offer)
+    loaded = repo.get(_OFFER_ID)
+    assert loaded is not None
+    assert loaded.versions[0].charges_definition == charges
+    assert loaded == offer
+
+
+def test_sqlite_offer_roundtrip_preserves_absent_charges_definition(
+    tmp_path: Path,
+) -> None:
+    repo = SQLiteOfferRepository(tmp_path / "offer.db")
+    offer = _offer(versions=(_version(charges_definition=None),))
+    repo.save(offer)
+    loaded = repo.get(_OFFER_ID)
+    assert loaded is not None
+    assert loaded.versions[0].charges_definition is None
+
+
+def test_pre_migration_9_rows_load_with_charges_definition_none(
+    tmp_path: Path,
+) -> None:
+    """Migration/backward-compat: rows persisted before
+    CONFIGURABLE_OFFER_CHARGES_V1 load with charges_definition=None rather
+    than failing or inventing a default."""
+    db = tmp_path / "pre_migration.db"
+    conn = sqlite3.connect(db)
+    apply_migrations(conn, "offers", _MIGRATIONS[:8])
+    conn.execute(
+        "INSERT INTO offers (offer_id, source_inquiry_id, created_at) VALUES (?, ?, ?)",
+        (_OFFER_ID, _INQUIRY_ID, _NOW.isoformat()),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_versions (
+            offer_version_id, offer_id, version_number, created_at, valid_until,
+            snapshot_id, snapshot_hash, event_date, time_window_text,
+            location_text, guest_count, planning_mode, payment_method,
+            payment_customer_visible_text, customer_title,
+            customer_introduction, customer_notes, budget_definition_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _V1_ID,
+            _OFFER_ID,
+            1,
+            _NOW.isoformat(),
+            date(2026, 7, 31).isoformat(),
+            "77777777-7777-7777-7777-777777777771",
+            _HASH_V1,
+            _EVENT_DATE.isoformat(),
+            "18:00–22:00",
+            "Hamburg",
+            80,
+            "caterer_suggestion",
+            "RECHNUNG",
+            "Zahlung per Rechnung",
+            None,
+            None,
+            None,
+            None,
+        ),
+    )
+    conn.execute(
+        "INSERT INTO offer_variants "
+        "(variant_id, offer_version_id, offer_id, label, sort_order) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (_A_ID, _V1_ID, _OFFER_ID, "Variante A", 0),
+    )
+    conn.execute(
+        """
+        INSERT INTO offer_positions (
+            position_id, variant_id, offer_version_id, kind, name,
+            unit_net_cents, net_total_cents, vat_rate_percent,
+            vat_amount_cents, gross_total_cents, related_position_id,
+            sort_order
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _POS_A,
+            _A_ID,
+            _V1_ID,
+            "catalog",
+            "Fingerfood Paket",
+            290,
+            23200,
+            7,
+            1624,
+            24824,
+            None,
+            0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    repo = SQLiteOfferRepository(db)  # migration 9 runs defensively on open
+    loaded = repo.get(_OFFER_ID)
+    repo.close()
+    assert loaded is not None
+    assert loaded.versions[0].charges_definition is None
+
+
 def test_prepare_offer_document_after_sqlite_reload_gets_frozen_narrative(
     tmp_path: Path,
 ) -> None:
@@ -821,6 +948,7 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         (6, "offer_position_catalog_snapshot_fields"),
         (7, "offer_version_customer_narrative"),
         (8, "offer_version_budget_definition"),
+        (9, "offer_version_charges_definition"),
     ]
     conn = sqlite3.connect(db)
     apply_migrations(conn, "offers", _MIGRATIONS)
@@ -828,4 +956,4 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM schema_migrations WHERE component = 'offers'"
     ).fetchone()
     conn.close()
-    assert rows_after == (8,)
+    assert rows_after == (9,)

--- a/tests/unit/test_offer_service.py
+++ b/tests/unit/test_offer_service.py
@@ -7,6 +7,7 @@ from tests.helpers.order_seed import seed_order
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from typing import cast
 
 import pytest
 
@@ -175,6 +176,75 @@ def _budget_definition_payload(
         "tax_basis": tax_basis,
         "cost_scope": cost_scope,
     }
+
+
+_DELIVERY_POSITION_ID = "88888888-8888-4888-8888-888888888891"
+
+
+def _delivery_position(amount_cents: int = 3500) -> dict[str, object]:
+    vat_amount_cents = round(amount_cents * 0.19)
+    return {
+        "position_id": _DELIVERY_POSITION_ID,
+        "kind": "delivery",
+        "catalog_item_id": None,
+        "name": "Anlieferung",
+        "description": None,
+        "composition": None,
+        "quantity_mode": "total",
+        "quantity": "1",
+        "unit_label": "Pauschale",
+        "unit_net_cents": amount_cents,
+        "net_total_cents": amount_cents,
+        "vat_rate_percent": 19,
+        "vat_amount_cents": vat_amount_cents,
+        "gross_total_cents": amount_cents + vat_amount_cents,
+        "notes": None,
+        "related_position_id": None,
+    }
+
+
+def _charges_definition_payload(
+    *, delivery_amount_cents: int = 3500
+) -> dict[str, object]:
+    """CONFIGURABLE_OFFER_CHARGES_V1: delivery-only shape (dishware/buffet
+    NONE) so no extra materialized positions are required beyond delivery —
+    the full cross-product of consistency-check scenarios is already
+    covered by tests/unit/test_offer_charges_validation.py."""
+    return {
+        "delivery": {"amount_cents": delivery_amount_cents},
+        "dishware": {
+            "base_mode": "NONE",
+            "pauschale_per_person_cents": 200,
+            "additional_lines": [],
+        },
+        "buffet": {"base_mode": "NONE", "pauschale_per_person_cents": 50},
+    }
+
+
+def _snapshot_with_charges_definition(
+    *, delivery_amount_cents: int = 3500
+) -> dict[str, object]:
+    payload = _valid_snapshot()
+    variant = cast(dict[str, object], cast(list[object], payload["variants"])[0])
+    positions = cast(list[dict[str, object]], variant["positions"])
+    positions.append(_delivery_position(delivery_amount_cents))
+    totals = cast(dict[str, object], variant["totals"])
+    totals["net_cents"] = cast(int, totals["net_cents"]) + delivery_amount_cents
+    vat_amount_cents = round(delivery_amount_cents * 0.19)
+    totals["vat_19_base_cents"] = (
+        cast(int, totals["vat_19_base_cents"]) + delivery_amount_cents
+    )
+    totals["vat_19_amount_cents"] = (
+        cast(int, totals["vat_19_amount_cents"]) + vat_amount_cents
+    )
+    totals["gross_cents"] = (
+        cast(int, totals["gross_cents"]) + delivery_amount_cents + vat_amount_cents
+    )
+    payload["charges_definition"] = _charges_definition_payload(
+        delivery_amount_cents=delivery_amount_cents
+    )
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+    return payload
 
 
 def _sample_inquiry(*, inquiry_id: str = _INQUIRY_ID) -> Inquiry:
@@ -409,6 +479,53 @@ def test_prepare_offer_version_duplicate_preserves_original_budget_definition() 
     assert stored is not None
     assert stored.versions[0].budget_definition is not None
     assert stored.versions[0].budget_definition.amount_cents == 3500
+
+
+def test_prepare_offer_version_persists_charges_definition() -> None:
+    """CONFIGURABLE_OFFER_CHARGES_V1: preserved through Offer preparation."""
+    _inquiries, _orders, offers, service = _world(inquiry=_sample_inquiry())
+    payload = _snapshot_with_charges_definition()
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, payload)
+
+    version = offer.versions[0]
+    assert version.charges_definition is not None
+    assert version.charges_definition.delivery.amount_cents == 3500
+    assert version.charges_definition.dishware.base_mode == "NONE"
+    assert version.charges_definition.buffet.base_mode == "NONE"
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    assert stored.versions[0].charges_definition == version.charges_definition
+
+
+def test_prepare_offer_version_without_charges_definition_stays_none() -> None:
+    """Legacy snapshot — no charges_definition — no default is invented."""
+    _inquiries, _orders, _offers, service = _world(inquiry=_sample_inquiry())
+
+    offer = service.prepare_offer_version(_INQUIRY_ID, _valid_snapshot())
+
+    assert offer.versions[0].charges_definition is None
+
+
+def test_prepare_offer_version_duplicate_preserves_original_charges_definition() -> (
+    None
+):
+    """Duplicate protection (offer_already_exists) must not touch the
+    already-persisted Offer — its charges_definition is untouched by the
+    rejected second prepare attempt, even when the retry carries a
+    different charges_definition."""
+    _inquiries, _orders, offers, service = _world(inquiry=_sample_inquiry())
+    first_payload = _snapshot_with_charges_definition(delivery_amount_cents=3500)
+    original = service.prepare_offer_version(_INQUIRY_ID, first_payload)
+
+    second_payload = _snapshot_with_charges_definition(delivery_amount_cents=9999)
+    with pytest.raises(OfferPreparationBlockedError):
+        service.prepare_offer_version(_INQUIRY_ID, second_payload)
+
+    stored = offers.get(original.offer_id)
+    assert stored is not None
+    assert stored.versions[0].charges_definition is not None
+    assert stored.versions[0].charges_definition.delivery.amount_cents == 3500
 
 
 def test_prepare_offer_version_narrative_normalization() -> None:
@@ -1526,6 +1643,16 @@ def _revision_snapshot(*, inquiry_id: str = _INQUIRY_ID) -> dict[str, object]:
     return payload
 
 
+def _revision_snapshot_with_charges_definition() -> dict[str, object]:
+    payload = _snapshot_with_charges_definition()
+    payload["snapshot_id"] = _SNAPSHOT_ID_V2
+    payload["source_draft_id"] = "draft-2"
+    payload["snapshot_created_at"] = "2026-07-16T08:30:00+00:00"
+    payload["valid_until"] = "2026-08-05"
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+    return payload
+
+
 def test_prepare_next_offer_version_after_sent() -> None:
     offers = _CountingOfferRepository()
     _inquiries, _orders, _offers, service = _world(
@@ -1553,6 +1680,33 @@ def test_prepare_next_offer_version_after_sent() -> None:
         )
         == "Prepared"
     )
+
+
+def test_prepare_next_offer_version_preserves_charges_definition() -> None:
+    """CONFIGURABLE_OFFER_CHARGES_V1: preserved through prepare_next_offer_version
+    (the replay/revision path shares `_build_version_from_snapshot` with
+    prepare_offer_version, so this is the same one-line wiring — verified
+    end to end rather than assumed)."""
+    offers = _CountingOfferRepository()
+    _inquiries, _orders, _offers, service = _world(
+        inquiry=_sample_inquiry(), offers=offers
+    )
+    offer = service.prepare_offer_version(
+        _INQUIRY_ID, _snapshot_with_charges_definition(delivery_amount_cents=3500)
+    )
+    version_id = offer.versions[0].offer_version_id
+    service.record_sent_evidence(offer.offer_id, version_id, **_record_args())
+
+    updated = service.prepare_next_offer_version(
+        offer.offer_id,
+        _revision_snapshot_with_charges_definition(),
+        expected_latest_version_number=1,
+    )
+
+    assert updated.versions[1].charges_definition is not None
+    assert updated.versions[1].charges_definition.delivery.amount_cents == 3500
+    assert updated.versions[0].charges_definition is not None
+    assert updated.versions[0].charges_definition.delivery.amount_cents == 3500
 
 
 def test_prepare_next_blocked_while_prepared() -> None:


### PR DESCRIPTION
## Summary

Closes #61 (Stage 2A only — Core side). Introduces `charges_definition` as an optional, structured, versioned field on the Offer snapshot contract, covering delivery/dishware/buffet charges that today are unconditional, hardcoded `kind="fee"` positions materialized by the Configurator backend.

- **Domain** (`domain/offer_charges.py`, new): `DeliveryChargeDefinition`, `DishwareAdditionalLineDefinition` (derives `net_total_cents`, never stores it), `DishwareChargeDefinition` (`base_mode: NONE|PAUSCHALE` + independent `additional_lines`), `BuffetChargeDefinition`, `OfferChargesDefinition`. New Offers default to `dishware.base_mode = "NONE"` — an intentional, approved revenue-affecting change.
- **Position kinds**: `PositionKind`/`SnapshotPositionKind` extended with `delivery`, `dishware`, `buffet_fee`. Legacy `kind="fee"` positions are untouched. Budget FULL_OFFER/POSITIONS_ONLY exclusion, per-position/per-variant arithmetic validation, and Office Panel/PDF rendering are all kind-agnostic already — zero code changes needed there, only regression tests.
- **Validation** (`services/offer_snapshot_validation.py`): strict parsing when `charges_definition` is present (unknown-key rejection at every level, integer-cents/whole-number/bool-as-int checks, reused existing text-length/position-count limits), plus a new consistency pass cross-checking the definition against the snapshot's own materialized `delivery`/`dishware`/`buffet_fee` positions and totals. Never applied to legacy snapshots without `charges_definition`.
- **Persistence**: migration 9 (`offer_versions.charges_definition_json TEXT NULL`) — additive, nullable, no backfill, same safety profile as migration 8. `_build_version_from_snapshot` threads the field through prepare/next-version/replay for free; rejected duplicates never overwrite the original version.
- **Docs**: `docs/runbooks/lenovo-production.md` gets a migration-9 section mirroring migration 8's (verify/rollback/restore guidance).

Configurator wiring (Stage 2B) is a separate, later PR, gated on this being live in production — same dependency-order lesson as OFFER_BUDGET_DEFINITION_V1 / migration 8. Issue #17 is out of scope.

## Canonical wire schema

```json
"charges_definition": {
  "delivery": { "amount_cents": 3500 },
  "dishware": {
    "base_mode": "NONE",
    "pauschale_per_person_cents": 200,
    "additional_lines": [
      { "description": "Weinglas", "quantity": 20, "unit_net_cents": 80 }
    ]
  },
  "buffet": { "base_mode": "NONE", "pauschale_per_person_cents": 50 }
}
```

## Test plan

- [x] Domain unit tests (`test_offer_charges_domain.py`) — value object validation, immutability, derived `net_total_cents`.
- [x] Validation tests (`test_offer_charges_validation.py`) — schema shape, unknown-key rejection, bool-as-int rejection, all 4 dishware mode×lines combinations, consistency-check positive/negative cases, legacy-snapshot unaffected.
- [x] Persistence round-trip tests (`test_offer_repository.py`) — save/load, absent definition, pre-migration-9 backward compat, migration-count assertion.
- [x] Service tests (`test_offer_service.py`) — prepare/next-version/replay preserve the definition, rejected duplicates don't overwrite.
- [x] Rendering regression tests (`test_offer_charges_rendering.py`) — new kinds render normally in Office Panel + PDF, legacy `fee` positions unchanged, `charges_definition` never exposed by the Office API detail view or printed in the customer PDF.
- [x] Full suite: 2420 passed.
- [x] `ruff check`, `ruff format --check`, `mypy src/catering_system`, `git diff --check` — all clean (repo-wide, ignoring one pre-existing unrelated formatting drift in `scripts/seed_catalog_from_items.py`, not touched by this PR).

**Not merging** — Core must be live in production before Configurator Stage 2B starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)