### PR TITLE
AUTH-2A: Office Panel employee login

### DIFF
--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -22,6 +22,34 @@ reconstructable from CRM or staging; protect it before every deployment.
 | `catering-kiosk` | 8082 | LAN/Tailscale | no |
 | `catering-website-intake` | 8083 | loopback only | Inquiry only |
 
+## Planned AUTH-2A rollout (not yet executed)
+
+AUTH-2A introduces employee login for the Office Panel. The approved production
+front door is private Tailscale Serve HTTPS on the Lenovo hostname's `.ts.net`
+origin, terminating TLS before proxying to the Office Panel on
+`127.0.0.1:8081`. Do not apply these steps during ordinary development or
+review; this section is the planned no-lockout rollout only.
+
+1. Create a database backup and confirm the latest backup completed normally.
+2. Verify current Tailscale health and record the current `tailscale serve status`.
+3. Configure private HTTPS Serve for the Office Panel's `.ts.net` origin.
+4. Bind the Office Panel to `127.0.0.1` instead of a LAN/Tailscale address.
+5. Deploy the Office Panel in `migration` mode first, never directly to
+   `employee` mode.
+6. Run the employee-auth schema bootstrap/migrations on the production Core
+   database.
+7. Bootstrap Viktor as the initial `SUPERADMIN` with a temporary password.
+8. Perform the first employee login through the Tailscale Serve HTTPS origin.
+9. Complete the forced password-change flow, then log out.
+10. Log in again with the new password and verify normal Office Panel access.
+11. Smoke-test the Office Panel in `migration` mode, including temporary Basic
+   fallback behaviour.
+12. Switch production from `migration` to `employee` mode.
+13. Confirm the shared Basic fallback is no longer accepted.
+14. Keep rollback limited to code/config rollback: return temporarily to
+   `basic` mode if necessary without deleting employee-auth tables or audit
+   history.
+
 ## Connect and inspect
 
 ```bash

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -44,9 +44,14 @@ _SCRYPT_KEY_BYTES = 32
 _SCRYPT_MAXMEM = 128 * 1024 * 1024
 _SESSION_TOKEN_BYTES = 32
 _CSRF_TOKEN_BYTES = 32
+_LAST_SEEN_WRITE_INTERVAL = timedelta(minutes=5)
 
 
 class AuthenticationError(Exception):
+    pass
+
+
+class CsrfValidationError(AuthenticationError):
     pass
 
 
@@ -470,8 +475,10 @@ class EmployeeAuthService:
             )
             self.repository.update_session(revoked)
             raise AuthenticationError("session invalidated")
-        touched = replace(session, last_seen_at=now)
-        self.repository.update_session(touched)
+        touched = session
+        if now - session.last_seen_at >= _LAST_SEEN_WRITE_INTERVAL:
+            touched = replace(session, last_seen_at=now)
+            self.repository.update_session(touched)
         resolved_permissions = self.repository.get_explicit_permissions(account.id)
         application_access_allowed = _application_access_allowed(account)
         return AuthenticatedEmployee(
@@ -489,7 +496,7 @@ class EmployeeAuthService:
         if not csrf_token or not hmac.compare_digest(
             session.csrf_token_hash, _token_hash(csrf_token)
         ):
-            raise AuthenticationError("invalid csrf token")
+            raise CsrfValidationError("invalid csrf token")
 
     def logout(self, employee: AuthenticatedEmployee) -> None:
         revoked = replace(

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -9,10 +9,8 @@ from __future__ import annotations
 
 import argparse
 import json
-from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any
 
 from catering_system.repositories.bootstrap_employee_auth_schema import (
     bootstrap_employee_auth_schema,
@@ -23,11 +21,17 @@ from catering_system.repositories.sqlite_employee_auth_repository import (
 )
 from catering_system.services.employee_auth_service import (
     AuthenticationError,
+    CsrfValidationError,
     EmployeeAuthService,
+)
+from catering_system.ui.employee_auth_http import (
+    bearer_token_from_headers,
+    clear_cookie_header,
+    session_cookie_header,
+    session_token_from_headers,
 )
 
 _MAX_BODY_BYTES = 16 * 1024
-_SESSION_COOKIE_NAME = "sl_employee_session"
 
 
 def _read_service_tokens_from_env() -> dict[str, str]:
@@ -52,46 +56,6 @@ def _strict_json(raw: bytes) -> dict[str, object]:
     if not isinstance(parsed, dict):
         raise ValueError("invalid JSON")
     return parsed
-
-
-def _get_cookie_token(headers: Any) -> str | None:
-    raw = headers.get("Cookie", "")
-    if not raw:
-        return None
-    cookie = SimpleCookie()
-    cookie.load(raw)
-    morsel = cookie.get(_SESSION_COOKIE_NAME)
-    if morsel is None:
-        return None
-    value = morsel.value.strip()
-    return value or None
-
-
-def _bearer_token(headers: Any) -> str | None:
-    raw = headers.get("Authorization", "")
-    if not raw.startswith("Bearer "):
-        return None
-    token = raw.removeprefix("Bearer ").strip()
-    return token or None
-
-
-def _session_cookie_header(
-    token: str,
-    *,
-    secure: bool,
-    max_age: int | None = None,
-) -> str:
-    cookie = SimpleCookie()
-    cookie[_SESSION_COOKIE_NAME] = token
-    morsel = cookie[_SESSION_COOKIE_NAME]
-    morsel["path"] = "/"
-    morsel["httponly"] = True
-    morsel["samesite"] = "Lax"
-    if secure:
-        morsel["secure"] = True
-    if max_age is not None:
-        morsel["max-age"] = str(max_age)
-    return morsel.OutputString()
 
 
 def make_employee_auth_handler(
@@ -149,7 +113,7 @@ def make_employee_auth_handler(
             return _strict_json(self.rfile.read(length))
 
         def _employee(self):
-            session_token = _get_cookie_token(self.headers)
+            session_token = session_token_from_headers(self.headers)
             if session_token is None:
                 raise AuthenticationError("missing session")
             return service.authenticate_session(session_token)
@@ -165,7 +129,7 @@ def make_employee_auth_handler(
                 except AuthenticationError:
                     self._json(401, {"error": "unauthorized"})
                     return
-                session_token = _get_cookie_token(self.headers)
+                session_token = session_token_from_headers(self.headers)
                 assert session_token is not None
                 self._json(
                     200,
@@ -189,8 +153,8 @@ def make_employee_auth_handler(
                 )
                 return
             if self.path == "/auth/introspect":
-                session_token = _get_cookie_token(self.headers)
-                bearer_token = _bearer_token(self.headers)
+                session_token = session_token_from_headers(self.headers)
+                bearer_token = bearer_token_from_headers(self.headers)
                 introspection = service.introspect(
                     session_token=session_token, bearer_token=bearer_token
                 )
@@ -250,7 +214,7 @@ def make_employee_auth_handler(
                             "expires_at": result.session.expires_at.isoformat(),
                         },
                     },
-                    cookie_header=_session_cookie_header(
+                    cookie_header=session_cookie_header(
                         result.session_token, secure=secure_cookie
                     ),
                 )
@@ -260,13 +224,18 @@ def make_employee_auth_handler(
                     employee = self._employee()
                     self._csrf(employee)
                     service.logout(employee)
+                except CsrfValidationError:
+                    self._json(403, {"error": "forbidden"})
+                    return
                 except AuthenticationError:
                     self._json(401, {"error": "unauthorized"})
                     return
                 self._empty(
                     204,
-                    cookie_header=_session_cookie_header(
-                        "", secure=secure_cookie, max_age=0
+                    cookie_header=clear_cookie_header(
+                        "sl_employee_session",
+                        secure=secure_cookie,
+                        http_only=True,
                     ),
                 )
                 return
@@ -280,6 +249,9 @@ def make_employee_auth_handler(
                         current_password=str(body.get("current_password", "")),
                         new_password=str(body.get("new_password", "")),
                     )
+                except CsrfValidationError:
+                    self._json(403, {"error": "forbidden"})
+                    return
                 except ValueError:
                     self._json(400, {"error": "invalid_request"})
                     return
@@ -288,8 +260,10 @@ def make_employee_auth_handler(
                     return
                 self._empty(
                     204,
-                    cookie_header=_session_cookie_header(
-                        "", secure=secure_cookie, max_age=0
+                    cookie_header=clear_cookie_header(
+                        "sl_employee_session",
+                        secure=secure_cookie,
+                        http_only=True,
                     ),
                 )
                 return

--- a/src/catering_system/ui/employee_auth_http.py
+++ b/src/catering_system/ui/employee_auth_http.py
@@ -1,0 +1,100 @@
+"""Shared HTTP helpers for AUTH_RBAC_V1 employee session handling."""
+
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from typing import Any
+
+SESSION_COOKIE_NAME = "sl_employee_session"
+CSRF_COOKIE_NAME = "sl_employee_csrf"
+
+
+def cookie_value(headers: Any, name: str) -> str | None:
+    raw = headers.get("Cookie", "")
+    if not raw:
+        return None
+    cookie = SimpleCookie()
+    cookie.load(raw)
+    morsel = cookie.get(name)
+    if morsel is None:
+        return None
+    value = morsel.value.strip()
+    return value or None
+
+
+def session_token_from_headers(headers: Any) -> str | None:
+    return cookie_value(headers, SESSION_COOKIE_NAME)
+
+
+def csrf_token_from_headers(headers: Any) -> str | None:
+    return cookie_value(headers, CSRF_COOKIE_NAME)
+
+
+def bearer_token_from_headers(headers: Any) -> str | None:
+    raw = headers.get("Authorization", "")
+    if not raw.startswith("Bearer "):
+        return None
+    token = raw.removeprefix("Bearer ").strip()
+    return token or None
+
+
+def _cookie_header(
+    name: str,
+    value: str,
+    *,
+    secure: bool,
+    http_only: bool,
+    max_age: int | None = None,
+) -> str:
+    cookie = SimpleCookie()
+    cookie[name] = value
+    morsel = cookie[name]
+    morsel["path"] = "/"
+    morsel["samesite"] = "Lax"
+    if http_only:
+        morsel["httponly"] = True
+    if secure:
+        morsel["secure"] = True
+    if max_age is not None:
+        morsel["max-age"] = str(max_age)
+    return morsel.OutputString()
+
+
+def session_cookie_header(
+    token: str,
+    *,
+    secure: bool,
+    max_age: int | None = None,
+) -> str:
+    return _cookie_header(
+        SESSION_COOKIE_NAME,
+        token,
+        secure=secure,
+        http_only=True,
+        max_age=max_age,
+    )
+
+
+def csrf_cookie_header(
+    token: str,
+    *,
+    secure: bool,
+    max_age: int | None = None,
+) -> str:
+    return _cookie_header(
+        CSRF_COOKIE_NAME,
+        token,
+        secure=secure,
+        http_only=True,
+        max_age=max_age,
+    )
+
+
+def clear_cookie_header(name: str, *, secure: bool, http_only: bool) -> str:
+    return _cookie_header(
+        name,
+        "",
+        secure=secure,
+        http_only=http_only,
+        max_age=0,
+    )

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -15,7 +15,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import quote, urlencode
 
 
@@ -3846,6 +3846,9 @@ def create_office_panel_server(
     offer_document_repo: OfferDocumentSnapshotRepository | None = None,
     offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
+    auth_mode: Literal["basic", "migration", "employee"] = "basic",
+    auth_service: Any | None = None,
+    secure_cookie: bool = True,
 ) -> HTTPServer:
     """Compatibility wrapper; server construction lives in office_panel_http."""
     from catering_system.ui.office_panel_http import (
@@ -3877,6 +3880,9 @@ def create_office_panel_server(
         offer_document_repo=offer_document_repo,
         offer_pdf_static_content=offer_pdf_static_content,
         ui_version=ui_version,
+        auth_mode=auth_mode,
+        auth_service=auth_service,
+        secure_cookie=secure_cookie,
     )
 
 
@@ -3899,11 +3905,25 @@ def main() -> None:
         "without ever opening core.db",
     )
     parser.add_argument("--port", type=int, default=8081)
-    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("OFFICE_PANEL_HOST", "0.0.0.0"),
+    )
+    parser.add_argument(
+        "--auth-mode",
+        default=os.environ.get("OFFICE_PANEL_AUTH_MODE", "basic"),
+        help="Office auth mode: basic, migration, employee",
+    )
     parser.add_argument(
         "--password",
         default=os.environ.get("OFFICE_PANEL_PASSWORD", ""),
         help="Office password (or set OFFICE_PANEL_PASSWORD)",
+    )
+    parser.add_argument(
+        "--allow-insecure-cookie",
+        action="store_true",
+        default=os.environ.get("OFFICE_PANEL_ALLOW_INSECURE_COOKIE", "") == "1",
+        help="Allow non-Secure employee cookies for local HTTP development only",
     )
     parser.add_argument(
         "--auerswald-url",
@@ -3941,11 +3961,15 @@ def main() -> None:
         "legacy is the safe rollout default",
     )
     args = parser.parse_args()
-    if not args.password:
+    from catering_system.ui.office_panel_http import validate_office_panel_auth_mode
+
+    auth_mode = validate_office_panel_auth_mode(args.auth_mode)
+    if auth_mode in {"basic", "migration"} and not args.password:
         raise SystemExit(
             "office panel refuses to start without a password "
             "(--password or OFFICE_PANEL_PASSWORD): it is a write surface (pack §7)"
         )
+    secure_cookie = not args.allow_insecure_cookie
 
     # Phase 2 dual mode (pack §7): CORE_OFFICE_API_URL and CORE_OFFICE_API_TOKEN
     # must be set together (remote mode) or both left empty (direct mode) — a
@@ -3959,6 +3983,27 @@ def main() -> None:
         raise SystemExit(
             "CORE_OFFICE_API_URL and CORE_OFFICE_API_TOKEN must be set together "
             "(remote mode) or both left empty (direct mode)"
+        )
+
+    auth_service = None
+    if auth_mode in {"migration", "employee"}:
+        if not args.db:
+            raise SystemExit(
+                "--db is required when OFFICE_PANEL_AUTH_MODE is migration or employee"
+            )
+        from catering_system.repositories.bootstrap_employee_auth_schema import (
+            bootstrap_employee_auth_schema,
+        )
+        from catering_system.repositories.core_transaction import open_core_connection
+        from catering_system.repositories.sqlite_employee_auth_repository import (
+            SQLiteEmployeeAuthRepository,
+        )
+        from catering_system.services.employee_auth_service import EmployeeAuthService
+
+        auth_connection = open_core_connection(args.db)
+        bootstrap_employee_auth_schema(auth_connection)
+        auth_service = EmployeeAuthService(
+            SQLiteEmployeeAuthRepository.from_connection(auth_connection)
         )
 
     if core_api_url:
@@ -3978,10 +4023,15 @@ def main() -> None:
             args.configurator_url,
             remote=remote,
             ui_version=args.ui_version,
+            auth_mode=auth_mode,
+            auth_service=auth_service,
+            secure_cookie=secure_cookie,
         )
         print(
-            f"Office panel on http://{args.host}:{args.port}/ (user: office) "
-            f"— remote mode against {core_api_url}"
+            "Office panel on "
+            f"http://{args.host}:{args.port}/ — remote mode against {core_api_url} "
+            f"(auth_mode={auth_mode}, secure_cookie={secure_cookie}, "
+            f"basic_fallback_active={auth_mode in {'basic', 'migration'}})"
         )
     else:
         if not args.db:
@@ -4097,8 +4147,16 @@ def main() -> None:
             offer_document_repo=offer_document_repo,
             offer_pdf_static_content=offer_pdf_static_content,
             ui_version=args.ui_version,
+            auth_mode=auth_mode,
+            auth_service=auth_service,
+            secure_cookie=secure_cookie,
         )
-        print(f"Office panel on http://{args.host}:{args.port}/ (user: office)")
+        print(
+            "Office panel on "
+            f"http://{args.host}:{args.port}/ "
+            f"(auth_mode={auth_mode}, secure_cookie={secure_cookie}, "
+            f"basic_fallback_active={auth_mode in {'basic', 'migration'}})"
+        )
     server.serve_forever()
 
 

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -507,11 +507,16 @@ def make_office_panel_handler(
                 auth = getattr(self, "_request_auth", None)
             if auth is None:
                 auth = self._resolve_request_auth()
-            resolved_rueckruf_count = (
-                fetch_rueckruf_count(auerswald_url, auerswald_user, auerswald_password)
-                if rueckruf_count is _RUECKRUF_COUNT_UNSET
-                else rueckruf_count
-            )
+            if rueckruf_count is _RUECKRUF_COUNT_UNSET:
+                resolved_rueckruf_count = fetch_rueckruf_count(
+                    auerswald_url,
+                    auerswald_user,
+                    auerswald_password,
+                )
+            elif isinstance(rueckruf_count, int) or rueckruf_count is None:
+                resolved_rueckruf_count = rueckruf_count
+            else:
+                resolved_rueckruf_count = None
             return OfficePageContext(
                 rueckruf_count=resolved_rueckruf_count,
                 csrf_token=auth.csrf_token if auth is not None else "",

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 from urllib.parse import parse_qs, quote, unquote, urlparse
 
+from catering_system.domain.employee_auth import AuthenticatedEmployee
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.catalog_repository import CatalogRepository
@@ -47,6 +49,7 @@ from catering_system.ui.office_panel import (
     OfferPdfUnavailableError,
     OfficePageContext,
     OfficePanel,
+    _csrf_input,
     _e,
     _page,
     fetch_rueckruf_count,
@@ -76,7 +79,21 @@ from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentNotFoundError,
 )
 from catering_system.services.buffet_cards_service import BuffetCardsService
+from catering_system.services.employee_auth_service import (
+    AuthenticationError,
+    CsrfValidationError,
+    EmployeeAuthService,
+)
 from catering_system.ui.remote_core_client import RemoteCoreError
+from catering_system.ui.employee_auth_http import (
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    clear_cookie_header,
+    csrf_cookie_header,
+    csrf_token_from_headers,
+    session_cookie_header,
+    session_token_from_headers,
+)
 
 if TYPE_CHECKING:
     from catering_system.repositories.core_transaction import CoreCommandExecutor
@@ -85,6 +102,16 @@ if TYPE_CHECKING:
 _CSRF_CONTEXT = b"catering-office-panel-csrf-v1"
 _MAX_FORM_BODY_BYTES = 256 * 1024
 _UNAVAILABLE_MESSAGE = "Core nicht erreichbar — nichts wurde gespeichert."
+_RUECKRUF_COUNT_UNSET = object()
+
+OfficePanelAuthMode = Literal["basic", "migration", "employee"]
+
+_ROLE_LABELS = {
+    "SUPERADMIN": "Superadmin",
+    "ADMIN": "Administrator",
+    "USER": "Benutzer",
+    "VIEWER": "Leser",
+}
 
 _INQUIRY_COMMAND_ERROR_LABELS: dict[str, str] = {
     "conversion_blocked": (
@@ -257,6 +284,35 @@ def csrf_token_for_password(password: str) -> str:
     return hmac.new(password.encode("utf-8"), _CSRF_CONTEXT, hashlib.sha256).hexdigest()
 
 
+def validate_office_panel_auth_mode(value: str) -> OfficePanelAuthMode:
+    if value not in {"basic", "migration", "employee"}:
+        raise ValueError(f"unknown office auth mode: {value}")
+    return cast(OfficePanelAuthMode, value)
+
+
+def _safe_redirect_target(raw: str) -> str:
+    candidate = raw.strip()
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return "/"
+    parsed = urlparse(candidate)
+    if parsed.scheme or parsed.netloc:
+        return "/"
+    return candidate or "/"
+
+
+@dataclass(frozen=True)
+class OfficePanelRequestAuth:
+    kind: Literal["basic", "employee"]
+    current_user_name: str
+    current_user_role_label: str
+    csrf_token: str
+    show_transition_banner: bool
+    legacy_shared_access: bool
+    password_change_path: str = ""
+    logout_path: str = ""
+    employee: AuthenticatedEmployee | None = None
+
+
 def make_office_panel_handler(
     inquiry_repo: InquiryRepository,
     order_repo: OrderRepository,
@@ -281,7 +337,15 @@ def make_office_panel_handler(
     offer_document_repo: OfferDocumentSnapshotRepository | None = None,
     offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
+    auth_mode: OfficePanelAuthMode = "basic",
+    auth_service: EmployeeAuthService | None = None,
+    secure_cookie: bool = True,
 ) -> type[BaseHTTPRequestHandler]:
+    validated_auth_mode = validate_office_panel_auth_mode(auth_mode)
+    if validated_auth_mode in {"migration", "employee"} and auth_service is None:
+        raise ValueError(
+            "employee auth service is required for migration/employee mode"
+        )
     panel = OfficePanel(
         inquiry_repo,
         order_repo,
@@ -308,8 +372,164 @@ def make_office_panel_handler(
     class OfficePanelHandler(BaseHTTPRequestHandler):
         server_version = "OfficePanel/1.0"
 
-        def _authorized(self) -> bool:
+        def _legacy_authorized(self) -> bool:
             return hmac.compare_digest(self.headers.get("Authorization", ""), expected)
+
+        def _employee_from_session(self) -> AuthenticatedEmployee | None:
+            if auth_service is None:
+                return None
+            session_token = session_token_from_headers(self.headers)
+            if session_token is None:
+                return None
+            return auth_service.authenticate_session(session_token)
+
+        def _resolve_request_auth(self) -> OfficePanelRequestAuth | None:
+            employee: AuthenticatedEmployee | None = None
+            employee_auth_failed = False
+            if validated_auth_mode in {"migration", "employee"}:
+                try:
+                    employee = self._employee_from_session()
+                except AuthenticationError:
+                    employee_auth_failed = True
+                if employee is not None:
+                    return OfficePanelRequestAuth(
+                        kind="employee",
+                        current_user_name=employee.account.display_name,
+                        current_user_role_label=_ROLE_LABELS.get(
+                            employee.account.role, employee.account.role
+                        ),
+                        csrf_token=csrf_token_from_headers(self.headers) or "",
+                        show_transition_banner=validated_auth_mode == "migration",
+                        legacy_shared_access=False,
+                        password_change_path="/password-change",
+                        logout_path="/logout",
+                        employee=employee,
+                    )
+            if (
+                validated_auth_mode in {"basic", "migration"}
+                and self._legacy_authorized()
+            ):
+                return OfficePanelRequestAuth(
+                    kind="basic",
+                    current_user_name="Gemeinsamer Office-Zugang",
+                    current_user_role_label="Legacy-Zugang",
+                    csrf_token=csrf_token,
+                    show_transition_banner=validated_auth_mode == "migration",
+                    legacy_shared_access=True,
+                )
+            if employee_auth_failed:
+                return None
+            return None
+
+        def _render_login_page(
+            self, *, next_path: str, error_message: str = "", status: int = 200
+        ) -> None:
+            body = [
+                "<fieldset><legend>Anmeldung</legend>",
+                "<p>Bitte mit Ihrem Mitarbeiterkonto anmelden.</p>",
+            ]
+            if error_message:
+                body.append(f'<p class="blocked">{_e(error_message)}</p>')
+            body.extend(
+                [
+                    '<form method="post" action="/login">',
+                    f'<input type="hidden" name="next" value="{_e(next_path)}">',
+                    '<p><label for="username">Benutzername oder E-Mail</label><br>',
+                    '<input id="username" name="username" autocomplete="username"></p>',
+                    '<p><label for="password">Passwort</label><br>',
+                    '<input id="password" name="password" type="password" '
+                    'autocomplete="current-password"></p>',
+                    '<p><button type="submit">Anmelden</button></p>',
+                    "</form></fieldset>",
+                ]
+            )
+            self._html(
+                _page(
+                    "Anmeldung",
+                    "".join(body),
+                    active_section="home",
+                    context=OfficePageContext(),
+                ),
+                status=status,
+            )
+
+        def _render_password_change_page(
+            self,
+            auth: OfficePanelRequestAuth,
+            *,
+            error_message: str = "",
+            status: int = 200,
+        ) -> None:
+            body = [
+                "<fieldset><legend>Passwort ändern</legend>",
+                "<p>Ihr Konto ist angemeldet, der Zugriff bleibt aber bis zur Passwortänderung eingeschränkt.</p>",
+            ]
+            if error_message:
+                body.append(f'<p class="blocked">{_e(error_message)}</p>')
+            body.extend(
+                [
+                    '<form method="post" action="/password-change">',
+                    f"{_csrf_input(self._page_context(auth))}",
+                    '<p><label for="current_password">Aktuelles Passwort</label><br>',
+                    '<input id="current_password" name="current_password" type="password" '
+                    'autocomplete="current-password"></p>',
+                    '<p><label for="new_password">Neues Passwort</label><br>',
+                    '<input id="new_password" name="new_password" type="password" '
+                    'autocomplete="new-password"></p>',
+                    '<p><button type="submit">Passwort speichern</button></p>',
+                    "</form></fieldset>",
+                ]
+            )
+            self._html(
+                _page(
+                    "Passwort ändern",
+                    "".join(body),
+                    active_section="home",
+                    context=self._page_context(auth),
+                ),
+                status=status,
+            )
+
+        def _redirect_to_login(self) -> None:
+            next_path = _safe_redirect_target(self.path)
+            location = "/login"
+            if next_path != "/":
+                location = f"/login?next={quote(next_path, safe='')}"
+            self._redirect(location)
+
+        def _page_context(
+            self,
+            auth: OfficePanelRequestAuth | None = None,
+            *,
+            rueckruf_count: int | None | object = _RUECKRUF_COUNT_UNSET,
+        ) -> OfficePageContext:
+            if auth is None:
+                auth = getattr(self, "_request_auth", None)
+            if auth is None:
+                auth = self._resolve_request_auth()
+            resolved_rueckruf_count = (
+                fetch_rueckruf_count(auerswald_url, auerswald_user, auerswald_password)
+                if rueckruf_count is _RUECKRUF_COUNT_UNSET
+                else rueckruf_count
+            )
+            return OfficePageContext(
+                rueckruf_count=resolved_rueckruf_count,
+                csrf_token=auth.csrf_token if auth is not None else "",
+                current_user_name=auth.current_user_name if auth is not None else "",
+                current_user_role_label=(
+                    auth.current_user_role_label if auth is not None else ""
+                ),
+                password_change_path=auth.password_change_path
+                if auth is not None
+                else "",
+                logout_path=auth.logout_path if auth is not None else "",
+                show_transition_banner=(
+                    auth.show_transition_banner if auth is not None else False
+                ),
+                legacy_shared_access=auth.legacy_shared_access
+                if auth is not None
+                else False,
+            )
 
         def _security_headers(self) -> None:
             self.send_header("Cache-Control", "no-store")
@@ -331,11 +551,19 @@ def make_office_panel_handler(
             self.send_header("WWW-Authenticate", 'Basic realm="Office"')
             self.end_headers()
 
-        def _html(self, page: str, status: int = 200) -> None:
+        def _html(
+            self,
+            page: str,
+            status: int = 200,
+            *,
+            cookie_headers: tuple[str, ...] = (),
+        ) -> None:
             payload = page.encode("utf-8")
             self.send_response(status)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(payload)))
+            for cookie_header in cookie_headers:
+                self.send_header("Set-Cookie", cookie_header)
             self.end_headers()
             self.wfile.write(payload)
 
@@ -349,18 +577,14 @@ def make_office_panel_handler(
             self.end_headers()
             self.wfile.write(payload)
 
-        def _redirect(self, location: str) -> None:
+        def _redirect(
+            self, location: str, *, cookie_headers: tuple[str, ...] = ()
+        ) -> None:
             self.send_response(303)
             self.send_header("Location", location)
+            for cookie_header in cookie_headers:
+                self.send_header("Set-Cookie", cookie_header)
             self.end_headers()
-
-        def _fetch_page_context(self) -> OfficePageContext:
-            return OfficePageContext(
-                rueckruf_count=fetch_rueckruf_count(
-                    auerswald_url, auerswald_user, auerswald_password
-                ),
-                csrf_token=csrf_token,
-            )
 
         def _fetch_enriched_missed_board(self) -> tuple[list[dict] | None, str | None]:
             items, error = fetch_missed_board(
@@ -376,7 +600,7 @@ def make_office_panel_handler(
                     "Fehler",
                     f'<p class="blocked">{_e(message)}</p>',
                     active_section="home",
-                    context=self._fetch_page_context(),
+                    context=self._page_context(),
                 ),
                 status,
             )
@@ -396,7 +620,7 @@ def make_office_panel_handler(
                         "Fehler",
                         f'<p class="blocked">{_e(_UNAVAILABLE_MESSAGE)}</p>',
                         active_section="home",
-                        context=self._fetch_page_context(),
+                        context=self._page_context(),
                     ),
                     503,
                 )
@@ -430,8 +654,60 @@ def make_office_panel_handler(
             pass
 
         def do_GET(self) -> None:  # noqa: N802
-            if not self._authorized():
-                self._deny()
+            parsed = urlparse(self.path)
+            parts = [part for part in parsed.path.split("/") if part]
+            auth = self._resolve_request_auth()
+            self._request_auth = auth
+            if parts == ["login"]:
+                if validated_auth_mode == "basic":
+                    self.send_error(404)
+                    return
+                if auth is not None and auth.kind == "employee":
+                    if (
+                        auth.employee is not None
+                        and not auth.employee.application_access_allowed
+                    ):
+                        self._redirect("/password-change")
+                    else:
+                        self._redirect(
+                            _safe_redirect_target(
+                                parse_qs(parsed.query).get("next", ["/"])[0]
+                            )
+                        )
+                    return
+                self._render_login_page(
+                    next_path=_safe_redirect_target(
+                        parse_qs(parsed.query).get("next", ["/"])[0]
+                    )
+                )
+                return
+            if parts == ["password-change"]:
+                if auth is None or auth.kind != "employee":
+                    if validated_auth_mode == "basic":
+                        self._deny()
+                    else:
+                        self._redirect_to_login()
+                    return
+                if (
+                    auth.employee is not None
+                    and auth.employee.application_access_allowed
+                ):
+                    self._redirect("/")
+                    return
+                self._render_password_change_page(auth)
+                return
+            if auth is None:
+                if validated_auth_mode == "basic":
+                    self._deny()
+                else:
+                    self._redirect_to_login()
+                return
+            if (
+                auth.kind == "employee"
+                and auth.employee is not None
+                and not auth.employee.application_access_allowed
+            ):
+                self._redirect("/password-change")
                 return
             panel.begin_request()
             try:
@@ -448,22 +724,40 @@ def make_office_panel_handler(
                         render_rueckruf(
                             None,
                             "Rückruf-Liste: nur vor Ort verfügbar",
-                            context=OfficePageContext(csrf_token=csrf_token),
+                            context=self._page_context(),
                         )
                     )
                     return
                 items, error = self._fetch_enriched_missed_board()
+                context = self._page_context(
+                    rueckruf_count=len(items) if items is not None else None
+                )
                 context = OfficePageContext(
                     rueckruf_count=len(items) if items is not None else None,
-                    csrf_token=csrf_token,
+                    csrf_token=context.csrf_token,
+                    current_user_name=context.current_user_name,
+                    current_user_role_label=context.current_user_role_label,
+                    password_change_path=context.password_change_path,
+                    logout_path=context.logout_path,
+                    show_transition_banner=context.show_transition_banner,
+                    legacy_shared_access=context.legacy_shared_access,
                 )
                 self._html(render_rueckruf(items, error, context=context))
                 return
             if not parts:
                 items, error = self._fetch_enriched_missed_board()
+                context = self._page_context(
+                    rueckruf_count=len(items) if items is not None else None
+                )
                 context = OfficePageContext(
                     rueckruf_count=len(items) if items is not None else None,
-                    csrf_token=csrf_token,
+                    csrf_token=context.csrf_token,
+                    current_user_name=context.current_user_name,
+                    current_user_role_label=context.current_user_role_label,
+                    password_change_path=context.password_change_path,
+                    logout_path=context.logout_path,
+                    show_transition_banner=context.show_transition_banner,
+                    legacy_shared_access=context.legacy_shared_access,
                 )
                 kalender_view = parse_qs(parsed.query).get("kalender", ["woche"])[0]
                 self._html(
@@ -475,7 +769,7 @@ def make_office_panel_handler(
                     )
                 )
                 return
-            context = self._fetch_page_context()
+            context = self._page_context()
             if parts == ["anfragen"]:
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_anfragen(search_query, context=context))
@@ -696,9 +990,9 @@ def make_office_panel_handler(
             self._html(body)
 
         def do_POST(self) -> None:  # noqa: N802
-            if not self._authorized():
-                self._deny()
-                return
+            parts = [part for part in urlparse(self.path).path.split("/") if part]
+            auth = self._resolve_request_auth()
+            self._request_auth = auth
             try:
                 form = self._form()
             except FormBodyTooLargeError as exc:
@@ -707,14 +1001,143 @@ def make_office_panel_handler(
             except (UnicodeDecodeError, ValueError) as exc:
                 self._error_page(str(exc), status=400)
                 return
+            if parts == ["login"]:
+                if validated_auth_mode == "basic":
+                    self.send_error(404)
+                    return
+                assert auth_service is not None
+                next_path = _safe_redirect_target(form.get("next", "/"))
+                try:
+                    result = auth_service.authenticate(
+                        username=form.get("username", ""),
+                        password=form.get("password", ""),
+                    )
+                except AuthenticationError:
+                    self._render_login_page(
+                        next_path=next_path,
+                        error_message="Anmeldung fehlgeschlagen.",
+                        status=401,
+                    )
+                    return
+                self._redirect(
+                    next_path,
+                    cookie_headers=(
+                        session_cookie_header(
+                            result.session_token, secure=secure_cookie
+                        ),
+                        csrf_cookie_header(result.csrf_token, secure=secure_cookie),
+                    ),
+                )
+                return
+            if parts == ["logout"]:
+                if auth is None or auth.kind != "employee" or auth.employee is None:
+                    if validated_auth_mode == "basic":
+                        self._deny()
+                    else:
+                        self._redirect_to_login()
+                    return
+                try:
+                    assert auth_service is not None
+                    auth_service.validate_csrf(
+                        auth.employee.session, form.get("_csrf_token", "")
+                    )
+                    auth_service.logout(auth.employee)
+                except CsrfValidationError:
+                    self._error_page(
+                        "Ungültiger oder fehlender CSRF-Sicherheitstoken.", status=403
+                    )
+                    return
+                self._redirect(
+                    "/login",
+                    cookie_headers=(
+                        clear_cookie_header(
+                            SESSION_COOKIE_NAME,
+                            secure=secure_cookie,
+                            http_only=True,
+                        ),
+                        clear_cookie_header(
+                            CSRF_COOKIE_NAME,
+                            secure=secure_cookie,
+                            http_only=True,
+                        ),
+                    ),
+                )
+                return
+            if parts == ["password-change"]:
+                if auth is None or auth.kind != "employee" or auth.employee is None:
+                    if validated_auth_mode == "basic":
+                        self._deny()
+                    else:
+                        self._redirect_to_login()
+                    return
+                try:
+                    assert auth_service is not None
+                    auth_service.validate_csrf(
+                        auth.employee.session, form.get("_csrf_token", "")
+                    )
+                    auth_service.change_password(
+                        auth.employee,
+                        current_password=form.get("current_password", ""),
+                        new_password=form.get("new_password", ""),
+                    )
+                except CsrfValidationError:
+                    self._error_page(
+                        "Ungültiger oder fehlender CSRF-Sicherheitstoken.", status=403
+                    )
+                    return
+                except (AuthenticationError, ValueError):
+                    self._render_password_change_page(
+                        auth,
+                        error_message="Passwort konnte nicht geändert werden.",
+                        status=401,
+                    )
+                    return
+                self._redirect(
+                    "/login",
+                    cookie_headers=(
+                        clear_cookie_header(
+                            SESSION_COOKIE_NAME,
+                            secure=secure_cookie,
+                            http_only=True,
+                        ),
+                        clear_cookie_header(
+                            CSRF_COOKIE_NAME,
+                            secure=secure_cookie,
+                            http_only=True,
+                        ),
+                    ),
+                )
+                return
+            if auth is None:
+                if validated_auth_mode == "basic":
+                    self._deny()
+                else:
+                    self._redirect_to_login()
+                return
+            if (
+                auth.kind == "employee"
+                and auth.employee is not None
+                and not auth.employee.application_access_allowed
+            ):
+                self._redirect("/password-change")
+                return
             submitted_token = form.get("_csrf_token", "")
-            if not hmac.compare_digest(submitted_token, csrf_token):
+            if auth.kind == "employee":
+                try:
+                    assert auth.employee is not None
+                    assert auth_service is not None
+                    auth_service.validate_csrf(auth.employee.session, submitted_token)
+                except CsrfValidationError:
+                    self._error_page(
+                        "Ungültiger oder fehlender CSRF-Sicherheitstoken.", status=403
+                    )
+                    return
+            elif not hmac.compare_digest(submitted_token, csrf_token):
                 self._error_page(
                     "Ungültiger oder fehlender CSRF-Sicherheitstoken.", status=403
                 )
                 return
             panel.begin_request(form)
-            parts = [part for part in urlparse(self.path).path.split("/") if part]
             try:
                 self._route_post(parts)
             except CatalogCommandError as exc:
@@ -751,7 +1174,7 @@ def make_office_panel_handler(
             elif parts == ["proposal-preview"]:
                 payload = parse_proposal_payload(self._form().get("payload_json", ""))
                 self._html(
-                    render_proposal_preview(payload, context=self._fetch_page_context())
+                    render_proposal_preview(payload, context=self._page_context())
                 )
             elif parts == ["proposal-preview", "prepare"]:
                 payload = parse_proposal_payload(self._form().get("payload_json", ""))
@@ -770,7 +1193,7 @@ def make_office_panel_handler(
                         intake_message=payload.get("notes") or "",
                         intake_summary=summary_lines,
                         intake_external_ref=payload.get("proposal_id") or "",
-                        context=self._fetch_page_context(),
+                        context=self._page_context(),
                     )
                 )
             elif parts == ["rueckruf", "resolve"]:
@@ -816,7 +1239,7 @@ def make_office_panel_handler(
             except CatalogCommandError as exc:
                 self._html(
                     panel.render_gericht_new(
-                        context=self._fetch_page_context(),
+                        context=self._page_context(),
                         form=form,
                         error_message=office_command_error_message(exc.code),
                     ),
@@ -829,7 +1252,7 @@ def make_office_panel_handler(
             except (ValueError, KeyError) as exc:
                 self._html(
                     panel.render_gericht_new(
-                        context=self._fetch_page_context(),
+                        context=self._page_context(),
                         form=form,
                         error_message=office_command_error_message(str(exc)),
                     ),
@@ -952,6 +1375,9 @@ def create_office_panel_server(
     offer_document_repo: OfferDocumentSnapshotRepository | None = None,
     offer_pdf_static_content: OfferPdfStaticContent | None = None,
     ui_version: str = "legacy",
+    auth_mode: OfficePanelAuthMode = "basic",
+    auth_service: EmployeeAuthService | None = None,
+    secure_cookie: bool = True,
 ) -> HTTPServer:
     """Create the intentionally single-threaded office HTTP server."""
     return HTTPServer(
@@ -979,5 +1405,8 @@ def create_office_panel_server(
             offer_document_repo=offer_document_repo,
             offer_pdf_static_content=offer_pdf_static_content,
             ui_version=ui_version,
+            auth_mode=auth_mode,
+            auth_service=auth_service,
+            secure_cookie=secure_cookie,
         ),
     )

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -189,6 +189,8 @@ svg { display: block; }
   z-index: 20;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 18px;
   min-height: 76px;
   padding: 0 clamp(24px, 4vw, 54px);
   border-bottom: 1px solid var(--line);
@@ -197,6 +199,58 @@ svg { display: block; }
 .office-crumb {
   color: var(--muted);
   font-size: 13px;
+}
+.office-account {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  min-width: 0;
+}
+.office-account-meta {
+  min-width: 0;
+  text-align: right;
+}
+.office-account-meta strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.office-account-meta span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.office-account-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.office-account-form { margin: 0; }
+.office-account-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--accent-deep);
+  background: var(--surface);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.1;
+  text-decoration: none;
+}
+button.office-account-link {
+  color: var(--accent-deep);
+  background: var(--surface);
+}
+.office-account-link:hover,
+button.office-account-link:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
 }
 .office-content {
   max-width: 1440px;
@@ -327,6 +381,14 @@ svg { display: block; }
   color: #76501c;
   background: var(--warning-soft);
   font-weight: 700;
+}
+.office-global-banner {
+  margin: 0 0 20px;
+  padding: 12px 15px;
+  border: 1px solid #e5cfab;
+  border-radius: var(--radius-small);
+  color: #76501c;
+  background: var(--warning-soft);
 }
 .office-content ul,
 .office-content ol { padding-left: 22px; }
@@ -1447,7 +1509,14 @@ svg { display: block; }
     position: static;
     min-height: 58px;
     padding-inline: 18px;
+    align-items: flex-start;
+    flex-direction: column;
   }
+  .office-account {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .office-account-meta { text-align: left; }
   .office-content { padding: 26px 18px 48px; }
   .office-content table {
     display: block;

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -118,6 +118,12 @@ class OfficePageContext:
 
     rueckruf_count: int | None = None
     csrf_token: str = ""
+    current_user_name: str = ""
+    current_user_role_label: str = ""
+    password_change_path: str = ""
+    logout_path: str = ""
+    show_transition_banner: bool = False
+    legacy_shared_access: bool = False
 
 
 _EMPTY_PAGE_CONTEXT = OfficePageContext()
@@ -195,6 +201,39 @@ def _page(
         )
     )
     page_title = f"<h1>{_e(title)}</h1>" if show_title else ""
+    account_meta = (
+        '<div class="office-account-meta">'
+        f"<strong>{_e(context.current_user_name or 'Office Panel')}</strong>"
+        f"<span>{_e(context.current_user_role_label or 'Tägliche Arbeitszentrale')}</span>"
+        "</div>"
+    )
+    account_actions = ""
+    if context.password_change_path or context.logout_path:
+        password_link = (
+            f'<a class="office-account-link" href="{_e(context.password_change_path)}">'
+            "Passwort ändern</a>"
+            if context.password_change_path
+            else ""
+        )
+        logout_form = (
+            '<form class="office-account-form" method="post" '
+            f'action="{_e(context.logout_path)}">{_csrf_input(context)}'
+            '<button type="submit" class="office-account-link">Abmelden</button>'
+            "</form>"
+            if context.logout_path
+            else ""
+        )
+        account_actions = (
+            f'<div class="office-account-actions">{password_link}{logout_form}</div>'
+        )
+    transition_banner = (
+        '<div class="office-global-banner">'
+        "<strong>Übergangsmodus aktiv:</strong> "
+        "Die Anmeldung mit dem gemeinsamen Office-Passwort ist noch möglich."
+        "</div>"
+        if context.show_transition_banner
+        else ""
+    )
     refresh_meta = (
         f'<meta http-equiv="refresh" content="{auto_refresh_seconds}">'
         if auto_refresh_seconds is not None
@@ -215,8 +254,9 @@ def _page(
         '<div class="office-user"><strong>Office Panel</strong>'
         "<span>Tägliche Arbeitszentrale</span></div></aside>"
         '<main class="office-workspace">'
-        f'<header class="office-topbar"><span class="office-crumb">{_e(title)}</span></header>'
-        f'<div class="office-content">{page_title}{body}</div>'
+        f'<header class="office-topbar"><span class="office-crumb">{_e(title)}</span>'
+        f'<div class="office-account">{account_meta}{account_actions}</div></header>'
+        f'<div class="office-content">{transition_banner}{page_title}{body}</div>'
         "</main></div></body></html>"
     )
 

--- a/tests/unit/test_employee_auth_api.py
+++ b/tests/unit/test_employee_auth_api.py
@@ -127,7 +127,7 @@ def test_login_logout_me_and_change_password_flow(auth_api) -> None:
         method="POST",
         headers={"Cookie": cookie},
     )
-    assert status == 401
+    assert status == 403
 
     status, _body, _headers = _request(
         f"{auth_api}/auth/password/change",
@@ -192,8 +192,8 @@ def test_csrf_required_for_state_changing_requests(auth_api) -> None:
         method="POST",
         headers={"Cookie": cookie},
     )
-    assert status == 401
-    assert body["error"] == "unauthorized"
+    assert status == 403
+    assert body["error"] == "forbidden"
 
 
 def test_csrf_token_from_another_session_is_rejected(auth_api) -> None:
@@ -220,8 +220,8 @@ def test_csrf_token_from_another_session_is_rejected(auth_api) -> None:
         method="POST",
         headers={"Cookie": cookie_b, "X-CSRF-Token": csrf_a},
     )
-    assert status == 401
-    assert body["error"] == "unauthorized"
+    assert status == 403
+    assert body["error"] == "forbidden"
     status, _body, _headers = _request(
         f"{auth_api}/auth/me",
         headers={"Cookie": cookie_a},

--- a/tests/unit/test_employee_auth_service.py
+++ b/tests/unit/test_employee_auth_service.py
@@ -164,6 +164,25 @@ def test_auth_version_mismatch_rejects_session(auth) -> None:
         service.authenticate_session(result.session_token)
 
 
+def test_last_seen_at_writes_are_bounded(auth) -> None:
+    service, repo, result, _employee = _login_superadmin(auth)
+    session = repo.get_session_by_token_hash(result.session.token_hash)
+    assert session is not None
+    first_seen = session.last_seen_at
+
+    auth[2].value = auth[2].value + timedelta(minutes=4)
+    service.authenticate_session(result.session_token)
+    session = repo.get_session_by_token_hash(result.session.token_hash)
+    assert session is not None
+    assert session.last_seen_at == first_seen
+
+    auth[2].value = auth[2].value + timedelta(minutes=1)
+    service.authenticate_session(result.session_token)
+    session = repo.get_session_by_token_hash(result.session.token_hash)
+    assert session is not None
+    assert session.last_seen_at == auth[2].value
+
+
 def test_must_change_password_blocks_application_permissions_until_changed(
     auth,
 ) -> None:

--- a/tests/unit/test_office_panel_employee_auth.py
+++ b/tests/unit/test_office_panel_employee_auth.py
@@ -1,0 +1,538 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_panel import create_office_panel_server
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+@dataclass
+class PanelHarness:
+    base: str
+    server: object
+    thread: threading.Thread
+    service: EmployeeAuthService
+    repo: SQLiteEmployeeAuthRepository
+    clock: Clock
+    password: str
+
+
+def _auth_header(password: str) -> str:
+    return "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = None
+    if data is not None:
+        payload = urllib.parse.urlencode(data).encode()
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    try:
+        with opener.open(request) as response:
+            return (
+                response.status,
+                response.url,
+                response.read().decode("utf-8"),
+                response.headers,
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8"), exc.headers
+
+
+def _create_panel(
+    tmp_path: Path,
+    *,
+    auth_mode: str,
+    password: str = "shared-office-password",
+    secure_cookie: bool = True,
+) -> PanelHarness:
+    db = tmp_path / "core.db"
+    connection = sqlite3.connect(str(db), check_same_thread=False)
+    repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    service = EmployeeAuthService(repo, now=clock.now)
+    account = service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "office-panel"},
+    )
+    assert account.username == "viktor.admin"
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        password,
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        auth_service=service,
+        secure_cookie=secure_cookie,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return PanelHarness(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        service=service,
+        repo=repo,
+        clock=clock,
+        password=password,
+    )
+
+
+def _shutdown(panel: PanelHarness) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+    panel.repo.close()
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee", secure_cookie=False)
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def employee_panel_secure(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee", secure_cookie=True)
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def migration_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="migration", secure_cookie=False)
+    yield panel
+    _shutdown(panel)
+
+
+def test_employee_mode_redirects_unauthenticated_get_to_login(
+    employee_panel: PanelHarness,
+) -> None:
+    status, _url, _body, headers = _request(employee_panel.base, "/")
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_login_page_remains_accessible(employee_panel: PanelHarness) -> None:
+    status, _url, body, _headers = _request(employee_panel.base, "/login")
+    assert status == 200
+    assert "Bitte mit Ihrem Mitarbeiterkonto anmelden." in body
+
+
+def test_valid_employee_login_sets_secure_cookies_and_redirects(
+    employee_panel_secure: PanelHarness,
+) -> None:
+    jar = http.cookiejar.CookieJar()
+    status, _url, _body, headers = _request(
+        employee_panel_secure.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    assert status == 303
+    assert headers["Location"] == "/"
+    set_cookies = headers.get_all("Set-Cookie")
+    assert set_cookies is not None
+    assert any(
+        "sl_employee_session=" in value and "Secure" in value for value in set_cookies
+    )
+    assert any(
+        "sl_employee_csrf=" in value and "Secure" in value for value in set_cookies
+    )
+
+
+def test_bad_username_or_password_returns_generic_error(
+    employee_panel: PanelHarness,
+) -> None:
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "wrong", "next": "/"},
+    )
+    assert status == 401
+    assert "Anmeldung fehlgeschlagen." in body
+    assert "inactive" not in body.lower()
+
+
+def test_employee_mode_rejects_basic_fallback(employee_panel: PanelHarness) -> None:
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/",
+        headers={"Authorization": _auth_header(employee_panel.password)},
+    )
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_migration_mode_accepts_basic_fallback_and_displays_warning(
+    migration_panel: PanelHarness,
+) -> None:
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+    )
+    assert status == 200
+    assert "Gemeinsamer Office-Zugang" in body
+    assert "Legacy-Zugang" in body
+    assert "Übergangsmodus aktiv" in body
+
+
+def test_must_change_password_redirects_normal_routes(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    status, _url, _body, headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 303
+    assert headers["Location"] == "/password-change"
+
+
+def test_password_change_page_and_submit_remain_available(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/password-change", jar=jar
+    )
+    assert status == 200
+    assert "Passwort ändern" in body
+
+    csrf_token = _cookie_value(jar, "sl_employee_csrf")
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/password-change",
+        method="POST",
+        data={
+            "_csrf_token": csrf_token,
+            "current_password": "TempPassw0rd!",
+            "new_password": "ChangedTemp1!",
+        },
+        jar=jar,
+    )
+    assert status == 303
+    assert headers["Location"] == "/login"
+    set_cookies = headers.get_all("Set-Cookie")
+    assert set_cookies is not None
+    assert any(
+        "sl_employee_session=" in value and "Max-Age=0" in value
+        for value in set_cookies
+    )
+    status, _url, _body, headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_header_displays_real_employee_identity_and_role(
+    employee_panel: PanelHarness,
+) -> None:
+    login = employee_panel.service.authenticate(
+        username="viktor.admin", password="TempPassw0rd!"
+    )
+    employee = employee_panel.service.authenticate_session(login.session_token)
+    employee_panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "ChangedTemp1!", "next": "/"},
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert "Viktor Johanson" in body
+    assert "Superadmin" in body
+
+
+def test_logout_requires_csrf_and_revokes_session(employee_panel: PanelHarness) -> None:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/logout",
+        method="POST",
+        data={},
+        jar=jar,
+    )
+    assert status == 403
+    assert "CSRF" in body
+
+    csrf_token = _cookie_value(jar, "sl_employee_csrf")
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/logout",
+        method="POST",
+        data={"_csrf_token": csrf_token},
+        jar=jar,
+    )
+    assert status == 303
+    assert headers["Location"] == "/login"
+    status, _url, _body, headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_cross_session_csrf_returns_403(employee_panel: PanelHarness) -> None:
+    jar_a = http.cookiejar.CookieJar()
+    jar_b = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar_a,
+    )
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar_b,
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/logout",
+        method="POST",
+        data={"_csrf_token": _cookie_value(jar_a, "sl_employee_csrf")},
+        jar=jar_b,
+    )
+    assert status == 403
+    assert "CSRF" in body
+
+
+def test_employee_session_takes_precedence_over_basic_fallback(
+    migration_panel: PanelHarness,
+) -> None:
+    login = migration_panel.service.authenticate(
+        username="viktor.admin", password="TempPassw0rd!"
+    )
+    employee = migration_panel.service.authenticate_session(login.session_token)
+    migration_panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+
+    jar = http.cookiejar.CookieJar()
+    _request(
+        migration_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "ChangedTemp1!", "next": "/"},
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+        jar=jar,
+    )
+    assert status == 200
+    assert "Viktor Johanson" in body
+    assert "Gemeinsamer Office-Zugang" not in body
+
+
+def test_revoked_session_redirects_back_to_login(employee_panel: PanelHarness) -> None:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    session_token = _cookie_value(jar, "sl_employee_session")
+    employee = employee_panel.service.authenticate_session(session_token)
+    employee_panel.service.logout(employee)
+    status, _url, _body, headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_inactive_account_cannot_log_in(employee_panel: PanelHarness) -> None:
+    login = employee_panel.service.authenticate(
+        username="viktor.admin", password="TempPassw0rd!"
+    )
+    employee = employee_panel.service.authenticate_session(login.session_token)
+    employee_panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    admin_login = employee_panel.service.authenticate(
+        username="viktor.admin", password="ChangedTemp1!"
+    )
+    admin = employee_panel.service.authenticate_session(admin_login.session_token)
+    worker = employee_panel.service.create_account(
+        admin,
+        username="worker.inactive",
+        display_name="Worker Inactive",
+        password="AnotherTemp1!",
+        role="USER",
+    )
+    employee_panel.service.deactivate_account(admin, worker.id)
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "worker.inactive", "password": "AnotherTemp1!", "next": "/"},
+    )
+    assert status == 401
+    assert "Anmeldung fehlgeschlagen." in body
+
+
+def test_unknown_auth_mode_fails_startup(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown office auth mode"):
+        create_office_panel_server(
+            InMemoryInquiryRepository(),
+            InMemoryOrderRepository(),
+            "shared-office-password",
+            host="127.0.0.1",
+            port=0,
+            auth_mode="mystery",
+        )
+
+
+def test_open_redirect_attempt_is_rejected(employee_panel: PanelHarness) -> None:
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={
+            "username": "viktor.admin",
+            "password": "TempPassw0rd!",
+            "next": "https://evil.example/steal",
+        },
+    )
+    assert status == 303
+    assert headers["Location"] == "/"
+
+
+def test_login_redirect_preserves_safe_internal_target(
+    employee_panel: PanelHarness,
+) -> None:
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={
+            "username": "viktor.admin",
+            "password": "TempPassw0rd!",
+            "next": "/angebote",
+        },
+    )
+    assert status == 303
+    assert headers["Location"] == "/angebote"
+
+
+def test_last_seen_writes_are_bounded_in_practice(employee_panel: PanelHarness) -> None:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        employee_panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    session_token = _cookie_value(jar, "sl_employee_session")
+    employee = employee_panel.service.authenticate_session(session_token)
+    first_seen = employee.session.last_seen_at
+
+    employee_panel.clock.value = employee_panel.clock.value + timedelta(minutes=4)
+    employee = employee_panel.service.authenticate_session(session_token)
+    assert employee.session.last_seen_at == first_seen
+
+    employee_panel.clock.value = employee_panel.clock.value + timedelta(minutes=1)
+    employee = employee_panel.service.authenticate_session(session_token)
+    assert employee.session.last_seen_at == employee_panel.clock.value


### PR DESCRIPTION
## Summary
- add explicit Office Panel auth modes for `basic`, `migration`, and `employee`
- add server-rendered employee login, forced password-change, and logout flows that reuse AUTH-1 sessions and CSRF
- surface authenticated employee identity in the Office Panel shell and document the planned Lenovo/Tailscale rollout

## Why
The Office Panel needs a first employee-auth slice that can run safely alongside the legacy shared Basic rollout path, while enforcing AUTH-1 session state and `must_change_password` restrictions server-side.

## Scope
- Office Panel auth-mode wiring and HTML routes
- shared employee auth cookie helpers
- bounded `last_seen_at` writes and 403 employee-CSRF mapping
- focused Office Panel employee-auth tests and affected regressions
- planned production rollout notes in the Lenovo runbook

## Validation
- focused AUTH-2A service/API/Office Panel auth tests
- affected Office Panel Basic-auth regression tests
- final full Core suite: `2467 passed in 466.69s (0:07:46)`
- `ruff check`
- `ruff format --check`
- `mypy src/catering_system`
- `git diff --check`

## Follow-up risks carried into AUTH-2B
- last-active-SUPERADMIN concurrency protection
- bounded `last_seen_at` is implemented, but broader auth/Office integration still continues in AUTH-2B
- CSRF 403 mapping is now corrected here; Office Panel and Configurator still need later employee-session protection work outside AUTH-2A

Closes #66
