### PR TITLE
AUTH-2B: employee account-management service and API

### DIFF
--- a/src/catering_system/domain/employee_auth.py
+++ b/src/catering_system/domain/employee_auth.py
@@ -354,3 +354,58 @@ class AuthIntrospection:
     account: EmployeeAccount | None = None
     effective_permissions: frozenset[str] = frozenset()
     service_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EmployeeAccountSummary:
+    id: str
+    username: str
+    email: str | None
+    display_name: str
+    role: EmployeeRole
+    is_active: bool
+    must_change_password: bool
+    created_at: datetime
+    updated_at: datetime
+    deactivated_at: datetime | None
+    last_login_at: datetime | None
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
+class EmployeeAccountDetail:
+    id: str
+    username: str
+    email: str | None
+    display_name: str
+    role: EmployeeRole
+    is_active: bool
+    must_change_password: bool
+    created_at: datetime
+    updated_at: datetime
+    deactivated_at: datetime | None
+    last_login_at: datetime | None
+    read_only: bool
+    explicit_permissions: frozenset[str]
+    effective_permissions: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SecurityAuditEventView:
+    event_id: str
+    occurred_at: datetime
+    actor_account_id: str | None
+    actor_display_name_snapshot: str | None
+    actor_role_snapshot: EmployeeRole | None
+    action: str
+    target_type: str
+    target_id: str | None
+    permission_code: str | None
+    outcome: AuditOutcome
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class PasswordResetResult:
+    account: EmployeeAccount
+    temporary_password: str | None = None

--- a/src/catering_system/repositories/sqlite_employee_auth_repository.py
+++ b/src/catering_system/repositories/sqlite_employee_auth_repository.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from contextlib import nullcontext
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from typing import Iterator
 
 from catering_system.domain.employee_auth import (
     EmployeeAccount,
@@ -123,6 +124,10 @@ _AUDIT_INDEXES = (
     CREATE INDEX IF NOT EXISTS idx_security_audit_events_actor
     ON security_audit_events (actor_account_id, occurred_at);
     """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_security_audit_events_target
+    ON security_audit_events (target_id, occurred_at);
+    """,
 )
 
 _AUDIT_APPEND_ONLY_TRIGGERS = (
@@ -168,25 +173,20 @@ def _migration_4_create_security_audit_events(connection: sqlite3.Connection) ->
         connection.execute(statement)
 
 
+def _migration_5_audit_target_index(connection: sqlite3.Connection) -> None:
+    connection.execute(_AUDIT_INDEXES[2])
+
+
 _MIGRATIONS = (
     (1, "create_employee_accounts", _migration_1_create_employee_accounts),
     (2, "create_account_permissions", _migration_2_create_account_permissions),
     (3, "create_employee_sessions", _migration_3_create_employee_sessions),
     (4, "create_security_audit_events", _migration_4_create_security_audit_events),
+    (5, "audit_target_index", _migration_5_audit_target_index),
 )
 
 
 class SQLiteEmployeeAuthRepository:
-    def __init__(self, db_path: str | Path) -> None:
-        self._conn = sqlite3.connect(str(db_path))
-        self._conn.execute("PRAGMA foreign_keys = ON")
-        self._manage_transactions = True
-        try:
-            apply_migrations(self._conn, "employee_auth", _MIGRATIONS)
-        except Exception:
-            self._conn.close()
-            raise
-
     @classmethod
     def from_connection(
         cls, connection: sqlite3.Connection
@@ -195,11 +195,42 @@ class SQLiteEmployeeAuthRepository:
         repo._conn = connection
         repo._conn.execute("PRAGMA foreign_keys = ON")
         repo._manage_transactions = False
+        repo._transaction_depth = 0
         apply_migrations(connection, "employee_auth", _MIGRATIONS)
         return repo
 
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._manage_transactions = True
+        self._transaction_depth = 0
+        try:
+            apply_migrations(self._conn, "employee_auth", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @contextmanager
+    def immediate_transaction(self) -> Iterator[sqlite3.Connection]:
+        if not self._manage_transactions:
+            yield self._conn
+            return
+        self._transaction_depth += 1
+        if self._transaction_depth == 1:
+            self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield self._conn
+            if self._transaction_depth == 1:
+                self._conn.commit()
+        except Exception:
+            if self._transaction_depth == 1:
+                self._conn.rollback()
+            raise
+        finally:
+            self._transaction_depth -= 1
+
     def _write_scope(self):  # noqa: ANN202
-        return self._conn if self._manage_transactions else nullcontext()
+        return self.immediate_transaction()
 
     def close(self) -> None:
         self._conn.close()
@@ -424,6 +455,46 @@ class SQLiteEmployeeAuthRepository:
                     event.metadata_json,
                 ),
             )
+
+    def list_accounts(self) -> list[EmployeeAccount]:
+        rows = self._conn.execute(
+            """
+            SELECT * FROM employee_accounts
+            ORDER BY username COLLATE NOCASE, account_id
+            """
+        ).fetchall()
+        return [self._row_to_account(row) for row in rows]
+
+    def list_audit_events_for_account(
+        self, account_id: str
+    ) -> list[SecurityAuditEvent]:
+        rows = self._conn.execute(
+            """
+            SELECT * FROM security_audit_events
+            WHERE target_id = ?
+            ORDER BY occurred_at, event_id
+            """,
+            (account_id,),
+        ).fetchall()
+        return [self._row_to_audit_event(row) for row in rows]
+
+    def replace_explicit_permissions(
+        self, account_id: str, permissions: set[str]
+    ) -> None:
+        for permission in permissions:
+            validate_permission_code(permission)
+        with self._write_scope():
+            self._conn.execute(
+                "DELETE FROM account_permissions WHERE account_id = ?", (account_id,)
+            )
+            if permissions:
+                self._conn.executemany(
+                    """
+                    INSERT INTO account_permissions (account_id, permission_code)
+                    VALUES (?, ?)
+                    """,
+                    [(account_id, permission) for permission in sorted(permissions)],
+                )
 
     def list_audit_events(self) -> list[SecurityAuditEvent]:
         rows = self._conn.execute(

--- a/src/catering_system/repositories/sqlite_employee_auth_repository.py
+++ b/src/catering_system/repositories/sqlite_employee_auth_repository.py
@@ -130,6 +130,13 @@ _AUDIT_INDEXES = (
     """,
 )
 
+_AUDIT_TARGET_TYPE_ID_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_security_audit_events_employee_account_target
+ON security_audit_events (target_type, target_id, occurred_at);
+"""
+
+_EMPLOYEE_ACCOUNT_AUDIT_TARGET_TYPE = "employee_account"
+
 _AUDIT_APPEND_ONLY_TRIGGERS = (
     """
     CREATE TRIGGER IF NOT EXISTS trg_security_audit_events_no_update
@@ -174,7 +181,7 @@ def _migration_4_create_security_audit_events(connection: sqlite3.Connection) ->
 
 
 def _migration_5_audit_target_index(connection: sqlite3.Connection) -> None:
-    connection.execute(_AUDIT_INDEXES[2])
+    connection.execute(_AUDIT_TARGET_TYPE_ID_INDEX)
 
 
 _MIGRATIONS = (
@@ -466,15 +473,16 @@ class SQLiteEmployeeAuthRepository:
         return [self._row_to_account(row) for row in rows]
 
     def list_audit_events_for_account(
-        self, account_id: str
+        self, account_id: str, *, limit: int
     ) -> list[SecurityAuditEvent]:
         rows = self._conn.execute(
             """
             SELECT * FROM security_audit_events
-            WHERE target_id = ?
-            ORDER BY occurred_at, event_id
+            WHERE target_type = ? AND target_id = ?
+            ORDER BY occurred_at ASC, event_id ASC
+            LIMIT ?
             """,
-            (account_id,),
+            (_EMPLOYEE_ACCOUNT_AUDIT_TARGET_TYPE, account_id, limit),
         ).fetchall()
         return [self._row_to_audit_event(row) for row in rows]
 

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import json
 import secrets
+import sqlite3
 import uuid
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -18,9 +19,13 @@ from catering_system.domain.employee_auth import (
     AuthIntrospection,
     AuthenticatedEmployee,
     EmployeeAccount,
+    EmployeeAccountDetail,
+    EmployeeAccountSummary,
     EmployeeRole,
     EmployeeSession,
+    PasswordResetResult,
     SecurityAuditEvent,
+    SecurityAuditEventView,
     SessionLoginResult,
     effective_permissions,
     ensure_permissions_within_role,
@@ -45,6 +50,7 @@ _SCRYPT_MAXMEM = 128 * 1024 * 1024
 _SESSION_TOKEN_BYTES = 32
 _CSRF_TOKEN_BYTES = 32
 _LAST_SEEN_WRITE_INTERVAL = timedelta(minutes=5)
+_UNSET = object()
 
 
 class AuthenticationError(Exception):
@@ -61,6 +67,17 @@ class AuthorizationError(Exception):
 
 class LastActiveSuperadminError(Exception):
     pass
+
+
+class AccountNotFoundError(Exception):
+    pass
+
+
+class AccountConflictError(Exception):
+    pass
+
+
+_TEMPORARY_PASSWORD_BYTES = 12
 
 
 def _utc_now() -> datetime:
@@ -239,8 +256,12 @@ class EmployeeAuthService:
                 raise AuthorizationError(
                     f"ADMIN may grant only own effective permissions: {sorted(overflow)}"
                 )
-        self.repository.add_account(account)
-        self.repository.set_explicit_permissions(account.id, permissions)
+        try:
+            with self.repository.immediate_transaction():
+                self.repository.add_account(account)
+                self.repository.set_explicit_permissions(account.id, permissions)
+        except sqlite3.IntegrityError as exc:
+            raise AccountConflictError("username or email already exists") from exc
         self._append_audit(
             actor_type="employee",
             actor_account=actor.account,
@@ -254,6 +275,135 @@ class EmployeeAuthService:
         )
         return account
 
+    def list_accounts(
+        self, actor: AuthenticatedEmployee
+    ) -> list[EmployeeAccountSummary]:
+        self._assert_permission(actor, "users.view")
+        return [
+            self._account_summary(actor, account)
+            for account in self.repository.list_accounts()
+        ]
+
+    def get_account(
+        self, actor: AuthenticatedEmployee, target_account_id: str
+    ) -> EmployeeAccountDetail:
+        self._assert_permission(actor, "users.view")
+        target = self._require_visible_account(target_account_id)
+        explicit = self.repository.get_explicit_permissions(target.id)
+        return self._account_detail(actor, target, explicit)
+
+    def update_account_profile(
+        self,
+        actor: AuthenticatedEmployee,
+        target_account_id: str,
+        *,
+        username: str | None = None,
+        display_name: str | None = None,
+        email: object | None = _UNSET,
+    ) -> EmployeeAccountDetail:
+        self._assert_permission(actor, "users.edit")
+        target = self._require_visible_account(target_account_id)
+        self._assert_can_mutate_account(actor, target)
+        changes: dict[str, object] = {}
+        updated = target
+        if username is not None:
+            next_username = normalize_username(username)
+            if next_username != target.username:
+                changes["username"] = {"old": target.username, "new": next_username}
+                updated = replace(updated, username=next_username)
+        if display_name is not None:
+            next_display_name = validate_display_name(display_name)
+            if next_display_name != target.display_name:
+                changes["display_name"] = {
+                    "old": target.display_name,
+                    "new": next_display_name,
+                }
+                updated = replace(updated, display_name=next_display_name)
+        if email is not _UNSET:
+            next_email = normalize_optional_email(email)
+            if next_email != target.email:
+                changes["email"] = {"old": target.email, "new": next_email}
+                updated = replace(updated, email=next_email)
+        if not changes:
+            explicit = self.repository.get_explicit_permissions(target.id)
+            return self._account_detail(actor, target, explicit)
+        updated = replace(updated, updated_at=self._now())
+        try:
+            with self.repository.immediate_transaction():
+                self.repository.update_account(updated)
+        except sqlite3.IntegrityError as exc:
+            raise AccountConflictError("username or email already exists") from exc
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.account_profile_updated",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"changes": changes},
+        )
+        explicit = self.repository.get_explicit_permissions(updated.id)
+        return self._account_detail(actor, updated, explicit)
+
+    def list_account_audit_events(
+        self, actor: AuthenticatedEmployee, target_account_id: str
+    ) -> list[SecurityAuditEventView]:
+        self._assert_permission(actor, "audit.view")
+        target = self._require_visible_account(target_account_id)
+        return [
+            self._audit_event_view(event)
+            for event in self.repository.list_audit_events_for_account(target.id)
+        ]
+
+    def reset_account_password(
+        self,
+        actor: AuthenticatedEmployee,
+        target_account_id: str,
+        *,
+        temporary_password: str | None = None,
+    ) -> PasswordResetResult:
+        self._assert_permission(actor, "users.password.reset")
+        target = self._require_visible_account(target_account_id)
+        self._assert_can_mutate_account(actor, target)
+        generated = temporary_password is None
+        resolved_password = (
+            secrets.token_urlsafe(_TEMPORARY_PASSWORD_BYTES)
+            if generated
+            else temporary_password
+        )
+        if not isinstance(resolved_password, str) or len(resolved_password) < 8:
+            raise ValueError("temporary_password must be at least 8 characters")
+        now = self._now()
+        updated = replace(
+            target,
+            password_hash=_hash_password(resolved_password),
+            must_change_password=True,
+            updated_at=now,
+            auth_version=target.auth_version + 1,
+        )
+        with self.repository.immediate_transaction():
+            self.repository.update_account(updated)
+            self.repository.revoke_sessions_for_account(
+                target.id, revoked_at=now, reason="password_reset"
+            )
+        self._append_audit(
+            actor_type="employee",
+            actor_account=actor.account,
+            session_id=actor.session.id,
+            action="auth.password_reset",
+            target_type="employee_account",
+            target_id=target.id,
+            permission_code=None,
+            outcome="success",
+            metadata={"username": target.username, "generated": generated},
+        )
+        return PasswordResetResult(
+            account=updated,
+            temporary_password=resolved_password if generated else None,
+        )
+
     def set_account_permissions(
         self,
         actor: AuthenticatedEmployee,
@@ -262,7 +412,8 @@ class EmployeeAuthService:
     ) -> EmployeeAccount:
         self._assert_permission(actor, "users.permissions.assign")
         target = self._require_account(target_account_id)
-        self._assert_can_manage_existing_account(actor, target)
+        self._assert_can_mutate_account(actor, target)
+        permissions = set(permissions)
         ensure_permissions_within_role(target.role, permissions)
         if actor.account.role == "ADMIN":
             overflow = permissions.difference(actor.effective_permissions)
@@ -270,7 +421,11 @@ class EmployeeAuthService:
                 raise AuthorizationError(
                     f"ADMIN may grant only own effective permissions: {sorted(overflow)}"
                 )
-        self.repository.set_explicit_permissions(target.id, permissions)
+        previous = self.repository.get_explicit_permissions(target.id)
+        added = sorted(permissions.difference(previous))
+        removed = sorted(previous.difference(permissions))
+        with self.repository.immediate_transaction():
+            self.repository.replace_explicit_permissions(target.id, permissions)
         self._append_audit(
             actor_type="employee",
             actor_account=actor.account,
@@ -280,7 +435,7 @@ class EmployeeAuthService:
             target_id=target.id,
             permission_code=None,
             outcome="success",
-            metadata={"permissions": sorted(permissions)},
+            metadata={"added": added, "removed": removed},
         )
         return target
 
@@ -291,19 +446,19 @@ class EmployeeAuthService:
         target = self._require_account(target_account_id)
         next_role = validate_role(new_role)
         self._assert_can_manage_role(actor, next_role)
-        self._assert_can_manage_existing_account(actor, target)
-        if target.role == "SUPERADMIN" and next_role != "SUPERADMIN":
-            self._assert_not_last_active_superadmin(target)
+        self._assert_can_mutate_account(actor, target)
         updated = replace(
             target,
             role=next_role,
             updated_at=self._now(),
         )
-        self.repository.update_account(updated)
         current_permissions = self.repository.get_explicit_permissions(target.id)
-        self.repository.set_explicit_permissions(
-            target.id, set(effective_permissions(next_role, current_permissions))
-        )
+        pruned_permissions = set(effective_permissions(next_role, current_permissions))
+        with self.repository.immediate_transaction():
+            if target.role == "SUPERADMIN" and next_role != "SUPERADMIN":
+                self._assert_not_last_active_superadmin(target)
+            self.repository.update_account(updated)
+            self.repository.replace_explicit_permissions(target.id, pruned_permissions)
         self._append_audit(
             actor_type="employee",
             actor_account=actor.account,
@@ -322,9 +477,7 @@ class EmployeeAuthService:
     ) -> EmployeeAccount:
         self._assert_permission(actor, "users.deactivate")
         target = self._require_account(target_account_id)
-        self._assert_can_manage_existing_account(actor, target)
-        if target.role == "SUPERADMIN":
-            self._assert_not_last_active_superadmin(target)
+        self._assert_can_mutate_account(actor, target)
         now = self._now()
         updated = replace(
             target,
@@ -333,10 +486,13 @@ class EmployeeAuthService:
             deactivated_at=now,
             auth_version=target.auth_version + 1,
         )
-        self.repository.update_account(updated)
-        self.repository.revoke_sessions_for_account(
-            target.id, revoked_at=now, reason="account_deactivated"
-        )
+        with self.repository.immediate_transaction():
+            if target.role == "SUPERADMIN":
+                self._assert_not_last_active_superadmin(target)
+            self.repository.update_account(updated)
+            self.repository.revoke_sessions_for_account(
+                target.id, revoked_at=now, reason="account_deactivated"
+            )
         self._append_audit(
             actor_type="employee",
             actor_account=actor.account,
@@ -355,7 +511,7 @@ class EmployeeAuthService:
     ) -> EmployeeAccount:
         self._assert_permission(actor, "users.reactivate")
         target = self._require_account(target_account_id)
-        self._assert_can_manage_existing_account(actor, target)
+        self._assert_can_mutate_account(actor, target)
         updated = replace(
             target,
             is_active=True,
@@ -563,7 +719,7 @@ class EmployeeAuthService:
         actor_type: ActorType
         if actor is not None:
             self._assert_permission(actor, "users.password.reset")
-            self._assert_can_manage_existing_account(actor, target)
+            self._assert_can_mutate_account(actor, target)
             actor_type = "employee"
             actor_account = actor.account
             session_id = actor.session.id
@@ -655,8 +811,84 @@ class EmployeeAuthService:
     def _require_account(self, account_id: str) -> EmployeeAccount:
         account = self.repository.get_account_by_id(account_id)
         if account is None:
-            raise ValueError(f"unknown account_id {account_id!r}")
+            raise AccountNotFoundError(f"unknown account_id {account_id!r}")
         return account
+
+    def _require_visible_account(self, account_id: str) -> EmployeeAccount:
+        account = self._require_account(account_id)
+        return account
+
+    def _account_is_read_only(
+        self, actor: AuthenticatedEmployee, target: EmployeeAccount
+    ) -> bool:
+        return actor.account.role == "ADMIN" and target.role in ("ADMIN", "SUPERADMIN")
+
+    def _account_summary(
+        self, actor: AuthenticatedEmployee, account: EmployeeAccount
+    ) -> EmployeeAccountSummary:
+        return EmployeeAccountSummary(
+            id=account.id,
+            username=account.username,
+            email=account.email,
+            display_name=account.display_name,
+            role=account.role,
+            is_active=account.is_active,
+            must_change_password=account.must_change_password,
+            created_at=account.created_at,
+            updated_at=account.updated_at,
+            deactivated_at=account.deactivated_at,
+            last_login_at=account.last_login_at,
+            read_only=self._account_is_read_only(actor, account),
+        )
+
+    def _account_detail(
+        self,
+        actor: AuthenticatedEmployee,
+        account: EmployeeAccount,
+        explicit_permissions: set[str],
+    ) -> EmployeeAccountDetail:
+        summary = self._account_summary(actor, account)
+        return EmployeeAccountDetail(
+            id=summary.id,
+            username=summary.username,
+            email=summary.email,
+            display_name=summary.display_name,
+            role=summary.role,
+            is_active=summary.is_active,
+            must_change_password=summary.must_change_password,
+            created_at=summary.created_at,
+            updated_at=summary.updated_at,
+            deactivated_at=summary.deactivated_at,
+            last_login_at=summary.last_login_at,
+            read_only=summary.read_only,
+            explicit_permissions=frozenset(explicit_permissions),
+            effective_permissions=effective_permissions(
+                account.role, explicit_permissions
+            ),
+        )
+
+    def _audit_event_view(self, event: SecurityAuditEvent) -> SecurityAuditEventView:
+        metadata = json.loads(event.metadata_json)
+        return SecurityAuditEventView(
+            event_id=event.event_id,
+            occurred_at=event.occurred_at,
+            actor_account_id=event.actor_account_id,
+            actor_display_name_snapshot=event.actor_display_name_snapshot,
+            actor_role_snapshot=event.actor_role_snapshot,
+            action=event.action,
+            target_type=event.target_type,
+            target_id=event.target_id,
+            permission_code=event.permission_code,
+            outcome=event.outcome,
+            metadata=metadata,
+        )
+
+    def _assert_can_mutate_account(
+        self, actor: AuthenticatedEmployee, target: EmployeeAccount
+    ) -> None:
+        if self._account_is_read_only(actor, target):
+            raise AuthorizationError(f"ADMIN may not manage {target.role} accounts")
+        self._assert_can_manage_existing_account(actor, target)
 
     def _require_account_by_username(self, username: str) -> EmployeeAccount:
         account = self.repository.get_account_by_username(normalize_username(username))
@@ -675,9 +907,9 @@ class EmployeeAuthService:
     def _assert_can_manage_existing_account(
         self, actor: AuthenticatedEmployee, target: EmployeeAccount
     ) -> None:
+        if actor.account.role == "ADMIN" and target.role in ("ADMIN", "SUPERADMIN"):
+            raise AuthorizationError(f"ADMIN may not manage {target.role} accounts")
         self._assert_can_manage_role(actor, target.role)
-        if actor.account.role == "ADMIN" and target.role == "SUPERADMIN":
-            raise AuthorizationError("ADMIN may not manage SUPERADMIN accounts")
 
     def _assert_permission(
         self, actor: AuthenticatedEmployee, permission_code: str

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -78,6 +78,8 @@ class AccountConflictError(Exception):
 
 
 _TEMPORARY_PASSWORD_BYTES = 12
+_ACCOUNT_AUDIT_LIST_DEFAULT_LIMIT = 100
+_ACCOUNT_AUDIT_LIST_MAX_LIMIT = 500
 
 
 def _utc_now() -> datetime:
@@ -260,19 +262,19 @@ class EmployeeAuthService:
             with self.repository.immediate_transaction():
                 self.repository.add_account(account)
                 self.repository.set_explicit_permissions(account.id, permissions)
+                self._append_audit(
+                    actor_type="employee",
+                    actor_account=actor.account,
+                    session_id=actor.session.id,
+                    action="auth.account_created",
+                    target_type="employee_account",
+                    target_id=account.id,
+                    permission_code=None,
+                    outcome="success",
+                    metadata={"role": account.role, "username": account.username},
+                )
         except sqlite3.IntegrityError as exc:
             raise AccountConflictError("username or email already exists") from exc
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.account_created",
-            target_type="employee_account",
-            target_id=account.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"role": account.role, "username": account.username},
-        )
         return account
 
     def list_accounts(
@@ -331,30 +333,46 @@ class EmployeeAuthService:
         try:
             with self.repository.immediate_transaction():
                 self.repository.update_account(updated)
+                self._append_audit(
+                    actor_type="employee",
+                    actor_account=actor.account,
+                    session_id=actor.session.id,
+                    action="auth.account_profile_updated",
+                    target_type="employee_account",
+                    target_id=target.id,
+                    permission_code=None,
+                    outcome="success",
+                    metadata={"changes": changes},
+                )
         except sqlite3.IntegrityError as exc:
             raise AccountConflictError("username or email already exists") from exc
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.account_profile_updated",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"changes": changes},
-        )
         explicit = self.repository.get_explicit_permissions(updated.id)
         return self._account_detail(actor, updated, explicit)
 
     def list_account_audit_events(
-        self, actor: AuthenticatedEmployee, target_account_id: str
+        self,
+        actor: AuthenticatedEmployee,
+        target_account_id: str,
+        *,
+        limit: int | None = None,
     ) -> list[SecurityAuditEventView]:
+        """Return employee-account audit events oldest-first, bounded by limit."""
         self._assert_permission(actor, "audit.view")
         target = self._require_visible_account(target_account_id)
+        resolved_limit = _ACCOUNT_AUDIT_LIST_DEFAULT_LIMIT if limit is None else limit
+        if (
+            not isinstance(resolved_limit, int)
+            or resolved_limit < 1
+            or resolved_limit > _ACCOUNT_AUDIT_LIST_MAX_LIMIT
+        ):
+            raise ValueError(
+                f"limit must be between 1 and {_ACCOUNT_AUDIT_LIST_MAX_LIMIT}"
+            )
         return [
             self._audit_event_view(event)
-            for event in self.repository.list_audit_events_for_account(target.id)
+            for event in self.repository.list_audit_events_for_account(
+                target.id, limit=resolved_limit
+            )
         ]
 
     def reset_account_password(
@@ -388,17 +406,17 @@ class EmployeeAuthService:
             self.repository.revoke_sessions_for_account(
                 target.id, revoked_at=now, reason="password_reset"
             )
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.password_reset",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"username": target.username, "generated": generated},
-        )
+            self._append_audit(
+                actor_type="employee",
+                actor_account=actor.account,
+                session_id=actor.session.id,
+                action="auth.password_reset",
+                target_type="employee_account",
+                target_id=target.id,
+                permission_code=None,
+                outcome="success",
+                metadata={"username": target.username, "generated": generated},
+            )
         return PasswordResetResult(
             account=updated,
             temporary_password=resolved_password if generated else None,
@@ -426,17 +444,17 @@ class EmployeeAuthService:
         removed = sorted(previous.difference(permissions))
         with self.repository.immediate_transaction():
             self.repository.replace_explicit_permissions(target.id, permissions)
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.permission_changed",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"added": added, "removed": removed},
-        )
+            self._append_audit(
+                actor_type="employee",
+                actor_account=actor.account,
+                session_id=actor.session.id,
+                action="auth.permission_changed",
+                target_type="employee_account",
+                target_id=target.id,
+                permission_code=None,
+                outcome="success",
+                metadata={"added": added, "removed": removed},
+            )
         return target
 
     def change_account_role(
@@ -454,22 +472,27 @@ class EmployeeAuthService:
         )
         current_permissions = self.repository.get_explicit_permissions(target.id)
         pruned_permissions = set(effective_permissions(next_role, current_permissions))
+        removed_by_ceiling = sorted(current_permissions.difference(pruned_permissions))
         with self.repository.immediate_transaction():
             if target.role == "SUPERADMIN" and next_role != "SUPERADMIN":
                 self._assert_not_last_active_superadmin(target)
             self.repository.update_account(updated)
             self.repository.replace_explicit_permissions(target.id, pruned_permissions)
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.role_changed",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"role": next_role},
-        )
+            self._append_audit(
+                actor_type="employee",
+                actor_account=actor.account,
+                session_id=actor.session.id,
+                action="auth.role_changed",
+                target_type="employee_account",
+                target_id=target.id,
+                permission_code=None,
+                outcome="success",
+                metadata={
+                    "old_role": target.role,
+                    "new_role": next_role,
+                    "removed_permission_codes": removed_by_ceiling,
+                },
+            )
         return updated
 
     def deactivate_account(
@@ -493,17 +516,17 @@ class EmployeeAuthService:
             self.repository.revoke_sessions_for_account(
                 target.id, revoked_at=now, reason="account_deactivated"
             )
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.account_deactivated",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"username": target.username},
-        )
+            self._append_audit(
+                actor_type="employee",
+                actor_account=actor.account,
+                session_id=actor.session.id,
+                action="auth.account_deactivated",
+                target_type="employee_account",
+                target_id=target.id,
+                permission_code=None,
+                outcome="success",
+                metadata={"username": target.username},
+            )
         return updated
 
     def reactivate_account(
@@ -518,18 +541,19 @@ class EmployeeAuthService:
             updated_at=self._now(),
             deactivated_at=None,
         )
-        self.repository.update_account(updated)
-        self._append_audit(
-            actor_type="employee",
-            actor_account=actor.account,
-            session_id=actor.session.id,
-            action="auth.account_reactivated",
-            target_type="employee_account",
-            target_id=target.id,
-            permission_code=None,
-            outcome="success",
-            metadata={"username": target.username},
-        )
+        with self.repository.immediate_transaction():
+            self.repository.update_account(updated)
+            self._append_audit(
+                actor_type="employee",
+                actor_account=actor.account,
+                session_id=actor.session.id,
+                action="auth.account_reactivated",
+                target_type="employee_account",
+                target_id=target.id,
+                permission_code=None,
+                outcome="success",
+                metadata={"username": target.username},
+            )
         return updated
 
     def authenticate(self, *, username: str, password: str) -> SessionLoginResult:

--- a/src/catering_system/ui/employee_auth_account_api.py
+++ b/src/catering_system/ui/employee_auth_account_api.py
@@ -1,0 +1,349 @@
+"""Account-management HTTP routes for AUTH_RBAC_V1 (AUTH-2B)."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from catering_system.domain.employee_auth import (
+    EmployeeAccountDetail,
+    EmployeeAccountSummary,
+    SecurityAuditEventView,
+)
+from catering_system.services.employee_auth_service import (
+    AccountConflictError,
+    AccountNotFoundError,
+    AuthenticationError,
+    AuthorizationError,
+    CsrfValidationError,
+    EmployeeAuthService,
+    LastActiveSuperadminError,
+)
+
+
+def _reject_unknown_keys(body: dict[str, object], allowed: set[str]) -> None:
+    unknown = set(body).difference(allowed)
+    if unknown:
+        raise ValueError(f"unknown fields: {sorted(unknown)}")
+
+
+def parse_accounts_route(path: str) -> tuple[str, str | None, str | None]:
+    if path == "/auth/accounts":
+        return ("collection", None, None)
+    prefix = "/auth/accounts/"
+    if not path.startswith(prefix):
+        return ("", None, None)
+    remainder = path[len(prefix) :]
+    if not remainder:
+        return ("", None, None)
+    parts = remainder.split("/")
+    account_id = parts[0]
+    action = parts[1] if len(parts) > 1 else None
+    if len(parts) > 2:
+        raise ValueError("invalid account route")
+    return ("member", account_id, action)
+
+
+def account_summary_json(summary: EmployeeAccountSummary) -> dict[str, object]:
+    return {
+        "id": summary.id,
+        "username": summary.username,
+        "email": summary.email,
+        "display_name": summary.display_name,
+        "role": summary.role,
+        "is_active": summary.is_active,
+        "must_change_password": summary.must_change_password,
+        "created_at": summary.created_at.isoformat(),
+        "updated_at": summary.updated_at.isoformat(),
+        "deactivated_at": (
+            summary.deactivated_at.isoformat() if summary.deactivated_at else None
+        ),
+        "last_login_at": (
+            summary.last_login_at.isoformat() if summary.last_login_at else None
+        ),
+        "read_only": summary.read_only,
+    }
+
+
+def account_detail_json(detail: EmployeeAccountDetail) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": detail.id,
+        "username": detail.username,
+        "email": detail.email,
+        "display_name": detail.display_name,
+        "role": detail.role,
+        "is_active": detail.is_active,
+        "must_change_password": detail.must_change_password,
+        "created_at": detail.created_at.isoformat(),
+        "updated_at": detail.updated_at.isoformat(),
+        "deactivated_at": (
+            detail.deactivated_at.isoformat() if detail.deactivated_at else None
+        ),
+        "last_login_at": (
+            detail.last_login_at.isoformat() if detail.last_login_at else None
+        ),
+        "read_only": detail.read_only,
+    }
+    payload["explicit_permissions"] = sorted(detail.explicit_permissions)
+    payload["effective_permissions"] = sorted(detail.effective_permissions)
+    return payload
+
+
+def audit_event_json(event: SecurityAuditEventView) -> dict[str, object]:
+    return {
+        "event_id": event.event_id,
+        "occurred_at": event.occurred_at.isoformat(),
+        "actor_account_id": event.actor_account_id,
+        "actor_display_name_snapshot": event.actor_display_name_snapshot,
+        "actor_role_snapshot": event.actor_role_snapshot,
+        "action": event.action,
+        "target_type": event.target_type,
+        "target_id": event.target_id,
+        "permission_code": event.permission_code,
+        "outcome": event.outcome,
+        "metadata": event.metadata,
+    }
+
+
+def handle_accounts_get(
+    service: EmployeeAuthService,
+    *,
+    route_kind: str,
+    account_id: str | None,
+    action: str | None,
+    employee,
+) -> tuple[int, dict[str, object]]:
+    if route_kind == "collection":
+        accounts = service.list_accounts(employee)
+        return 200, {"accounts": [account_summary_json(item) for item in accounts]}
+    if route_kind != "member" or account_id is None:
+        return 404, {"error": "not_found"}
+    if action == "audit-events":
+        events = service.list_account_audit_events(employee, account_id)
+        return 200, {"events": [audit_event_json(item) for item in events]}
+    if action is not None:
+        return 404, {"error": "not_found"}
+    detail = service.get_account(employee, account_id)
+    return 200, {"account": account_detail_json(detail)}
+
+
+def handle_accounts_post(
+    service: EmployeeAuthService,
+    *,
+    route_kind: str,
+    account_id: str | None,
+    action: str | None,
+    employee,
+    body: dict[str, object],
+) -> tuple[int, dict[str, object]]:
+    if route_kind == "collection":
+        _reject_unknown_keys(
+            body,
+            {
+                "username",
+                "display_name",
+                "email",
+                "role",
+                "temporary_password",
+                "permissions",
+                "is_active",
+            },
+        )
+        if body.get("is_active") is False:
+            raise ValueError("is_active must be true for new accounts")
+        permissions_raw = body.get("permissions")
+        permissions = None
+        if permissions_raw is not None:
+            if not isinstance(permissions_raw, list):
+                raise ValueError("permissions must be a list")
+            permissions = {str(item) for item in permissions_raw}
+        email_value: str | None
+        if "email" in body:
+            email_value = str(body["email"]) if body["email"] is not None else None
+        else:
+            email_value = None
+        account = service.create_account(
+            employee,
+            username=str(body.get("username", "")),
+            display_name=str(body.get("display_name", "")),
+            password=str(body.get("temporary_password", "")),
+            role=str(body.get("role", "")),
+            email=email_value,
+            explicit_permissions=permissions,
+            must_change_password=True,
+        )
+        detail = service.get_account(employee, account.id)
+        return 201, {"account": account_detail_json(detail)}
+
+    if route_kind != "member" or account_id is None or action is None:
+        return 404, {"error": "not_found"}
+
+    if action == "role":
+        _reject_unknown_keys(body, {"role"})
+        updated = service.change_account_role(
+            employee, account_id, str(body.get("role", ""))
+        )
+        detail = service.get_account(employee, updated.id)
+        return 200, {"account": account_detail_json(detail)}
+
+    if action == "deactivate":
+        _reject_unknown_keys(body, set())
+        updated = service.deactivate_account(employee, account_id)
+        detail = service.get_account(employee, updated.id)
+        return 200, {"account": account_detail_json(detail)}
+
+    if action == "reactivate":
+        _reject_unknown_keys(body, set())
+        updated = service.reactivate_account(employee, account_id)
+        detail = service.get_account(employee, updated.id)
+        return 200, {"account": account_detail_json(detail)}
+
+    if action == "reset-password":
+        _reject_unknown_keys(body, {"temporary_password"})
+        temporary_password = body.get("temporary_password")
+        if temporary_password is not None and not isinstance(temporary_password, str):
+            raise ValueError("temporary_password must be a string")
+        result = service.reset_account_password(
+            employee,
+            account_id,
+            temporary_password=(
+                str(temporary_password) if temporary_password is not None else None
+            ),
+        )
+        detail = service.get_account(employee, result.account.id)
+        payload: dict[str, object] = {"account": account_detail_json(detail)}
+        if result.temporary_password is not None:
+            payload["temporary_password"] = result.temporary_password
+        return 200, payload
+
+    return 404, {"error": "not_found"}
+
+
+def handle_accounts_patch(
+    service: EmployeeAuthService,
+    *,
+    account_id: str | None,
+    action: str | None,
+    employee,
+    body: dict[str, object],
+) -> tuple[int, dict[str, object]]:
+    if account_id is None or action is not None:
+        return 404, {"error": "not_found"}
+    _reject_unknown_keys(body, {"username", "display_name", "email"})
+    username = str(body["username"]) if "username" in body else None
+    display_name = str(body["display_name"]) if "display_name" in body else None
+    if "email" in body:
+        detail = service.update_account_profile(
+            employee,
+            account_id,
+            username=username,
+            display_name=display_name,
+            email=body["email"],
+        )
+    else:
+        detail = service.update_account_profile(
+            employee,
+            account_id,
+            username=username,
+            display_name=display_name,
+        )
+    return 200, {"account": account_detail_json(detail)}
+
+
+def handle_accounts_put(
+    service: EmployeeAuthService,
+    *,
+    account_id: str | None,
+    action: str | None,
+    employee,
+    body: dict[str, object],
+) -> tuple[int, dict[str, object]]:
+    if account_id is None or action != "permissions":
+        return 404, {"error": "not_found"}
+    _reject_unknown_keys(body, {"permissions"})
+    permissions_raw = body.get("permissions")
+    if not isinstance(permissions_raw, list):
+        raise ValueError("permissions must be a list")
+    permissions = {str(item) for item in permissions_raw}
+    service.set_account_permissions(employee, account_id, permissions)
+    detail = service.get_account(employee, account_id)
+    return 200, {"account": account_detail_json(detail)}
+
+
+def map_account_management_error(exc: Exception) -> tuple[int, str]:
+    if isinstance(exc, CsrfValidationError):
+        return 403, "forbidden"
+    if isinstance(exc, AuthenticationError):
+        return 401, "unauthorized"
+    if isinstance(exc, AuthorizationError):
+        return 403, "forbidden"
+    if isinstance(exc, AccountNotFoundError):
+        return 404, "not_found"
+    if isinstance(exc, AccountConflictError):
+        return 409, "conflict"
+    if isinstance(exc, LastActiveSuperadminError):
+        return 409, "last_active_superadmin"
+    if isinstance(exc, ValueError):
+        return 400, "invalid_request"
+    return 500, "internal_error"
+
+
+def dispatch_account_route(
+    service: EmployeeAuthService,
+    *,
+    method: str,
+    path: str,
+    employee,
+    body: dict[str, object] | None,
+    respond: Callable[[int, dict[str, object]], None],
+) -> bool:
+    route_kind, account_id, action = parse_accounts_route(path)
+    if route_kind == "":
+        return False
+    try:
+        if method == "GET":
+            status, payload = handle_accounts_get(
+                service,
+                route_kind=route_kind,
+                account_id=account_id,
+                action=action,
+                employee=employee,
+            )
+        elif method == "POST":
+            assert body is not None
+            status, payload = handle_accounts_post(
+                service,
+                route_kind=route_kind,
+                account_id=account_id,
+                action=action,
+                employee=employee,
+                body=body,
+            )
+        elif method == "PATCH":
+            assert body is not None
+            status, payload = handle_accounts_patch(
+                service,
+                account_id=account_id,
+                action=action,
+                employee=employee,
+                body=body,
+            )
+        elif method == "PUT":
+            assert body is not None
+            status, payload = handle_accounts_put(
+                service,
+                account_id=account_id,
+                action=action,
+                employee=employee,
+                body=body,
+            )
+        else:
+            return False
+    except Exception as exc:  # noqa: BLE001
+        status, code = map_account_management_error(exc)
+        payload = {"error": code}
+        if status == 400 and isinstance(exc, ValueError):
+            payload["message"] = str(exc)
+        respond(status, payload)
+        return True
+    respond(status, payload)
+    return True

--- a/src/catering_system/ui/employee_auth_account_api.py
+++ b/src/catering_system/ui/employee_auth_account_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Callable
+from urllib.parse import parse_qs
 
 from catering_system.domain.employee_auth import (
     EmployeeAccountDetail,
@@ -18,6 +19,9 @@ from catering_system.services.employee_auth_service import (
     EmployeeAuthService,
     LastActiveSuperadminError,
 )
+
+_ACCOUNT_AUDIT_LIST_DEFAULT_LIMIT = 100
+_ACCOUNT_AUDIT_LIST_MAX_LIMIT = 500
 
 
 def _reject_unknown_keys(body: dict[str, object], allowed: set[str]) -> None:
@@ -104,6 +108,26 @@ def audit_event_json(event: SecurityAuditEventView) -> dict[str, object]:
     }
 
 
+def _parse_audit_events_limit(query: str) -> int | None:
+    if not query:
+        return None
+    params = parse_qs(query, keep_blank_values=True)
+    if "limit" not in params:
+        return None
+    raw_values = params["limit"]
+    if len(raw_values) != 1 or not raw_values[0].strip():
+        raise ValueError(f"limit must be between 1 and {_ACCOUNT_AUDIT_LIST_MAX_LIMIT}")
+    try:
+        limit = int(raw_values[0])
+    except ValueError as exc:
+        raise ValueError(
+            f"limit must be between 1 and {_ACCOUNT_AUDIT_LIST_MAX_LIMIT}"
+        ) from exc
+    if limit < 1 or limit > _ACCOUNT_AUDIT_LIST_MAX_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_ACCOUNT_AUDIT_LIST_MAX_LIMIT}")
+    return limit
+
+
 def handle_accounts_get(
     service: EmployeeAuthService,
     *,
@@ -111,6 +135,7 @@ def handle_accounts_get(
     account_id: str | None,
     action: str | None,
     employee,
+    query: str = "",
 ) -> tuple[int, dict[str, object]]:
     if route_kind == "collection":
         accounts = service.list_accounts(employee)
@@ -118,7 +143,8 @@ def handle_accounts_get(
     if route_kind != "member" or account_id is None:
         return 404, {"error": "not_found"}
     if action == "audit-events":
-        events = service.list_account_audit_events(employee, account_id)
+        limit = _parse_audit_events_limit(query)
+        events = service.list_account_audit_events(employee, account_id, limit=limit)
         return 200, {"events": [audit_event_json(item) for item in events]}
     if action is not None:
         return 404, {"error": "not_found"}
@@ -295,6 +321,7 @@ def dispatch_account_route(
     employee,
     body: dict[str, object] | None,
     respond: Callable[[int, dict[str, object]], None],
+    query: str = "",
 ) -> bool:
     route_kind, account_id, action = parse_accounts_route(path)
     if route_kind == "":
@@ -307,6 +334,7 @@ def dispatch_account_route(
                 account_id=account_id,
                 action=action,
                 employee=employee,
+                query=query,
             )
         elif method == "POST":
             assert body is not None

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -9,13 +9,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
-from catering_system.repositories.bootstrap_employee_auth_schema import (
-    bootstrap_employee_auth_schema,
-)
-from catering_system.repositories.core_transaction import open_core_connection
 from catering_system.repositories.sqlite_employee_auth_repository import (
     SQLiteEmployeeAuthRepository,
 )
@@ -37,6 +34,12 @@ from catering_system.ui.employee_auth_http import (
 )
 
 _MAX_BODY_BYTES = 16 * 1024
+
+
+class EmployeeAuthHTTPServer(HTTPServer):
+    request_lock: threading.RLock
+    auth_repository: SQLiteEmployeeAuthRepository
+    auth_service: EmployeeAuthService
 
 
 def _read_service_tokens_from_env() -> dict[str, str]:
@@ -68,6 +71,14 @@ def make_employee_auth_handler(
 ) -> type[BaseHTTPRequestHandler]:
     class EmployeeAuthHandler(BaseHTTPRequestHandler):
         server_version = "EmployeeAuth/1.0"
+
+        def handle(self) -> None:
+            lock = getattr(self.server, "request_lock", None)
+            if lock is None:
+                super().handle()
+                return
+            with lock:
+                super().handle()
 
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002
             pass
@@ -353,18 +364,29 @@ def create_employee_auth_server(
     port: int = 8085,
     secure_cookie: bool = True,
     service_tokens: dict[str, str] | None = None,
-) -> HTTPServer:
-    connection = open_core_connection(db_path)
-    bootstrap_employee_auth_schema(connection)
-    repository = SQLiteEmployeeAuthRepository.from_connection(connection)
+) -> EmployeeAuthHTTPServer:
+    """Create the employee-auth HTTP server with a managed repository.
+
+    The server owns one transaction-capable SQLite connection. Request handling
+    is serialized through ``server.request_lock`` so nested repository
+    transaction depth remains safe if the server is ever run with a threading
+    HTTP mixin.
+    """
+    resolved_path = Path(db_path)
+    repository = SQLiteEmployeeAuthRepository(resolved_path)
+    repository._conn.execute("PRAGMA busy_timeout = 2000")
     service = EmployeeAuthService(
         repository,
         service_tokens=service_tokens,
     )
-    return HTTPServer(
+    server = EmployeeAuthHTTPServer(
         (host, port),
         make_employee_auth_handler(service, secure_cookie=secure_cookie),
     )
+    server.request_lock = threading.RLock()
+    server.auth_repository = repository
+    server.auth_service = service
+    return server
 
 
 def main() -> None:

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -21,8 +21,13 @@ from catering_system.repositories.sqlite_employee_auth_repository import (
 )
 from catering_system.services.employee_auth_service import (
     AuthenticationError,
+    AuthorizationError,
     CsrfValidationError,
     EmployeeAuthService,
+)
+from catering_system.ui.employee_auth_account_api import (
+    dispatch_account_route,
+    parse_accounts_route,
 )
 from catering_system.ui.employee_auth_http import (
     bearer_token_from_headers,
@@ -118,11 +123,49 @@ def make_employee_auth_handler(
                 raise AuthenticationError("missing session")
             return service.authenticate_session(session_token)
 
+        def _employee_with_access(self):
+            employee = self._employee()
+            if not employee.application_access_allowed:
+                raise AuthorizationError("password change required")
+            return employee
+
         def _csrf(self, employee) -> None:
             token = self.headers.get("X-CSRF-Token", "")
             service.validate_csrf(employee.session, token)
 
+        def _dispatch_accounts(self, *, method: str, body: dict[str, object] | None):
+            try:
+                employee = self._employee_with_access()
+            except CsrfValidationError:
+                self._json(403, {"error": "forbidden"})
+                return
+            except AuthorizationError:
+                self._json(403, {"error": "forbidden"})
+                return
+            except AuthenticationError:
+                self._json(401, {"error": "unauthorized"})
+                return
+            if method != "GET":
+                try:
+                    self._csrf(employee)
+                except CsrfValidationError:
+                    self._json(403, {"error": "forbidden"})
+                    return
+            handled = dispatch_account_route(
+                service,
+                method=method,
+                path=self.path.split("?", 1)[0],
+                employee=employee,
+                body=body,
+                respond=lambda status, payload: self._json(status, payload),
+            )
+            if not handled:
+                self.send_error(404)
+
         def do_GET(self) -> None:  # noqa: N802
+            if parse_accounts_route(self.path.split("?", 1)[0])[0]:
+                self._dispatch_accounts(method="GET", body=None)
+                return
             if self.path == "/auth/me":
                 try:
                     employee = self._employee()
@@ -181,6 +224,14 @@ def make_employee_auth_handler(
             self.send_error(404)
 
         def do_POST(self) -> None:  # noqa: N802
+            if parse_accounts_route(self.path.split("?", 1)[0])[0]:
+                try:
+                    body = self._read_json_body()
+                except ValueError:
+                    self._json(400, {"error": "invalid_request"})
+                    return
+                self._dispatch_accounts(method="POST", body=body)
+                return
             if self.path == "/auth/login":
                 try:
                     body = self._read_json_body()
@@ -269,8 +320,27 @@ def make_employee_auth_handler(
                 return
             self.send_error(404)
 
-        do_PUT = do_POST
-        do_PATCH = do_POST
+        def do_PUT(self) -> None:  # noqa: N802
+            if parse_accounts_route(self.path.split("?", 1)[0])[0]:
+                try:
+                    body = self._read_json_body()
+                except ValueError:
+                    self._json(400, {"error": "invalid_request"})
+                    return
+                self._dispatch_accounts(method="PUT", body=body)
+                return
+            self.send_error(404)
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            if parse_accounts_route(self.path.split("?", 1)[0])[0]:
+                try:
+                    body = self._read_json_body()
+                except ValueError:
+                    self._json(400, {"error": "invalid_request"})
+                    return
+                self._dispatch_accounts(method="PATCH", body=body)
+                return
+            self.send_error(404)
 
     return EmployeeAuthHandler
 

--- a/src/catering_system/ui/employee_auth_api.py
+++ b/src/catering_system/ui/employee_auth_api.py
@@ -158,6 +158,7 @@ def make_employee_auth_handler(
                 employee=employee,
                 body=body,
                 respond=lambda status, payload: self._json(status, payload),
+                query=self.path.split("?", 1)[1] if "?" in self.path else "",
             )
             if not handled:
                 self.send_error(404)

--- a/tests/unit/test_employee_auth_accounts_api.py
+++ b/tests/unit/test_employee_auth_accounts_api.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+
+
+def _seed(db: Path) -> None:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(
+        repo,
+        now=lambda: datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "accounts-api"},
+    )
+    repo.close()
+
+
+def _start_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.employee_auth_api import create_employee_auth_server
+
+        server = create_employee_auth_server(
+            db,
+            host="127.0.0.1",
+            port=0,
+            secure_cookie=False,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+@pytest.fixture()
+def auth_api(tmp_path: Path):
+    db = tmp_path / "core.db"
+    _seed(db)
+    server, thread, base = _start_server(db)
+    yield base
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    if body is not None and "Content-Type" not in (headers or {}):
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            parsed = json.loads(raw) if raw else {}
+            return response.status, parsed, dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed, dict(exc.headers)
+
+
+def _login_ready(base: str, *, username: str, password: str) -> tuple[str, str]:
+    status, body, headers = _request(
+        f"{base}/auth/login",
+        method="POST",
+        body={"username": username, "password": password},
+    )
+    assert status == 200
+    cookie = headers["Set-Cookie"]
+    csrf = str(body["csrf_token"])
+    status, _body, _headers = _request(
+        f"{base}/auth/password/change",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"current_password": password, "new_password": "ChangedTemp1!"},
+    )
+    assert status == 204
+    status, body, headers = _request(
+        f"{base}/auth/login",
+        method="POST",
+        body={"username": username, "password": "ChangedTemp1!"},
+    )
+    assert status == 200
+    return headers["Set-Cookie"], str(body["csrf_token"])
+
+
+@pytest.fixture()
+def superadmin_session(auth_api: str):
+    return _login_ready(auth_api, username="super.admin", password="TempPassw0rd!")
+
+
+def test_unauthenticated_accounts_request_returns_401(auth_api: str) -> None:
+    status, body, _headers = _request(f"{auth_api}/auth/accounts")
+    assert status == 401
+    assert body["error"] == "unauthorized"
+
+
+def test_superadmin_can_list_and_create_accounts(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    assert body["accounts"]
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": "worker.api",
+            "display_name": "Worker API",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+    )
+    assert status == 201
+    assert body["account"]["username"] == "worker.api"
+
+
+def test_unknown_json_key_rejected(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": "worker.unknown",
+            "display_name": "Worker Unknown",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+            "unexpected": True,
+        },
+    )
+    assert status == 400
+    assert body["error"] == "invalid_request"
+
+
+def test_csrf_missing_and_cross_session_return_403(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, _csrf = superadmin_session
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie},
+        body={
+            "username": "worker.csrf",
+            "display_name": "Worker CSRF",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+    )
+    assert status == 403
+    assert body["error"] == "forbidden"
+
+    _status, _body, headers_b = _request(
+        f"{auth_api}/auth/login",
+        method="POST",
+        body={"username": "super.admin", "password": "ChangedTemp1!"},
+    )
+    cookie_b = headers_b["Set-Cookie"]
+    csrf_a = superadmin_session[1]
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie_b, "X-CSRF-Token": csrf_a},
+        body={
+            "username": "worker.cross",
+            "display_name": "Worker Cross",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+    )
+    assert status == 403
+    assert body["error"] == "forbidden"
+
+
+def test_account_detail_permissions_role_and_reset_password_flow(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, created, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": "worker.flow",
+            "display_name": "Worker Flow",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+            "permissions": ["offers.prepare", "offers.view"],
+        },
+    )
+    assert status == 201
+    account_id = str(created["account"]["id"])
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    assert "offers.prepare" in body["account"]["effective_permissions"]
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}",
+        method="PATCH",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"display_name": "Worker Flow Updated"},
+    )
+    assert status == 200
+    assert body["account"]["display_name"] == "Worker Flow Updated"
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/role",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"role": "VIEWER"},
+    )
+    assert status == 200
+    assert body["account"]["role"] == "VIEWER"
+    assert body["account"]["effective_permissions"] == ["offers.view"]
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/permissions",
+        method="PUT",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"permissions": ["inquiries.view", "offers.view"]},
+    )
+    assert status == 200
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/reset-password",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={},
+    )
+    assert status == 200
+    assert body["account"]["must_change_password"] is True
+    assert "temporary_password" in body
+    assert "WorkerTemp1!" not in json.dumps(body)
+
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/audit-events",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    assert body["events"]
+
+
+def test_admin_cannot_create_admin_via_api(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, _body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": "team.admin",
+            "display_name": "Team Admin",
+            "role": "ADMIN",
+            "temporary_password": "AdminTemp1!",
+        },
+    )
+    assert status == 201
+    admin_cookie, admin_csrf = _login_ready(
+        auth_api, username="team.admin", password="AdminTemp1!"
+    )
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": admin_cookie, "X-CSRF-Token": admin_csrf},
+        body={
+            "username": "blocked.admin",
+            "display_name": "Blocked Admin",
+            "role": "ADMIN",
+            "temporary_password": "BlockedTemp1!",
+        },
+    )
+    assert status == 403
+    assert body["error"] == "forbidden"
+
+
+def test_last_active_superadmin_conflict_via_api(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, me, _headers = _request(
+        f"{auth_api}/auth/me",
+        headers={"Cookie": cookie},
+    )
+    assert status == 200
+    account_id = str(me["account"]["id"])
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/deactivate",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={},
+    )
+    assert status == 409
+    assert body["error"] == "last_active_superadmin"

--- a/tests/unit/test_employee_auth_accounts_api.py
+++ b/tests/unit/test_employee_auth_accounts_api.py
@@ -333,3 +333,28 @@ def test_last_active_superadmin_conflict_via_api(
     )
     assert status == 409
     assert body["error"] == "last_active_superadmin"
+
+
+def test_audit_events_invalid_limit_rejected_via_api(
+    auth_api: str, superadmin_session: tuple[str, str]
+) -> None:
+    cookie, csrf = superadmin_session
+    status, created, _headers = _request(
+        f"{auth_api}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": "worker.limitapi",
+            "display_name": "Worker Limit API",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+    )
+    assert status == 201
+    account_id = str(created["account"]["id"])
+    status, body, _headers = _request(
+        f"{auth_api}/auth/accounts/{account_id}/audit-events?limit=0",
+        headers={"Cookie": cookie},
+    )
+    assert status == 400
+    assert body["error"] == "invalid_request"

--- a/tests/unit/test_employee_auth_accounts_service.py
+++ b/tests/unit/test_employee_auth_accounts_service.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.services.employee_auth_service import (
+    AccountConflictError,
+    AuthorizationError,
+    EmployeeAuthService,
+    LastActiveSuperadminError,
+)
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+@pytest.fixture()
+def auth(tmp_path: Path):
+    from catering_system.repositories.sqlite_employee_auth_repository import (
+        SQLiteEmployeeAuthRepository,
+    )
+
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    repo = SQLiteEmployeeAuthRepository(tmp_path / "core.db")
+    service = EmployeeAuthService(repo, now=clock.now)
+    return service, repo, clock
+
+
+def _bootstrap(auth):
+    service, repo, _clock = auth
+    account = service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "accounts"},
+    )
+    return service, repo, account
+
+
+def _ready_superadmin(auth):
+    service, repo, _account = _bootstrap(auth)
+    login = service.authenticate(username="super.admin", password="TempPassw0rd!")
+    employee = service.authenticate_session(login.session_token)
+    service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    relogin = service.authenticate(username="super.admin", password="ChangedTemp1!")
+    return service, repo, service.authenticate_session(relogin.session_token)
+
+
+def _ready_admin(auth, superadmin):
+    service = auth[0]
+    admin = service.create_account(
+        superadmin,
+        username="team.admin",
+        display_name="Team Admin",
+        password="AdminTemp1!",
+        role="ADMIN",
+    )
+    login = service.authenticate(username=admin.username, password="AdminTemp1!")
+    employee = service.authenticate_session(login.session_token)
+    service.change_password(
+        employee,
+        current_password="AdminTemp1!",
+        new_password="AdminChanged1!",
+    )
+    relogin = service.authenticate(username=admin.username, password="AdminChanged1!")
+    return service.authenticate_session(relogin.session_token)
+
+
+def test_superadmin_lists_all_accounts(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    service.create_account(
+        superadmin,
+        username="worker.one",
+        display_name="Worker One",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    accounts = service.list_accounts(superadmin)
+    assert {item.username for item in accounts} == {"super.admin", "worker.one"}
+
+
+def test_admin_lists_all_but_cannot_mutate_admin_or_superadmin(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    admin_employee = _ready_admin(auth, superadmin)
+    worker = service.create_account(
+        superadmin,
+        username="worker.viewer",
+        display_name="Worker Viewer",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        explicit_permissions={"inquiries.view"},
+    )
+    listed = service.list_accounts(admin_employee)
+    assert {item.username for item in listed} == {
+        "super.admin",
+        "team.admin",
+        "worker.viewer",
+    }
+    assert next(item for item in listed if item.username == "super.admin").read_only
+    with pytest.raises(AuthorizationError):
+        service.deactivate_account(admin_employee, superadmin.account.id)
+    with pytest.raises(AuthorizationError):
+        service.update_account_profile(
+            admin_employee, superadmin.account.id, display_name="Blocked"
+        )
+    detail = service.update_account_profile(
+        admin_employee, worker.id, display_name="Updated Viewer"
+    )
+    assert detail.display_name == "Updated Viewer"
+
+
+def test_user_and_viewer_denied_account_management(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    user = service.create_account(
+        superadmin,
+        username="worker.user",
+        display_name="Worker User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    login = service.authenticate(username=user.username, password="WorkerTemp1!")
+    employee = service.authenticate_session(login.session_token)
+    service.change_password(
+        employee,
+        current_password="WorkerTemp1!",
+        new_password="WorkerChanged1!",
+    )
+    relogin = service.authenticate(username=user.username, password="WorkerChanged1!")
+    ready = service.authenticate_session(relogin.session_token)
+    with pytest.raises(AuthorizationError):
+        service.list_accounts(ready)
+
+
+def test_create_user_and_viewer_with_read_only_grants(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    user = service.create_account(
+        superadmin,
+        username="worker.new",
+        display_name="Worker New",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    viewer = service.create_account(
+        superadmin,
+        username="viewer.new",
+        display_name="Viewer New",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        explicit_permissions={"inquiries.view", "offers.view"},
+    )
+    detail = service.get_account(superadmin, viewer.id)
+    assert detail.effective_permissions == frozenset({"inquiries.view", "offers.view"})
+    assert user.must_change_password is True
+
+
+def test_admin_cannot_create_admin_and_superadmin_can(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    admin_employee = _ready_admin(auth, superadmin)
+    with pytest.raises(AuthorizationError):
+        service.create_account(
+            admin_employee,
+            username="blocked.admin",
+            display_name="Blocked Admin",
+            password="BlockedTemp1!",
+            role="ADMIN",
+        )
+    created = service.create_account(
+        superadmin,
+        username="second.admin",
+        display_name="Second Admin",
+        password="SecondAdmin1!",
+        role="ADMIN",
+    )
+    assert created.role == "ADMIN"
+
+
+def test_case_insensitive_username_conflict(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    service.create_account(
+        superadmin,
+        username="worker.case",
+        display_name="Worker Case",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    with pytest.raises(AccountConflictError):
+        service.create_account(
+            superadmin,
+            username="Worker.Case",
+            display_name="Worker Duplicate",
+            password="WorkerTemp1!",
+            role="USER",
+        )
+
+
+def test_profile_update_preserves_immutable_account_id(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.profile",
+        display_name="Worker Profile",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    detail = service.update_account_profile(
+        superadmin,
+        worker.id,
+        username="worker.renamed",
+        display_name="Worker Renamed",
+        email="worker@example.com",
+    )
+    assert detail.id == worker.id
+    assert detail.username == "worker.renamed"
+
+
+def test_role_change_applies_immediately_and_unknown_role_rejected(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.role",
+        display_name="Worker Role",
+        password="WorkerTemp1!",
+        role="USER",
+        explicit_permissions={"offers.prepare", "offers.view"},
+    )
+    service.change_account_role(superadmin, worker.id, "VIEWER")
+    detail = service.get_account(superadmin, worker.id)
+    assert detail.role == "VIEWER"
+    assert detail.effective_permissions == frozenset({"offers.view"})
+    with pytest.raises(ValueError, match="role must be one of"):
+        service.change_account_role(superadmin, worker.id, "MYSTERY")
+
+
+def test_permission_replacement_is_atomic_and_unknown_permission_rejected(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.perms",
+        display_name="Worker Perms",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    with pytest.raises(ValueError, match="permission_code"):
+        service.set_account_permissions(
+            superadmin, worker.id, {"offers.prepare", "not.real"}
+        )
+    service.set_account_permissions(
+        superadmin, worker.id, {"offers.prepare", "offers.view"}
+    )
+    detail = service.get_account(superadmin, worker.id)
+    assert detail.effective_permissions == frozenset({"offers.prepare", "offers.view"})
+
+
+def test_viewer_write_grant_rejected(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    viewer = service.create_account(
+        superadmin,
+        username="viewer.write",
+        display_name="Viewer Write",
+        password="ViewerTemp1!",
+        role="VIEWER",
+    )
+    with pytest.raises(ValueError, match="permissions exceed VIEWER ceiling"):
+        service.set_account_permissions(
+            superadmin, viewer.id, {"offers.view", "offers.prepare"}
+        )
+
+
+def test_admin_cannot_grant_permission_not_owned(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    limited_admin = service.create_account(
+        superadmin,
+        username="limited.admin",
+        display_name="Limited Admin",
+        password="LimitedAdmin1!",
+        role="ADMIN",
+        explicit_permissions={
+            "users.view",
+            "users.permissions.assign",
+            "inquiries.view",
+        },
+    )
+    login = service.authenticate(
+        username=limited_admin.username, password="LimitedAdmin1!"
+    )
+    admin_employee = service.authenticate_session(login.session_token)
+    service.change_password(
+        admin_employee,
+        current_password="LimitedAdmin1!",
+        new_password="LimitedChanged1!",
+    )
+    relogin = service.authenticate(
+        username=limited_admin.username, password="LimitedChanged1!"
+    )
+    admin_employee = service.authenticate_session(relogin.session_token)
+    worker = service.create_account(
+        superadmin,
+        username="worker.grant",
+        display_name="Worker Grant",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    with pytest.raises(AuthorizationError):
+        service.set_account_permissions(admin_employee, worker.id, {"offers.prepare"})
+
+
+def test_deactivation_revokes_sessions_and_reactivation_does_not_create_session(
+    auth,
+) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.lifecycle",
+        display_name="Worker Lifecycle",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    login = service.authenticate(username=worker.username, password="WorkerTemp1!")
+    service.deactivate_account(superadmin, worker.id)
+    session = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session is not None
+    assert session.revoked_at is not None
+    service.reactivate_account(superadmin, worker.id)
+    assert repo.get_session_by_token_hash(login.session.token_hash) is not None
+
+
+def test_reset_password_sets_must_change_password_and_revokes_sessions(auth) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.reset",
+        display_name="Worker Reset",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    login = service.authenticate(username=worker.username, password="WorkerTemp1!")
+    result = service.reset_account_password(
+        superadmin, worker.id, temporary_password="ResetTemp1!"
+    )
+    assert result.temporary_password is None
+    updated = service.get_account(superadmin, worker.id)
+    assert updated.must_change_password is True
+    session = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session is not None
+    assert session.revoked_at is not None
+
+
+def test_plaintext_password_absent_from_audit_and_generated_reset(auth) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.audit",
+        display_name="Worker Audit",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    result = service.reset_account_password(superadmin, worker.id)
+    assert result.temporary_password is not None
+    events = repo.list_audit_events_for_account(worker.id)
+    assert events
+    for event in events:
+        assert result.temporary_password not in event.metadata_json
+        assert "WorkerTemp1!" not in event.metadata_json
+
+
+def test_last_active_superadmin_cannot_be_deactivated_or_demoted(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    with pytest.raises(LastActiveSuperadminError):
+        service.deactivate_account(superadmin, superadmin.account.id)
+    with pytest.raises(LastActiveSuperadminError):
+        service.change_account_role(superadmin, superadmin.account.id, "ADMIN")
+
+
+def test_last_active_superadmin_guard_allows_one_demotion_then_blocks_second(
+    auth,
+) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    backup = service.create_account(
+        superadmin,
+        username="super.two",
+        display_name="Super Two",
+        password="SecondTemp1!",
+        role="SUPERADMIN",
+    )
+    service.change_account_role(superadmin, backup.id, "ADMIN")
+    with pytest.raises(LastActiveSuperadminError):
+        service.change_account_role(superadmin, superadmin.account.id, "ADMIN")
+
+
+def test_account_specific_audit_listing_is_permission_protected(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.auditlist",
+        display_name="Worker Audit List",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    service.deactivate_account(superadmin, worker.id)
+    events = service.list_account_audit_events(superadmin, worker.id)
+    assert events
+    assert all(event.target_id == worker.id for event in events)
+    admin_employee = _ready_admin(auth, superadmin)
+    with pytest.raises(AuthorizationError):
+        service.list_account_audit_events(admin_employee, worker.id)

--- a/tests/unit/test_employee_auth_accounts_service.py
+++ b/tests/unit/test_employee_auth_accounts_service.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import json
+import sqlite3
+import threading
+import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from catering_system.domain.employee_auth import SecurityAuditEvent
 from catering_system.services.employee_auth_service import (
     AccountConflictError,
     AuthorizationError,
@@ -367,7 +372,7 @@ def test_plaintext_password_absent_from_audit_and_generated_reset(auth) -> None:
     )
     result = service.reset_account_password(superadmin, worker.id)
     assert result.temporary_password is not None
-    events = repo.list_audit_events_for_account(worker.id)
+    events = repo.list_audit_events_for_account(worker.id, limit=100)
     assert events
     for event in events:
         assert result.temporary_password not in event.metadata_json
@@ -411,6 +416,221 @@ def test_account_specific_audit_listing_is_permission_protected(auth) -> None:
     events = service.list_account_audit_events(superadmin, worker.id)
     assert events
     assert all(event.target_id == worker.id for event in events)
+    assert all(event.target_type == "employee_account" for event in events)
     admin_employee = _ready_admin(auth, superadmin)
     with pytest.raises(AuthorizationError):
         service.list_account_audit_events(admin_employee, worker.id)
+
+
+def test_successful_profile_update_rolls_back_when_audit_insert_fails(auth) -> None:
+    service, _repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.rollback",
+        display_name="Worker Rollback",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    original_append = service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.account_profile_updated":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    service._append_audit = failing_append  # type: ignore[method-assign]
+
+    with pytest.raises(sqlite3.OperationalError, match="audit insert failed"):
+        service.update_account_profile(
+            superadmin, worker.id, display_name="Should Roll Back"
+        )
+
+    detail = service.get_account(superadmin, worker.id)
+    assert detail.display_name == "Worker Rollback"
+
+
+def test_account_audit_listing_filters_by_target_type(auth) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.targettype",
+        display_name="Worker Target Type",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    repo.append_audit_event(
+        SecurityAuditEvent(
+            event_id=str(uuid.uuid4()),
+            occurred_at=datetime(2026, 8, 1, 12, 0, tzinfo=UTC),
+            actor_type="system",
+            actor_account_id=None,
+            actor_display_name_snapshot=None,
+            actor_role_snapshot=None,
+            session_id=None,
+            action="other.entity_updated",
+            target_type="other_entity",
+            target_id=worker.id,
+            permission_code=None,
+            outcome="success",
+            metadata_json='{"note": "cross-type probe"}',
+        )
+    )
+    service.deactivate_account(superadmin, worker.id)
+    events = service.list_account_audit_events(superadmin, worker.id)
+    assert events
+    assert all(event.target_type == "employee_account" for event in events)
+    assert all(event.action != "other.entity_updated" for event in events)
+
+
+def test_role_change_audit_metadata_records_old_new_and_removed_permissions(
+    auth,
+) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.roleaudit",
+        display_name="Worker Role Audit",
+        password="WorkerTemp1!",
+        role="USER",
+        explicit_permissions={"offers.prepare", "offers.view", "inquiries.view"},
+    )
+    service.change_account_role(superadmin, worker.id, "VIEWER")
+    role_events = [
+        event
+        for event in repo.list_audit_events_for_account(worker.id, limit=100)
+        if event.action == "auth.role_changed"
+    ]
+    assert len(role_events) == 1
+    metadata = json.loads(role_events[0].metadata_json)
+    assert metadata["old_role"] == "USER"
+    assert metadata["new_role"] == "VIEWER"
+    assert metadata["removed_permission_codes"] == ["offers.prepare"]
+
+
+def test_concurrent_last_superadmin_demotions_leave_one_active_superadmin(
+    auth, tmp_path: Path
+) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    db_path = tmp_path / "core.db"
+    backup = service.create_account(
+        superadmin,
+        username="super.two",
+        display_name="Super Two",
+        password="SecondTemp1!",
+        role="SUPERADMIN",
+    )
+    super_one_id = superadmin.account.id
+    super_two_id = backup.id
+    repo.close()
+
+    clock = Clock(datetime(2026, 8, 1, 9, 30, tzinfo=UTC))
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str]] = []
+
+    def attempt_demote(target_id: str) -> None:
+        from catering_system.repositories.sqlite_employee_auth_repository import (
+            SQLiteEmployeeAuthRepository,
+        )
+
+        thread_repo = SQLiteEmployeeAuthRepository(db_path)
+        thread_service = EmployeeAuthService(thread_repo, now=clock.now)
+        login = thread_service.authenticate(
+            username="super.admin", password="ChangedTemp1!"
+        )
+        actor = thread_service.authenticate_session(login.session_token)
+        barrier.wait(timeout=5)
+        try:
+            thread_service.change_account_role(actor, target_id, "ADMIN")
+            results.append(("ok", target_id))
+        except LastActiveSuperadminError:
+            results.append(("blocked", target_id))
+        finally:
+            thread_repo.close()
+
+    threads = [
+        threading.Thread(target=attempt_demote, args=(super_one_id,)),
+        threading.Thread(target=attempt_demote, args=(super_two_id,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    from catering_system.repositories.sqlite_employee_auth_repository import (
+        SQLiteEmployeeAuthRepository,
+    )
+
+    verify_repo = SQLiteEmployeeAuthRepository(db_path)
+    try:
+        assert verify_repo.count_active_superadmins() >= 1
+    finally:
+        verify_repo.close()
+
+    outcomes = {item[0] for item in results}
+    assert outcomes == {"ok", "blocked"}
+    assert len(results) == 2
+
+
+def test_account_audit_listing_default_and_max_limits(auth) -> None:
+    service, repo, superadmin = _ready_superadmin(auth)
+    worker = service.create_account(
+        superadmin,
+        username="worker.limit",
+        display_name="Worker Limit",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    for index in range(105):
+        repo.append_audit_event(
+            SecurityAuditEvent(
+                event_id=str(uuid.uuid4()),
+                occurred_at=datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+                + timedelta(seconds=index),
+                actor_type="system",
+                actor_account_id=None,
+                actor_display_name_snapshot=None,
+                actor_role_snapshot=None,
+                session_id=None,
+                action=f"auth.probe_{index}",
+                target_type="employee_account",
+                target_id=worker.id,
+                permission_code=None,
+                outcome="success",
+                metadata_json='{"index": ' + str(index) + "}",
+            )
+        )
+
+    default_events = service.list_account_audit_events(superadmin, worker.id)
+    assert len(default_events) == 100
+    assert default_events[0].action == "auth.account_created"
+
+    bounded_events = service.list_account_audit_events(superadmin, worker.id, limit=10)
+    assert len(bounded_events) == 10
+
+    with pytest.raises(ValueError, match="limit must be between"):
+        service.list_account_audit_events(superadmin, worker.id, limit=0)
+    with pytest.raises(ValueError, match="limit must be between"):
+        service.list_account_audit_events(superadmin, worker.id, limit=501)
+
+
+def test_employee_auth_migration_5_creates_target_type_index(tmp_path: Path) -> None:
+    from catering_system.repositories.sqlite_employee_auth_repository import (
+        SQLiteEmployeeAuthRepository,
+        _MIGRATIONS,
+    )
+    from catering_system.repositories.sqlite_migrations import apply_migrations
+
+    db_path = tmp_path / "migration5.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        apply_migrations(connection, "employee_auth", _MIGRATIONS[:4])
+        apply_migrations(connection, "employee_auth", _MIGRATIONS)
+        row = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index' "
+            "AND name = 'idx_security_audit_events_employee_account_target'"
+        ).fetchone()
+        assert row is not None
+        rerun = SQLiteEmployeeAuthRepository(db_path)
+        rerun.close()
+    finally:
+        connection.close()

--- a/tests/unit/test_employee_auth_server_wiring.py
+++ b/tests/unit/test_employee_auth_server_wiring.py
@@ -1,0 +1,357 @@
+"""Production HTTP wiring tests for AUTH-2B account-management transactions."""
+
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import threading
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import (
+    EmployeeAuthService,
+    LastActiveSuperadminError,
+)
+from catering_system.ui.employee_auth_api import create_employee_auth_server
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    body: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    if body is not None and "Content-Type" not in (headers or {}):
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            parsed = json.loads(raw) if raw else {}
+            return response.status, parsed, dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        parsed = json.loads(raw) if raw else {}
+        return exc.code, parsed, dict(exc.headers)
+
+
+def _seed_superadmin(db: Path) -> None:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(
+        repo,
+        now=lambda: datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "server-wiring"},
+    )
+    repo.close()
+
+
+def _login_ready(base: str, *, username: str, password: str) -> tuple[str, str]:
+    status, body, headers = _request(
+        f"{base}/auth/login",
+        method="POST",
+        body={"username": username, "password": password},
+    )
+    assert status == 200
+    cookie = headers["Set-Cookie"]
+    csrf = str(body["csrf_token"])
+    status, _body, _headers = _request(
+        f"{base}/auth/password/change",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"current_password": password, "new_password": "ChangedTemp1!"},
+    )
+    assert status == 204
+    status, body, headers = _request(
+        f"{base}/auth/login",
+        method="POST",
+        body={"username": username, "password": "ChangedTemp1!"},
+    )
+    assert status == 200
+    return headers["Set-Cookie"], str(body["csrf_token"])
+
+
+def _start_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        server = create_employee_auth_server(
+            db,
+            host="127.0.0.1",
+            port=0,
+            secure_cookie=False,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+def _stop_server(server: HTTPServer, thread: threading.Thread) -> None:
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
+def _runtime_repository(db: Path) -> SQLiteEmployeeAuthRepository:
+    repository = SQLiteEmployeeAuthRepository(db)
+    repository._conn.execute("PRAGMA busy_timeout = 2000")
+    assert repository._manage_transactions is True
+    return repository
+
+
+def _create_worker_via_http(base: str, cookie: str, csrf: str, *, username: str) -> str:
+    status, body, _headers = _request(
+        f"{base}/auth/accounts",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={
+            "username": username,
+            "display_name": "Worker Wiring",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+    )
+    assert status == 201
+    return str(body["account"]["id"])
+
+
+@pytest.fixture()
+def wired_server(tmp_path: Path):
+    db = tmp_path / "core.db"
+    _seed_superadmin(db)
+    server, thread, base = _start_server(db)
+    yield db, server, base
+    _stop_server(server, thread)
+
+
+def test_runtime_repository_uses_managed_transactions(tmp_path: Path) -> None:
+    db = tmp_path / "managed.db"
+    repository = _runtime_repository(db)
+    try:
+        assert repository._manage_transactions is True
+        assert not repository._conn.in_transaction
+        with repository.immediate_transaction():
+            assert repository._conn.in_transaction
+        assert not repository._conn.in_transaction
+    finally:
+        repository.close()
+
+
+def test_http_profile_update_rolls_back_when_success_audit_fails(
+    wired_server: tuple[Path, HTTPServer, str],
+) -> None:
+    db, server, base = wired_server
+    assert server.auth_repository._manage_transactions is True
+    cookie, csrf = _login_ready(base, username="super.admin", password="TempPassw0rd!")
+    worker_id = _create_worker_via_http(
+        base, cookie, csrf, username="worker.http.rollback"
+    )
+
+    verify_before = _runtime_repository(db)
+    try:
+        before = verify_before.get_account_by_id(worker_id)
+        assert before is not None
+        assert before.display_name == "Worker Wiring"
+    finally:
+        verify_before.close()
+
+    original_append = server.auth_service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.account_profile_updated":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    server.auth_service._append_audit = failing_append  # type: ignore[method-assign]
+
+    status, body, _headers = _request(
+        f"{base}/auth/accounts/{worker_id}",
+        method="PATCH",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"display_name": "Should Roll Back"},
+    )
+    assert status == 500
+    assert body["error"] == "internal_error"
+
+    verify_after = _runtime_repository(db)
+    try:
+        after = verify_after.get_account_by_id(worker_id)
+        assert after is not None
+        assert after.display_name == "Worker Wiring"
+        events = verify_after.list_audit_events_for_account(worker_id, limit=100)
+        assert not any(
+            event.action == "auth.account_profile_updated" for event in events
+        )
+    finally:
+        verify_after.close()
+
+
+def test_http_password_reset_rolls_back_when_success_audit_fails(
+    wired_server: tuple[Path, HTTPServer, str],
+) -> None:
+    db, server, base = wired_server
+    cookie, csrf = _login_ready(base, username="super.admin", password="TempPassw0rd!")
+    worker_id = _create_worker_via_http(
+        base, cookie, csrf, username="worker.http.reset"
+    )
+
+    worker_login = _request(
+        f"{base}/auth/login",
+        method="POST",
+        body={"username": "worker.http.reset", "password": "WorkerTemp1!"},
+    )
+    assert worker_login[0] == 200
+
+    verify_before = _runtime_repository(db)
+    try:
+        before = verify_before.get_account_by_id(worker_id)
+        assert before is not None
+        original_hash = before.password_hash
+        original_auth_version = before.auth_version
+        original_must_change = before.must_change_password
+        sessions = verify_before._conn.execute(
+            "SELECT revoked_at FROM employee_sessions WHERE account_id = ?",
+            (worker_id,),
+        ).fetchall()
+        assert sessions
+        assert all(row[0] is None for row in sessions)
+    finally:
+        verify_before.close()
+
+    original_append = server.auth_service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.password_reset":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    server.auth_service._append_audit = failing_append  # type: ignore[method-assign]
+
+    status, body, _headers = _request(
+        f"{base}/auth/accounts/{worker_id}/reset-password",
+        method="POST",
+        headers={"Cookie": cookie, "X-CSRF-Token": csrf},
+        body={"temporary_password": "ResetTemp1!"},
+    )
+    assert status == 500
+    assert body["error"] == "internal_error"
+
+    verify_after = _runtime_repository(db)
+    try:
+        after = verify_after.get_account_by_id(worker_id)
+        assert after is not None
+        assert after.password_hash == original_hash
+        assert after.auth_version == original_auth_version
+        assert after.must_change_password == original_must_change
+        sessions = verify_after._conn.execute(
+            "SELECT revoked_at FROM employee_sessions WHERE account_id = ?",
+            (worker_id,),
+        ).fetchall()
+        assert sessions
+        assert all(row[0] is None for row in sessions)
+        events = verify_after.list_audit_events_for_account(worker_id, limit=100)
+        assert not any(
+            event.action == "auth.password_reset" and event.outcome == "success"
+            for event in events
+        )
+    finally:
+        verify_after.close()
+
+
+def test_runtime_repository_concurrent_last_superadmin_protection(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "concurrent.db"
+    setup_repo = _runtime_repository(db)
+    setup_service = EmployeeAuthService(
+        setup_repo,
+        now=lambda: datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    setup_service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+    )
+    login = setup_service.authenticate(username="super.admin", password="TempPassw0rd!")
+    actor = setup_service.authenticate_session(login.session_token)
+    setup_service.change_password(
+        actor,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    relogin = setup_service.authenticate(
+        username="super.admin", password="ChangedTemp1!"
+    )
+    actor = setup_service.authenticate_session(relogin.session_token)
+    backup = setup_service.create_account(
+        actor,
+        username="super.two",
+        display_name="Super Two",
+        password="SecondTemp1!",
+        role="SUPERADMIN",
+    )
+    super_one_id = actor.account.id
+    super_two_id = backup.id
+    setup_repo.close()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str]] = []
+
+    def attempt_demote(target_id: str) -> None:
+        repository = _runtime_repository(db)
+        service = EmployeeAuthService(
+            repository,
+            now=lambda: datetime(2026, 8, 1, 10, 30, tzinfo=UTC),
+        )
+        login_result = service.authenticate(
+            username="super.admin", password="ChangedTemp1!"
+        )
+        thread_actor = service.authenticate_session(login_result.session_token)
+        barrier.wait(timeout=5)
+        try:
+            service.change_account_role(thread_actor, target_id, "ADMIN")
+            results.append(("ok", target_id))
+        except LastActiveSuperadminError:
+            results.append(("blocked", target_id))
+        finally:
+            repository.close()
+
+    threads = [
+        threading.Thread(target=attempt_demote, args=(super_one_id,)),
+        threading.Thread(target=attempt_demote, args=(super_two_id,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    verify_repo = _runtime_repository(db)
+    try:
+        assert verify_repo.count_active_superadmins() >= 1
+    finally:
+        verify_repo.close()
+
+    assert len(results) == 2
+    assert {item[0] for item in results} == {"ok", "blocked"}

--- a/tests/unit/test_employee_auth_service.py
+++ b/tests/unit/test_employee_auth_service.py
@@ -17,6 +17,7 @@ from catering_system.repositories.sqlite_employee_auth_repository import (
     SQLiteEmployeeAuthRepository,
 )
 from catering_system.services.employee_auth_service import (
+    AccountConflictError,
     AuthenticationError,
     AuthorizationError,
     EmployeeAuthService,
@@ -103,7 +104,7 @@ def test_username_uniqueness_is_case_insensitive(auth) -> None:
         password="AnotherTemp1!",
         role="USER",
     )
-    with pytest.raises(sqlite3.IntegrityError):
+    with pytest.raises(AccountConflictError):
         service.create_account(
             employee,
             username="Worker.One",


### PR DESCRIPTION
## Summary

- Add authenticated `/auth/accounts/*` HTTP API for employee account management (backend only; no Office Panel UI).
- Extend `EmployeeAuthService` with list/read/profile update, audit listing, password reset wrapper, atomic permission replacement, and ADMIN read-only visibility rules.
- Harden last-active-SUPERADMIN protection using SQLite `BEGIN IMMEDIATE` transactions inside `immediate_transaction()`.
- Add employee_auth migration 5: index on `security_audit_events(target_id, occurred_at)`.

Closes #68

## Routes

- `GET /auth/accounts`
- `GET /auth/accounts/{account_id}`
- `POST /auth/accounts`
- `PATCH /auth/accounts/{account_id}`
- `POST /auth/accounts/{account_id}/role`
- `PUT /auth/accounts/{account_id}/permissions`
- `POST /auth/accounts/{account_id}/deactivate`
- `POST /auth/accounts/{account_id}/reactivate`
- `POST /auth/accounts/{account_id}/reset-password`
- `GET /auth/accounts/{account_id}/audit-events`

## Test plan

- [x] Focused service tests (`test_employee_auth_accounts_service.py`)
- [x] Focused API tests (`test_employee_auth_accounts_api.py`)
- [x] AUTH-1/AUTH-2A regressions (`test_employee_auth_service.py`, `test_employee_auth_api.py`)
- [x] Full Core suite: 2491 passed
- [x] mypy / ruff / diff --check clean

## Out of scope

- Office Panel Benutzer & Rechte UI (AUTH-2C)
- Server-side business permission enforcement sweep (AUTH-2D)
- Production deploy / Tailscale / account bootstrap

Made with [Cursor](https://cursor.com)