### PR TITLE
AUTH_RBAC_V1 — Stage AUTH-1 Core authentication foundation

### DIFF
--- a/src/catering_system/domain/employee_auth.py
+++ b/src/catering_system/domain/employee_auth.py
@@ -1,0 +1,353 @@
+"""Employee authentication and authorization foundation for AUTH_RBAC_V1."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, cast
+
+EmployeeRole = Literal["SUPERADMIN", "ADMIN", "USER", "VIEWER"]
+ActorType = Literal["employee", "service", "system", "public"]
+AuditOutcome = Literal["success", "failure"]
+
+_ROLE_VALUES: tuple[EmployeeRole, ...] = ("SUPERADMIN", "ADMIN", "USER", "VIEWER")
+ROLE_SET: frozenset[str] = frozenset(_ROLE_VALUES)
+
+PERMISSION_REGISTRY: tuple[str, ...] = (
+    "inquiries.view",
+    "inquiries.create",
+    "inquiries.edit",
+    "inquiries.verify",
+    "customers.view",
+    "customers.edit",
+    "offers.view",
+    "offers.prepare",
+    "offers.version.create",
+    "offers.pdf.generate",
+    "offers.send",
+    "offers.status.change",
+    "offers.timing.acknowledge",
+    "orders.view",
+    "orders.version.create",
+    "orders.print.confirm",
+    "orders.effective.set",
+    "orders.ready.release",
+    "orders.pause",
+    "orders.cancel",
+    "catalog.view",
+    "catalog.edit",
+    "prices.view",
+    "prices.edit",
+    "calendar.view",
+    "queue.view",
+    "documents.view",
+    "users.view",
+    "users.create",
+    "users.edit",
+    "users.deactivate",
+    "users.reactivate",
+    "users.password.reset",
+    "users.permissions.assign",
+    "users.roles.assign",
+    "audit.view",
+    "settings.view",
+    "settings.edit",
+)
+PERMISSION_SET: frozenset[str] = frozenset(PERMISSION_REGISTRY)
+VIEW_PERMISSION_SET: frozenset[str] = frozenset(
+    permission for permission in PERMISSION_REGISTRY if permission.endswith(".view")
+)
+
+ADMIN_ROLE_CEILING: frozenset[str] = frozenset(
+    {
+        "inquiries.view",
+        "inquiries.create",
+        "inquiries.edit",
+        "inquiries.verify",
+        "customers.view",
+        "customers.edit",
+        "offers.view",
+        "offers.prepare",
+        "offers.version.create",
+        "offers.pdf.generate",
+        "offers.send",
+        "offers.status.change",
+        "offers.timing.acknowledge",
+        "orders.view",
+        "orders.version.create",
+        "orders.print.confirm",
+        "orders.effective.set",
+        "orders.ready.release",
+        "orders.pause",
+        "orders.cancel",
+        "catalog.view",
+        "catalog.edit",
+        "prices.view",
+        "prices.edit",
+        "calendar.view",
+        "queue.view",
+        "documents.view",
+        "users.view",
+        "users.create",
+        "users.edit",
+        "users.deactivate",
+        "users.reactivate",
+        "users.password.reset",
+        "users.permissions.assign",
+        "users.roles.assign",
+        "settings.view",
+    }
+)
+
+USER_ROLE_CEILING: frozenset[str] = frozenset(
+    {
+        "inquiries.view",
+        "inquiries.create",
+        "inquiries.edit",
+        "inquiries.verify",
+        "customers.view",
+        "customers.edit",
+        "offers.view",
+        "offers.prepare",
+        "offers.version.create",
+        "offers.pdf.generate",
+        "offers.send",
+        "offers.status.change",
+        "offers.timing.acknowledge",
+        "orders.view",
+        "orders.version.create",
+        "orders.print.confirm",
+        "orders.effective.set",
+        "orders.ready.release",
+        "orders.pause",
+        "orders.cancel",
+        "catalog.view",
+        "catalog.edit",
+        "prices.view",
+        "prices.edit",
+        "calendar.view",
+        "queue.view",
+        "documents.view",
+    }
+)
+
+ROLE_CEILINGS: dict[EmployeeRole, frozenset[str]] = {
+    "SUPERADMIN": PERMISSION_SET,
+    "ADMIN": ADMIN_ROLE_CEILING,
+    "USER": USER_ROLE_CEILING,
+    "VIEWER": VIEW_PERMISSION_SET,
+}
+
+ROLE_DEFAULT_GRANTS: dict[EmployeeRole, frozenset[str]] = {
+    "SUPERADMIN": PERMISSION_SET,
+    "ADMIN": frozenset(
+        {
+            "inquiries.view",
+            "inquiries.create",
+            "inquiries.edit",
+            "inquiries.verify",
+            "customers.view",
+            "customers.edit",
+            "offers.view",
+            "offers.prepare",
+            "offers.version.create",
+            "offers.pdf.generate",
+            "offers.send",
+            "offers.status.change",
+            "offers.timing.acknowledge",
+            "orders.view",
+            "orders.version.create",
+            "orders.print.confirm",
+            "orders.effective.set",
+            "orders.ready.release",
+            "orders.pause",
+            "orders.cancel",
+            "calendar.view",
+            "queue.view",
+            "documents.view",
+            "users.view",
+            "users.create",
+            "users.edit",
+            "users.deactivate",
+            "users.reactivate",
+            "users.password.reset",
+            "users.permissions.assign",
+            "users.roles.assign",
+            "settings.view",
+        }
+    ),
+    "USER": frozenset(
+        {
+            "inquiries.view",
+            "inquiries.create",
+            "inquiries.edit",
+            "customers.view",
+            "offers.view",
+            "offers.prepare",
+            "offers.version.create",
+            "documents.view",
+            "orders.view",
+            "calendar.view",
+            "queue.view",
+        }
+    ),
+    "VIEWER": frozenset(),
+}
+
+_USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,63}$")
+
+
+def validate_role(value: str) -> EmployeeRole:
+    if value not in ROLE_SET:
+        raise ValueError(f"role must be one of {sorted(ROLE_SET)}, got {value!r}")
+    return cast(EmployeeRole, value)
+
+
+def validate_permission_code(value: str) -> str:
+    if value not in PERMISSION_SET:
+        raise ValueError(
+            f"permission_code must be one of the AUTH_RBAC_V1 registry, got {value!r}"
+        )
+    return value
+
+
+def normalize_username(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("username must be a string")
+    normalized = value.strip().lower()
+    if not _USERNAME_RE.fullmatch(normalized):
+        raise ValueError(
+            "username must be 3-64 chars of lowercase letters, digits, dot, dash, underscore"
+        )
+    return normalized
+
+
+def normalize_optional_email(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("email must be a string or null")
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if "@" not in normalized or len(normalized) > 320:
+        raise ValueError("email must be a valid address-like string")
+    return normalized
+
+
+def validate_display_name(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("display_name must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("display_name must not be empty")
+    if len(normalized) > 200:
+        raise ValueError("display_name exceeds length limit")
+    return normalized
+
+
+def role_ceiling(role: EmployeeRole) -> frozenset[str]:
+    return ROLE_CEILINGS[role]
+
+
+def role_default_grants(role: EmployeeRole) -> frozenset[str]:
+    return ROLE_DEFAULT_GRANTS[role]
+
+
+def effective_permissions(
+    role: EmployeeRole, explicit_permissions: set[str] | frozenset[str]
+) -> frozenset[str]:
+    ceiling = role_ceiling(role)
+    return frozenset(
+        permission for permission in explicit_permissions if permission in ceiling
+    )
+
+
+def ensure_permissions_within_role(role: EmployeeRole, permissions: set[str]) -> None:
+    for permission in permissions:
+        validate_permission_code(permission)
+    overflow = permissions.difference(role_ceiling(role))
+    if overflow:
+        raise ValueError(f"permissions exceed {role} ceiling: {sorted(overflow)}")
+
+
+def manageable_roles_for(role: EmployeeRole) -> frozenset[EmployeeRole]:
+    if role == "SUPERADMIN":
+        return frozenset(_ROLE_VALUES)
+    if role == "ADMIN":
+        return frozenset({"USER", "VIEWER"})
+    return frozenset()
+
+
+@dataclass(frozen=True)
+class EmployeeAccount:
+    id: str
+    username: str
+    email: str | None
+    display_name: str
+    password_hash: str
+    role: EmployeeRole
+    is_active: bool
+    must_change_password: bool
+    created_at: datetime
+    updated_at: datetime
+    deactivated_at: datetime | None
+    last_login_at: datetime | None
+    auth_version: int
+
+
+@dataclass(frozen=True)
+class EmployeeSession:
+    id: str
+    account_id: str
+    token_hash: str
+    csrf_token_hash: str
+    created_at: datetime
+    last_seen_at: datetime
+    expires_at: datetime
+    revoked_at: datetime | None
+    revoked_reason: str | None
+    auth_version: int
+
+
+@dataclass(frozen=True)
+class SecurityAuditEvent:
+    event_id: str
+    occurred_at: datetime
+    actor_type: ActorType
+    actor_account_id: str | None
+    actor_display_name_snapshot: str | None
+    actor_role_snapshot: EmployeeRole | None
+    session_id: str | None
+    action: str
+    target_type: str
+    target_id: str | None
+    permission_code: str | None
+    outcome: AuditOutcome
+    metadata_json: str
+
+
+@dataclass(frozen=True)
+class AuthenticatedEmployee:
+    account: EmployeeAccount
+    session: EmployeeSession
+    effective_permissions: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SessionLoginResult:
+    account: EmployeeAccount
+    session: EmployeeSession
+    session_token: str
+    csrf_token: str
+    effective_permissions: frozenset[str]
+
+
+@dataclass(frozen=True)
+class AuthIntrospection:
+    kind: Literal["employee_session", "service_token", "public"]
+    authenticated: bool
+    account: EmployeeAccount | None = None
+    effective_permissions: frozenset[str] = frozenset()
+    service_id: str | None = None

--- a/src/catering_system/domain/employee_auth.py
+++ b/src/catering_system/domain/employee_auth.py
@@ -332,6 +332,7 @@ class SecurityAuditEvent:
 class AuthenticatedEmployee:
     account: EmployeeAccount
     session: EmployeeSession
+    application_access_allowed: bool
     effective_permissions: frozenset[str]
 
 
@@ -341,6 +342,7 @@ class SessionLoginResult:
     session: EmployeeSession
     session_token: str
     csrf_token: str
+    application_access_allowed: bool
     effective_permissions: frozenset[str]
 
 
@@ -348,6 +350,7 @@ class SessionLoginResult:
 class AuthIntrospection:
     kind: Literal["employee_session", "service_token", "public"]
     authenticated: bool
+    application_access_allowed: bool = False
     account: EmployeeAccount | None = None
     effective_permissions: frozenset[str] = frozenset()
     service_id: str | None = None

--- a/src/catering_system/repositories/bootstrap_employee_auth_schema.py
+++ b/src/catering_system/repositories/bootstrap_employee_auth_schema.py
@@ -1,0 +1,13 @@
+"""Bootstrap AUTH_RBAC_V1 employee auth schema on a shared Core connection."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+
+
+def bootstrap_employee_auth_schema(connection: sqlite3.Connection) -> None:
+    SQLiteEmployeeAuthRepository.from_connection(connection)

--- a/src/catering_system/repositories/sqlite_employee_auth_repository.py
+++ b/src/catering_system/repositories/sqlite_employee_auth_repository.py
@@ -1,0 +1,484 @@
+"""SQLite persistence for AUTH_RBAC_V1 employee auth foundation."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+
+from catering_system.domain.employee_auth import (
+    EmployeeAccount,
+    EmployeeSession,
+    SecurityAuditEvent,
+    validate_permission_code,
+    validate_role,
+)
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+_CREATE_EMPLOYEE_ACCOUNTS = """
+CREATE TABLE IF NOT EXISTS employee_accounts (
+    account_id TEXT PRIMARY KEY,
+    username TEXT NOT NULL COLLATE NOCASE,
+    email TEXT COLLATE NOCASE,
+    display_name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL,
+    is_active INTEGER NOT NULL,
+    must_change_password INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    deactivated_at TEXT,
+    last_login_at TEXT,
+    auth_version INTEGER NOT NULL
+);
+"""
+
+_ACCOUNT_INDEXES = (
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_employee_accounts_username
+    ON employee_accounts (username);
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_employee_accounts_email
+    ON employee_accounts (email)
+    WHERE email IS NOT NULL AND email <> '';
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_employee_accounts_role
+    ON employee_accounts (role);
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_employee_accounts_active
+    ON employee_accounts (is_active, role);
+    """,
+)
+
+_CREATE_ACCOUNT_PERMISSIONS = """
+CREATE TABLE IF NOT EXISTS account_permissions (
+    account_id TEXT NOT NULL,
+    permission_code TEXT NOT NULL,
+    PRIMARY KEY (account_id, permission_code),
+    FOREIGN KEY (account_id) REFERENCES employee_accounts (account_id)
+);
+"""
+
+_ACCOUNT_PERMISSION_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_account_permissions_account
+ON account_permissions (account_id);
+"""
+
+_CREATE_EMPLOYEE_SESSIONS = """
+CREATE TABLE IF NOT EXISTS employee_sessions (
+    session_id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    csrf_token_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    revoked_at TEXT,
+    revoked_reason TEXT,
+    auth_version INTEGER NOT NULL,
+    FOREIGN KEY (account_id) REFERENCES employee_accounts (account_id)
+);
+"""
+
+_SESSION_INDEXES = (
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_employee_sessions_token_hash
+    ON employee_sessions (token_hash);
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_employee_sessions_account
+    ON employee_sessions (account_id);
+    """,
+)
+
+_CREATE_SECURITY_AUDIT_EVENTS = """
+CREATE TABLE IF NOT EXISTS security_audit_events (
+    event_id TEXT PRIMARY KEY,
+    occurred_at TEXT NOT NULL,
+    actor_type TEXT NOT NULL,
+    actor_account_id TEXT,
+    actor_display_name_snapshot TEXT,
+    actor_role_snapshot TEXT,
+    session_id TEXT,
+    action TEXT NOT NULL,
+    target_type TEXT NOT NULL,
+    target_id TEXT,
+    permission_code TEXT,
+    outcome TEXT NOT NULL,
+    metadata_json TEXT NOT NULL
+);
+"""
+
+_AUDIT_INDEXES = (
+    """
+    CREATE INDEX IF NOT EXISTS idx_security_audit_events_occurred_at
+    ON security_audit_events (occurred_at);
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_security_audit_events_actor
+    ON security_audit_events (actor_account_id, occurred_at);
+    """,
+)
+
+_AUDIT_APPEND_ONLY_TRIGGERS = (
+    """
+    CREATE TRIGGER IF NOT EXISTS trg_security_audit_events_no_update
+    BEFORE UPDATE ON security_audit_events
+    BEGIN
+        SELECT RAISE(ABORT, 'security audit events are append-only');
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS trg_security_audit_events_no_delete
+    BEFORE DELETE ON security_audit_events
+    BEGIN
+        SELECT RAISE(ABORT, 'security audit events are append-only');
+    END
+    """,
+)
+
+
+def _migration_1_create_employee_accounts(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE_EMPLOYEE_ACCOUNTS)
+    for statement in _ACCOUNT_INDEXES:
+        connection.execute(statement)
+
+
+def _migration_2_create_account_permissions(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE_ACCOUNT_PERMISSIONS)
+    connection.execute(_ACCOUNT_PERMISSION_INDEX)
+
+
+def _migration_3_create_employee_sessions(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE_EMPLOYEE_SESSIONS)
+    for statement in _SESSION_INDEXES:
+        connection.execute(statement)
+
+
+def _migration_4_create_security_audit_events(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE_SECURITY_AUDIT_EVENTS)
+    for statement in _AUDIT_INDEXES:
+        connection.execute(statement)
+    for statement in _AUDIT_APPEND_ONLY_TRIGGERS:
+        connection.execute(statement)
+
+
+_MIGRATIONS = (
+    (1, "create_employee_accounts", _migration_1_create_employee_accounts),
+    (2, "create_account_permissions", _migration_2_create_account_permissions),
+    (3, "create_employee_sessions", _migration_3_create_employee_sessions),
+    (4, "create_security_audit_events", _migration_4_create_security_audit_events),
+)
+
+
+class SQLiteEmployeeAuthRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "employee_auth", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteEmployeeAuthRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._conn.execute("PRAGMA foreign_keys = ON")
+        repo._manage_transactions = False
+        apply_migrations(connection, "employee_auth", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def count_accounts(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM employee_accounts").fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def count_active_superadmins(self) -> int:
+        row = self._conn.execute(
+            """
+            SELECT COUNT(*) FROM employee_accounts
+            WHERE role = 'SUPERADMIN' AND is_active = 1
+            """
+        ).fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def add_account(self, account: EmployeeAccount) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO employee_accounts (
+                    account_id, username, email, display_name, password_hash, role,
+                    is_active, must_change_password, created_at, updated_at,
+                    deactivated_at, last_login_at, auth_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    account.id,
+                    account.username,
+                    account.email,
+                    account.display_name,
+                    account.password_hash,
+                    account.role,
+                    int(account.is_active),
+                    int(account.must_change_password),
+                    account.created_at.isoformat(),
+                    account.updated_at.isoformat(),
+                    account.deactivated_at.isoformat()
+                    if account.deactivated_at is not None
+                    else None,
+                    account.last_login_at.isoformat()
+                    if account.last_login_at is not None
+                    else None,
+                    account.auth_version,
+                ),
+            )
+
+    def update_account(self, account: EmployeeAccount) -> None:
+        with self._write_scope():
+            updated = self._conn.execute(
+                """
+                UPDATE employee_accounts
+                SET username = ?, email = ?, display_name = ?, password_hash = ?,
+                    role = ?, is_active = ?, must_change_password = ?,
+                    updated_at = ?, deactivated_at = ?, last_login_at = ?,
+                    auth_version = ?
+                WHERE account_id = ?
+                """,
+                (
+                    account.username,
+                    account.email,
+                    account.display_name,
+                    account.password_hash,
+                    account.role,
+                    int(account.is_active),
+                    int(account.must_change_password),
+                    account.updated_at.isoformat(),
+                    account.deactivated_at.isoformat()
+                    if account.deactivated_at is not None
+                    else None,
+                    account.last_login_at.isoformat()
+                    if account.last_login_at is not None
+                    else None,
+                    account.auth_version,
+                    account.id,
+                ),
+            ).rowcount
+            if updated != 1:
+                raise KeyError(account.id)
+
+    def get_account_by_id(self, account_id: str) -> EmployeeAccount | None:
+        row = self._conn.execute(
+            "SELECT * FROM employee_accounts WHERE account_id = ?", (account_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_account(row)
+
+    def get_account_by_username(self, username: str) -> EmployeeAccount | None:
+        row = self._conn.execute(
+            "SELECT * FROM employee_accounts WHERE username = ?", (username,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_account(row)
+
+    def set_explicit_permissions(self, account_id: str, permissions: set[str]) -> None:
+        for permission in permissions:
+            validate_permission_code(permission)
+        with self._write_scope():
+            self._conn.execute(
+                "DELETE FROM account_permissions WHERE account_id = ?", (account_id,)
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO account_permissions (account_id, permission_code)
+                VALUES (?, ?)
+                """,
+                [(account_id, permission) for permission in sorted(permissions)],
+            )
+
+    def get_explicit_permissions(self, account_id: str) -> set[str]:
+        rows = self._conn.execute(
+            """
+            SELECT permission_code FROM account_permissions
+            WHERE account_id = ?
+            ORDER BY permission_code
+            """,
+            (account_id,),
+        ).fetchall()
+        return {validate_permission_code(row[0]) for row in rows}
+
+    def create_session(self, session: EmployeeSession) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO employee_sessions (
+                    session_id, account_id, token_hash, csrf_token_hash,
+                    created_at, last_seen_at, expires_at, revoked_at,
+                    revoked_reason, auth_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session.id,
+                    session.account_id,
+                    session.token_hash,
+                    session.csrf_token_hash,
+                    session.created_at.isoformat(),
+                    session.last_seen_at.isoformat(),
+                    session.expires_at.isoformat(),
+                    session.revoked_at.isoformat()
+                    if session.revoked_at is not None
+                    else None,
+                    session.revoked_reason,
+                    session.auth_version,
+                ),
+            )
+
+    def get_session_by_token_hash(self, token_hash: str) -> EmployeeSession | None:
+        row = self._conn.execute(
+            "SELECT * FROM employee_sessions WHERE token_hash = ?",
+            (token_hash,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_session(row)
+
+    def update_session(self, session: EmployeeSession) -> None:
+        with self._write_scope():
+            updated = self._conn.execute(
+                """
+                UPDATE employee_sessions
+                SET last_seen_at = ?, expires_at = ?, revoked_at = ?, revoked_reason = ?,
+                    auth_version = ?
+                WHERE session_id = ?
+                """,
+                (
+                    session.last_seen_at.isoformat(),
+                    session.expires_at.isoformat(),
+                    session.revoked_at.isoformat()
+                    if session.revoked_at is not None
+                    else None,
+                    session.revoked_reason,
+                    session.auth_version,
+                    session.id,
+                ),
+            ).rowcount
+            if updated != 1:
+                raise KeyError(session.id)
+
+    def revoke_sessions_for_account(
+        self, account_id: str, *, revoked_at: datetime, reason: str
+    ) -> int:
+        with self._write_scope():
+            return self._conn.execute(
+                """
+                UPDATE employee_sessions
+                SET revoked_at = ?, revoked_reason = ?
+                WHERE account_id = ? AND revoked_at IS NULL
+                """,
+                (revoked_at.isoformat(), reason, account_id),
+            ).rowcount
+
+    def append_audit_event(self, event: SecurityAuditEvent) -> None:
+        json.loads(event.metadata_json)
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO security_audit_events (
+                    event_id, occurred_at, actor_type, actor_account_id,
+                    actor_display_name_snapshot, actor_role_snapshot, session_id,
+                    action, target_type, target_id, permission_code, outcome,
+                    metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.occurred_at.isoformat(),
+                    event.actor_type,
+                    event.actor_account_id,
+                    event.actor_display_name_snapshot,
+                    event.actor_role_snapshot,
+                    event.session_id,
+                    event.action,
+                    event.target_type,
+                    event.target_id,
+                    event.permission_code,
+                    event.outcome,
+                    event.metadata_json,
+                ),
+            )
+
+    def list_audit_events(self) -> list[SecurityAuditEvent]:
+        rows = self._conn.execute(
+            "SELECT * FROM security_audit_events ORDER BY occurred_at, event_id"
+        ).fetchall()
+        return [self._row_to_audit_event(row) for row in rows]
+
+    @staticmethod
+    def _row_to_account(row: tuple) -> EmployeeAccount:
+        return EmployeeAccount(
+            id=row[0],
+            username=row[1],
+            email=row[2],
+            display_name=row[3],
+            password_hash=row[4],
+            role=validate_role(row[5]),
+            is_active=bool(row[6]),
+            must_change_password=bool(row[7]),
+            created_at=datetime.fromisoformat(row[8]),
+            updated_at=datetime.fromisoformat(row[9]),
+            deactivated_at=datetime.fromisoformat(row[10]) if row[10] else None,
+            last_login_at=datetime.fromisoformat(row[11]) if row[11] else None,
+            auth_version=int(row[12]),
+        )
+
+    @staticmethod
+    def _row_to_session(row: tuple) -> EmployeeSession:
+        return EmployeeSession(
+            id=row[0],
+            account_id=row[1],
+            token_hash=row[2],
+            csrf_token_hash=row[3],
+            created_at=datetime.fromisoformat(row[4]),
+            last_seen_at=datetime.fromisoformat(row[5]),
+            expires_at=datetime.fromisoformat(row[6]),
+            revoked_at=datetime.fromisoformat(row[7]) if row[7] else None,
+            revoked_reason=row[8],
+            auth_version=int(row[9]),
+        )
+
+    @staticmethod
+    def _row_to_audit_event(row: tuple) -> SecurityAuditEvent:
+        role = validate_role(row[5]) if row[5] is not None else None
+        return SecurityAuditEvent(
+            event_id=row[0],
+            occurred_at=datetime.fromisoformat(row[1]),
+            actor_type=row[2],
+            actor_account_id=row[3],
+            actor_display_name_snapshot=row[4],
+            actor_role_snapshot=role,
+            session_id=row[6],
+            action=row[7],
+            target_type=row[8],
+            target_id=row[9],
+            permission_code=row[10],
+            outcome=row[11],
+            metadata_json=row[12],
+        )

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -1,0 +1,711 @@
+"""AUTH_RBAC_V1 authentication, session, and account-management services."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import Any, Callable
+
+from catering_system.domain.employee_auth import (
+    ActorType,
+    AuditOutcome,
+    AuthIntrospection,
+    AuthenticatedEmployee,
+    EmployeeAccount,
+    EmployeeRole,
+    EmployeeSession,
+    SecurityAuditEvent,
+    SessionLoginResult,
+    effective_permissions,
+    ensure_permissions_within_role,
+    manageable_roles_for,
+    normalize_optional_email,
+    normalize_username,
+    role_default_grants,
+    validate_display_name,
+    validate_role,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+
+_SESSION_TTL = timedelta(hours=12)
+_SCRYPT_N = 2**15
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SCRYPT_SALT_BYTES = 16
+_SCRYPT_KEY_BYTES = 32
+_SCRYPT_MAXMEM = 128 * 1024 * 1024
+_SESSION_TOKEN_BYTES = 32
+_CSRF_TOKEN_BYTES = 32
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+class AuthorizationError(Exception):
+    pass
+
+
+class LastActiveSuperadminError(Exception):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _hash_password(password: str) -> str:
+    if not isinstance(password, str) or len(password) < 8:
+        raise ValueError("password must be at least 8 characters")
+    salt = secrets.token_bytes(_SCRYPT_SALT_BYTES)
+    derived = hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=salt,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        dklen=_SCRYPT_KEY_BYTES,
+        maxmem=_SCRYPT_MAXMEM,
+    )
+    return (
+        "scrypt"
+        f"${_SCRYPT_N}"
+        f"${_SCRYPT_R}"
+        f"${_SCRYPT_P}"
+        f"${base64.urlsafe_b64encode(salt).decode('ascii')}"
+        f"${base64.urlsafe_b64encode(derived).decode('ascii')}"
+    )
+
+
+def verify_password(password: str, encoded_hash: str) -> bool:
+    try:
+        algorithm, n_raw, r_raw, p_raw, salt_raw, derived_raw = encoded_hash.split("$")
+    except ValueError:
+        return False
+    if algorithm != "scrypt":
+        return False
+    try:
+        salt = base64.urlsafe_b64decode(salt_raw.encode("ascii"))
+        expected = base64.urlsafe_b64decode(derived_raw.encode("ascii"))
+        derived = hashlib.scrypt(
+            password.encode("utf-8"),
+            salt=salt,
+            n=int(n_raw),
+            r=int(r_raw),
+            p=int(p_raw),
+            dklen=len(expected),
+            maxmem=_SCRYPT_MAXMEM,
+        )
+    except Exception:
+        return False
+    return hmac.compare_digest(derived, expected)
+
+
+def _redacted_metadata(metadata: dict[str, Any]) -> str:
+    redacted: dict[str, Any] = {}
+    for key, value in metadata.items():
+        lowered = key.lower()
+        if any(token in lowered for token in ("password", "token", "secret", "hash")):
+            redacted[key] = "[redacted]"
+        else:
+            redacted[key] = value
+    return json.dumps(redacted, sort_keys=True, ensure_ascii=False)
+
+
+def _session_cookie_value(token: str) -> str:
+    return token
+
+
+class EmployeeAuthService:
+    def __init__(
+        self,
+        repository: SQLiteEmployeeAuthRepository,
+        *,
+        now: Callable[[], datetime] = _utc_now,
+        session_ttl: timedelta = _SESSION_TTL,
+        service_tokens: dict[str, str] | None = None,
+    ) -> None:
+        self.repository = repository
+        self._now = now
+        self._session_ttl = session_ttl
+        self._service_tokens = {
+            service_id: token
+            for service_id, token in (service_tokens or {}).items()
+            if token
+        }
+
+    def bootstrap_superadmin(
+        self,
+        *,
+        username: str,
+        display_name: str,
+        password: str,
+        email: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> EmployeeAccount:
+        if self.repository.count_accounts() != 0:
+            raise ValueError(
+                "bootstrap is allowed only when no employee account exists"
+            )
+        account = self._create_account_record(
+            username=username,
+            display_name=display_name,
+            password=password,
+            email=email,
+            role="SUPERADMIN",
+            must_change_password=True,
+        )
+        self.repository.add_account(account)
+        self.repository.set_explicit_permissions(
+            account.id, set(role_default_grants("SUPERADMIN"))
+        )
+        self._append_audit(
+            actor_type="system",
+            actor_account=None,
+            session_id=None,
+            action="auth.bootstrap_superadmin",
+            target_type="employee_account",
+            target_id=account.id,
+            permission_code=None,
+            outcome="success",
+            metadata=metadata or {"username": account.username},
+        )
+        self._append_audit(
+            actor_type="system",
+            actor_account=None,
+            session_id=None,
+            action="auth.account_created",
+            target_type="employee_account",
+            target_id=account.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"role": account.role, "username": account.username},
+        )
+        return account
+
+    def create_account(
+        self,
+        actor: AuthenticatedEmployee,
+        *,
+        username: str,
+        display_name: str,
+        password: str,
+        role: str,
+        email: str | None = None,
+        explicit_permissions: set[str] | None = None,
+        must_change_password: bool = True,
+    ) -> EmployeeAccount:
+        target_role = validate_role(role)
+        self._assert_can_manage_role(actor, target_role)
+        self._assert_permission(actor, "users.create")
+        account = self._create_account_record(
+            username=username,
+            display_name=display_name,
+            password=password,
+            email=email,
+            role=target_role,
+            must_change_password=must_change_password,
+        )
+        permissions = (
+            set(role_default_grants(target_role))
+            if explicit_permissions is None
+            else set(explicit_permissions)
+        )
+        ensure_permissions_within_role(target_role, permissions)
+        if actor.account.role == "ADMIN":
+            overflow = permissions.difference(actor.effective_permissions)
+            if overflow:
+                raise AuthorizationError(
+                    f"ADMIN may grant only own effective permissions: {sorted(overflow)}"
+                )
+        self.repository.add_account(account)
+        self.repository.set_explicit_permissions(account.id, permissions)
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.account_created",
+            target_type="employee_account",
+            target_id=account.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"role": account.role, "username": account.username},
+        )
+        return account
+
+    def set_account_permissions(
+        self,
+        actor: AuthenticatedEmployee,
+        target_account_id: str,
+        permissions: set[str],
+    ) -> EmployeeAccount:
+        self._assert_permission(actor, "users.permissions.assign")
+        target = self._require_account(target_account_id)
+        self._assert_can_manage_existing_account(actor, target)
+        ensure_permissions_within_role(target.role, permissions)
+        if actor.account.role == "ADMIN":
+            overflow = permissions.difference(actor.effective_permissions)
+            if overflow:
+                raise AuthorizationError(
+                    f"ADMIN may grant only own effective permissions: {sorted(overflow)}"
+                )
+        self.repository.set_explicit_permissions(target.id, permissions)
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.permission_changed",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"permissions": sorted(permissions)},
+        )
+        return target
+
+    def change_account_role(
+        self, actor: AuthenticatedEmployee, target_account_id: str, new_role: str
+    ) -> EmployeeAccount:
+        self._assert_permission(actor, "users.roles.assign")
+        target = self._require_account(target_account_id)
+        next_role = validate_role(new_role)
+        self._assert_can_manage_role(actor, next_role)
+        self._assert_can_manage_existing_account(actor, target)
+        if target.role == "SUPERADMIN" and next_role != "SUPERADMIN":
+            self._assert_not_last_active_superadmin(target)
+        updated = replace(
+            target,
+            role=next_role,
+            updated_at=self._now(),
+        )
+        self.repository.update_account(updated)
+        current_permissions = self.repository.get_explicit_permissions(target.id)
+        self.repository.set_explicit_permissions(
+            target.id, set(effective_permissions(next_role, current_permissions))
+        )
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.role_changed",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"role": next_role},
+        )
+        return updated
+
+    def deactivate_account(
+        self, actor: AuthenticatedEmployee, target_account_id: str
+    ) -> EmployeeAccount:
+        self._assert_permission(actor, "users.deactivate")
+        target = self._require_account(target_account_id)
+        self._assert_can_manage_existing_account(actor, target)
+        if target.role == "SUPERADMIN":
+            self._assert_not_last_active_superadmin(target)
+        now = self._now()
+        updated = replace(
+            target,
+            is_active=False,
+            updated_at=now,
+            deactivated_at=now,
+            auth_version=target.auth_version + 1,
+        )
+        self.repository.update_account(updated)
+        self.repository.revoke_sessions_for_account(
+            target.id, revoked_at=now, reason="account_deactivated"
+        )
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.account_deactivated",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": target.username},
+        )
+        return updated
+
+    def reactivate_account(
+        self, actor: AuthenticatedEmployee, target_account_id: str
+    ) -> EmployeeAccount:
+        self._assert_permission(actor, "users.reactivate")
+        target = self._require_account(target_account_id)
+        self._assert_can_manage_existing_account(actor, target)
+        updated = replace(
+            target,
+            is_active=True,
+            updated_at=self._now(),
+            deactivated_at=None,
+        )
+        self.repository.update_account(updated)
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.account_reactivated",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": target.username},
+        )
+        return updated
+
+    def authenticate(self, *, username: str, password: str) -> SessionLoginResult:
+        normalized_username = normalize_username(username)
+        account = self.repository.get_account_by_username(normalized_username)
+        if account is None or not verify_password(password, account.password_hash):
+            self._append_audit(
+                actor_type="public",
+                actor_account=None,
+                session_id=None,
+                action="auth.login",
+                target_type="employee_account",
+                target_id=account.id if account is not None else None,
+                permission_code=None,
+                outcome="failure",
+                metadata={"username": normalized_username},
+            )
+            raise AuthenticationError("invalid credentials")
+        if not account.is_active:
+            self._append_audit(
+                actor_type="public",
+                actor_account=None,
+                session_id=None,
+                action="auth.login",
+                target_type="employee_account",
+                target_id=account.id,
+                permission_code=None,
+                outcome="failure",
+                metadata={"username": normalized_username, "reason": "inactive"},
+            )
+            raise AuthenticationError("account is inactive")
+        now = self._now()
+        updated = replace(account, last_login_at=now, updated_at=now)
+        self.repository.update_account(updated)
+        session_token = secrets.token_urlsafe(_SESSION_TOKEN_BYTES)
+        csrf_token = secrets.token_urlsafe(_CSRF_TOKEN_BYTES)
+        session = EmployeeSession(
+            id=str(uuid.uuid4()),
+            account_id=updated.id,
+            token_hash=_token_hash(session_token),
+            csrf_token_hash=_token_hash(csrf_token),
+            created_at=now,
+            last_seen_at=now,
+            expires_at=now + self._session_ttl,
+            revoked_at=None,
+            revoked_reason=None,
+            auth_version=updated.auth_version,
+        )
+        self.repository.create_session(session)
+        resolved_permissions = self.repository.get_explicit_permissions(updated.id)
+        self._append_audit(
+            actor_type="employee",
+            actor_account=updated,
+            session_id=session.id,
+            action="auth.login",
+            target_type="employee_account",
+            target_id=updated.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": updated.username},
+        )
+        return SessionLoginResult(
+            account=updated,
+            session=session,
+            session_token=session_token,
+            csrf_token=csrf_token,
+            effective_permissions=effective_permissions(
+                updated.role, resolved_permissions
+            ),
+        )
+
+    def authenticate_session(self, session_token: str) -> AuthenticatedEmployee:
+        session = self.repository.get_session_by_token_hash(_token_hash(session_token))
+        if session is None:
+            raise AuthenticationError("session not found")
+        now = self._now()
+        if session.revoked_at is not None:
+            raise AuthenticationError("session revoked")
+        if session.expires_at <= now:
+            revoked = replace(
+                session,
+                revoked_at=now,
+                revoked_reason="expired",
+            )
+            self.repository.update_session(revoked)
+            raise AuthenticationError("session expired")
+        account = self._require_account(session.account_id)
+        if not account.is_active:
+            raise AuthenticationError("account is inactive")
+        if session.auth_version != account.auth_version:
+            revoked = replace(
+                session,
+                revoked_at=now,
+                revoked_reason="auth_version_changed",
+            )
+            self.repository.update_session(revoked)
+            raise AuthenticationError("session invalidated")
+        touched = replace(session, last_seen_at=now)
+        self.repository.update_session(touched)
+        resolved_permissions = self.repository.get_explicit_permissions(account.id)
+        return AuthenticatedEmployee(
+            account=account,
+            session=touched,
+            effective_permissions=effective_permissions(
+                account.role, resolved_permissions
+            ),
+        )
+
+    def validate_csrf(self, session: EmployeeSession, csrf_token: str) -> None:
+        if not csrf_token or not hmac.compare_digest(
+            session.csrf_token_hash, _token_hash(csrf_token)
+        ):
+            raise AuthenticationError("invalid csrf token")
+
+    def logout(self, employee: AuthenticatedEmployee) -> None:
+        revoked = replace(
+            employee.session,
+            revoked_at=self._now(),
+            revoked_reason="logout",
+        )
+        self.repository.update_session(revoked)
+        self._append_audit(
+            actor_type="employee",
+            actor_account=employee.account,
+            session_id=employee.session.id,
+            action="auth.logout",
+            target_type="employee_account",
+            target_id=employee.account.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": employee.account.username},
+        )
+
+    def change_password(
+        self,
+        employee: AuthenticatedEmployee,
+        *,
+        current_password: str,
+        new_password: str,
+    ) -> EmployeeAccount:
+        if not verify_password(current_password, employee.account.password_hash):
+            raise AuthenticationError("current password is invalid")
+        now = self._now()
+        updated = replace(
+            employee.account,
+            password_hash=_hash_password(new_password),
+            must_change_password=False,
+            updated_at=now,
+            auth_version=employee.account.auth_version + 1,
+        )
+        self.repository.update_account(updated)
+        self.repository.revoke_sessions_for_account(
+            employee.account.id, revoked_at=now, reason="password_changed"
+        )
+        self._append_audit(
+            actor_type="employee",
+            actor_account=employee.account,
+            session_id=employee.session.id,
+            action="auth.password_changed",
+            target_type="employee_account",
+            target_id=employee.account.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": employee.account.username},
+        )
+        return updated
+
+    def reset_password(
+        self,
+        *,
+        actor: AuthenticatedEmployee | None,
+        target_username: str,
+        temporary_password: str,
+        recovery: bool = False,
+    ) -> EmployeeAccount:
+        target = self._require_account_by_username(target_username)
+        actor_type: ActorType
+        if actor is not None:
+            self._assert_permission(actor, "users.password.reset")
+            self._assert_can_manage_existing_account(actor, target)
+            actor_type = "employee"
+            actor_account = actor.account
+            session_id = actor.session.id
+        else:
+            actor_type = "system"
+            actor_account = None
+            session_id = None
+        now = self._now()
+        updated = replace(
+            target,
+            password_hash=_hash_password(temporary_password),
+            must_change_password=True,
+            updated_at=now,
+            auth_version=target.auth_version + 1,
+        )
+        self.repository.update_account(updated)
+        self.repository.revoke_sessions_for_account(
+            target.id, revoked_at=now, reason="password_reset"
+        )
+        self._append_audit(
+            actor_type=actor_type,
+            actor_account=actor_account,
+            session_id=session_id,
+            action="auth.password_reset",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": target.username, "recovery": recovery},
+        )
+        return updated
+
+    def introspect(
+        self,
+        *,
+        session_token: str | None,
+        bearer_token: str | None,
+    ) -> AuthIntrospection:
+        if session_token:
+            try:
+                employee = self.authenticate_session(session_token)
+            except AuthenticationError:
+                pass
+            else:
+                return AuthIntrospection(
+                    kind="employee_session",
+                    authenticated=True,
+                    account=employee.account,
+                    effective_permissions=employee.effective_permissions,
+                )
+        if bearer_token:
+            for service_id, token in self._service_tokens.items():
+                if hmac.compare_digest(token, bearer_token):
+                    return AuthIntrospection(
+                        kind="service_token",
+                        authenticated=True,
+                        service_id=service_id,
+                    )
+        return AuthIntrospection(kind="public", authenticated=False)
+
+    def _create_account_record(
+        self,
+        *,
+        username: str,
+        display_name: str,
+        password: str,
+        role: EmployeeRole,
+        email: str | None,
+        must_change_password: bool,
+    ) -> EmployeeAccount:
+        now = self._now()
+        return EmployeeAccount(
+            id=str(uuid.uuid4()),
+            username=normalize_username(username),
+            email=normalize_optional_email(email),
+            display_name=validate_display_name(display_name),
+            password_hash=_hash_password(password),
+            role=role,
+            is_active=True,
+            must_change_password=must_change_password,
+            created_at=now,
+            updated_at=now,
+            deactivated_at=None,
+            last_login_at=None,
+            auth_version=1,
+        )
+
+    def _require_account(self, account_id: str) -> EmployeeAccount:
+        account = self.repository.get_account_by_id(account_id)
+        if account is None:
+            raise ValueError(f"unknown account_id {account_id!r}")
+        return account
+
+    def _require_account_by_username(self, username: str) -> EmployeeAccount:
+        account = self.repository.get_account_by_username(normalize_username(username))
+        if account is None:
+            raise ValueError(f"unknown username {username!r}")
+        return account
+
+    def _assert_can_manage_role(
+        self, actor: AuthenticatedEmployee, target_role: EmployeeRole
+    ) -> None:
+        if target_role not in manageable_roles_for(actor.account.role):
+            raise AuthorizationError(
+                f"{actor.account.role} may not manage role {target_role}"
+            )
+
+    def _assert_can_manage_existing_account(
+        self, actor: AuthenticatedEmployee, target: EmployeeAccount
+    ) -> None:
+        self._assert_can_manage_role(actor, target.role)
+        if actor.account.role == "ADMIN" and target.role == "SUPERADMIN":
+            raise AuthorizationError("ADMIN may not manage SUPERADMIN accounts")
+
+    def _assert_permission(
+        self, actor: AuthenticatedEmployee, permission_code: str
+    ) -> None:
+        if permission_code not in actor.effective_permissions:
+            raise AuthorizationError(f"missing permission {permission_code}")
+
+    def _assert_not_last_active_superadmin(self, target: EmployeeAccount) -> None:
+        if target.role != "SUPERADMIN" or not target.is_active:
+            return
+        if self.repository.count_active_superadmins() <= 1:
+            raise LastActiveSuperadminError(
+                "cannot remove or deactivate the last active SUPERADMIN"
+            )
+
+    def _append_audit(
+        self,
+        *,
+        actor_type: ActorType,
+        actor_account: EmployeeAccount | None,
+        session_id: str | None,
+        action: str,
+        target_type: str,
+        target_id: str | None,
+        permission_code: str | None,
+        outcome: AuditOutcome,
+        metadata: dict[str, Any],
+    ) -> None:
+        self.repository.append_audit_event(
+            SecurityAuditEvent(
+                event_id=str(uuid.uuid4()),
+                occurred_at=self._now(),
+                actor_type=actor_type,
+                actor_account_id=actor_account.id
+                if actor_account is not None
+                else None,
+                actor_display_name_snapshot=(
+                    actor_account.display_name if actor_account is not None else None
+                ),
+                actor_role_snapshot=actor_account.role
+                if actor_account is not None
+                else None,
+                session_id=session_id,
+                action=action,
+                target_type=target_type,
+                target_id=target_id,
+                permission_code=permission_code,
+                outcome=outcome,
+                metadata_json=_redacted_metadata(metadata),
+            )
+        )

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -128,6 +128,10 @@ def _session_cookie_value(token: str) -> str:
     return token
 
 
+def _application_access_allowed(account: EmployeeAccount) -> bool:
+    return not account.must_change_password
+
+
 class EmployeeAuthService:
     def __init__(
         self,
@@ -415,6 +419,7 @@ class EmployeeAuthService:
         )
         self.repository.create_session(session)
         resolved_permissions = self.repository.get_explicit_permissions(updated.id)
+        application_access_allowed = _application_access_allowed(updated)
         self._append_audit(
             actor_type="employee",
             actor_account=updated,
@@ -431,8 +436,11 @@ class EmployeeAuthService:
             session=session,
             session_token=session_token,
             csrf_token=csrf_token,
-            effective_permissions=effective_permissions(
-                updated.role, resolved_permissions
+            application_access_allowed=application_access_allowed,
+            effective_permissions=(
+                effective_permissions(updated.role, resolved_permissions)
+                if application_access_allowed
+                else frozenset()
             ),
         )
 
@@ -465,11 +473,15 @@ class EmployeeAuthService:
         touched = replace(session, last_seen_at=now)
         self.repository.update_session(touched)
         resolved_permissions = self.repository.get_explicit_permissions(account.id)
+        application_access_allowed = _application_access_allowed(account)
         return AuthenticatedEmployee(
             account=account,
             session=touched,
-            effective_permissions=effective_permissions(
-                account.role, resolved_permissions
+            application_access_allowed=application_access_allowed,
+            effective_permissions=(
+                effective_permissions(account.role, resolved_permissions)
+                if application_access_allowed
+                else frozenset()
             ),
         )
 
@@ -592,6 +604,7 @@ class EmployeeAuthService:
                 return AuthIntrospection(
                     kind="employee_session",
                     authenticated=True,
+                    application_access_allowed=employee.application_access_allowed,
                     account=employee.account,
                     effective_permissions=employee.effective_permissions,
                 )
@@ -662,6 +675,8 @@ class EmployeeAuthService:
     def _assert_permission(
         self, actor: AuthenticatedEmployee, permission_code: str
     ) -> None:
+        if not actor.application_access_allowed:
+            raise AuthorizationError("password change required")
         if permission_code not in actor.effective_permissions:
             raise AuthorizationError(f"missing permission {permission_code}")
 

--- a/src/catering_system/ui/employee_auth_admin.py
+++ b/src/catering_system/ui/employee_auth_admin.py
@@ -1,0 +1,105 @@
+"""Operator CLI for AUTH_RBAC_V1 bootstrap and recovery."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+from pathlib import Path
+
+from catering_system.repositories.bootstrap_employee_auth_schema import (
+    bootstrap_employee_auth_schema,
+)
+from catering_system.repositories.core_transaction import open_core_connection
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+
+
+def _read_password(args: argparse.Namespace, *, prompt: str) -> str:
+    if args.password_stdin:
+        import sys
+
+        value = sys.stdin.readline().rstrip("\n")
+    else:
+        value = getpass.getpass(prompt)
+    if not value:
+        raise SystemExit("password must not be empty")
+    return value
+
+
+def _service(db_path: str | Path) -> EmployeeAuthService:
+    connection = open_core_connection(db_path)
+    bootstrap_employee_auth_schema(connection)
+    repository = SQLiteEmployeeAuthRepository.from_connection(connection)
+    return EmployeeAuthService(repository)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Employee auth bootstrap/recovery CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap = subparsers.add_parser(
+        "bootstrap-superadmin",
+        help="Create the first SUPERADMIN when no employee account exists",
+    )
+    bootstrap.add_argument(
+        "--db", required=True, help="Path to the Core SQLite database"
+    )
+    bootstrap.add_argument("--username", required=True)
+    bootstrap.add_argument("--display-name", required=True)
+    bootstrap.add_argument("--email")
+    bootstrap.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the temporary password from stdin instead of prompting",
+    )
+
+    reset = subparsers.add_parser(
+        "reset-password",
+        help="Audited local recovery reset for an existing employee account",
+    )
+    reset.add_argument("--db", required=True, help="Path to the Core SQLite database")
+    reset.add_argument("--username", required=True)
+    reset.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the new temporary password from stdin instead of prompting",
+    )
+
+    args = parser.parse_args()
+    service = _service(args.db)
+    if args.command == "bootstrap-superadmin":
+        password = _read_password(
+            args, prompt="Temporary password for first SUPERADMIN: "
+        )
+        account = service.bootstrap_superadmin(
+            username=args.username,
+            display_name=args.display_name,
+            email=args.email,
+            password=password,
+            metadata={"operator_flow": "bootstrap-superadmin"},
+        )
+        print(
+            f"Bootstrapped SUPERADMIN {account.username} ({account.display_name}); "
+            "must_change_password=true"
+        )
+        return
+    if args.command == "reset-password":
+        password = _read_password(args, prompt="New temporary password: ")
+        account = service.reset_password(
+            actor=None,
+            target_username=args.username,
+            temporary_password=password,
+            recovery=True,
+        )
+        print(
+            f"Reset password for {account.username}; all existing sessions revoked; "
+            "must_change_password=true"
+        )
+        return
+    raise SystemExit(f"unknown command {args.command!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -95,7 +95,7 @@ def _session_cookie_header(
 
 
 def make_employee_auth_handler(
-    service: EmployeeAuthService, *, secure_cookie: bool = False
+    service: EmployeeAuthService, *, secure_cookie: bool = True
 ) -> type[BaseHTTPRequestHandler]:
     class EmployeeAuthHandler(BaseHTTPRequestHandler):
         server_version = "EmployeeAuth/1.0"
@@ -179,6 +179,7 @@ def make_employee_auth_handler(
                             "is_active": employee.account.is_active,
                             "must_change_password": employee.account.must_change_password,
                         },
+                        "application_access_allowed": employee.application_access_allowed,
                         "effective_permissions": sorted(employee.effective_permissions),
                         "session": {
                             "id": employee.session.id,
@@ -196,6 +197,7 @@ def make_employee_auth_handler(
                 payload: dict[str, object] = {
                     "kind": introspection.kind,
                     "authenticated": introspection.authenticated,
+                    "application_access_allowed": introspection.application_access_allowed,
                 }
                 if introspection.account is not None:
                     payload["account"] = {
@@ -240,6 +242,7 @@ def make_employee_auth_handler(
                             "is_active": result.account.is_active,
                             "must_change_password": result.account.must_change_password,
                         },
+                        "application_access_allowed": result.application_access_allowed,
                         "effective_permissions": sorted(result.effective_permissions),
                         "csrf_token": result.csrf_token,
                         "session": {
@@ -303,7 +306,7 @@ def create_employee_auth_server(
     *,
     host: str = "127.0.0.1",
     port: int = 8085,
-    secure_cookie: bool = False,
+    secure_cookie: bool = True,
     service_tokens: dict[str, str] | None = None,
 ) -> HTTPServer:
     connection = open_core_connection(db_path)
@@ -325,16 +328,16 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8085)
     parser.add_argument(
-        "--secure-cookie",
+        "--allow-insecure-cookie",
         action="store_true",
-        help="Mark the session cookie Secure (required behind private HTTPS reverse proxy)",
+        help="Allow non-Secure employee session cookies for local HTTP development only",
     )
     args = parser.parse_args()
     server = create_employee_auth_server(
         args.db,
         host=args.host,
         port=args.port,
-        secure_cookie=args.secure_cookie,
+        secure_cookie=not args.allow_insecure_cookie,
         service_tokens=_read_service_tokens_from_env(),
     )
     print(f"Employee auth API on http://{args.host}:{args.port}/auth/")

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -1,0 +1,345 @@
+"""Cookie-session employee authentication API for AUTH_RBAC_V1.
+
+Production rollout still requires a private HTTPS reverse-proxy origin so the
+session cookie can be Secure and same-origin for both Office Panel and
+Configurator. This module provides the Core-side contract only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.cookies import SimpleCookie
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+from catering_system.repositories.bootstrap_employee_auth_schema import (
+    bootstrap_employee_auth_schema,
+)
+from catering_system.repositories.core_transaction import open_core_connection
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import (
+    AuthenticationError,
+    EmployeeAuthService,
+)
+
+_MAX_BODY_BYTES = 16 * 1024
+_SESSION_COOKIE_NAME = "sl_employee_session"
+
+
+def _read_service_tokens_from_env() -> dict[str, str]:
+    raw = __import__("os").environ.get("EMPLOYEE_AUTH_SERVICE_TOKENS_JSON", "")
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise SystemExit("EMPLOYEE_AUTH_SERVICE_TOKENS_JSON must be a JSON object")
+    tokens: dict[str, str] = {}
+    for key, value in parsed.items():
+        if isinstance(key, str) and isinstance(value, str) and value:
+            tokens[key] = value
+    return tokens
+
+
+def _strict_json(raw: bytes) -> dict[str, object]:
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("invalid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("invalid JSON")
+    return parsed
+
+
+def _get_cookie_token(headers: Any) -> str | None:
+    raw = headers.get("Cookie", "")
+    if not raw:
+        return None
+    cookie = SimpleCookie()
+    cookie.load(raw)
+    morsel = cookie.get(_SESSION_COOKIE_NAME)
+    if morsel is None:
+        return None
+    value = morsel.value.strip()
+    return value or None
+
+
+def _bearer_token(headers: Any) -> str | None:
+    raw = headers.get("Authorization", "")
+    if not raw.startswith("Bearer "):
+        return None
+    token = raw.removeprefix("Bearer ").strip()
+    return token or None
+
+
+def _session_cookie_header(
+    token: str,
+    *,
+    secure: bool,
+    max_age: int | None = None,
+) -> str:
+    cookie = SimpleCookie()
+    cookie[_SESSION_COOKIE_NAME] = token
+    morsel = cookie[_SESSION_COOKIE_NAME]
+    morsel["path"] = "/"
+    morsel["httponly"] = True
+    morsel["samesite"] = "Lax"
+    if secure:
+        morsel["secure"] = True
+    if max_age is not None:
+        morsel["max-age"] = str(max_age)
+    return morsel.OutputString()
+
+
+def make_employee_auth_handler(
+    service: EmployeeAuthService, *, secure_cookie: bool = False
+) -> type[BaseHTTPRequestHandler]:
+    class EmployeeAuthHandler(BaseHTTPRequestHandler):
+        server_version = "EmployeeAuth/1.0"
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            pass
+
+        def end_headers(self) -> None:
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Security-Policy", "default-src 'none'")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            super().end_headers()
+
+        def _json(
+            self,
+            status: int,
+            payload: dict[str, object],
+            *,
+            cookie_header: str | None = None,
+        ) -> None:
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            if cookie_header is not None:
+                self.send_header("Set-Cookie", cookie_header)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _empty(self, status: int, *, cookie_header: str | None = None) -> None:
+            self.send_response(status)
+            self.send_header("Content-Length", "0")
+            if cookie_header is not None:
+                self.send_header("Set-Cookie", cookie_header)
+            self.end_headers()
+
+        def _read_json_body(self) -> dict[str, object]:
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError as exc:
+                raise ValueError("invalid content length") from exc
+            if length <= 0 or length > _MAX_BODY_BYTES:
+                raise ValueError("invalid content length")
+            if (
+                self.headers.get("Content-Type", "").split(";")[0].strip()
+                != "application/json"
+            ):
+                raise ValueError("unsupported content type")
+            return _strict_json(self.rfile.read(length))
+
+        def _employee(self):
+            session_token = _get_cookie_token(self.headers)
+            if session_token is None:
+                raise AuthenticationError("missing session")
+            return service.authenticate_session(session_token)
+
+        def _csrf(self, employee) -> None:
+            token = self.headers.get("X-CSRF-Token", "")
+            service.validate_csrf(employee.session, token)
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/auth/me":
+                try:
+                    employee = self._employee()
+                except AuthenticationError:
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                session_token = _get_cookie_token(self.headers)
+                assert session_token is not None
+                self._json(
+                    200,
+                    {
+                        "account": {
+                            "id": employee.account.id,
+                            "username": employee.account.username,
+                            "email": employee.account.email,
+                            "display_name": employee.account.display_name,
+                            "role": employee.account.role,
+                            "is_active": employee.account.is_active,
+                            "must_change_password": employee.account.must_change_password,
+                        },
+                        "effective_permissions": sorted(employee.effective_permissions),
+                        "session": {
+                            "id": employee.session.id,
+                            "expires_at": employee.session.expires_at.isoformat(),
+                        },
+                    },
+                )
+                return
+            if self.path == "/auth/introspect":
+                session_token = _get_cookie_token(self.headers)
+                bearer_token = _bearer_token(self.headers)
+                introspection = service.introspect(
+                    session_token=session_token, bearer_token=bearer_token
+                )
+                payload: dict[str, object] = {
+                    "kind": introspection.kind,
+                    "authenticated": introspection.authenticated,
+                }
+                if introspection.account is not None:
+                    payload["account"] = {
+                        "id": introspection.account.id,
+                        "username": introspection.account.username,
+                        "display_name": introspection.account.display_name,
+                        "role": introspection.account.role,
+                        "must_change_password": introspection.account.must_change_password,
+                    }
+                    payload["effective_permissions"] = sorted(
+                        introspection.effective_permissions
+                    )
+                if introspection.service_id is not None:
+                    payload["service_id"] = introspection.service_id
+                self._json(200, payload)
+                return
+            self.send_error(404)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path == "/auth/login":
+                try:
+                    body = self._read_json_body()
+                    result = service.authenticate(
+                        username=str(body.get("username", "")),
+                        password=str(body.get("password", "")),
+                    )
+                except ValueError:
+                    self._json(400, {"error": "invalid_request"})
+                    return
+                except AuthenticationError:
+                    self._json(401, {"error": "invalid_credentials"})
+                    return
+                self._json(
+                    200,
+                    {
+                        "account": {
+                            "id": result.account.id,
+                            "username": result.account.username,
+                            "email": result.account.email,
+                            "display_name": result.account.display_name,
+                            "role": result.account.role,
+                            "is_active": result.account.is_active,
+                            "must_change_password": result.account.must_change_password,
+                        },
+                        "effective_permissions": sorted(result.effective_permissions),
+                        "csrf_token": result.csrf_token,
+                        "session": {
+                            "id": result.session.id,
+                            "expires_at": result.session.expires_at.isoformat(),
+                        },
+                    },
+                    cookie_header=_session_cookie_header(
+                        result.session_token, secure=secure_cookie
+                    ),
+                )
+                return
+            if self.path == "/auth/logout":
+                try:
+                    employee = self._employee()
+                    self._csrf(employee)
+                    service.logout(employee)
+                except AuthenticationError:
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                self._empty(
+                    204,
+                    cookie_header=_session_cookie_header(
+                        "", secure=secure_cookie, max_age=0
+                    ),
+                )
+                return
+            if self.path == "/auth/password/change":
+                try:
+                    employee = self._employee()
+                    self._csrf(employee)
+                    body = self._read_json_body()
+                    service.change_password(
+                        employee,
+                        current_password=str(body.get("current_password", "")),
+                        new_password=str(body.get("new_password", "")),
+                    )
+                except ValueError:
+                    self._json(400, {"error": "invalid_request"})
+                    return
+                except AuthenticationError:
+                    self._json(401, {"error": "unauthorized"})
+                    return
+                self._empty(
+                    204,
+                    cookie_header=_session_cookie_header(
+                        "", secure=secure_cookie, max_age=0
+                    ),
+                )
+                return
+            self.send_error(404)
+
+        do_PUT = do_POST
+        do_PATCH = do_POST
+
+    return EmployeeAuthHandler
+
+
+def create_employee_auth_server(
+    db_path: str | Path,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8085,
+    secure_cookie: bool = False,
+    service_tokens: dict[str, str] | None = None,
+) -> HTTPServer:
+    connection = open_core_connection(db_path)
+    bootstrap_employee_auth_schema(connection)
+    repository = SQLiteEmployeeAuthRepository.from_connection(connection)
+    service = EmployeeAuthService(
+        repository,
+        service_tokens=service_tokens,
+    )
+    return HTTPServer(
+        (host, port),
+        make_employee_auth_handler(service, secure_cookie=secure_cookie),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Employee auth API (AUTH_RBAC_V1)")
+    parser.add_argument("--db", required=True, help="Path to the Core SQLite database")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8085)
+    parser.add_argument(
+        "--secure-cookie",
+        action="store_true",
+        help="Mark the session cookie Secure (required behind private HTTPS reverse proxy)",
+    )
+    args = parser.parse_args()
+    server = create_employee_auth_server(
+        args.db,
+        host=args.host,
+        port=args.port,
+        secure_cookie=args.secure_cookie,
+        service_tokens=_read_service_tokens_from_env(),
+    )
+    print(f"Employee auth API on http://{args.host}:{args.port}/auth/")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_employee_auth_api.py
+++ b/tests/unit/test_employee_auth_api.py
@@ -33,7 +33,9 @@ def _seed_auth(db: Path) -> None:
     repo.close()
 
 
-def _start_auth_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+def _start_auth_server(
+    db: Path, *, secure_cookie: bool = True
+) -> tuple[HTTPServer, threading.Thread, str]:
     ready: queue.Queue[HTTPServer] = queue.Queue()
 
     def run() -> None:
@@ -43,6 +45,7 @@ def _start_auth_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
             db,
             host="127.0.0.1",
             port=0,
+            secure_cookie=secure_cookie,
             service_tokens={"office-api": "svc-office-token"},
         )
         ready.put(server)
@@ -100,8 +103,14 @@ def test_login_logout_me_and_change_password_flow(auth_api) -> None:
     assert status == 200
     assert body["account"]["username"] == "viktor.admin"
     assert body["account"]["must_change_password"] is True
+    assert body["application_access_allowed"] is False
+    assert body["effective_permissions"] == []
     cookie = headers["Set-Cookie"]
     csrf_token = body["csrf_token"]
+    assert "Secure" in cookie
+    assert "HttpOnly" in cookie
+    assert "SameSite=Lax" in cookie
+    assert "Path=/" in cookie
 
     status, me, _headers = _request(
         f"{auth_api}/auth/me",
@@ -109,7 +118,9 @@ def test_login_logout_me_and_change_password_flow(auth_api) -> None:
     )
     assert status == 200
     assert me["account"]["role"] == "SUPERADMIN"
-    assert "settings.edit" in me["effective_permissions"]
+    assert me["account"]["must_change_password"] is True
+    assert me["application_access_allowed"] is False
+    assert me["effective_permissions"] == []
 
     status, _body, _headers = _request(
         f"{auth_api}/auth/logout",
@@ -139,6 +150,8 @@ def test_login_logout_me_and_change_password_flow(auth_api) -> None:
     )
     assert status == 200
     assert body["account"]["must_change_password"] is False
+    assert body["application_access_allowed"] is True
+    assert "settings.edit" in body["effective_permissions"]
     cookie = headers["Set-Cookie"]
     csrf_token = body["csrf_token"]
 
@@ -149,6 +162,10 @@ def test_login_logout_me_and_change_password_flow(auth_api) -> None:
     )
     assert status == 204
     assert "Max-Age=0" in headers["Set-Cookie"]
+    assert "Secure" in headers["Set-Cookie"]
+    assert "HttpOnly" in headers["Set-Cookie"]
+    assert "SameSite=Lax" in headers["Set-Cookie"]
+    assert "Path=/" in headers["Set-Cookie"]
 
 
 def test_login_rejects_wrong_password(auth_api) -> None:
@@ -179,6 +196,39 @@ def test_csrf_required_for_state_changing_requests(auth_api) -> None:
     assert body["error"] == "unauthorized"
 
 
+def test_csrf_token_from_another_session_is_rejected(auth_api) -> None:
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+    )
+    assert status == 200
+    cookie_a = headers["Set-Cookie"]
+    csrf_a = body["csrf_token"]
+
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+    )
+    assert status == 200
+    cookie_b = headers["Set-Cookie"]
+    assert body["csrf_token"] != csrf_a
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/logout",
+        method="POST",
+        headers={"Cookie": cookie_b, "X-CSRF-Token": csrf_a},
+    )
+    assert status == 401
+    assert body["error"] == "unauthorized"
+    status, _body, _headers = _request(
+        f"{auth_api}/auth/me",
+        headers={"Cookie": cookie_a},
+    )
+    assert status == 200
+
+
 def test_introspect_distinguishes_employee_session_service_and_public(auth_api) -> None:
     status, body, headers = _request(
         f"{auth_api}/auth/login",
@@ -194,6 +244,9 @@ def test_introspect_distinguishes_employee_session_service_and_public(auth_api) 
     )
     assert status == 200
     assert body["kind"] == "employee_session"
+    assert body["authenticated"] is True
+    assert body["application_access_allowed"] is False
+    assert body["effective_permissions"] == []
 
     status, body, _headers = _request(
         f"{auth_api}/auth/introspect",
@@ -202,7 +255,31 @@ def test_introspect_distinguishes_employee_session_service_and_public(auth_api) 
     assert status == 200
     assert body["kind"] == "service_token"
     assert body["service_id"] == "office-api"
+    assert body["application_access_allowed"] is False
 
     status, body, _headers = _request(f"{auth_api}/auth/introspect")
     assert status == 200
     assert body["kind"] == "public"
+    assert body["application_access_allowed"] is False
+
+
+def test_explicit_dev_insecure_mode_omits_secure_cookie(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    _seed_auth(db)
+    server, thread, base = _start_auth_server(db, secure_cookie=False)
+    try:
+        status, _body, headers = _request(
+            f"{base}/auth/login",
+            method="POST",
+            body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+        )
+        assert status == 200
+        assert "Secure" not in headers["Set-Cookie"]
+        assert "HttpOnly" in headers["Set-Cookie"]
+        assert "SameSite=Lax" in headers["Set-Cookie"]
+        assert "Path=/" in headers["Set-Cookie"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert thread.is_alive() is False

--- a/tests/unit/test_employee_auth_api.py
+++ b/tests/unit/test_employee_auth_api.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+
+
+def _seed_auth(db: Path) -> None:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(
+        repo,
+        now=lambda: datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+        service_tokens={"office-api": "svc-office-token"},
+    )
+    service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "http"},
+    )
+    repo.close()
+
+
+def _start_auth_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.employee_auth_api import create_employee_auth_server
+
+        server = create_employee_auth_server(
+            db,
+            host="127.0.0.1",
+            port=0,
+            service_tokens={"office-api": "svc-office-token"},
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+@pytest.fixture()
+def auth_api(tmp_path: Path):
+    db = tmp_path / "core.db"
+    _seed_auth(db)
+    server, thread, base = _start_auth_server(db)
+    yield base
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    if body is not None and "Content-Type" not in (headers or {}):
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            parsed = json.loads(raw) if raw else {}
+            return response.status, parsed, dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed, dict(exc.headers)
+
+
+def test_login_logout_me_and_change_password_flow(auth_api) -> None:
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+    )
+    assert status == 200
+    assert body["account"]["username"] == "viktor.admin"
+    assert body["account"]["must_change_password"] is True
+    cookie = headers["Set-Cookie"]
+    csrf_token = body["csrf_token"]
+
+    status, me, _headers = _request(
+        f"{auth_api}/auth/me",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    assert me["account"]["role"] == "SUPERADMIN"
+    assert "settings.edit" in me["effective_permissions"]
+
+    status, _body, _headers = _request(
+        f"{auth_api}/auth/logout",
+        method="POST",
+        headers={"Cookie": cookie},
+    )
+    assert status == 401
+
+    status, _body, _headers = _request(
+        f"{auth_api}/auth/password/change",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf_token},
+        body={"current_password": "TempPassw0rd!", "new_password": "ChangedPassw0rd!"},
+    )
+    assert status == 204
+
+    status, _body, _headers = _request(
+        f"{auth_api}/auth/me",
+        headers={"Cookie": cookie},
+    )
+    assert status == 401
+
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "ChangedPassw0rd!"},
+    )
+    assert status == 200
+    assert body["account"]["must_change_password"] is False
+    cookie = headers["Set-Cookie"]
+    csrf_token = body["csrf_token"]
+
+    status, _body, headers = _request(
+        f"{auth_api}/auth/logout",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf_token},
+    )
+    assert status == 204
+    assert "Max-Age=0" in headers["Set-Cookie"]
+
+
+def test_login_rejects_wrong_password(auth_api) -> None:
+    status, body, _headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "wrong"},
+    )
+    assert status == 401
+    assert body["error"] == "invalid_credentials"
+
+
+def test_csrf_required_for_state_changing_requests(auth_api) -> None:
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+    )
+    assert status == 200
+    cookie = headers["Set-Cookie"]
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/logout",
+        method="POST",
+        headers={"Cookie": cookie},
+    )
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_introspect_distinguishes_employee_session_service_and_public(auth_api) -> None:
+    status, body, headers = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "viktor.admin", "password": "TempPassw0rd!"},
+    )
+    assert status == 200
+    cookie = headers["Set-Cookie"]
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/introspect",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    assert body["kind"] == "employee_session"
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/introspect",
+        headers={"Authorization": "Bearer svc-office-token"},
+    )
+    assert status == 200
+    assert body["kind"] == "service_token"
+    assert body["service_id"] == "office-api"
+
+    status, body, _headers = _request(f"{auth_api}/auth/introspect")
+    assert status == 200
+    assert body["kind"] == "public"

--- a/tests/unit/test_employee_auth_service.py
+++ b/tests/unit/test_employee_auth_service.py
@@ -63,6 +63,18 @@ def _login_superadmin(auth):
     return service, repo, result, employee
 
 
+def _login_superadmin_ready(auth):
+    service, repo, result, employee = _login_superadmin(auth)
+    service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    relogin = service.authenticate(username="viktor.admin", password="ChangedTemp1!")
+    ready_employee = service.authenticate_session(relogin.session_token)
+    return service, repo, relogin, ready_employee
+
+
 def test_username_normalization_and_display_name_validation() -> None:
     assert normalize_username("  Viktor.Admin  ") == "viktor.admin"
     assert validate_display_name("  Viktor Johanson ") == "Viktor Johanson"
@@ -79,10 +91,11 @@ def test_password_hashing_and_verification(auth) -> None:
     assert stored.password_hash != "TempPassw0rd!"
     assert verify_password("TempPassw0rd!", stored.password_hash) is True
     assert verify_password("wrong-password", stored.password_hash) is False
+    assert verify_password("TempPassw0rd!", "scrypt$bad") is False
 
 
 def test_username_uniqueness_is_case_insensitive(auth) -> None:
-    service, repo, _result, employee = _login_superadmin(auth)
+    service, repo, _result, employee = _login_superadmin_ready(auth)
     service.create_account(
         employee,
         username="worker.one",
@@ -126,8 +139,72 @@ def test_session_creation_validation_expiry_and_revocation(auth) -> None:
         service.authenticate_session(result.session_token)
 
 
+def test_inactive_account_login_is_rejected(auth) -> None:
+    service, _repo, _result, employee = _login_superadmin_ready(auth)
+    target = service.create_account(
+        employee,
+        username="worker.inactive",
+        display_name="Worker Inactive",
+        password="AnotherTemp1!",
+        role="USER",
+    )
+    service.deactivate_account(employee, target.id)
+    with pytest.raises(AuthenticationError, match="inactive"):
+        service.authenticate(username="worker.inactive", password="AnotherTemp1!")
+
+
+def test_auth_version_mismatch_rejects_session(auth) -> None:
+    service, _repo, result, employee = _login_superadmin(auth)
+    service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    with pytest.raises(AuthenticationError, match="revoked|invalidated"):
+        service.authenticate_session(result.session_token)
+
+
+def test_must_change_password_blocks_application_permissions_until_changed(
+    auth,
+) -> None:
+    service, _repo, _account = _bootstrap(auth)
+    result = service.authenticate(username="viktor.admin", password="TempPassw0rd!")
+    employee = service.authenticate_session(result.session_token)
+    assert employee.account.must_change_password is True
+    assert employee.application_access_allowed is False
+    assert employee.effective_permissions == frozenset()
+    introspection = service.introspect(
+        session_token=result.session_token,
+        bearer_token=None,
+    )
+    assert introspection.authenticated is True
+    assert introspection.application_access_allowed is False
+    assert introspection.effective_permissions == frozenset()
+    with pytest.raises(AuthorizationError, match="password change required"):
+        service.create_account(
+            employee,
+            username="blocked.user",
+            display_name="Blocked User",
+            password="BlockedTemp1!",
+            role="USER",
+        )
+
+    updated = service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    assert updated.must_change_password is False
+    with pytest.raises(AuthenticationError):
+        service.authenticate_session(result.session_token)
+
+    relogin = service.authenticate(username="viktor.admin", password="ChangedTemp1!")
+    assert relogin.application_access_allowed is True
+    assert "settings.edit" in relogin.effective_permissions
+
+
 def test_deactivation_and_password_change_invalidate_sessions(auth) -> None:
-    service, repo, result, employee = _login_superadmin(auth)
+    service, repo, result, employee = _login_superadmin_ready(auth)
     target = service.create_account(
         employee,
         username="worker.two",
@@ -158,7 +235,7 @@ def test_deactivation_and_password_change_invalidate_sessions(auth) -> None:
 
 
 def test_last_active_superadmin_guard(auth) -> None:
-    service, _repo, _result, employee = _login_superadmin(auth)
+    service, _repo, _result, employee = _login_superadmin_ready(auth)
     with pytest.raises(LastActiveSuperadminError):
         service.deactivate_account(employee, employee.account.id)
     with pytest.raises(LastActiveSuperadminError):
@@ -180,7 +257,7 @@ def test_bootstrap_and_recovery_reset(auth) -> None:
 
 
 def test_admin_may_grant_only_within_own_effective_permissions(auth) -> None:
-    service, _repo, _result, superadmin = _login_superadmin(auth)
+    service, _repo, _result, superadmin = _login_superadmin_ready(auth)
     admin = service.create_account(
         superadmin,
         username="team.admin",

--- a/tests/unit/test_employee_auth_service.py
+++ b/tests/unit/test_employee_auth_service.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.employee_auth import (
+    effective_permissions,
+    normalize_username,
+    role_ceiling,
+    validate_display_name,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import (
+    AuthenticationError,
+    AuthorizationError,
+    EmployeeAuthService,
+    LastActiveSuperadminError,
+    verify_password,
+)
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+@pytest.fixture()
+def auth(tmp_path: Path):
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    repo = SQLiteEmployeeAuthRepository(tmp_path / "core.db")
+    service = EmployeeAuthService(
+        repo,
+        now=clock.now,
+        service_tokens={"office-api": "svc-office-token"},
+    )
+    return service, repo, clock
+
+
+def _bootstrap(auth):
+    service, repo, _clock = auth
+    account = service.bootstrap_superadmin(
+        username="Viktor.Admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "test"},
+    )
+    return service, repo, account
+
+
+def _login_superadmin(auth):
+    service, repo, _account = _bootstrap(auth)
+    result = service.authenticate(username="viktor.admin", password="TempPassw0rd!")
+    employee = service.authenticate_session(result.session_token)
+    return service, repo, result, employee
+
+
+def test_username_normalization_and_display_name_validation() -> None:
+    assert normalize_username("  Viktor.Admin  ") == "viktor.admin"
+    assert validate_display_name("  Viktor Johanson ") == "Viktor Johanson"
+    with pytest.raises(ValueError, match="username"):
+        normalize_username("AB")
+    with pytest.raises(ValueError, match="display_name"):
+        validate_display_name("   ")
+
+
+def test_password_hashing_and_verification(auth) -> None:
+    service, repo, account = _bootstrap(auth)
+    stored = repo.get_account_by_id(account.id)
+    assert stored is not None
+    assert stored.password_hash != "TempPassw0rd!"
+    assert verify_password("TempPassw0rd!", stored.password_hash) is True
+    assert verify_password("wrong-password", stored.password_hash) is False
+
+
+def test_username_uniqueness_is_case_insensitive(auth) -> None:
+    service, repo, _result, employee = _login_superadmin(auth)
+    service.create_account(
+        employee,
+        username="worker.one",
+        display_name="Worker One",
+        password="AnotherTemp1!",
+        role="USER",
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        service.create_account(
+            employee,
+            username="Worker.One",
+            display_name="Worker Duplicate",
+            password="AnotherTemp1!",
+            role="USER",
+        )
+
+
+def test_role_ceilings_and_viewer_read_only_enforcement() -> None:
+    assert "offers.prepare" in role_ceiling("ADMIN")
+    assert "users.roles.assign" not in role_ceiling("USER")
+    assert "offers.prepare" not in role_ceiling("VIEWER")
+    assert all(permission.endswith(".view") for permission in role_ceiling("VIEWER"))
+
+
+def test_effective_permissions_intersect_role_ceiling() -> None:
+    explicit = {"offers.prepare", "offers.view", "settings.edit"}
+    assert effective_permissions("USER", explicit) == frozenset(
+        {"offers.prepare", "offers.view"}
+    )
+    assert effective_permissions("VIEWER", explicit) == frozenset({"offers.view"})
+
+
+def test_session_creation_validation_expiry_and_revocation(auth) -> None:
+    service, _repo, _account = _bootstrap(auth)
+    result = service.authenticate(username="viktor.admin", password="TempPassw0rd!")
+    employee = service.authenticate_session(result.session_token)
+    assert employee.account.username == "viktor.admin"
+    clock = auth[2]
+    clock.value = clock.value + timedelta(hours=13)
+    with pytest.raises(AuthenticationError, match="expired"):
+        service.authenticate_session(result.session_token)
+
+
+def test_deactivation_and_password_change_invalidate_sessions(auth) -> None:
+    service, repo, result, employee = _login_superadmin(auth)
+    target = service.create_account(
+        employee,
+        username="worker.two",
+        display_name="Worker Two",
+        password="AnotherTemp1!",
+        role="USER",
+    )
+    worker_login = service.authenticate(username="worker.two", password="AnotherTemp1!")
+    service.authenticate_session(worker_login.session_token)
+    service.deactivate_account(employee, target.id)
+    with pytest.raises(AuthenticationError, match="revoked"):
+        service.authenticate_session(worker_login.session_token)
+
+    service.reactivate_account(employee, target.id)
+    worker_login2 = service.authenticate(
+        username="worker.two", password="AnotherTemp1!"
+    )
+    worker2 = service.authenticate_session(worker_login2.session_token)
+    service.change_password(
+        worker2,
+        current_password="AnotherTemp1!",
+        new_password="ChangedTemp1!",
+    )
+    with pytest.raises(AuthenticationError):
+        service.authenticate_session(worker_login2.session_token)
+    relogin = service.authenticate(username="worker.two", password="ChangedTemp1!")
+    assert relogin.account.must_change_password is False
+
+
+def test_last_active_superadmin_guard(auth) -> None:
+    service, _repo, _result, employee = _login_superadmin(auth)
+    with pytest.raises(LastActiveSuperadminError):
+        service.deactivate_account(employee, employee.account.id)
+    with pytest.raises(LastActiveSuperadminError):
+        service.change_account_role(employee, employee.account.id, "ADMIN")
+
+
+def test_bootstrap_and_recovery_reset(auth) -> None:
+    service, repo, account = _bootstrap(auth)
+    assert repo.count_accounts() == 1
+    reset = service.reset_password(
+        actor=None,
+        target_username=account.username,
+        temporary_password="RecoveredTemp1!",
+        recovery=True,
+    )
+    assert reset.must_change_password is True
+    login = service.authenticate(username=account.username, password="RecoveredTemp1!")
+    assert login.account.must_change_password is True
+
+
+def test_admin_may_grant_only_within_own_effective_permissions(auth) -> None:
+    service, _repo, _result, superadmin = _login_superadmin(auth)
+    admin = service.create_account(
+        superadmin,
+        username="team.admin",
+        display_name="Team Admin",
+        password="AdminTemp1!",
+        role="ADMIN",
+        explicit_permissions={"users.view", "users.create", "users.permissions.assign"},
+    )
+    worker = service.create_account(
+        superadmin,
+        username="worker.three",
+        display_name="Worker Three",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    admin_login = service.authenticate(username=admin.username, password="AdminTemp1!")
+    admin_employee = service.authenticate_session(admin_login.session_token)
+    with pytest.raises(AuthorizationError):
+        service.set_account_permissions(
+            admin_employee,
+            worker.id,
+            {"offers.prepare"},
+        )
+
+
+def test_introspection_distinguishes_session_service_and_public(auth) -> None:
+    service, _repo, _account = _bootstrap(auth)
+    result = service.authenticate(username="viktor.admin", password="TempPassw0rd!")
+    session = service.introspect(session_token=result.session_token, bearer_token=None)
+    assert session.kind == "employee_session"
+    assert session.authenticated is True
+    service_token = service.introspect(
+        session_token=None, bearer_token="svc-office-token"
+    )
+    assert service_token.kind == "service_token"
+    public = service.introspect(session_token=None, bearer_token="wrong")
+    assert public.kind == "public"
+    assert public.authenticated is False
+
+
+def test_audit_redaction_and_append_only(auth) -> None:
+    service, repo, account = _bootstrap(auth)
+    service.reset_password(
+        actor=None,
+        target_username=account.username,
+        temporary_password="RecoveredTemp1!",
+        recovery=True,
+    )
+    events = repo.list_audit_events()
+    assert events
+    assert all("RecoveredTemp1!" not in event.metadata_json for event in events)
+    assert all(
+        "password" not in json.loads(event.metadata_json).get("temporary_password", "")
+        for event in events
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        repo._conn.execute(  # noqa: SLF001
+            "DELETE FROM security_audit_events WHERE event_id = ?",
+            (events[0].event_id,),
+        )


### PR DESCRIPTION
Closes #64

## Summary
- add the Core employee auth foundation: accounts, role ceilings, explicit permissions, sessions, audit events, auth API, and operator bootstrap/recovery CLI
- keep this stage scoped away from Office Panel Basic Auth replacement, fingerfood-app changes, DET-2, and PR #63 acknowledgement-contract changes
- add focused auth service and auth API regression coverage
- enforce restricted authenticated-but-not-authorized state while `must_change_password=true`
- make employee session cookies Secure by default with an explicit local-development-only insecure override

## Implementation notes
- employee auth migrations are under the new `employee_auth` component and use identifiers 1-4:
  - 1 `create_employee_accounts`
  - 2 `create_account_permissions`
  - 3 `create_employee_sessions`
  - 4 `create_security_audit_events`
- password hashing uses salted adaptive stdlib `hashlib.scrypt`
- session tokens are random high-entropy bearer secrets; only SHA-256 hashes are stored
- CSRF is session-bound and checked via `X-CSRF-Token` on cookie-authenticated state-changing requests
- the auth API exposes login, logout, `auth/me`, password change, and introspection that distinguishes employee sessions, service tokens, and public callers
- when `must_change_password=true`, the account may log in, inspect `auth/me`, change password, and log out, but receives `application_access_allowed=false` and an empty `effective_permissions` set until a fresh post-change login
- production/default auth API startup issues Secure employee cookies; local HTTP development requires explicit `--allow-insecure-cookie`
- production rollout still requires a private HTTPS reverse-proxy origin before employee cookies should be used live

## Validation
- focused auth service tests
- focused auth API tests
- `ruff check`
- `ruff format --check` on affected auth source/tests
- `/Users/viktorjohanson/projects/silberlöffelcatering/.venv/bin/mypy src/catering_system`
- `git diff --check`
- one final full Core suite: `2448 passed`

## Accepted follow-up items
- `last_seen_at` still updates on every authenticated request
- last-active-SUPERADMIN protection still has a residual count/update race under concurrent writes
- CSRF failures still map to `401` instead of `403`
- AUTH-1 remains a dormant foundation: Office Panel and Configurator are not yet protected by employee sessions or business-action permission enforcement

## Note
- repo-wide `ruff format --check` still reports `scripts/seed_catalog_from_items.py`, but that file is unchanged by this PR and its blob is identical to `origin/main`
