### PR TITLE
AUTH-2C: Office Panel Benutzer & Rechte UI

### DIFF
--- a/src/catering_system/repositories/employee_auth_runtime.py
+++ b/src/catering_system/repositories/employee_auth_runtime.py
@@ -1,0 +1,50 @@
+"""Managed employee-auth runtime wiring for long-lived Office Panel processes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+
+_BUSY_TIMEOUT_MS = 2000
+
+
+@dataclass
+class ManagedEmployeeAuthRuntime:
+    """Owns one transaction-capable SQLite connection for employee auth."""
+
+    repository: SQLiteEmployeeAuthRepository
+    service: EmployeeAuthService
+
+    def close(self) -> None:
+        self.repository.close()
+
+
+def open_managed_employee_auth_runtime(
+    db_path: str | Path,
+    *,
+    now: Callable[[], datetime] | None = None,
+) -> ManagedEmployeeAuthRuntime:
+    """Open the Office Panel production employee-auth stack.
+
+    Uses ``SQLiteEmployeeAuthRepository(db_path)`` so ``immediate_transaction()``
+    performs real ``BEGIN IMMEDIATE`` / COMMIT / ROLLBACK. Schema migrations run
+    on the owned connection during repository construction.
+
+    The Office Panel HTTP server is intentionally single-threaded; this runtime
+    must not be shared across concurrent request threads without external
+    locking.
+    """
+    repository = SQLiteEmployeeAuthRepository(db_path)
+    repository._conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+    if now is not None:
+        service = EmployeeAuthService(repository, now=now)
+    else:
+        service = EmployeeAuthService(repository)
+    return ManagedEmployeeAuthRuntime(repository=repository, service=service)

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3985,26 +3985,19 @@ def main() -> None:
             "(remote mode) or both left empty (direct mode)"
         )
 
+    auth_runtime = None
     auth_service = None
     if auth_mode in {"migration", "employee"}:
         if not args.db:
             raise SystemExit(
                 "--db is required when OFFICE_PANEL_AUTH_MODE is migration or employee"
             )
-        from catering_system.repositories.bootstrap_employee_auth_schema import (
-            bootstrap_employee_auth_schema,
+        from catering_system.repositories.employee_auth_runtime import (
+            open_managed_employee_auth_runtime,
         )
-        from catering_system.repositories.core_transaction import open_core_connection
-        from catering_system.repositories.sqlite_employee_auth_repository import (
-            SQLiteEmployeeAuthRepository,
-        )
-        from catering_system.services.employee_auth_service import EmployeeAuthService
 
-        auth_connection = open_core_connection(args.db)
-        bootstrap_employee_auth_schema(auth_connection)
-        auth_service = EmployeeAuthService(
-            SQLiteEmployeeAuthRepository.from_connection(auth_connection)
-        )
+        auth_runtime = open_managed_employee_auth_runtime(args.db)
+        auth_service = auth_runtime.service
 
     if core_api_url:
         from catering_system.ui.remote_core_client import RemoteCoreClient
@@ -4157,7 +4150,11 @@ def main() -> None:
             f"(auth_mode={auth_mode}, secure_cookie={secure_cookie}, "
             f"basic_fallback_active={auth_mode in {'basic', 'migration'}})"
         )
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    finally:
+        if auth_runtime is not None:
+            auth_runtime.close()
 
 
 if __name__ == "__main__":

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -14,7 +14,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, Literal, cast
 from urllib.parse import parse_qs, quote, unquote, urlparse
 
-from catering_system.domain.employee_auth import AuthenticatedEmployee
+from catering_system.domain.employee_auth import AuthenticatedEmployee, validate_role
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.catalog_repository import CatalogRepository
@@ -80,11 +80,26 @@ from catering_system.services.order_confirmation_document_service import (
 )
 from catering_system.services.buffet_cards_service import BuffetCardsService
 from catering_system.services.employee_auth_service import (
+    AccountConflictError,
+    AccountNotFoundError,
     AuthenticationError,
+    AuthorizationError,
     CsrfValidationError,
     EmployeeAuthService,
+    LastActiveSuperadminError,
 )
 from catering_system.ui.remote_core_client import RemoteCoreError
+from catering_system.ui.office_panel_settings_users import (
+    SettingsUsersAccessDenied,
+    parse_selected_permissions,
+    permission_matrix_state,
+    render_user_deactivate_confirm,
+    render_user_detail,
+    render_user_new,
+    render_users_list,
+    settings_users_error_message,
+    show_users_nav_for,
+)
 from catering_system.ui.employee_auth_http import (
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
@@ -517,6 +532,14 @@ def make_office_panel_handler(
                 resolved_rueckruf_count = rueckruf_count
             else:
                 resolved_rueckruf_count = None
+            show_users_nav = False
+            if (
+                auth is not None
+                and auth.kind == "employee"
+                and auth.employee is not None
+                and not auth.legacy_shared_access
+            ):
+                show_users_nav = show_users_nav_for(auth.employee)
             return OfficePageContext(
                 rueckruf_count=resolved_rueckruf_count,
                 csrf_token=auth.csrf_token if auth is not None else "",
@@ -534,7 +557,54 @@ def make_office_panel_handler(
                 legacy_shared_access=auth.legacy_shared_access
                 if auth is not None
                 else False,
+                show_users_nav=show_users_nav,
             )
+
+        def _require_settings_users_actor(
+            self, auth: OfficePanelRequestAuth | None
+        ) -> AuthenticatedEmployee:
+            if auth is None:
+                raise SettingsUsersAccessDenied()
+            if auth.kind != "employee" or auth.employee is None:
+                raise SettingsUsersAccessDenied()
+            if auth.legacy_shared_access:
+                raise SettingsUsersAccessDenied()
+            if not auth.employee.application_access_allowed:
+                raise SettingsUsersAccessDenied()
+            if "users.view" not in auth.employee.effective_permissions:
+                raise SettingsUsersAccessDenied()
+            return auth.employee
+
+        def _settings_users_forbidden(self) -> None:
+            self._html(
+                _page(
+                    "Zugriff verweigert",
+                    '<p class="blocked">Ihre Berechtigung reicht für diese Aktion nicht aus.</p>',
+                    active_section="settings",
+                    context=self._page_context(),
+                ),
+                403,
+            )
+
+        def _settings_users_actor_or_forbidden(
+            self, auth: OfficePanelRequestAuth | None
+        ) -> AuthenticatedEmployee | None:
+            try:
+                return self._require_settings_users_actor(auth)
+            except SettingsUsersAccessDenied:
+                self._settings_users_forbidden()
+                return None
+
+        def _settings_users_audit(
+            self, actor: AuthenticatedEmployee, account_id: str
+        ) -> list:
+            assert auth_service is not None
+            if "audit.view" not in actor.effective_permissions:
+                return []
+            try:
+                return auth_service.list_account_audit_events(actor, account_id)
+            except AuthorizationError:
+                return []
 
         def _security_headers(self) -> None:
             self.send_header("Cache-Control", "no-store")
@@ -648,12 +718,16 @@ def make_office_panel_handler(
             if length > _MAX_FORM_BODY_BYTES:
                 raise FormBodyTooLargeError("form body too large")
             raw = self.rfile.read(length).decode("utf-8")
-            parsed = {
-                key: values[0]
-                for key, values in parse_qs(raw, keep_blank_values=True).items()
-            }
+            parsed_lists = parse_qs(raw, keep_blank_values=True)
+            parsed = {key: values[0] for key, values in parsed_lists.items()}
             self._form_cache = parsed
+            self._form_lists_cache = parsed_lists
             return parsed
+
+        def _form_list(self, key: str) -> list[str]:
+            self._form()
+            lists = getattr(self, "_form_lists_cache", {})
+            return lists.get(key, [])
 
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002
             pass
@@ -723,6 +797,7 @@ def make_office_panel_handler(
         def _route_get(self) -> None:
             parsed = urlparse(self.path)
             parts = [part for part in parsed.path.split("/") if part]
+            auth = self._request_auth
             if parts == ["rueckruf"]:
                 if remote is not None and not auerswald_url:
                     self._html(
@@ -746,6 +821,7 @@ def make_office_panel_handler(
                     logout_path=context.logout_path,
                     show_transition_banner=context.show_transition_banner,
                     legacy_shared_access=context.legacy_shared_access,
+                    show_users_nav=context.show_users_nav,
                 )
                 self._html(render_rueckruf(items, error, context=context))
                 return
@@ -763,6 +839,7 @@ def make_office_panel_handler(
                     logout_path=context.logout_path,
                     show_transition_banner=context.show_transition_banner,
                     legacy_shared_access=context.legacy_shared_access,
+                    show_users_nav=context.show_users_nav,
                 )
                 kalender_view = parse_qs(parsed.query).get("kalender", ["woche"])[0]
                 self._html(
@@ -876,6 +953,79 @@ def make_office_panel_handler(
                 and parts[3] == "fake-outbox"
             ):
                 self._confirmation_fake_outbox(parts[1])
+            elif parts == ["settings", "users"]:
+                actor = self._settings_users_actor_or_forbidden(auth)
+                if actor is None:
+                    return
+                assert auth_service is not None
+                query = parse_qs(parsed.query)
+                self._html(
+                    render_users_list(
+                        auth_service.list_accounts(actor),
+                        status_filter=query.get("status", ["all"])[0],
+                        role_filter=query.get("role", ["all"])[0],
+                        flash=query.get("msg", [""])[0],
+                        context=self._page_context(),
+                    )
+                )
+            elif parts == ["settings", "users", "new"]:
+                actor = self._settings_users_actor_or_forbidden(auth)
+                if actor is None:
+                    return
+                self._html(
+                    render_user_new(
+                        actor=actor,
+                        form={},
+                        context=self._page_context(),
+                    )
+                )
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "deactivate"
+            ):
+                actor = self._settings_users_actor_or_forbidden(auth)
+                if actor is None:
+                    return
+                assert auth_service is not None
+                account_id = unquote(parts[2])
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_deactivate_confirm(
+                        detail=detail,
+                        context=self._page_context(),
+                    )
+                )
+            elif len(parts) == 3 and parts[0] == "settings" and parts[1] == "users":
+                actor = self._settings_users_actor_or_forbidden(auth)
+                if actor is None:
+                    return
+                assert auth_service is not None
+                account_id = unquote(parts[2])
+                query = parse_qs(parsed.query)
+                removed = [
+                    item for item in query.get("removed", [""])[0].split(",") if item
+                ]
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        flash=query.get("msg", [""])[0],
+                        role_change_removed=removed or None,
+                        context=self._page_context(),
+                    )
+                )
             else:
                 self.send_error(404)
 
@@ -1159,6 +1309,7 @@ def make_office_panel_handler(
                 self._error_page(inquiry_command_error_message(str(exc)))
 
         def _route_post(self, parts: list[str]) -> None:
+            auth = self._request_auth
             if parts == ["inquiry", "new"]:
                 inquiry = panel.create_inquiry(self._form())
                 self._redirect(f"/inquiry/{inquiry.inquiry_id}")
@@ -1230,8 +1381,351 @@ def make_office_panel_handler(
                 contact_key = unquote(parts[1])
                 panel.add_contact_note(contact_key, self._form())
                 self._redirect(f"/kontakt/{quote(contact_key, safe='')}")
+            elif parts == ["settings", "users"]:
+                self._settings_users_create(auth)
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "profile"
+            ):
+                self._settings_users_profile(auth, unquote(parts[2]))
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "role"
+            ):
+                self._settings_users_role(auth, unquote(parts[2]))
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "permissions"
+            ):
+                self._settings_users_permissions(auth, unquote(parts[2]))
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "deactivate"
+            ):
+                self._settings_users_deactivate(auth, unquote(parts[2]))
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "reactivate"
+            ):
+                self._settings_users_reactivate(auth, unquote(parts[2]))
+            elif (
+                len(parts) == 4
+                and parts[0] == "settings"
+                and parts[1] == "users"
+                and parts[3] == "reset-password"
+            ):
+                self._settings_users_reset_password(auth, unquote(parts[2]))
             else:
                 self.send_error(404)
+
+        def _settings_users_create(self, auth: OfficePanelRequestAuth | None) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            form = self._form()
+            selected = self._form_list("permission")
+            role = form.get("role", "USER")
+            selectable, _disabled = permission_matrix_state(
+                actor,
+                target_role=validate_role(role),
+                target_read_only=False,
+                explicit_permissions=set(),
+                effective_permissions=set(),
+            )
+            permissions = parse_selected_permissions(selected, selectable)
+            try:
+                account = auth_service.create_account(
+                    actor,
+                    username=form.get("username", ""),
+                    display_name=form.get("display_name", ""),
+                    password=form.get("temporary_password", ""),
+                    role=role,
+                    email=form.get("email") or None,
+                    explicit_permissions=permissions if permissions else None,
+                    must_change_password=True,
+                )
+            except (
+                AccountConflictError,
+                AuthorizationError,
+                LastActiveSuperadminError,
+                ValueError,
+            ) as exc:
+                self._html(
+                    render_user_new(
+                        actor=actor,
+                        form=form,
+                        selected_permissions=selected,
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    403
+                    if isinstance(exc, AuthorizationError)
+                    else 400
+                    if isinstance(exc, ValueError)
+                    else 409,
+                )
+                return
+            if form.get("is_active", "1") != "1":
+                auth_service.deactivate_account(actor, account.id)
+            self._redirect(f"/settings/users/{quote(account.id, safe='')}?msg=created")
+
+        def _settings_users_profile(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            form = self._form()
+            try:
+                auth_service.update_account_profile(
+                    actor,
+                    account_id,
+                    username=form.get("username"),
+                    display_name=form.get("display_name"),
+                    email=form.get("email", ""),
+                )
+            except (
+                AccountConflictError,
+                AuthorizationError,
+                AccountNotFoundError,
+                ValueError,
+            ) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    409 if isinstance(exc, AccountConflictError) else 400,
+                )
+                return
+            self._redirect(f"/settings/users/{quote(account_id, safe='')}?msg=saved")
+
+        def _settings_users_role(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            form = self._form()
+            new_role = form.get("role", "")
+            try:
+                before = auth_service.get_account(actor, account_id)
+                auth_service.change_account_role(actor, account_id, new_role)
+                after = auth_service.get_account(actor, account_id)
+            except (
+                AuthorizationError,
+                LastActiveSuperadminError,
+                AccountNotFoundError,
+                ValueError,
+            ) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            removed = sorted(
+                set(before.explicit_permissions).difference(after.explicit_permissions)
+            )
+            removed_query = ""
+            if removed:
+                removed_query = "&removed=" + quote(",".join(removed), safe="")
+            self._redirect(
+                f"/settings/users/{quote(account_id, safe='')}?msg=role_changed{removed_query}"
+            )
+
+        def _settings_users_permissions(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            selected = self._form_list("permission")
+            try:
+                detail = auth_service.get_account(actor, account_id)
+                selectable, _disabled = permission_matrix_state(
+                    actor,
+                    target_role=detail.role,
+                    target_read_only=detail.read_only,
+                    explicit_permissions=set(detail.explicit_permissions),
+                    effective_permissions=set(detail.effective_permissions),
+                )
+                permissions = parse_selected_permissions(selected, selectable)
+                auth_service.set_account_permissions(actor, account_id, permissions)
+            except (
+                AuthorizationError,
+                AccountNotFoundError,
+                ValueError,
+            ) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            self._redirect(
+                f"/settings/users/{quote(account_id, safe='')}?msg=permissions_saved"
+            )
+
+        def _settings_users_deactivate(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            try:
+                auth_service.deactivate_account(actor, account_id)
+            except (
+                AuthorizationError,
+                LastActiveSuperadminError,
+                AccountNotFoundError,
+            ) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_deactivate_confirm(
+                        detail=detail,
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            self._redirect("/settings/users?msg=deactivated")
+
+        def _settings_users_reactivate(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            try:
+                auth_service.reactivate_account(actor, account_id)
+            except (AuthorizationError, AccountNotFoundError) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            self._redirect(
+                f"/settings/users/{quote(account_id, safe='')}?msg=reactivated"
+            )
+
+        def _settings_users_reset_password(
+            self, auth: OfficePanelRequestAuth | None, account_id: str
+        ) -> None:
+            actor = self._settings_users_actor_or_forbidden(auth)
+            if actor is None:
+                return
+            assert auth_service is not None
+            form = self._form()
+            password = form.get("temporary_password", "")
+            confirm = form.get("temporary_password_confirm", "")
+            if password != confirm:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message="Die Passwortbestätigung stimmt nicht überein.",
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            try:
+                auth_service.reset_account_password(
+                    actor,
+                    account_id,
+                    temporary_password=password,
+                )
+            except (
+                AuthorizationError,
+                AccountNotFoundError,
+                ValueError,
+            ) as exc:
+                try:
+                    detail = auth_service.get_account(actor, account_id)
+                except (AuthorizationError, AccountNotFoundError):
+                    self._settings_users_forbidden()
+                    return
+                self._html(
+                    render_user_detail(
+                        actor=actor,
+                        detail=detail,
+                        audit_events=self._settings_users_audit(actor, account_id),
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
+            self._redirect(
+                f"/settings/users/{quote(account_id, safe='')}?msg=password_reset"
+            )
 
         def _create_catalog_dish(self) -> None:
             """CATALOG_ADMIN_PANEL_V1: a rejected create re-renders the form

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import sqlite3
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, Literal, cast
@@ -1436,9 +1437,23 @@ def make_office_panel_handler(
             form = self._form()
             selected = self._form_list("permission")
             role = form.get("role", "USER")
+            try:
+                target_role = validate_role(role)
+            except ValueError as exc:
+                self._html(
+                    render_user_new(
+                        actor=actor,
+                        form=form,
+                        selected_permissions=selected,
+                        error_message=settings_users_error_message(exc),
+                        context=self._page_context(),
+                    ),
+                    400,
+                )
+                return
             selectable, _disabled = permission_matrix_state(
                 actor,
-                target_role=validate_role(role),
+                target_role=target_role,
                 target_read_only=False,
                 explicit_permissions=set(),
                 effective_permissions=set(),
@@ -1450,7 +1465,7 @@ def make_office_panel_handler(
                     username=form.get("username", ""),
                     display_name=form.get("display_name", ""),
                     password=form.get("temporary_password", ""),
-                    role=role,
+                    role=target_role,
                     email=form.get("email") or None,
                     explicit_permissions=permissions if permissions else None,
                     must_change_password=True,
@@ -1476,8 +1491,6 @@ def make_office_panel_handler(
                     else 409,
                 )
                 return
-            if form.get("is_active", "1") != "1":
-                auth_service.deactivate_account(actor, account.id)
             self._redirect(f"/settings/users/{quote(account.id, safe='')}?msg=created")
 
         def _settings_users_profile(
@@ -1501,6 +1514,7 @@ def make_office_panel_handler(
                 AuthorizationError,
                 AccountNotFoundError,
                 ValueError,
+                sqlite3.Error,
             ) as exc:
                 try:
                     detail = auth_service.get_account(actor, account_id)
@@ -1515,7 +1529,9 @@ def make_office_panel_handler(
                         error_message=settings_users_error_message(exc),
                         context=self._page_context(),
                     ),
-                    409 if isinstance(exc, AccountConflictError) else 400,
+                    500
+                    if isinstance(exc, sqlite3.Error)
+                    else (409 if isinstance(exc, AccountConflictError) else 400),
                 )
                 return
             self._redirect(f"/settings/users/{quote(account_id, safe='')}?msg=saved")
@@ -1622,6 +1638,7 @@ def make_office_panel_handler(
                 AuthorizationError,
                 LastActiveSuperadminError,
                 AccountNotFoundError,
+                sqlite3.Error,
             ) as exc:
                 try:
                     detail = auth_service.get_account(actor, account_id)
@@ -1634,7 +1651,7 @@ def make_office_panel_handler(
                         error_message=settings_users_error_message(exc),
                         context=self._page_context(),
                     ),
-                    400,
+                    500 if isinstance(exc, sqlite3.Error) else 400,
                 )
                 return
             self._redirect("/settings/users?msg=deactivated")
@@ -1706,6 +1723,7 @@ def make_office_panel_handler(
                 AuthorizationError,
                 AccountNotFoundError,
                 ValueError,
+                sqlite3.Error,
             ) as exc:
                 try:
                     detail = auth_service.get_account(actor, account_id)
@@ -1720,7 +1738,7 @@ def make_office_panel_handler(
                         error_message=settings_users_error_message(exc),
                         context=self._page_context(),
                     ),
-                    400,
+                    500 if isinstance(exc, sqlite3.Error) else 400,
                 )
                 return
             self._redirect(

--- a/src/catering_system/ui/office_panel_settings_users.py
+++ b/src/catering_system/ui/office_panel_settings_users.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime
 from urllib.parse import quote
 
@@ -151,8 +152,12 @@ def settings_users_error_message(exc: Exception) -> str:
         return "Ihre Berechtigung reicht für diese Aktion nicht aus."
     if isinstance(exc, AccountNotFoundError):
         return "Benutzerkonto wurde nicht gefunden."
+    if isinstance(exc, sqlite3.Error):
+        return "Die Aktion konnte nicht ausgeführt werden."
     if isinstance(exc, ValueError):
         message = str(exc)
+        if message.startswith("role must be one of"):
+            return "Die ausgewählte Rolle ist nicht zulässig."
         if "temporary_password" in message or "password must be at least" in message:
             return "Das temporäre Passwort muss mindestens 8 Zeichen haben."
         if "permissions exceed" in message:
@@ -416,11 +421,7 @@ def render_user_new(
         "</label><br>"
         "<label>Temporäres Passwort<br>"
         '<input name="temporary_password" type="password" autocomplete="new-password" required>'
-        "</label><br>"
-        "<label>"
-        '<input type="checkbox" name="is_active" value="1" '
-        + ("checked" if form.get("is_active", "1") == "1" else "")
-        + "> Konto ist aktiv</label>"
+        "</label>"
         "</fieldset>" + matrix + '<p><button type="submit">Benutzer anlegen</button> '
         '<a href="/settings/users">Abbrechen</a></p>'
         "</form>"

--- a/src/catering_system/ui/office_panel_settings_users.py
+++ b/src/catering_system/ui/office_panel_settings_users.py
@@ -1,0 +1,723 @@
+"""Office Panel — Einstellungen → Benutzer & Rechte (AUTH-2C)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import quote
+
+from catering_system.domain.employee_auth import (
+    PERMISSION_REGISTRY,
+    AuthenticatedEmployee,
+    EmployeeAccountDetail,
+    EmployeeAccountSummary,
+    EmployeeRole,
+    SecurityAuditEventView,
+    manageable_roles_for,
+    role_ceiling,
+    validate_role,
+)
+from catering_system.services.employee_auth_service import (
+    AccountConflictError,
+    AccountNotFoundError,
+    AuthorizationError,
+    LastActiveSuperadminError,
+)
+from catering_system.ui.office_panel_views import (
+    OfficePageContext,
+    _csrf_input,
+    _e,
+    _page,
+)
+
+ROLE_LABELS: dict[str, str] = {
+    "SUPERADMIN": "Superadmin",
+    "ADMIN": "Administrator",
+    "USER": "Benutzer",
+    "VIEWER": "Leser",
+}
+
+PERMISSION_GROUP_LABELS: dict[str, str] = {
+    "inquiries": "Anfragen",
+    "customers": "Kunden",
+    "offers": "Angebote",
+    "orders": "Aufträge",
+    "catalog": "Katalog",
+    "prices": "Preise",
+    "calendar": "Kalender",
+    "queue": "Warteschlange",
+    "documents": "Dokumente",
+    "users": "Benutzer",
+    "audit": "Audit",
+    "settings": "Einstellungen",
+}
+
+PERMISSION_GROUP_ORDER: tuple[str, ...] = tuple(PERMISSION_GROUP_LABELS.keys())
+
+PERMISSION_LABELS: dict[str, str] = {
+    "inquiries.view": "Anfragen ansehen",
+    "inquiries.create": "Anfragen anlegen",
+    "inquiries.edit": "Anfragen bearbeiten",
+    "inquiries.verify": "Anfragen verifizieren",
+    "customers.view": "Kunden ansehen",
+    "customers.edit": "Kunden bearbeiten",
+    "offers.view": "Angebote ansehen",
+    "offers.prepare": "Angebote vorbereiten",
+    "offers.version.create": "Angebotsversionen anlegen",
+    "offers.pdf.generate": "Angebots-PDF erzeugen",
+    "offers.send": "Angebote versenden",
+    "offers.status.change": "Angebotsstatus ändern",
+    "offers.timing.acknowledge": "Angebots-Timing bestätigen",
+    "orders.view": "Aufträge ansehen",
+    "orders.version.create": "Auftragsversionen anlegen",
+    "orders.print.confirm": "Küchendruck bestätigen",
+    "orders.effective.set": "Wirksame Version setzen",
+    "orders.ready.release": "Versandbereit freigeben",
+    "orders.pause": "Aufträge pausieren",
+    "orders.cancel": "Aufträge stornieren",
+    "catalog.view": "Katalog ansehen",
+    "catalog.edit": "Katalog bearbeiten",
+    "prices.view": "Preise ansehen",
+    "prices.edit": "Preise bearbeiten",
+    "calendar.view": "Kalender ansehen",
+    "queue.view": "Warteschlange ansehen",
+    "documents.view": "Dokumente ansehen",
+    "users.view": "Benutzer ansehen",
+    "users.create": "Benutzer anlegen",
+    "users.edit": "Benutzer bearbeiten",
+    "users.deactivate": "Benutzer deaktivieren",
+    "users.reactivate": "Benutzer reaktivieren",
+    "users.password.reset": "Passwort zurücksetzen",
+    "users.permissions.assign": "Berechtigungen zuweisen",
+    "users.roles.assign": "Rollen zuweisen",
+    "audit.view": "Audit ansehen",
+    "settings.view": "Einstellungen ansehen",
+    "settings.edit": "Einstellungen bearbeiten",
+}
+
+_STATUS_FILTERS = (
+    ("all", "Alle"),
+    ("active", "Aktiv"),
+    ("inactive", "Inaktiv"),
+)
+
+_ROLE_FILTERS = (
+    ("all", "Alle Rollen"),
+    ("SUPERADMIN", "Superadmin"),
+    ("ADMIN", "Administrator"),
+    ("USER", "Benutzer"),
+    ("VIEWER", "Leser"),
+)
+
+_FLASH_MESSAGES: dict[str, str] = {
+    "created": (
+        "Benutzer wurde angelegt. Beim ersten Login muss das Passwort geändert werden."
+    ),
+    "saved": "Änderungen wurden gespeichert.",
+    "deactivated": "Benutzer wurde deaktiviert.",
+    "reactivated": "Benutzer wurde reaktiviert.",
+    "password_reset": (
+        "Temporäres Passwort wurde gesetzt. Alle Sitzungen wurden beendet; "
+        "Passwortänderung ist beim nächsten Login erforderlich."
+    ),
+    "role_changed": "Rolle wurde geändert.",
+    "permissions_saved": "Berechtigungen wurden gespeichert.",
+}
+
+
+class SettingsUsersAccessDenied(Exception):
+    """Raised when the Office Panel user-management UI must not be shown."""
+
+
+def show_users_nav_for(employee: AuthenticatedEmployee) -> bool:
+    return "users.view" in employee.effective_permissions
+
+
+def settings_users_error_message(exc: Exception) -> str:
+    if isinstance(exc, AccountConflictError):
+        return "Benutzername ist bereits vergeben."
+    if isinstance(exc, LastActiveSuperadminError):
+        return (
+            "Der letzte aktive Superadmin kann nicht deaktiviert "
+            "oder herabgestuft werden."
+        )
+    if isinstance(exc, AuthorizationError):
+        message = str(exc)
+        if "ADMIN may not manage" in message or "may not manage" in message:
+            return "Diese Aktion ist für dieses Benutzerkonto nicht zulässig."
+        if "missing permission" in message:
+            return "Ihre Berechtigung reicht für diese Aktion nicht aus."
+        if "may grant only own effective permissions" in message:
+            return "Ihre Berechtigung reicht für diese Aktion nicht aus."
+        return "Ihre Berechtigung reicht für diese Aktion nicht aus."
+    if isinstance(exc, AccountNotFoundError):
+        return "Benutzerkonto wurde nicht gefunden."
+    if isinstance(exc, ValueError):
+        message = str(exc)
+        if "temporary_password" in message or "password must be at least" in message:
+            return "Das temporäre Passwort muss mindestens 8 Zeichen haben."
+        if "permissions exceed" in message:
+            return (
+                "Die ausgewählten Berechtigungen sind für diese Rolle nicht zulässig."
+            )
+        if "password" in message.lower():
+            return "Passwort konnte nicht gesetzt werden."
+    return "Die Aktion konnte nicht ausgeführt werden."
+
+
+def _format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return "–"
+    return value.strftime("%d.%m.%Y · %H:%M")
+
+
+def _permission_group(code: str) -> str:
+    return code.split(".", 1)[0]
+
+
+def _permission_label(code: str) -> str:
+    return PERMISSION_LABELS.get(code, code.replace(".", " ").capitalize())
+
+
+def permission_matrix_state(
+    actor: AuthenticatedEmployee,
+    *,
+    target_role: EmployeeRole,
+    target_read_only: bool,
+    explicit_permissions: set[str],
+    effective_permissions: set[str],
+) -> tuple[set[str], dict[str, str]]:
+    """Return selectable permission codes and disabled reasons for the matrix."""
+    ceiling = role_ceiling(target_role)
+    selectable: set[str] = set()
+    disabled: dict[str, str] = {}
+    actor_grants = (
+        set(actor.effective_permissions)
+        if actor.account.role == "ADMIN"
+        else set(ceiling)
+    )
+    for code in PERMISSION_REGISTRY:
+        if target_role == "VIEWER" and not code.endswith(".view"):
+            disabled[code] = "Für Leser nur Leseberechtigungen"
+            continue
+        if code not in ceiling:
+            disabled[code] = "Außerhalb der Rollenobergrenze"
+            continue
+        if target_read_only:
+            disabled[code] = "Konto ist schreibgeschützt"
+            continue
+        if actor.account.role == "ADMIN" and code not in actor_grants:
+            disabled[code] = "Nicht in Ihren Berechtigungen"
+            continue
+        selectable.add(code)
+    return selectable, disabled
+
+
+def parse_selected_permissions(selected: list[str], selectable: set[str]) -> set[str]:
+    return {code for code in selected if code in selectable}
+
+
+def _flash_banner(message_key: str) -> str:
+    message = _FLASH_MESSAGES.get(message_key, "")
+    if not message:
+        return ""
+    return f'<p class="office-flash success">{_e(message)}</p>'
+
+
+def _error_banner(message: str) -> str:
+    if not message:
+        return ""
+    return f'<p class="office-flash blocked">{_e(message)}</p>'
+
+
+def _filter_links(
+    base_path: str,
+    *,
+    status_filter: str,
+    role_filter: str,
+    filters: tuple[tuple[str, str], ...],
+    param_name: str,
+) -> str:
+    links = []
+    for value, label in filters:
+        params = {"status": status_filter, "role": role_filter, param_name: value}
+        query = "&".join(
+            f"{key}={quote(str(param_value), safe='')}"
+            for key, param_value in params.items()
+            if param_value != "all"
+        )
+        current = status_filter if param_name == "status" else role_filter
+        if value == current:
+            links.append(f"<strong>{_e(label)}</strong>")
+        else:
+            links.append(f'<a href="{_e(base_path)}?{_e(query)}">{_e(label)}</a>')
+    return '<p class="users-filter">' + " | ".join(links) + "</p>"
+
+
+def _filter_accounts(
+    accounts: list[EmployeeAccountSummary],
+    *,
+    status_filter: str,
+    role_filter: str,
+) -> list[EmployeeAccountSummary]:
+    filtered = accounts
+    if status_filter == "active":
+        filtered = [item for item in filtered if item.is_active]
+    elif status_filter == "inactive":
+        filtered = [item for item in filtered if not item.is_active]
+    if role_filter != "all":
+        filtered = [item for item in filtered if item.role == role_filter]
+    return filtered
+
+
+def render_users_list(
+    accounts: list[EmployeeAccountSummary],
+    *,
+    status_filter: str,
+    role_filter: str,
+    flash: str = "",
+    context: OfficePageContext,
+) -> str:
+    rows_html = []
+    for account in _filter_accounts(
+        accounts, status_filter=status_filter, role_filter=role_filter
+    ):
+        status = "Aktiv" if account.is_active else "Inaktiv"
+        must_change = "Ja" if account.must_change_password else "Nein"
+        read_only = (
+            '<span class="badge badge-muted">Nur Lesen</span>'
+            if account.read_only
+            else "–"
+        )
+        email = _e(account.email) if account.email else "–"
+        rows_html.append(
+            "<tr>"
+            f"<td>{_e(account.display_name)}</td>"
+            f"<td>{_e(account.username)}</td>"
+            f"<td>{email}</td>"
+            f"<td>{_e(ROLE_LABELS.get(account.role, account.role))}</td>"
+            f"<td>{_e(status)}</td>"
+            f"<td>{_e(must_change)}</td>"
+            f"<td>{_e(_format_timestamp(account.last_login_at))}</td>"
+            f"<td>{_e(_format_timestamp(account.updated_at))}</td>"
+            f"<td>{read_only}</td>"
+            f'<td><a href="/settings/users/{_e(quote(account.id, safe=""))}">'
+            "Öffnen</a></td>"
+            "</tr>"
+        )
+    body = (
+        '<p class="subtitle">Mitarbeiterkonten und Berechtigungen verwalten.</p>'
+        + _flash_banner(flash)
+        + '<p><a href="/settings/users/new">Neuen Benutzer anlegen</a></p>'
+        + _filter_links(
+            "/settings/users",
+            status_filter=status_filter,
+            role_filter=role_filter,
+            filters=_STATUS_FILTERS,
+            param_name="status",
+        )
+        + _filter_links(
+            "/settings/users",
+            status_filter=status_filter,
+            role_filter=role_filter,
+            filters=_ROLE_FILTERS,
+            param_name="role",
+        )
+        + "<table><tr><th>Anzeigename</th><th>Benutzername</th><th>E-Mail</th>"
+        "<th>Rolle</th><th>Status</th><th>Passwortwechsel</th>"
+        "<th>Letzte Anmeldung</th><th>Aktualisiert</th><th></th><th></th></tr>"
+        + "".join(
+            rows_html or ['<tr><td colspan="10">Keine Benutzer gefunden.</td></tr>']
+        )
+        + "</table>"
+        + '<p><a href="/">← Zurück zur Arbeitszentrale</a></p>'
+    )
+    return _page(
+        "Benutzer & Rechte",
+        body,
+        active_section="settings",
+        context=context,
+    )
+
+
+_ROLE_VALUES: tuple[EmployeeRole, ...] = (
+    "SUPERADMIN",
+    "ADMIN",
+    "USER",
+    "VIEWER",
+)
+
+
+def _role_options(
+    actor: AuthenticatedEmployee,
+    *,
+    selected: str,
+    include_blank: bool = False,
+) -> str:
+    roles = sorted(
+        manageable_roles_for(actor.account.role),
+        key=lambda role: _ROLE_VALUES.index(role),
+    )
+    options = ['<option value="">—</option>'] if include_blank else []
+    for role in roles:
+        label = ROLE_LABELS.get(role, role)
+        selected_attr = " selected" if role == selected else ""
+        options.append(
+            f'<option value="{_e(role)}"{selected_attr}>{_e(label)}</option>'
+        )
+    return "".join(options)
+
+
+def render_user_new(
+    *,
+    actor: AuthenticatedEmployee,
+    form: dict[str, str],
+    selected_permissions: list[str] | None = None,
+    error_message: str = "",
+    context: OfficePageContext,
+) -> str:
+    role = form.get("role", "USER")
+    try:
+        target_role = validate_role(role)
+    except ValueError:
+        target_role = "USER"
+    selectable, disabled = permission_matrix_state(
+        actor,
+        target_role=target_role,
+        target_read_only=False,
+        explicit_permissions=set(),
+        effective_permissions=set(),
+    )
+    selected = parse_selected_permissions(selected_permissions or [], selectable)
+    matrix = _permission_matrix_html(
+        selectable=selectable,
+        disabled=disabled,
+        explicit=selected,
+        effective=selected,
+        field_prefix="permission",
+    )
+    body = (
+        '<p class="subtitle">Neues Mitarbeiterkonto anlegen.</p>'
+        + _error_banner(error_message)
+        + '<form method="post" action="/settings/users" class="users-form">'
+        + _csrf_input(context)
+        + "<fieldset>"
+        "<legend>Stammdaten</legend>"
+        "<label>Benutzername<br>"
+        f'<input name="username" required value="{_e(form.get("username", ""))}">'
+        "</label><br>"
+        "<label>Anzeigename<br>"
+        f'<input name="display_name" required value="{_e(form.get("display_name", ""))}">'
+        "</label><br>"
+        "<label>E-Mail (optional)<br>"
+        f'<input name="email" type="email" value="{_e(form.get("email", ""))}">'
+        "</label><br>"
+        "<label>Rolle<br>"
+        f'<select name="role">{_role_options(actor, selected=role)}</select>'
+        "</label><br>"
+        "<label>Temporäres Passwort<br>"
+        '<input name="temporary_password" type="password" autocomplete="new-password" required>'
+        "</label><br>"
+        "<label>"
+        '<input type="checkbox" name="is_active" value="1" '
+        + ("checked" if form.get("is_active", "1") == "1" else "")
+        + "> Konto ist aktiv</label>"
+        "</fieldset>" + matrix + '<p><button type="submit">Benutzer anlegen</button> '
+        '<a href="/settings/users">Abbrechen</a></p>'
+        "</form>"
+    )
+    return _page(
+        "Neuer Benutzer",
+        body,
+        active_section="settings",
+        context=context,
+    )
+
+
+def _permission_matrix_html(
+    *,
+    selectable: set[str],
+    disabled: dict[str, str],
+    explicit: set[str],
+    effective: set[str],
+    field_prefix: str,
+) -> str:
+    sections: list[str] = ["<fieldset><legend>Berechtigungen</legend>"]
+    grouped: dict[str, list[str]] = {key: [] for key in PERMISSION_GROUP_ORDER}
+    for code in PERMISSION_REGISTRY:
+        group = _permission_group(code)
+        grouped.setdefault(group, []).append(code)
+    for group_key in PERMISSION_GROUP_ORDER:
+        codes = grouped.get(group_key, [])
+        if not codes:
+            continue
+        sections.append(
+            f'<div class="users-perm-group"><h3>{_e(PERMISSION_GROUP_LABELS.get(group_key, group_key))}</h3>'
+        )
+        for code in codes:
+            label = _permission_label(code)
+            effective_state = "wirksam" if code in effective else "nicht wirksam"
+            if code in selectable:
+                checked = " checked" if code in explicit else ""
+                sections.append(
+                    "<label class='users-perm-row'>"
+                    f'<input type="checkbox" name="{_e(field_prefix)}" value="{_e(code)}"{checked}> '
+                    f"<span><strong>{_e(label)}</strong> "
+                    f'<span class="users-perm-code">{_e(code)}</span> '
+                    f'<span class="users-perm-effective">{_e(effective_state)}</span>'
+                    "</span></label>"
+                )
+            else:
+                reason = disabled.get(code, "Nicht verfügbar")
+                sections.append(
+                    "<div class='users-perm-row users-perm-disabled'>"
+                    f"<span><strong>{_e(label)}</strong> "
+                    f'<span class="users-perm-code">{_e(code)}</span> '
+                    f'<span class="users-perm-effective">{_e(effective_state)}</span> '
+                    f'<span class="users-perm-note">{_e(reason)}</span>'
+                    "</span></div>"
+                )
+        sections.append("</div>")
+    sections.append("</fieldset>")
+    return "".join(sections)
+
+
+def _safe_metadata_lines(metadata: dict[str, object]) -> str:
+    if not metadata:
+        return "–"
+    parts: list[str] = []
+    for key, value in metadata.items():
+        if key in {"password", "token", "csrf", "secret", "hash"}:
+            continue
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            text = "–" if value is None else str(value)
+            parts.append(f"{key}: {text}")
+        elif isinstance(value, list):
+            parts.append(f"{key}: {', '.join(str(item) for item in value)}")
+        elif isinstance(value, dict):
+            inner = ", ".join(f"{k}={v}" for k, v in value.items())
+            parts.append(f"{key}: {inner}")
+    return _e("; ".join(parts)) if parts else "–"
+
+
+def render_user_detail(
+    *,
+    actor: AuthenticatedEmployee,
+    detail: EmployeeAccountDetail,
+    audit_events: list[SecurityAuditEventView],
+    flash: str = "",
+    error_message: str = "",
+    role_change_removed: list[str] | None = None,
+    context: OfficePageContext,
+) -> str:
+    read_only_note = (
+        '<p class="users-readonly-note"><strong>Nur Lesen:</strong> '
+        "Dieses Konto kann von Ihrer Rolle aus nicht bearbeitet werden.</p>"
+        if detail.read_only
+        else ""
+    )
+    status = "Aktiv" if detail.is_active else "Inaktiv"
+    must_change = "Ja" if detail.must_change_password else "Nein"
+    email = _e(detail.email) if detail.email else "–"
+    selectable, disabled = permission_matrix_state(
+        actor,
+        target_role=detail.role,
+        target_read_only=detail.read_only,
+        explicit_permissions=set(detail.explicit_permissions),
+        effective_permissions=set(detail.effective_permissions),
+    )
+    removed_note = ""
+    if role_change_removed:
+        removed_note = (
+            '<p class="office-flash">Entfernte Berechtigungen außerhalb der '
+            "neuen Rollenobergrenze: " + _e(", ".join(role_change_removed)) + "</p>"
+        )
+    profile_form = (
+        '<form method="post" '
+        f'action="/settings/users/{_e(quote(detail.id, safe=""))}/profile" '
+        'class="users-form">'
+        + _csrf_input(context)
+        + "<fieldset><legend>Profil</legend>"
+        f"<p><strong>Konto-ID:</strong> {_e(detail.id)}</p>"
+        "<label>Benutzername<br>"
+        f'<input name="username" required value="{_e(detail.username)}">'
+        "</label><br>"
+        "<label>Anzeigename<br>"
+        f'<input name="display_name" required value="{_e(detail.display_name)}">'
+        "</label><br>"
+        "<label>E-Mail<br>"
+        f'<input name="email" type="email" value="{_e(detail.email or "")}">'
+        "</label><br>"
+        f"<p>Status: {_e(status)} · Passwortwechsel erforderlich: {_e(must_change)}</p>"
+        f"<p>Erstellt: {_e(_format_timestamp(detail.created_at))} · "
+        f"Aktualisiert: {_e(_format_timestamp(detail.updated_at))} · "
+        f"Letzte Anmeldung: {_e(_format_timestamp(detail.last_login_at))}</p>"
+        + (
+            '<p><button type="submit">Profil speichern</button></p>'
+            if not detail.read_only
+            else "<p>Profil ist schreibgeschützt.</p>"
+        )
+        + "</fieldset></form>"
+    )
+    manageable = manageable_roles_for(actor.account.role)
+    role_form = ""
+    if detail.role in manageable and not detail.read_only:
+        role_form = (
+            '<form method="post" '
+            f'action="/settings/users/{_e(quote(detail.id, safe=""))}/role" '
+            'class="users-form">'
+            + _csrf_input(context)
+            + "<fieldset><legend>Rolle</legend>"
+            "<label>Neue Rolle<br>"
+            f'<select name="role">{_role_options(actor, selected=detail.role)}</select>'
+            "</label><br>"
+            '<p><button type="submit">Rolle speichern</button></p>'
+            "</fieldset></form>"
+        )
+    elif detail.read_only:
+        role_form = (
+            "<fieldset><legend>Rolle</legend>"
+            f"<p>{_e(ROLE_LABELS.get(detail.role, detail.role))} "
+            "(schreibgeschützt)</p></fieldset>"
+        )
+    permissions_form = ""
+    if (
+        not detail.read_only
+        and "users.permissions.assign" in actor.effective_permissions
+    ):
+        permissions_form = (
+            '<form method="post" '
+            f'action="/settings/users/{_e(quote(detail.id, safe=""))}/permissions" '
+            'class="users-form">'
+            + _csrf_input(context)
+            + _permission_matrix_html(
+                selectable=selectable,
+                disabled=disabled,
+                explicit=set(detail.explicit_permissions),
+                effective=set(detail.effective_permissions),
+                field_prefix="permission",
+            )
+            + '<p><button type="submit">Berechtigungen speichern</button></p>'
+            "</form>"
+        )
+    else:
+        permissions_form = (
+            "<fieldset><legend>Berechtigungen</legend>"
+            + _permission_matrix_html(
+                selectable=set(),
+                disabled={code: "Schreibgeschützt" for code in PERMISSION_REGISTRY},
+                explicit=set(detail.explicit_permissions),
+                effective=set(detail.effective_permissions),
+                field_prefix="permission",
+            )
+            + "</fieldset>"
+        )
+    lifecycle = ""
+    if not detail.read_only:
+        if detail.is_active:
+            lifecycle = (
+                f'<p><a href="/settings/users/{_e(quote(detail.id, safe=""))}/deactivate">'
+                "Benutzer deaktivieren…</a></p>"
+            )
+        else:
+            lifecycle = (
+                '<form method="post" '
+                f'action="/settings/users/{_e(quote(detail.id, safe=""))}/reactivate" '
+                'class="users-inline-form">'
+                + _csrf_input(context)
+                + "<p>Benutzer ist inaktiv. "
+                "Reaktivierung erstellt keine Sitzung und setzt kein Passwort zurück.</p>"
+                '<button type="submit">Benutzer reaktivieren</button>'
+                "</form>"
+            )
+        lifecycle += (
+            '<form method="post" '
+            f'action="/settings/users/{_e(quote(detail.id, safe=""))}/reset-password" '
+            'class="users-form">'
+            + _csrf_input(context)
+            + "<fieldset><legend>Passwort zurücksetzen</legend>"
+            "<label>Temporäres Passwort<br>"
+            '<input name="temporary_password" type="password" autocomplete="new-password" required>'
+            "</label><br>"
+            "<label>Temporäres Passwort wiederholen<br>"
+            '<input name="temporary_password_confirm" type="password" autocomplete="new-password" required>'
+            "</label><br>"
+            "<p>Alle aktiven Sitzungen werden beendet; Passwortänderung ist "
+            "beim nächsten Login erforderlich.</p>"
+            '<p><button type="submit">Temporäres Passwort setzen</button></p>'
+            "</fieldset></form>"
+        )
+    audit_rows = []
+    for event in audit_events:
+        actor_role = (
+            ROLE_LABELS.get(event.actor_role_snapshot, event.actor_role_snapshot)
+            if event.actor_role_snapshot
+            else "–"
+        )
+        audit_rows.append(
+            "<tr>"
+            f"<td>{_e(_format_timestamp(event.occurred_at))}</td>"
+            f"<td>{_e(event.action)}</td>"
+            f"<td>{_e(event.outcome)}</td>"
+            f"<td>{_e(event.actor_display_name_snapshot or '–')}</td>"
+            f"<td>{_e(actor_role or '–')}</td>"
+            f"<td>{_safe_metadata_lines(event.metadata)}</td>"
+            "</tr>"
+        )
+    audit_table = (
+        "<fieldset><legend>Letzte Sicherheitsereignisse</legend>"
+        "<table><tr><th>Zeitpunkt</th><th>Aktion</th><th>Ergebnis</th>"
+        "<th>Akteur</th><th>Rolle</th><th>Details</th></tr>"
+        + "".join(
+            audit_rows or ['<tr><td colspan="6">Keine Ereignisse vorhanden.</td></tr>']
+        )
+        + "</table></fieldset>"
+    )
+    body = (
+        f"<h2>{_e(detail.display_name)}</h2>"
+        + read_only_note
+        + _flash_banner(flash)
+        + _error_banner(error_message)
+        + removed_note
+        + f"<p>Benutzername: {_e(detail.username)} · E-Mail: {email} · "
+        f"Rolle: {_e(ROLE_LABELS.get(detail.role, detail.role))}</p>"
+        + profile_form
+        + role_form
+        + permissions_form
+        + lifecycle
+        + audit_table
+        + '<p><a href="/settings/users">← Zurück zur Liste</a></p>'
+    )
+    return _page(
+        "Benutzerkonto",
+        body,
+        active_section="settings",
+        context=context,
+        show_title=False,
+    )
+
+
+def render_user_deactivate_confirm(
+    *,
+    detail: EmployeeAccountDetail,
+    context: OfficePageContext,
+    error_message: str = "",
+) -> str:
+    body = (
+        f"<h2>{_e(detail.display_name)} deaktivieren?</h2>"
+        + _error_banner(error_message)
+        + "<p>Der Benutzer wird deaktiviert, nicht gelöscht. "
+        "Alle aktiven Sitzungen werden beendet.</p>" + '<form method="post" '
+        f'action="/settings/users/{_e(quote(detail.id, safe=""))}/deactivate" '
+        'class="users-form">'
+        + _csrf_input(context)
+        + '<p><button type="submit">Deaktivierung bestätigen</button> '
+        f'<a href="/settings/users/{_e(quote(detail.id, safe=""))}">Abbrechen</a></p>'
+        "</form>"
+    )
+    return _page(
+        "Benutzer deaktivieren",
+        body,
+        active_section="settings",
+        context=context,
+        show_title=False,
+    )

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -17,6 +17,7 @@ OfficeSection = Literal[
     "callbacks",
     "proposal",
     "catalog",
+    "settings",
 ]
 
 OFFICE_PANEL_ICON_SPRITE = """<svg xmlns="http://www.w3.org/2000/svg"

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -124,6 +124,7 @@ class OfficePageContext:
     logout_path: str = ""
     show_transition_banner: bool = False
     legacy_shared_access: bool = False
+    show_users_nav: bool = False
 
 
 _EMPTY_PAGE_CONTEXT = OfficePageContext()
@@ -198,6 +199,20 @@ def _page(
             ),
             '<div class="office-nav-label">Verwaltung</div>',
             _nav_link("/gerichte", "Gerichte", "doc", "catalog", active_section),
+            *(
+                (
+                    '<div class="office-nav-label">Einstellungen</div>',
+                    _nav_link(
+                        "/settings/users",
+                        "Benutzer & Rechte",
+                        "users",
+                        "settings",
+                        active_section,
+                    ),
+                )
+                if context.show_users_nav
+                else ()
+            ),
         )
     )
     page_title = f"<h1>{_e(title)}</h1>" if show_title else ""

--- a/tests/unit/test_office_panel_employee_auth_wiring.py
+++ b/tests/unit/test_office_panel_employee_auth_wiring.py
@@ -1,0 +1,506 @@
+"""Production Office Panel employee-auth runtime wiring tests (AUTH-2C)."""
+
+from __future__ import annotations
+
+import http.cookiejar
+import queue
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.employee_auth_runtime import (
+    ManagedEmployeeAuthRuntime,
+    open_managed_employee_auth_runtime,
+)
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import LastActiveSuperadminError
+from catering_system.ui.office_panel import create_office_panel_server
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+@dataclass
+class WiredPanel:
+    base: str
+    server: object
+    thread: threading.Thread
+    runtime: ManagedEmployeeAuthRuntime
+    db: Path
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = urllib.parse.urlencode(data).encode() if data is not None else None
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    try:
+        with opener.open(request) as response:
+            return response.status, response.read().decode("utf-8"), response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8"), exc.headers
+
+
+def _fresh_repository(db: Path) -> SQLiteEmployeeAuthRepository:
+    return SQLiteEmployeeAuthRepository(db)
+
+
+def _start_wired_panel(tmp_path: Path) -> WiredPanel:
+    db = tmp_path / "core.db"
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    ready: queue.Queue[tuple[object, ManagedEmployeeAuthRuntime]] = queue.Queue()
+
+    def run() -> None:
+        runtime = open_managed_employee_auth_runtime(db, now=clock.now)
+        runtime.service.bootstrap_superadmin(
+            username="viktor.admin",
+            display_name="Viktor Johanson",
+            password="TempPassw0rd!",
+            metadata={"seed": "office-panel-wiring"},
+        )
+        server = create_office_panel_server(
+            InMemoryInquiryRepository(),
+            InMemoryOrderRepository(),
+            "shared-office-password",
+            host="127.0.0.1",
+            port=0,
+            auth_mode="employee",
+            auth_service=runtime.service,
+            secure_cookie=False,
+            ui_version="v2",
+        )
+        ready.put((server, runtime))
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server, runtime = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return WiredPanel(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        runtime=runtime,
+        db=db,
+    )
+
+
+def _shutdown(panel: WiredPanel) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+
+
+def _ready_superadmin_jar(panel: WiredPanel) -> http.cookiejar.CookieJar:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "TempPassw0rd!", "next": "/"},
+        jar=jar,
+    )
+    _request(
+        panel.base,
+        "/password-change",
+        method="POST",
+        data={
+            "_csrf_token": _cookie_value(jar, "sl_employee_csrf"),
+            "current_password": "TempPassw0rd!",
+            "new_password": "ChangedTemp1!",
+        },
+        jar=jar,
+    )
+    jar = http.cookiejar.CookieJar()
+    _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": "viktor.admin", "password": "ChangedTemp1!", "next": "/"},
+        jar=jar,
+    )
+    return jar
+
+
+def _create_worker(
+    panel: WiredPanel, jar: http.cookiejar.CookieJar, *, username: str
+) -> str:
+    status, _body, headers = _request(
+        panel.base,
+        "/settings/users",
+        method="POST",
+        data={
+            "_csrf_token": _cookie_value(jar, "sl_employee_csrf"),
+            "username": username,
+            "display_name": "Worker Wiring",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+        },
+        jar=jar,
+    )
+    assert status == 303
+    location = headers["Location"]
+    account_id = location.split("/settings/users/", 1)[1].split("?", 1)[0]
+    return account_id
+
+
+@pytest.fixture()
+def wired_panel(tmp_path: Path):
+    panel = _start_wired_panel(tmp_path)
+    yield panel
+    _shutdown(panel)
+
+
+def test_open_managed_employee_auth_runtime_uses_managed_transactions(
+    tmp_path: Path,
+) -> None:
+    runtime = open_managed_employee_auth_runtime(tmp_path / "managed.db")
+    try:
+        assert runtime.repository._manage_transactions is True
+        assert not runtime.repository._conn.in_transaction
+        with runtime.repository.immediate_transaction():
+            assert runtime.repository._conn.in_transaction
+        assert not runtime.repository._conn.in_transaction
+    finally:
+        runtime.close()
+
+
+def test_office_panel_profile_update_rolls_back_when_success_audit_fails(
+    wired_panel: WiredPanel,
+) -> None:
+    jar = _ready_superadmin_jar(wired_panel)
+    worker_id = _create_worker(wired_panel, jar, username="worker.profile.rollback")
+
+    verify_before = _fresh_repository(wired_panel.db)
+    try:
+        before = verify_before.get_account_by_id(worker_id)
+        assert before is not None
+        assert before.display_name == "Worker Wiring"
+    finally:
+        verify_before.close()
+
+    original_append = wired_panel.runtime.service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.account_profile_updated":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    wired_panel.runtime.service._append_audit = failing_append  # type: ignore[method-assign]
+
+    status, body, _headers = _request(
+        wired_panel.base,
+        f"/settings/users/{worker_id}/profile",
+        method="POST",
+        data={
+            "_csrf_token": _cookie_value(jar, "sl_employee_csrf"),
+            "username": "worker.profile.rollback",
+            "display_name": "Should Roll Back",
+            "email": "",
+        },
+        jar=jar,
+    )
+    assert status == 500
+    assert "Die Aktion konnte nicht ausgeführt werden." in body
+
+    verify_after = _fresh_repository(wired_panel.db)
+    try:
+        after = verify_after.get_account_by_id(worker_id)
+        assert after is not None
+        assert after.display_name == "Worker Wiring"
+        events = verify_after.list_audit_events_for_account(worker_id, limit=100)
+        assert not any(
+            event.action == "auth.account_profile_updated"
+            and event.outcome == "success"
+            for event in events
+        )
+    finally:
+        verify_after.close()
+
+
+def test_office_panel_password_reset_rolls_back_when_success_audit_fails(
+    wired_panel: WiredPanel,
+) -> None:
+    jar = _ready_superadmin_jar(wired_panel)
+    worker_id = _create_worker(wired_panel, jar, username="worker.reset.rollback")
+
+    _request(
+        wired_panel.base,
+        "/login",
+        method="POST",
+        data={
+            "username": "worker.reset.rollback",
+            "password": "WorkerTemp1!",
+            "next": "/",
+        },
+    )
+
+    verify_before = _fresh_repository(wired_panel.db)
+    try:
+        before = verify_before.get_account_by_id(worker_id)
+        assert before is not None
+        original_hash = before.password_hash
+        original_auth_version = before.auth_version
+        original_must_change = before.must_change_password
+        sessions = verify_before._conn.execute(
+            "SELECT revoked_at FROM employee_sessions WHERE account_id = ?",
+            (worker_id,),
+        ).fetchall()
+        assert sessions
+        assert all(row[0] is None for row in sessions)
+    finally:
+        verify_before.close()
+
+    original_append = wired_panel.runtime.service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.password_reset":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    wired_panel.runtime.service._append_audit = failing_append  # type: ignore[method-assign]
+
+    status, _body, _headers = _request(
+        wired_panel.base,
+        f"/settings/users/{worker_id}/reset-password",
+        method="POST",
+        data={
+            "_csrf_token": _cookie_value(jar, "sl_employee_csrf"),
+            "temporary_password": "ResetTemp1!",
+            "temporary_password_confirm": "ResetTemp1!",
+        },
+        jar=jar,
+    )
+    assert status == 500
+
+    verify_after = _fresh_repository(wired_panel.db)
+    try:
+        after = verify_after.get_account_by_id(worker_id)
+        assert after is not None
+        assert after.password_hash == original_hash
+        assert after.auth_version == original_auth_version
+        assert after.must_change_password == original_must_change
+        sessions = verify_after._conn.execute(
+            "SELECT revoked_at FROM employee_sessions WHERE account_id = ?",
+            (worker_id,),
+        ).fetchall()
+        assert sessions
+        assert all(row[0] is None for row in sessions)
+        events = verify_after.list_audit_events_for_account(worker_id, limit=100)
+        assert not any(
+            event.action == "auth.password_reset" and event.outcome == "success"
+            for event in events
+        )
+    finally:
+        verify_after.close()
+
+
+def test_office_panel_deactivate_rolls_back_when_success_audit_fails(
+    wired_panel: WiredPanel,
+) -> None:
+    jar = _ready_superadmin_jar(wired_panel)
+    worker_id = _create_worker(wired_panel, jar, username="worker.deact.rollback")
+
+    verify_before = _fresh_repository(wired_panel.db)
+    try:
+        before = verify_before.get_account_by_id(worker_id)
+        assert before is not None
+        assert before.is_active is True
+        assert before.deactivated_at is None
+        sessions = verify_before._conn.execute(
+            "SELECT revoked_at FROM employee_sessions WHERE account_id = ?",
+            (worker_id,),
+        ).fetchall()
+        assert not sessions or all(row[0] is None for row in sessions)
+    finally:
+        verify_before.close()
+
+    original_append = wired_panel.runtime.service._append_audit
+
+    def failing_append(**kwargs: object) -> None:
+        if kwargs.get("action") == "auth.account_deactivated":
+            raise sqlite3.OperationalError("audit insert failed")
+        original_append(**kwargs)  # type: ignore[arg-type]
+
+    wired_panel.runtime.service._append_audit = failing_append  # type: ignore[method-assign]
+
+    status, _body, _headers = _request(
+        wired_panel.base,
+        f"/settings/users/{worker_id}/deactivate",
+        method="POST",
+        data={"_csrf_token": _cookie_value(jar, "sl_employee_csrf")},
+        jar=jar,
+    )
+    assert status == 500
+
+    verify_after = _fresh_repository(wired_panel.db)
+    try:
+        after = verify_after.get_account_by_id(worker_id)
+        assert after is not None
+        assert after.is_active is True
+        assert after.deactivated_at is None
+        events = verify_after.list_audit_events_for_account(worker_id, limit=100)
+        assert not any(
+            event.action == "auth.account_deactivated" and event.outcome == "success"
+            for event in events
+        )
+    finally:
+        verify_after.close()
+
+
+def test_managed_runtime_concurrent_last_superadmin_protection(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "concurrent.db"
+    setup = open_managed_employee_auth_runtime(
+        db, now=lambda: datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    )
+    setup.service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+    )
+    login = setup.service.authenticate(username="super.admin", password="TempPassw0rd!")
+    actor = setup.service.authenticate_session(login.session_token)
+    setup.service.change_password(
+        actor,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    relogin = setup.service.authenticate(
+        username="super.admin", password="ChangedTemp1!"
+    )
+    actor = setup.service.authenticate_session(relogin.session_token)
+    backup = setup.service.create_account(
+        actor,
+        username="super.two",
+        display_name="Super Two",
+        password="SecondTemp1!",
+        role="SUPERADMIN",
+    )
+    super_one_id = actor.account.id
+    super_two_id = backup.id
+    setup.close()
+
+    barrier = threading.Barrier(2)
+    results: list[tuple[str, str]] = []
+
+    def attempt_demote(target_id: str) -> None:
+        runtime = open_managed_employee_auth_runtime(
+            db, now=lambda: datetime(2026, 8, 1, 10, 30, tzinfo=UTC)
+        )
+        login_result = runtime.service.authenticate(
+            username="super.admin", password="ChangedTemp1!"
+        )
+        thread_actor = runtime.service.authenticate_session(login_result.session_token)
+        barrier.wait(timeout=5)
+        try:
+            runtime.service.change_account_role(thread_actor, target_id, "ADMIN")
+            results.append(("ok", target_id))
+        except LastActiveSuperadminError:
+            results.append(("blocked", target_id))
+        finally:
+            runtime.close()
+
+    threads = [
+        threading.Thread(target=attempt_demote, args=(super_one_id,)),
+        threading.Thread(target=attempt_demote, args=(super_two_id,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    verify = open_managed_employee_auth_runtime(db)
+    try:
+        assert verify.repository.count_active_superadmins() >= 1
+    finally:
+        verify.close()
+
+    assert len(results) == 2
+    assert {item[0] for item in results} == {"ok", "blocked"}
+
+
+def test_create_account_is_always_active(wired_panel: WiredPanel) -> None:
+    jar = _ready_superadmin_jar(wired_panel)
+    worker_id = _create_worker(wired_panel, jar, username="worker.always.active")
+    verify = _fresh_repository(wired_panel.db)
+    try:
+        account = verify.get_account_by_id(worker_id)
+        assert account is not None
+        assert account.is_active is True
+    finally:
+        verify.close()
+
+
+def test_invalid_role_post_renders_safe_german_error(wired_panel: WiredPanel) -> None:
+    jar = _ready_superadmin_jar(wired_panel)
+    status, body, _headers = _request(
+        wired_panel.base,
+        "/settings/users",
+        method="POST",
+        data={
+            "_csrf_token": _cookie_value(jar, "sl_employee_csrf"),
+            "username": "bad.role.user",
+            "display_name": "Bad Role User",
+            "role": "NOT_A_ROLE",
+            "temporary_password": "WorkerTemp1!",
+        },
+        jar=jar,
+    )
+    assert status == 400
+    assert "Die ausgewählte Rolle ist nicht zulässig." in body
+    assert "role must be one of" not in body
+    assert 'value="WorkerTemp1!"' not in body
+
+    verify = _fresh_repository(wired_panel.db)
+    try:
+        assert verify.get_account_by_username("bad.role.user") is None
+    finally:
+        verify.close()

--- a/tests/unit/test_office_panel_settings_users.py
+++ b/tests/unit/test_office_panel_settings_users.py
@@ -349,7 +349,6 @@ def test_create_user_succeeds(employee_panel: PanelHarness) -> None:
             "email": "new@example.com",
             "role": "USER",
             "temporary_password": "WorkerTemp1!",
-            "is_active": "1",
         },
         jar=jar,
     )
@@ -402,7 +401,6 @@ def test_admin_cannot_select_admin_role_on_create(employee_panel: PanelHarness) 
             "display_name": "Blocked Admin",
             "role": "ADMIN",
             "temporary_password": "AdminTemp1!",
-            "is_active": "1",
         },
         jar=admin_jar,
     )
@@ -418,7 +416,6 @@ def test_username_conflict_renders_german_error(employee_panel: PanelHarness) ->
         "display_name": "Dup User",
         "role": "USER",
         "temporary_password": "WorkerTemp1!",
-        "is_active": "1",
     }
     _request(
         employee_panel.base,

--- a/tests/unit/test_office_panel_settings_users.py
+++ b/tests/unit/test_office_panel_settings_users.py
@@ -1,0 +1,817 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import re
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.employee_auth import PERMISSION_REGISTRY
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_panel import create_office_panel_server
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+@dataclass
+class PanelHarness:
+    base: str
+    server: object
+    thread: threading.Thread
+    service: EmployeeAuthService
+    repo: SQLiteEmployeeAuthRepository
+    clock: Clock
+    password: str
+
+
+def _auth_header(password: str) -> str:
+    return "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | list[tuple[str, str]] | None = None,
+    headers: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = None
+    if data is not None:
+        if isinstance(data, list):
+            payload = urllib.parse.urlencode(data, doseq=True).encode()
+        else:
+            payload = urllib.parse.urlencode(data).encode()
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    try:
+        with opener.open(request) as response:
+            return (
+                response.status,
+                response.url,
+                response.read().decode("utf-8"),
+                response.headers,
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8"), exc.headers
+
+
+def _create_panel(
+    tmp_path: Path,
+    *,
+    auth_mode: str,
+    password: str = "shared-office-password",
+) -> PanelHarness:
+    db = tmp_path / "core.db"
+    connection = sqlite3.connect(str(db), check_same_thread=False)
+    repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    service = EmployeeAuthService(repo, now=clock.now)
+    service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "settings-users"},
+    )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        password,
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        auth_service=service,
+        secure_cookie=False,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return PanelHarness(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        service=service,
+        repo=repo,
+        clock=clock,
+        password=password,
+    )
+
+
+def _shutdown(panel: PanelHarness) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+    panel.repo.close()
+
+
+def _login(
+    panel: PanelHarness, *, username: str, password: str
+) -> http.cookiejar.CookieJar:
+    jar = http.cookiejar.CookieJar()
+    _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": username, "password": password, "next": "/"},
+        jar=jar,
+    )
+    return jar
+
+
+def _ready_superadmin(panel: PanelHarness) -> http.cookiejar.CookieJar:
+    jar = _login(panel, username="viktor.admin", password="TempPassw0rd!")
+    employee = panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    return _login(panel, username="viktor.admin", password="ChangedTemp1!")
+
+
+def _csrf(jar: http.cookiejar.CookieJar) -> str:
+    return _cookie_value(jar, "sl_employee_csrf")
+
+
+def _ready_admin(
+    panel: PanelHarness, super_jar: http.cookiejar.CookieJar
+) -> http.cookiejar.CookieJar:
+    super_employee = panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    admin = panel.service.create_account(
+        super_employee,
+        username="team.admin",
+        display_name="Team Admin",
+        password="AdminTemp1!",
+        role="ADMIN",
+    )
+    jar = _login(panel, username=admin.username, password="AdminTemp1!")
+    employee = panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    panel.service.change_password(
+        employee,
+        current_password="AdminTemp1!",
+        new_password="AdminChanged1!",
+    )
+    return _login(panel, username=admin.username, password="AdminChanged1!")
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def migration_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="migration")
+    yield panel
+    _shutdown(panel)
+
+
+def test_users_nav_visible_with_users_view(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert "Benutzer &amp; Rechte" in body or "Benutzer & Rechte" in body
+    assert 'href="/settings/users"' in body
+
+
+def test_users_nav_hidden_without_users_view(employee_panel: PanelHarness) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    viewer = employee_panel.service.create_account(
+        super_employee,
+        username="reader.only",
+        display_name="Reader Only",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        explicit_permissions={"inquiries.view"},
+    )
+    jar = _login(employee_panel, username=viewer.username, password="ViewerTemp1!")
+    employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    employee_panel.service.change_password(
+        employee,
+        current_password="ViewerTemp1!",
+        new_password="ViewerChanged1!",
+    )
+    jar = _login(employee_panel, username=viewer.username, password="ViewerChanged1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert "/settings/users" not in body
+
+
+def test_basic_fallback_cannot_access_users_routes(
+    migration_panel: PanelHarness,
+) -> None:
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/settings/users",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+    )
+    assert status == 403
+    assert "Berechtigung" in body
+
+
+def test_unauthenticated_users_route_redirects_to_login(
+    employee_panel: PanelHarness,
+) -> None:
+    status, _url, _body, headers = _request(employee_panel.base, "/settings/users")
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_list_page_shows_account_fields(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    employee_panel.service.create_account(
+        super_employee,
+        username="worker.one",
+        display_name="Worker One",
+        password="WorkerTemp1!",
+        role="USER",
+        email="worker@example.com",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/settings/users", jar=jar
+    )
+    assert status == 200
+    assert "Worker One" in body
+    assert "worker.one" in body
+    assert "worker@example.com" in body
+    assert "Benutzer" in body
+
+
+def test_admin_sees_admin_rows_read_only(employee_panel: PanelHarness) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    admin_jar = _ready_admin(employee_panel, super_jar)
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/settings/users", jar=admin_jar
+    )
+    assert status == 200
+    assert "Nur Lesen" in body
+    assert "viktor.admin" in body
+
+
+def test_superadmin_can_open_editable_account_detail(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="editable.user",
+        display_name="Editable User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}",
+        jar=jar,
+    )
+    assert status == 200
+    assert worker.id in body
+    assert "Profil speichern" in body
+    assert "Passwort zurücksetzen" not in body or "Temporäres Passwort setzen" in body
+
+
+def test_create_user_succeeds(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/settings/users",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "username": "new.worker",
+            "display_name": "New Worker",
+            "email": "new@example.com",
+            "role": "USER",
+            "temporary_password": "WorkerTemp1!",
+            "is_active": "1",
+        },
+        jar=jar,
+    )
+    assert status == 303
+    assert "/settings/users/" in headers["Location"]
+    assert "msg=created" in headers["Location"]
+
+
+def test_create_viewer_exposes_only_read_permissions(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    viewer = employee_panel.service.create_account(
+        super_employee,
+        username="viewer.perms",
+        display_name="Viewer Perms",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        explicit_permissions={"inquiries.view"},
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{viewer.id}",
+        jar=jar,
+    )
+    assert status == 200
+    assert "Für Leser nur Leseberechtigungen" in body
+    assert 'name="permission" value="inquiries.create"' not in body
+
+
+def test_admin_cannot_select_admin_role_on_create(employee_panel: PanelHarness) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    admin_jar = _ready_admin(employee_panel, super_jar)
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/settings/users/new", jar=admin_jar
+    )
+    assert status == 200
+    assert "SUPERADMIN" not in body
+    assert "ADMIN" not in body or "Administrator" not in body.split("select")[1][:200]
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        "/settings/users",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(admin_jar),
+            "username": "blocked.admin",
+            "display_name": "Blocked Admin",
+            "role": "ADMIN",
+            "temporary_password": "AdminTemp1!",
+            "is_active": "1",
+        },
+        jar=admin_jar,
+    )
+    assert status in {403, 409}
+    assert headers.get("Location") is None or "blocked.admin" not in headers["Location"]
+
+
+def test_username_conflict_renders_german_error(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    payload = {
+        "_csrf_token": _csrf(jar),
+        "username": "dup.user",
+        "display_name": "Dup User",
+        "role": "USER",
+        "temporary_password": "WorkerTemp1!",
+        "is_active": "1",
+    }
+    _request(
+        employee_panel.base,
+        "/settings/users",
+        method="POST",
+        data=payload,
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/settings/users",
+        method="POST",
+        data=payload,
+        jar=jar,
+    )
+    assert status == 409
+    assert "Benutzername ist bereits vergeben." in body
+    assert 'type="password"' in body
+    assert 'value="WorkerTemp1!"' not in body
+
+
+def test_profile_edit_preserves_account_id(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="profile.user",
+        display_name="Profile User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/profile",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "username": "profile.user",
+            "display_name": "Updated Profile",
+            "email": "",
+        },
+        jar=jar,
+    )
+    assert status == 303
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}?msg=saved",
+        jar=jar,
+    )
+    assert worker.id in body
+    assert "Updated Profile" in body
+
+
+def test_role_change_refreshes_effective_permissions(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="role.user",
+        display_name="Role User",
+        password="WorkerTemp1!",
+        role="USER",
+        explicit_permissions={"inquiries.view", "inquiries.create"},
+    )
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/role",
+        method="POST",
+        data={"_csrf_token": _csrf(jar), "role": "VIEWER"},
+        jar=jar,
+    )
+    assert status == 303
+    assert "role_changed" in headers["Location"]
+    detail = employee_panel.service.get_account(super_employee, worker.id)
+    assert "inquiries.create" not in detail.effective_permissions
+
+
+def test_permission_matrix_uses_canonical_registry(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="perm.user",
+        display_name="Perm User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}",
+        jar=jar,
+    )
+    assert status == 200
+    for code in PERMISSION_REGISTRY:
+        assert code in body
+
+
+def test_unavailable_permissions_not_submitted_via_form(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    admin_jar = _ready_admin(employee_panel, super_jar)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="perm.target",
+        display_name="Perm Target",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/permissions",
+        method="POST",
+        data=[
+            ("_csrf_token", _csrf(admin_jar)),
+            ("permission", "settings.edit"),
+            ("permission", "inquiries.view"),
+        ],
+        jar=admin_jar,
+    )
+    assert status == 303
+    detail = employee_panel.service.get_account(super_employee, worker.id)
+    assert "settings.edit" not in detail.explicit_permissions
+
+
+def test_forged_post_still_denied_by_service(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    admin_jar = _ready_admin(employee_panel, super_jar)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{super_employee.account.id}/profile",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(admin_jar),
+            "username": super_employee.account.username,
+            "display_name": "Hack",
+            "email": "",
+        },
+        jar=admin_jar,
+    )
+    assert status in {400, 403}
+    assert "nicht zulässig" in body or "Berechtigung" in body
+
+
+def test_deactivate_confirmation_and_success(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="deact.user",
+        display_name="Deact User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/deactivate",
+        jar=jar,
+    )
+    assert status == 200
+    assert "Sitzungen werden beendet" in body or "Sitzungen" in body
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/deactivate",
+        method="POST",
+        data={"_csrf_token": _csrf(jar)},
+        jar=jar,
+    )
+    assert status == 303
+    assert "deactivated" in headers["Location"]
+
+
+def test_last_active_superadmin_conflict_rendered_safely(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{super_employee.account.id}/deactivate",
+        method="POST",
+        data={"_csrf_token": _csrf(jar)},
+        jar=jar,
+    )
+    assert status == 400
+    assert "letzte aktive Superadmin" in body
+
+
+def test_reactivate_success(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="react.user",
+        display_name="React User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    employee_panel.service.deactivate_account(super_employee, worker.id)
+    status, _url, _body, headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/reactivate",
+        method="POST",
+        data={"_csrf_token": _csrf(jar)},
+        jar=jar,
+    )
+    assert status == 303
+    assert "reactivated" in headers["Location"]
+
+
+def test_password_reset_does_not_echo_password(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="reset.user",
+        display_name="Reset User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    temp = "ResetTemp1!"
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/reset-password",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "temporary_password": temp,
+            "temporary_password_confirm": temp,
+        },
+        jar=jar,
+    )
+    assert status == 303
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}?msg=password_reset",
+        jar=jar,
+    )
+    assert temp not in body
+
+
+def test_password_reset_success_message(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="reset.msg",
+        display_name="Reset Msg",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    temp = "ResetTemp1!"
+    _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}/reset-password",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "temporary_password": temp,
+            "temporary_password_confirm": temp,
+        },
+        jar=jar,
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}?msg=password_reset",
+        jar=jar,
+    )
+    assert "Passwortänderung" in body
+    assert "Sitzungen" in body
+
+
+def test_audit_history_renders_redacted_fields(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    super_employee = employee_panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    worker = employee_panel.service.create_account(
+        super_employee,
+        username="audit.user",
+        display_name="Audit User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/settings/users/{worker.id}",
+        jar=jar,
+    )
+    assert status == 200
+    assert "auth.account_created" in body
+    assert "password_hash" not in body
+    assert "csrf" not in body.lower() or "CSRF" not in body
+
+
+def test_employee_csrf_missing_returns_403(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/settings/users",
+        method="POST",
+        data={"username": "x", "display_name": "X", "role": "USER"},
+        jar=jar,
+    )
+    assert status == 403
+    assert "CSRF" in body
+
+
+def test_cross_session_csrf_returns_403(employee_panel: PanelHarness) -> None:
+    jar_a = _ready_superadmin(employee_panel)
+    jar_b = _login(employee_panel, username="viktor.admin", password="ChangedTemp1!")
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/logout",
+        method="POST",
+        data={"_csrf_token": _csrf(jar_a)},
+        jar=jar_b,
+    )
+    assert status == 403
+
+
+def test_migration_mode_employee_can_access_users(
+    migration_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(migration_panel)
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/settings/users",
+        jar=jar,
+    )
+    assert status == 200
+    assert "Benutzer" in body
+
+
+def test_migration_mode_basic_fallback_denied(migration_panel: PanelHarness) -> None:
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/settings/users",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+    )
+    assert status == 403
+
+
+def test_no_delete_action_exists(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/settings/users", jar=jar
+    )
+    assert status == 200
+    assert re.search(r">Löschen<|/delete", body, re.IGNORECASE) is None
+
+
+def test_sidebar_shows_real_employee_identity(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/settings/users", jar=jar
+    )
+    assert status == 200
+    assert "Viktor Johanson" in body
+    assert "Superadmin" in body
+    assert "Gemeinsamer Office-Zugang" not in body
+
+
+def test_existing_home_route_still_works(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert "Arbeitszentrale" in body


### PR DESCRIPTION
## Summary
- Adds **Einstellungen → Benutzer & Rechte** to the Office Panel v2 shell with navigation gated by `users.view` (employee sessions only; Basic fallback denied).
- Implements server-rendered list/create/detail flows, role and permission matrix UI from `PERMISSION_REGISTRY`, deactivate/reactivate confirmation, operator-supplied password reset, and bounded audit display — all backed by direct `EmployeeAuthService` calls (AUTH-2B).
- Replaces sidebar identity with real employee display name and translated role; adds 28 focused HTTP/UI regression tests.

## Test plan
- [x] Focused AUTH-2C tests (`test_office_panel_settings_users.py`)
- [x] AUTH-2A login/session regressions
- [x] AUTH-2B service/API regressions
- [x] Full Core suite (2531 passed locally)
- [x] ruff check/format, mypy, git diff --check
- [ ] CI exact-head quality checks

Closes #70

Baseline: `4f701aa1e8a4381532140253c557e732feb914bb`

Made with [Cursor](https://cursor.com)