### PR TITLE
AUTH-2D1: Office Panel GET authorization and navigation visibility

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -762,13 +762,16 @@ class OfficePanel:
     ) -> str:
         operating_today = api_views.berlin_today()
         snapshot = self.build_work_center_snapshot(missed_calls_open)
+        calendar_entries = (
+            self._calendar_list_rows() if context.can("calendar.view") else []
+        )
         return render_arbeitszentrale(
             ArbeitszentraleData(
                 context=context,
                 today=operating_today,
                 snapshot=snapshot,
                 tasks=self._task_list_rows(),
-                calendar_entries=self._calendar_list_rows(),
+                calendar_entries=calendar_entries,
                 contact_check_open=self._contact_check_open_count(),
                 open_inquiries_open=self._open_inquiries_count(),
                 kalender_view=kalender_view,
@@ -839,11 +842,19 @@ class OfficePanel:
                 )
         version_id = surface_version_id(detail)
         pdf_download_url: str | None = None
-        if version_id and self.offer_document_exists(offer_id, version_id):
+        if (
+            version_id
+            and context.can("offers.pdf.generate")
+            and self.offer_document_exists(offer_id, version_id)
+        ):
             pdf_download_url = (
                 f"/offer/{quote(offer_id, safe='')}/offer-document/pdf"
                 f"?{urlencode({'offer_version_id': version_id})}"
             )
+        if revision_prefill_url is not None and not context.can(
+            "offers.version.create"
+        ):
+            revision_prefill_url = None
         return render_offer_detail(
             detail,
             context=context,
@@ -1776,8 +1787,12 @@ class OfficePanel:
             version = max(versions, key=lambda v: v.version_number)
         expect: dict[str, str] = {}
         if version.kitchen_print_confirmed_at is None:
+            if not context.can("orders.print.confirm"):
+                return ""
             label, action = "Druck bestätigen", "print-confirm"
         elif version.order_version_id != order.effective_order_version_id:
+            if not context.can("orders.effective.set"):
+                return ""
             label, action = "Wirksam machen", "effective"
             expect = {
                 "effective_version_id": order.effective_order_version_id or "",
@@ -1859,14 +1874,20 @@ class OfficePanel:
         context: OfficePageContext,
     ) -> str:
         if state.next_action == "verify":
+            if not context.can("inquiries.verify"):
+                return ""
             return (
                 f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/verify">'
                 f"{_csrf_input(context)}{self._command_fields()}"
                 "<button>Telefonisch verifiziert</button></form>"
             )
         if state.next_action == "prepare-offer":
+            if not context.can("offers.prepare"):
+                return ""
             return '<span class="muted">Angebot vorbereiten</span>'
         if state.next_action == "prepare-next-version":
+            if not context.can("offers.version.create"):
+                return ""
             return '<span class="muted">Neue Version vorbereiten</span>'
         if state.next_action == "offer-pending":
             return '<span class="muted">Angebot ausstehend</span>'
@@ -1994,18 +2015,20 @@ class OfficePanel:
             if self.kiosk_url
             else ""
         )
-        diese_woche = (
-            f'<h2 id="diese-woche">Diese Woche (KW {iso.week}/{iso.year})</h2>'
-            "<table><tr><th>Datum</th><th>Zeitfenster</th><th>Ort</th><th>Gäste</th><th>Auftrag</th></tr>"
-            + "".join(
-                week_rows
-                or [
-                    '<tr><td colspan="5">keine wirksamen Aufträge diese Woche</td></tr>'
-                ]
+        diese_woche = ""
+        if context.can("calendar.view"):
+            diese_woche = (
+                f'<h2 id="diese-woche">Diese Woche (KW {iso.week}/{iso.year})</h2>'
+                "<table><tr><th>Datum</th><th>Zeitfenster</th><th>Ort</th><th>Gäste</th><th>Auftrag</th></tr>"
+                + "".join(
+                    week_rows
+                    or [
+                        '<tr><td colspan="5">keine wirksamen Aufträge diese Woche</td></tr>'
+                    ]
+                )
+                + "</table>"
+                + kiosk_link
             )
-            + "</table>"
-            + kiosk_link
-        )
 
         # -- three action queues (§11 addendum): top 5 rows each, one
         # primary action per row, full lists live at /rueckruf, /anfragen,
@@ -2083,7 +2106,11 @@ class OfficePanel:
             + rueckruf_section
             + offene_anfragen_section
             + auftraege_section
-            + '<p><a href="/inquiry/new">+ Neue Anfrage erfassen</a></p>'
+            + (
+                '<p><a href="/inquiry/new">+ Neue Anfrage erfassen</a></p>'
+                if context.can("inquiries.create")
+                else ""
+            )
         )
         return _page("Büro-Übersicht", body, active_section="home", context=context)
 
@@ -2796,6 +2823,7 @@ class OfficePanel:
                 linked_orders_total_count=linked_orders_total_count,
                 linked_orders_truncated=linked_orders_truncated,
                 offer_url=offer_url,
+                context=context,
             )
             return _page(
                 detail.title,
@@ -3173,6 +3201,7 @@ class OfficePanel:
                         target is not None
                         and version.order_version_id == target.order_version_id
                         and version.kitchen_print_confirmed_at is None
+                        and context.can("orders.print.confirm")
                     ):
                         print_confirm_fields[version.order_version_id] = (
                             self._command_fields()
@@ -3182,6 +3211,7 @@ class OfficePanel:
                         and version.order_version_id == target.order_version_id
                         and version.kitchen_print_confirmed_at is not None
                         and version.order_version_id != order.effective_order_version_id
+                        and context.can("orders.effective.set")
                     ):
                         effective_fields[version.order_version_id] = (
                             self._command_fields(
@@ -3214,13 +3244,15 @@ class OfficePanel:
                     print_confirm_command_fields=print_confirm_fields,
                     effective_command_fields=effective_fields,
                     ready_command_fields=(
-                        self._command_fields() if not cancelled else ""
+                        self._command_fields()
+                        if not cancelled and context.can("orders.ready.release")
+                        else ""
                     ),
                     cancel_command_fields=(
                         self._command_fields(
                             {"updated_at": order.updated_at.isoformat()}
                         )
-                        if not cancelled
+                        if not cancelled and context.can("orders.cancel")
                         else ""
                     ),
                     version_command_fields=(
@@ -3235,7 +3267,7 @@ class OfficePanel:
                                 ),
                             }
                         )
-                        if not cancelled
+                        if not cancelled and context.can("orders.version.create")
                         else ""
                     ),
                     payment_command_fields=(
@@ -3275,12 +3307,20 @@ class OfficePanel:
                     ),
                     pause_command_fields=(
                         self._command_fields(self._pause_expect_fields(pause_view))
-                        if not cancelled and not pause_view.get("active")
+                        if (
+                            not cancelled
+                            and not pause_view.get("active")
+                            and context.can("orders.pause")
+                        )
                         else ""
                     ),
                     resume_command_fields=(
                         self._command_fields(self._resume_expect_fields(pause_view))
-                        if not cancelled and pause_view.get("active")
+                        if (
+                            not cancelled
+                            and pause_view.get("active")
+                            and context.can("orders.pause")
+                        )
                         else ""
                     ),
                     customer_addresses_command_fields=(

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3391,6 +3391,7 @@ class OfficePanel:
                     v.kitchen_print_confirmed_at is None
                     and action_target is not None
                     and v.order_version_id == action_target.order_version_id
+                    and context.can("orders.print.confirm")
                 ):
                     actions.append(
                         f'<form class="inline" method="post" action="/order/{_e(order_id)}/print-confirm">'
@@ -3403,6 +3404,7 @@ class OfficePanel:
                     and v.order_version_id != order.effective_order_version_id
                     and action_target is not None
                     and v.order_version_id == action_target.order_version_id
+                    and context.can("orders.effective.set")
                 ):
                     actions.append(
                         f'<form class="inline" method="post" action="/order/{_e(order_id)}/effective">'
@@ -3491,12 +3493,25 @@ class OfficePanel:
                 latest_version_number=latest_version_number,
             )
             assert prefill is not None
-            actions_block = f"""
-<p>
-<form class="inline" method="post" action="/order/{_e(order_id)}/ready">{_csrf_input(context)}{self._command_fields()}<button>Freigabe anfordern</button></form>
-<form class="inline" method="post" action="/order/{_e(order_id)}/cancel">{_csrf_input(context)}{self._command_fields({"updated_at": order.updated_at.isoformat()})}<button>Auftrag stornieren</button></form>
-</p>
-<h2>Neue Version</h2>
+            action_parts: list[str] = []
+            inline_forms: list[str] = []
+            if context.can("orders.ready.release"):
+                inline_forms.append(
+                    f'<form class="inline" method="post" action="/order/{_e(order_id)}/ready">'
+                    f"{_csrf_input(context)}{self._command_fields()}"
+                    "<button>Freigabe anfordern</button></form>"
+                )
+            if context.can("orders.cancel"):
+                inline_forms.append(
+                    f'<form class="inline" method="post" action="/order/{_e(order_id)}/cancel">'
+                    f"{_csrf_input(context)}{self._command_fields({'updated_at': order.updated_at.isoformat()})}"
+                    "<button>Auftrag stornieren</button></form>"
+                )
+            if inline_forms:
+                action_parts.append(f"<p>{''.join(inline_forms)}</p>")
+            if context.can("orders.version.create"):
+                action_parts.append(
+                    f"""<h2>Neue Version</h2>
 <form method="post" action="/order/{_e(order_id)}/version">{_csrf_input(context)}{self._command_fields({"latest_version_number": str(latest_version_number), "current_effective_order_version_id": order.effective_order_version_id or "", "current_candidate_order_version_id": order.candidate_order_version_id or ""})}<input type="hidden" name="latest_version_number" value="{_e(prefill.latest_version_number)}"><fieldset>
 <p><label>Datum*</label><input type="date" name="event_date" required value="{_e(prefill.event_date)}"></p>
 <p><label>Zeitfenster</label><input name="time_window_text" value="{_e(prefill.time_window_text)}"></p>
@@ -3507,6 +3522,8 @@ class OfficePanel:
 <p><label>Änderungsgrund*</label><textarea name="change_reason" maxlength="1000" required></textarea></p>
 <p><button type="submit">Version anlegen</button></p>
 </fieldset></form>"""
+                )
+            actions_block = "".join(action_parts)
         truncation_warning = (
             '<p class="blocked"><strong>Unvollständige Ansicht:</strong> '
             f"Es werden {len(versions)} von {versions_total_count} Versionen "
@@ -3546,12 +3563,20 @@ class OfficePanel:
             ),
             pause_command_fields=(
                 self._command_fields(self._pause_expect_fields(pause_view))
-                if not cancelled and not pause_view.get("active")
+                if (
+                    not cancelled
+                    and not pause_view.get("active")
+                    and context.can("orders.pause")
+                )
                 else ""
             ),
             resume_command_fields=(
                 self._command_fields(self._resume_expect_fields(pause_view))
-                if not cancelled and pause_view.get("active")
+                if (
+                    not cancelled
+                    and pause_view.get("active")
+                    and context.can("orders.pause")
+                )
                 else ""
             ),
             customer_addresses_command_fields=(

--- a/src/catering_system/ui/office_panel_authz.py
+++ b/src/catering_system/ui/office_panel_authz.py
@@ -1,0 +1,66 @@
+"""Office Panel business authorization helpers (AUTH-2D1).
+
+Centralizes permission checks for employee sessions while preserving the
+migration/basic legacy rollback path. Settings/users routes keep their
+separate employee-only actor rules from AUTH-2C.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from catering_system.domain.employee_auth import PERMISSION_SET, AuthenticatedEmployee
+
+if TYPE_CHECKING:
+    from catering_system.ui.office_panel_http import OfficePanelRequestAuth
+
+
+class BusinessAccessDenied(Exception):
+    """Raised when an employee session lacks a required business permission."""
+
+
+class BusinessAuthRequest(Protocol):
+    kind: Literal["basic", "employee"]
+    legacy_shared_access: bool
+    employee: AuthenticatedEmployee | None
+
+
+def can_access(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_code: str,
+) -> bool:
+    """Return whether ``permission_code`` is allowed for this request principal."""
+    if permission_code not in PERMISSION_SET:
+        return False
+    if auth is None:
+        return False
+    if auth.legacy_shared_access:
+        return True
+    if auth.kind != "employee" or auth.employee is None:
+        return False
+    if not auth.employee.application_access_allowed:
+        return False
+    return permission_code in auth.employee.effective_permissions
+
+
+def can_access_all(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_codes: tuple[str, ...],
+) -> bool:
+    return all(can_access(auth, code) for code in permission_codes)
+
+
+def require_business_permission(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_code: str,
+) -> None:
+    if not can_access(auth, permission_code):
+        raise BusinessAccessDenied()
+
+
+def require_all_business_permissions(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_codes: tuple[str, ...],
+) -> None:
+    for permission_code in permission_codes:
+        require_business_permission(auth, permission_code)

--- a/src/catering_system/ui/office_panel_catalog_detail.py
+++ b/src/catering_system/ui/office_panel_catalog_detail.py
@@ -107,7 +107,11 @@ def render_gericht_detail(
         + _allergen_block(detail.get("allergen_labels"))
         + f"<p><strong>Preis:</strong> {_e(str(detail.get('price_display', '–')))}</p>"
         + _price_history_block(detail.get("price_history"))
-        + f'<p><a href="/gerichte/{_e(dish_id)}/edit">Bearbeiten</a></p>'
+        + (
+            f'<p><a href="/gerichte/{_e(dish_id)}/edit">Bearbeiten</a></p>'
+            if context.can("catalog.edit")
+            else ""
+        )
         + '<p><a href="/gerichte">← Zurück zu Gerichte</a></p>'
     )
     return _page(name, body, active_section="catalog", context=context)

--- a/src/catering_system/ui/office_panel_catalog_list.py
+++ b/src/catering_system/ui/office_panel_catalog_list.py
@@ -135,7 +135,11 @@ def render_gerichte_list(
     body = (
         '<p class="subtitle">Stammdaten — Gerichte anlegen, bearbeiten und '
         "aktivieren.</p>"
-        '<p><a href="/gerichte/new">Neues Gericht anlegen</a></p>'
+        + (
+            '<p><a href="/gerichte/new">Neues Gericht anlegen</a></p>'
+            if context.can("catalog.edit")
+            else ""
+        )
         + _search_form(search_query, status_filter)
         + _status_tabs(search_query, status_filter)
         + limit_notice

--- a/src/catering_system/ui/office_panel_dashboard.py
+++ b/src/catering_system/ui/office_panel_dashboard.py
@@ -282,6 +282,8 @@ def _month_grid(data: ArbeitszentraleData) -> str:
 
 
 def _calendar_card(data: ArbeitszentraleData) -> str:
+    if not data.context.can("calendar.view"):
+        return ""
     if data.kalender_view == "monat":
         body = _month_grid(data)
         subtitle = f"{_MONTHS[data.today.month]} {data.today.year}"
@@ -331,32 +333,51 @@ def render_arbeitszentrale(data: ArbeitszentraleData) -> str:
         f"{_WEEKDAYS[today.weekday()]}, {today.day}. "
         f"{_MONTHS[today.month]} {today.year}"
     )
+    header_actions: list[str] = []
+    if data.context.can("orders.view"):
+        header_actions.append(
+            '<a class="dashboard-button secondary" href="/orders">Alle Aufträge</a>'
+        )
+    if data.context.can("inquiries.create"):
+        header_actions.append(
+            '<a class="dashboard-button" href="/inquiry/new">+ Neue Anfrage</a>'
+        )
     header = (
         '<header class="dashboard-page-header"><div>'
         f'<div class="dashboard-eyebrow">{_e(header_date)}</div>'
         "<h1>Heute im Büro</h1>"
         "<p>Anfragen, Rückrufe und operative Aufgaben im Blick.</p></div>"
         '<div class="dashboard-header-actions">'
-        '<a class="dashboard-button secondary" href="/orders">Alle Aufträge</a>'
-        '<a class="dashboard-button" href="/inquiry/new">+ Neue Anfrage</a>'
-        "</div></header>"
+        + "".join(header_actions)
+        + "</div></header>"
     )
+    events_section = ""
+    if data.context.can("calendar.view"):
+        events_section = (
+            '<section class="dashboard-card">'
+            '<div class="dashboard-card-head"><div>'
+            "<h2>Nächste Veranstaltungen</h2>"
+            "<p>Kommende Termine mit nächstem Schritt.</p></div>"
+            '<a class="dashboard-text-link" href="/kalender">Kalender öffnen</a></div>'
+            + _event_rows(data)
+            + "</section>"
+        )
     main_column = (
         '<div class="dashboard-main">'
         '<section class="dashboard-card">'
         '<div class="dashboard-card-head"><div>'
         "<h2>Was als Nächstes ansteht</h2>"
         "<p>Die wichtigsten offenen Schritte.</p></div>"
-        '<a class="dashboard-text-link" href="/aufgaben">Alle Aufgaben</a></div>'
+        + (
+            '<a class="dashboard-text-link" href="/aufgaben">Alle Aufgaben</a>'
+            if data.context.can("queue.view")
+            else ""
+        )
+        + "</div>"
         + _task_rows(data.tasks)
         + "</section>"
-        '<section class="dashboard-card">'
-        '<div class="dashboard-card-head"><div>'
-        "<h2>Nächste Veranstaltungen</h2>"
-        "<p>Kommende Termine mit nächstem Schritt.</p></div>"
-        '<a class="dashboard-text-link" href="/kalender">Kalender öffnen</a></div>'
-        + _event_rows(data)
-        + "</section></div>"
+        + events_section
+        + "</div>"
     )
     side_column = (
         '<div class="dashboard-side">'

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -584,7 +584,9 @@ def make_office_panel_handler(
                 raise SettingsUsersAccessDenied()
             return auth.employee
 
-        def _business_forbidden(self, *, active_section: OfficeSection = "home") -> None:
+        def _business_forbidden(
+            self, *, active_section: OfficeSection = "home"
+        ) -> None:
             self._html(
                 _page(
                     "Zugriff verweigert",

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -584,6 +584,12 @@ def make_office_panel_handler(
                 raise SettingsUsersAccessDenied()
             return auth.employee
 
+        def _forbidden_page_context(
+            self, auth: OfficePanelRequestAuth | None = None
+        ) -> OfficePageContext:
+            """Minimal shell context for 403 pages — no Auerswald or badge fetch."""
+            return self._page_context(auth, rueckruf_count=None)
+
         def _business_forbidden(
             self, *, active_section: OfficeSection = "home"
         ) -> None:
@@ -592,7 +598,7 @@ def make_office_panel_handler(
                     "Zugriff verweigert",
                     '<p class="blocked">Ihre Berechtigung reicht für diese Aktion nicht aus.</p>',
                     active_section=active_section,
-                    context=self._page_context(),
+                    context=self._forbidden_page_context(),
                 ),
                 403,
             )
@@ -865,12 +871,12 @@ def make_office_panel_handler(
                     )
                 )
                 return
-            context = self._page_context()
             if parts == ["anfragen"]:
                 if not self._require_business_permission_get(
                     auth, "inquiries.view", active_section="inquiries"
                 ):
                     return
+                context = self._page_context()
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_anfragen(search_query, context=context))
             elif parts == ["angebote"]:
@@ -878,12 +884,14 @@ def make_office_panel_handler(
                     auth, "offers.view", active_section="offers"
                 ):
                     return
+                context = self._page_context()
                 self._html(panel.render_angebote(context=context))
             elif parts == ["kontakte"]:
                 if not self._require_business_permission_get(
                     auth, "customers.view", active_section="contacts"
                 ):
                     return
+                context = self._page_context()
                 query = parse_qs(parsed.query)
                 search_query = query.get("q", [""])[0]
                 status_filter = query.get("status", ["all"])[0]
@@ -895,6 +903,7 @@ def make_office_panel_handler(
                     auth, "catalog.view", active_section="catalog"
                 ):
                     return
+                context = self._page_context()
                 query = parse_qs(parsed.query)
                 self._html(
                     panel.render_gerichte(
@@ -908,30 +917,35 @@ def make_office_panel_handler(
                     auth, "catalog.edit", active_section="catalog"
                 ):
                     return
+                context = self._page_context()
                 self._html(panel.render_gericht_new(context=context))
             elif parts == ["emails"] or parts == ["email"]:
                 if not self._require_business_permission_get(
                     auth, "inquiries.view", active_section="email"
                 ):
                     return
+                context = self._page_context()
                 self._html(panel.render_email(context=context))
             elif parts == ["aufgaben"]:
                 if not self._require_business_permission_get(
                     auth, "queue.view", active_section="tasks"
                 ):
                     return
+                context = self._page_context()
                 self._html(panel.render_aufgaben(context=context))
             elif parts == ["kalender"]:
                 if not self._require_business_permission_get(
                     auth, "calendar.view", active_section="calendar"
                 ):
                     return
+                context = self._page_context()
                 self._html(panel.render_kalender(context=context))
             elif parts == ["auftraege"]:
                 if not self._require_business_permission_get(
                     auth, "orders.view", active_section="orders"
                 ):
                     return
+                context = self._page_context()
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_auftraege(search_query, context=context))
             elif parts == ["orders"]:
@@ -939,6 +953,7 @@ def make_office_panel_handler(
                     auth, "orders.view", active_section="orders"
                 ):
                     return
+                context = self._page_context()
                 query = parse_qs(parsed.query)
                 self._html(
                     panel.render_orders(
@@ -952,12 +967,14 @@ def make_office_panel_handler(
                     auth, "inquiries.create", active_section="proposal"
                 ):
                     return
+                context = self._page_context()
                 self._html(render_proposal_preview_form(context=context))
             elif parts == ["inquiry", "new"]:
                 if not self._require_business_permission_get(
                     auth, "inquiries.create", active_section="inquiries"
                 ):
                     return
+                context = self._page_context()
                 form_defaults = parse_qs(parsed.query)
                 self._html(
                     panel.render_inquiry_form(
@@ -974,6 +991,7 @@ def make_office_panel_handler(
                     auth, "inquiries.view", active_section="inquiries"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_inquiry(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "order":
@@ -981,6 +999,7 @@ def make_office_panel_handler(
                     auth, "orders.view", active_section="orders"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_order(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "offer":
@@ -988,6 +1007,7 @@ def make_office_panel_handler(
                     auth, "offers.view", active_section="offers"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_offer(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif (
@@ -1006,6 +1026,7 @@ def make_office_panel_handler(
                     auth, "customers.view", active_section="contacts"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_kontakt(unquote(parts[1]), context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "gerichte":
@@ -1013,6 +1034,7 @@ def make_office_panel_handler(
                     auth, "catalog.view", active_section="catalog"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_gericht(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 3 and parts[0] == "gerichte" and parts[2] == "edit":
@@ -1020,6 +1042,7 @@ def make_office_panel_handler(
                     auth, "catalog.edit", active_section="catalog"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_gericht_edit(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] in ("emails", "email"):
@@ -1027,6 +1050,7 @@ def make_office_panel_handler(
                     auth, "inquiries.view", active_section="email"
                 ):
                     return
+                context = self._page_context()
                 page = panel.render_email_detail(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 3 and parts[0] == "order" and parts[2] == "print":

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -90,6 +90,7 @@ from catering_system.services.employee_auth_service import (
     LastActiveSuperadminError,
 )
 from catering_system.ui.remote_core_client import RemoteCoreError
+from catering_system.ui.office_panel_shell import OfficeSection
 from catering_system.ui.office_panel_settings_users import (
     SettingsUsersAccessDenied,
     parse_selected_permissions,
@@ -100,6 +101,10 @@ from catering_system.ui.office_panel_settings_users import (
     render_users_list,
     settings_users_error_message,
     show_users_nav_for,
+)
+from catering_system.ui.office_panel_authz import (
+    BusinessAccessDenied,
+    require_business_permission,
 )
 from catering_system.ui.employee_auth_http import (
     CSRF_COOKIE_NAME,
@@ -534,6 +539,7 @@ def make_office_panel_handler(
             else:
                 resolved_rueckruf_count = None
             show_users_nav = False
+            employee_effective_permissions: frozenset[str] = frozenset()
             if (
                 auth is not None
                 and auth.kind == "employee"
@@ -541,6 +547,7 @@ def make_office_panel_handler(
                 and not auth.legacy_shared_access
             ):
                 show_users_nav = show_users_nav_for(auth.employee)
+                employee_effective_permissions = auth.employee.effective_permissions
             return OfficePageContext(
                 rueckruf_count=resolved_rueckruf_count,
                 csrf_token=auth.csrf_token if auth is not None else "",
@@ -559,6 +566,7 @@ def make_office_panel_handler(
                 if auth is not None
                 else False,
                 show_users_nav=show_users_nav,
+                employee_effective_permissions=employee_effective_permissions,
             )
 
         def _require_settings_users_actor(
@@ -576,16 +584,33 @@ def make_office_panel_handler(
                 raise SettingsUsersAccessDenied()
             return auth.employee
 
-        def _settings_users_forbidden(self) -> None:
+        def _business_forbidden(self, *, active_section: OfficeSection = "home") -> None:
             self._html(
                 _page(
                     "Zugriff verweigert",
                     '<p class="blocked">Ihre Berechtigung reicht für diese Aktion nicht aus.</p>',
-                    active_section="settings",
+                    active_section=active_section,
                     context=self._page_context(),
                 ),
                 403,
             )
+
+        def _require_business_permission_get(
+            self,
+            auth: OfficePanelRequestAuth | None,
+            permission_code: str,
+            *,
+            active_section: OfficeSection = "home",
+        ) -> bool:
+            try:
+                require_business_permission(auth, permission_code)
+            except BusinessAccessDenied:
+                self._business_forbidden(active_section=active_section)
+                return False
+            return True
+
+        def _settings_users_forbidden(self) -> None:
+            self._business_forbidden(active_section="settings")
 
         def _settings_users_actor_or_forbidden(
             self, auth: OfficePanelRequestAuth | None
@@ -800,6 +825,10 @@ def make_office_panel_handler(
             parts = [part for part in parsed.path.split("/") if part]
             auth = self._request_auth
             if parts == ["rueckruf"]:
+                if not self._require_business_permission_get(
+                    auth, "queue.view", active_section="callbacks"
+                ):
+                    return
                 if remote is not None and not auerswald_url:
                     self._html(
                         render_rueckruf(
@@ -813,34 +842,16 @@ def make_office_panel_handler(
                 context = self._page_context(
                     rueckruf_count=len(items) if items is not None else None
                 )
-                context = OfficePageContext(
-                    rueckruf_count=len(items) if items is not None else None,
-                    csrf_token=context.csrf_token,
-                    current_user_name=context.current_user_name,
-                    current_user_role_label=context.current_user_role_label,
-                    password_change_path=context.password_change_path,
-                    logout_path=context.logout_path,
-                    show_transition_banner=context.show_transition_banner,
-                    legacy_shared_access=context.legacy_shared_access,
-                    show_users_nav=context.show_users_nav,
-                )
                 self._html(render_rueckruf(items, error, context=context))
                 return
             if not parts:
+                if not self._require_business_permission_get(
+                    auth, "queue.view", active_section="home"
+                ):
+                    return
                 items, error = self._fetch_enriched_missed_board()
                 context = self._page_context(
                     rueckruf_count=len(items) if items is not None else None
-                )
-                context = OfficePageContext(
-                    rueckruf_count=len(items) if items is not None else None,
-                    csrf_token=context.csrf_token,
-                    current_user_name=context.current_user_name,
-                    current_user_role_label=context.current_user_role_label,
-                    password_change_path=context.password_change_path,
-                    logout_path=context.logout_path,
-                    show_transition_banner=context.show_transition_banner,
-                    legacy_shared_access=context.legacy_shared_access,
-                    show_users_nav=context.show_users_nav,
                 )
                 kalender_view = parse_qs(parsed.query).get("kalender", ["woche"])[0]
                 self._html(
@@ -854,11 +865,23 @@ def make_office_panel_handler(
                 return
             context = self._page_context()
             if parts == ["anfragen"]:
+                if not self._require_business_permission_get(
+                    auth, "inquiries.view", active_section="inquiries"
+                ):
+                    return
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_anfragen(search_query, context=context))
             elif parts == ["angebote"]:
+                if not self._require_business_permission_get(
+                    auth, "offers.view", active_section="offers"
+                ):
+                    return
                 self._html(panel.render_angebote(context=context))
             elif parts == ["kontakte"]:
+                if not self._require_business_permission_get(
+                    auth, "customers.view", active_section="contacts"
+                ):
+                    return
                 query = parse_qs(parsed.query)
                 search_query = query.get("q", [""])[0]
                 status_filter = query.get("status", ["all"])[0]
@@ -866,6 +889,10 @@ def make_office_panel_handler(
                     panel.render_kontakte(search_query, status_filter, context=context)
                 )
             elif parts == ["gerichte"]:
+                if not self._require_business_permission_get(
+                    auth, "catalog.view", active_section="catalog"
+                ):
+                    return
                 query = parse_qs(parsed.query)
                 self._html(
                     panel.render_gerichte(
@@ -875,17 +902,41 @@ def make_office_panel_handler(
                     )
                 )
             elif parts == ["gerichte", "new"]:
+                if not self._require_business_permission_get(
+                    auth, "catalog.edit", active_section="catalog"
+                ):
+                    return
                 self._html(panel.render_gericht_new(context=context))
             elif parts == ["emails"] or parts == ["email"]:
+                if not self._require_business_permission_get(
+                    auth, "inquiries.view", active_section="email"
+                ):
+                    return
                 self._html(panel.render_email(context=context))
             elif parts == ["aufgaben"]:
+                if not self._require_business_permission_get(
+                    auth, "queue.view", active_section="tasks"
+                ):
+                    return
                 self._html(panel.render_aufgaben(context=context))
             elif parts == ["kalender"]:
+                if not self._require_business_permission_get(
+                    auth, "calendar.view", active_section="calendar"
+                ):
+                    return
                 self._html(panel.render_kalender(context=context))
             elif parts == ["auftraege"]:
+                if not self._require_business_permission_get(
+                    auth, "orders.view", active_section="orders"
+                ):
+                    return
                 search_query = parse_qs(parsed.query).get("q", [""])[0]
                 self._html(panel.render_auftraege(search_query, context=context))
             elif parts == ["orders"]:
+                if not self._require_business_permission_get(
+                    auth, "orders.view", active_section="orders"
+                ):
+                    return
                 query = parse_qs(parsed.query)
                 self._html(
                     panel.render_orders(
@@ -895,8 +946,16 @@ def make_office_panel_handler(
                     )
                 )
             elif parts == ["proposal-preview"]:
+                if not self._require_business_permission_get(
+                    auth, "inquiries.create", active_section="proposal"
+                ):
+                    return
                 self._html(render_proposal_preview_form(context=context))
             elif parts == ["inquiry", "new"]:
+                if not self._require_business_permission_get(
+                    auth, "inquiries.create", active_section="inquiries"
+                ):
+                    return
                 form_defaults = parse_qs(parsed.query)
                 self._html(
                     panel.render_inquiry_form(
@@ -909,12 +968,24 @@ def make_office_panel_handler(
                     )
                 )
             elif len(parts) == 2 and parts[0] == "inquiry":
+                if not self._require_business_permission_get(
+                    auth, "inquiries.view", active_section="inquiries"
+                ):
+                    return
                 page = panel.render_inquiry(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "order":
+                if not self._require_business_permission_get(
+                    auth, "orders.view", active_section="orders"
+                ):
+                    return
                 page = panel.render_order(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "offer":
+                if not self._require_business_permission_get(
+                    auth, "offers.view", active_section="offers"
+                ):
+                    return
                 page = panel.render_offer(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif (
@@ -923,22 +994,50 @@ def make_office_panel_handler(
                 and parts[2] == "offer-document"
                 and parts[3] == "pdf"
             ):
+                if not self._require_business_permission_get(
+                    auth, "offers.pdf.generate", active_section="offers"
+                ):
+                    return
                 self._offer_document_pdf_download(parts[1], parsed.query)
             elif len(parts) == 2 and parts[0] == "kontakt":
+                if not self._require_business_permission_get(
+                    auth, "customers.view", active_section="contacts"
+                ):
+                    return
                 page = panel.render_kontakt(unquote(parts[1]), context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] == "gerichte":
+                if not self._require_business_permission_get(
+                    auth, "catalog.view", active_section="catalog"
+                ):
+                    return
                 page = panel.render_gericht(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 3 and parts[0] == "gerichte" and parts[2] == "edit":
+                if not self._require_business_permission_get(
+                    auth, "catalog.edit", active_section="catalog"
+                ):
+                    return
                 page = panel.render_gericht_edit(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 2 and parts[0] in ("emails", "email"):
+                if not self._require_business_permission_get(
+                    auth, "inquiries.view", active_section="email"
+                ):
+                    return
                 page = panel.render_email_detail(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
             elif len(parts) == 3 and parts[0] == "order" and parts[2] == "print":
+                if not self._require_business_permission_get(
+                    auth, "orders.view", active_section="orders"
+                ):
+                    return
                 self._print_sheet(parts[1], parsed.query)
             elif len(parts) == 3 and parts[0] == "order" and parts[2] == "buffet-cards":
+                if not self._require_business_permission_get(
+                    auth, "orders.view", active_section="orders"
+                ):
+                    return
                 self._buffet_cards(parts[1], parsed.query)
             elif (
                 len(parts) == 4
@@ -946,6 +1045,10 @@ def make_office_panel_handler(
                 and parts[2] == "confirmation-document"
                 and parts[3] == "preview"
             ):
+                if not self._require_business_permission_get(
+                    auth, "documents.view", active_section="orders"
+                ):
+                    return
                 self._confirmation_document_preview(parts[1])
             elif (
                 len(parts) == 4
@@ -953,6 +1056,10 @@ def make_office_panel_handler(
                 and parts[2] == "confirmation-document"
                 and parts[3] == "fake-outbox"
             ):
+                if not self._require_business_permission_get(
+                    auth, "documents.view", active_section="orders"
+                ):
+                    return
                 self._confirmation_fake_outbox(parts[1])
             elif parts == ["settings", "users"]:
                 actor = self._settings_users_actor_or_forbidden(auth)

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -19,6 +19,7 @@ from catering_system.domain.inquiry_contact_completeness import (
     missing_contact_fields,
 )
 from catering_system.domain.order import Order
+from catering_system.ui.office_panel_views import OfficePageContext
 
 _SOURCE_LABELS = {
     "website_form": "Website-Anfrage",
@@ -154,8 +155,12 @@ def _primary_action(
     inquiry: Inquiry,
     state: InquiryOfficeState,
     forms: InquiryDetailFormFields,
+    *,
+    context: OfficePageContext,
 ) -> str:
     if state.next_action == "verify":
+        if not context.can("inquiries.verify"):
+            return ""
         heading = "Angaben telefonisch bestätigen"
         explanation = (
             "Datum, Ort und Gästezahl gemeinsam prüfen. Erst nach dem Gespräch "
@@ -164,6 +169,8 @@ def _primary_action(
         path = "verify"
         label = "Telefonisch verifiziert"
     elif state.next_action == "prepare-offer":
+        if not context.can("offers.prepare"):
+            return ""
         return (
             '<section class="inquiry-next-step">'
             '<div class="inquiry-eyebrow">Nächster Schritt</div>'
@@ -173,6 +180,8 @@ def _primary_action(
             "</section>"
         )
     elif state.next_action == "prepare-next-version":
+        if not context.can("offers.version.create"):
+            return ""
         return (
             '<section class="inquiry-next-step">'
             '<div class="inquiry-eyebrow">Nächster Schritt</div>'
@@ -383,7 +392,10 @@ def _edit_form(
     forms: InquiryDetailFormFields,
     *,
     has_active_order: bool,
+    context: OfficePageContext,
 ) -> str:
+    if not context.can("inquiries.edit"):
+        return ""
     guests = (
         str(inquiry.guest_count_estimate)
         if inquiry.guest_count_estimate is not None
@@ -435,8 +447,10 @@ def render_inquiry_detail(
     linked_orders_total_count: int | None = None,
     linked_orders_truncated: bool = False,
     offer_url: str | None = None,
+    context: OfficePageContext | None = None,
 ) -> InquiryDetailPage:
     """Render existing Inquiry facts and actions without performing any reads."""
+    page_context = context or OfficePageContext()
 
     subject = (inquiry.intake_subject or "").strip()
     title = subject or f"Anfrage vom {_date_text(inquiry)}"
@@ -495,14 +509,15 @@ def render_inquiry_detail(
             "Angebot öffnen</a></section>"
         )
     elif state.next_action == "prepare-offer" and offer_url:
-        offer = (
-            '<section class="inquiry-card inquiry-content-card">'
-            "<h2>Angebot</h2>"
-            '<p class="inquiry-section-note">Öffnet einen bearbeitbaren Entwurf. '
-            "Es wird noch kein Auftrag erzeugt.</p>"
-            f'<a class="inquiry-button secondary" href="{_e(offer_url)}">'
-            "Angebot vorbereiten</a></section>"
-        )
+        if page_context.can("offers.prepare"):
+            offer = (
+                '<section class="inquiry-card inquiry-content-card">'
+                "<h2>Angebot</h2>"
+                '<p class="inquiry-section-note">Öffnet einen bearbeitbaren Entwurf. '
+                "Es wird noch kein Auftrag erzeugt.</p>"
+                f'<a class="inquiry-button secondary" href="{_e(offer_url)}">'
+                "Angebot vorbereiten</a></section>"
+            )
     elif state.next_action == "prepare-offer":
         offer = (
             '<section class="inquiry-card inquiry-content-card">'
@@ -544,11 +559,13 @@ def render_inquiry_detail(
         f"<div><dt>Arbeitsstand</dt><dd>{_e(inquiry.crm_stage)}</dd></div>"
         "</dl></section>" + summary + "</div>"
         '<aside class="inquiry-detail-side">'
-        + _primary_action(inquiry, state, forms)
+        + _primary_action(inquiry, state, forms, context=page_context)
         + _linked_orders(linked_orders)
         + blocker_card
         + offer
         + "</aside></div>"
-        + _edit_form(inquiry, forms, has_active_order=has_active_order)
+        + _edit_form(
+            inquiry, forms, has_active_order=has_active_order, context=page_context
+        )
     )
     return InquiryDetailPage(title=title, body=body)

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -328,7 +328,11 @@ def _record_withdrawal_form(offer_id: str, *, forms: OfferDetailFormFields) -> s
     )
 
 
-def _prepare_next_version_cta(*, revision_prefill_url: str | None) -> str:
+def _prepare_next_version_cta(
+    *, revision_prefill_url: str | None, context: OfficePageContext
+) -> str:
+    if not context.can("offers.version.create"):
+        return ""
     if not revision_prefill_url:
         return (
             '<section class="offer-detail-section offer-action-section">'
@@ -353,12 +357,15 @@ def _sent_offer_actions(
     *,
     forms: OfferDetailFormFields,
     revision_prefill_url: str | None = None,
+    context: OfficePageContext,
 ) -> str:
     return (
         _record_acceptance_form(offer_id, variants, forms=forms)
         + _record_rejection_form(offer_id, forms=forms)
         + _record_withdrawal_form(offer_id, forms=forms)
-        + _prepare_next_version_cta(revision_prefill_url=revision_prefill_url)
+        + _prepare_next_version_cta(
+            revision_prefill_url=revision_prefill_url, context=context
+        )
     )
 
 
@@ -430,10 +437,11 @@ def render_offer_detail(
             variants,
             forms=forms,
             revision_prefill_url=revision_prefill_url,
+            context=context,
         )
     elif state in ("Expired", "Rejected", "Withdrawn"):
         action_section = _prepare_next_version_cta(
-            revision_prefill_url=revision_prefill_url
+            revision_prefill_url=revision_prefill_url, context=context
         )
     elif state == "Accepted":
         acceptance_id = detail.get("acceptance_id")
@@ -451,7 +459,7 @@ def render_offer_detail(
             )
     pdf_link = (
         f'<p><a href="{_e(pdf_download_url)}">PDF herunterladen</a></p>'
-        if pdf_download_url is not None
+        if pdf_download_url is not None and context.can("offers.pdf.generate")
         else ""
     )
     body = (

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -195,11 +195,10 @@ def _page(
             _nav_link("/kontakte", "Kontakte", "users", "contacts", active_section)
         )
     if _nav_visible(context, "inquiries.view"):
-        vertrieb.extend(
-            (
-                _nav_link("/emails", "E-Mail", "doc", "email", active_section),
-                _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section),
-            )
+        vertrieb.append(_nav_link("/emails", "E-Mail", "doc", "email", active_section))
+    if _nav_visible(context, "queue.view"):
+        vertrieb.append(
+            _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section)
         )
     if _nav_visible(context, "calendar.view"):
         vertrieb.append(

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -6,6 +6,7 @@ import html
 from dataclasses import dataclass
 from datetime import date, datetime
 
+from catering_system.domain.employee_auth import PERMISSION_SET
 from catering_system.domain.inquiry import CRM_PIPELINE, PLANNING_MODES
 from catering_system.services.buffet_cards_service import BuffetCard, buffet_card_body
 from catering_system.services.order_print_projection_service import OrderPrintProjection
@@ -125,6 +126,14 @@ class OfficePageContext:
     show_transition_banner: bool = False
     legacy_shared_access: bool = False
     show_users_nav: bool = False
+    employee_effective_permissions: frozenset[str] = frozenset()
+
+    def can(self, permission_code: str) -> bool:
+        if permission_code not in PERMISSION_SET:
+            return False
+        if self.legacy_shared_access:
+            return True
+        return permission_code in self.employee_effective_permissions
 
 
 _EMPTY_PAGE_CONTEXT = OfficePageContext()
@@ -134,6 +143,10 @@ def _csrf_input(context: OfficePageContext) -> str:
     if not context.csrf_token:
         return ""
     return f'<input type="hidden" name="_csrf_token" value="{_e(context.csrf_token)}">'
+
+
+def _nav_visible(context: OfficePageContext, permission_code: str) -> bool:
+    return context.can(permission_code)
 
 
 def _nav_link(
@@ -163,25 +176,52 @@ def _page(
     show_title: bool = True,
     auto_refresh_seconds: int | None = None,
 ) -> str:
-    nav = "".join(
-        (
-            _nav_link("/", "Arbeitszentrale", "grid", "home", active_section),
-            '<div class="office-nav-label">Vertrieb</div>',
-            _nav_link("/anfragen", "Anfragen", "doc", "inquiries", active_section),
-            _nav_link("/angebote", "Angebote", "doc", "offers", active_section),
-            _nav_link("/kontakte", "Kontakte", "users", "contacts", active_section),
-            _nav_link("/emails", "E-Mail", "doc", "email", active_section),
-            _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section),
-            _nav_link("/kalender", "Kalender", "calendar", "calendar", active_section),
-            '<div class="office-nav-label">Betrieb</div>',
-            _nav_link("/auftraege", "Aufträge", "briefcase", "orders", active_section),
+    nav_items: list[str] = []
+    if _nav_visible(context, "queue.view"):
+        nav_items.append(
+            _nav_link("/", "Arbeitszentrale", "grid", "home", active_section)
+        )
+    vertrieb: list[str] = []
+    if _nav_visible(context, "inquiries.view"):
+        vertrieb.append(
+            _nav_link("/anfragen", "Anfragen", "doc", "inquiries", active_section)
+        )
+    if _nav_visible(context, "offers.view"):
+        vertrieb.append(
+            _nav_link("/angebote", "Angebote", "doc", "offers", active_section)
+        )
+    if _nav_visible(context, "customers.view"):
+        vertrieb.append(
+            _nav_link("/kontakte", "Kontakte", "users", "contacts", active_section)
+        )
+    if _nav_visible(context, "inquiries.view"):
+        vertrieb.extend(
+            (
+                _nav_link("/emails", "E-Mail", "doc", "email", active_section),
+                _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section),
+            )
+        )
+    if _nav_visible(context, "calendar.view"):
+        vertrieb.append(
+            _nav_link("/kalender", "Kalender", "calendar", "calendar", active_section)
+        )
+    betrieb: list[str] = []
+    if _nav_visible(context, "orders.view"):
+        betrieb.append(
+            _nav_link("/auftraege", "Aufträge", "briefcase", "orders", active_section)
+        )
+    if _nav_visible(context, "calendar.view"):
+        betrieb.append(
             _nav_link(
                 "/#diese-woche",
                 "Diese Woche",
                 "calendar",
                 "week",
                 active_section,
-            ),
+            )
+        )
+    if _nav_visible(context, "queue.view"):
+        betrieb.append(
             _nav_link(
                 "/rueckruf",
                 "Rückrufliste",
@@ -189,32 +229,49 @@ def _page(
                 "callbacks",
                 active_section,
                 badge=context.rueckruf_count,
-            ),
+            )
+        )
+    if _nav_visible(context, "inquiries.create"):
+        betrieb.append(
             _nav_link(
                 "/proposal-preview",
                 "Angebots-Import",
                 "import",
                 "proposal",
                 active_section,
-            ),
-            '<div class="office-nav-label">Verwaltung</div>',
-            _nav_link("/gerichte", "Gerichte", "doc", "catalog", active_section),
-            *(
-                (
-                    '<div class="office-nav-label">Einstellungen</div>',
-                    _nav_link(
-                        "/settings/users",
-                        "Benutzer & Rechte",
-                        "users",
-                        "settings",
-                        active_section,
-                    ),
-                )
-                if context.show_users_nav
-                else ()
-            ),
+            )
         )
-    )
+    verwaltung: list[str] = []
+    if _nav_visible(context, "catalog.view"):
+        verwaltung.append(
+            _nav_link("/gerichte", "Gerichte", "doc", "catalog", active_section)
+        )
+    nav_parts: list[str] = []
+    if nav_items:
+        nav_parts.extend(nav_items)
+    if vertrieb:
+        nav_parts.append('<div class="office-nav-label">Vertrieb</div>')
+        nav_parts.extend(vertrieb)
+    if betrieb:
+        nav_parts.append('<div class="office-nav-label">Betrieb</div>')
+        nav_parts.extend(betrieb)
+    if verwaltung:
+        nav_parts.append('<div class="office-nav-label">Verwaltung</div>')
+        nav_parts.extend(verwaltung)
+    if context.show_users_nav:
+        nav_parts.extend(
+            (
+                '<div class="office-nav-label">Einstellungen</div>',
+                _nav_link(
+                    "/settings/users",
+                    "Benutzer & Rechte",
+                    "users",
+                    "settings",
+                    active_section,
+                ),
+            )
+        )
+    nav = "".join(nav_parts)
     page_title = f"<h1>{_e(title)}</h1>" if show_title else ""
     account_meta = (
         '<div class="office-account-meta">'

--- a/tests/helpers/office_panel_context.py
+++ b/tests/helpers/office_panel_context.py
@@ -1,0 +1,10 @@
+"""Shared Office Panel page contexts for non-auth unit tests."""
+
+from __future__ import annotations
+
+from catering_system.ui.office_panel_views import OfficePageContext
+
+
+def legacy_office_context(**kwargs: object) -> OfficePageContext:
+    """Preserve pre-AUTH-2D1 presentation expectations in focused UI tests."""
+    return OfficePageContext(legacy_shared_access=True, **kwargs)  # type: ignore[arg-type]

--- a/tests/unit/test_office_api_views.py
+++ b/tests/unit/test_office_api_views.py
@@ -56,11 +56,12 @@ def _panel_action(order: Order, repo: InMemoryOrderRepository) -> dict | None:
     """Extract (action, version) from the real panel's `_next_step_action`
     HTML so the API resolution is provably identical."""
     from catering_system.ui.office_panel import OfficePanel
+    from tests.helpers.office_panel_context import legacy_office_context
 
     panel = OfficePanel.__new__(OfficePanel)
     panel._orders = repo
     panel._remote = None
-    html = panel._next_step_action(order)
+    html = panel._next_step_action(order, context=legacy_office_context())
     if not html:
         return None
     action = re.search(r"/order/[^/]+/([a-z-]+)\"", html)

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -30,7 +30,6 @@ from catering_system.repositories.in_memory_order_repository import (
 )
 from catering_system.ui import office_api_views
 from catering_system.ui.office_panel import (
-    OfficePageContext,
     OfficePanel,
     create_office_panel_server,
     parse_proposal_payload,

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -39,6 +39,7 @@ from catering_system.ui.office_panel import (
 from catering_system.ui.office_panel_http import csrf_token_for_password
 from catering_system.ui.office_panel_shell import OFFICE_PANEL_STYLE
 from catering_system.ui.office_panel_views import _page
+from tests.helpers.office_panel_context import legacy_office_context
 
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
@@ -165,16 +166,21 @@ def _convert(base: str, inquiry_id: str) -> str:
 
 def test_page_context_badge_does_not_leak_between_renders() -> None:
     with_badge = render_proposal_preview_form(
-        context=OfficePageContext(rueckruf_count=3)
+        context=legacy_office_context(rueckruf_count=3)
     )
-    without_badge = render_proposal_preview_form()
+    without_badge = render_proposal_preview_form(context=legacy_office_context())
 
     assert '<span class="badge">3</span>' in with_badge
     assert '<span class="badge">' not in without_badge
 
 
 def test_v2_shell_uses_explicit_active_section_and_semantic_landmarks() -> None:
-    body = _page("Anfragen", "<p>Inhalt</p>", active_section="orders")
+    body = _page(
+        "Anfragen",
+        "<p>Inhalt</p>",
+        active_section="orders",
+        context=legacy_office_context(),
+    )
 
     assert '<nav class="office-nav" aria-label="Office Panel">' in body
     assert '<main class="office-workspace">' in body
@@ -186,7 +192,12 @@ def test_v2_shell_uses_explicit_active_section_and_semantic_landmarks() -> None:
 
 
 def test_v2_shell_is_local_no_js_and_has_complete_inline_icon_sprite() -> None:
-    body = _page("Büro-Übersicht", "<p>Inhalt</p>", active_section="home")
+    body = _page(
+        "Büro-Übersicht",
+        "<p>Inhalt</p>",
+        active_section="home",
+        context=legacy_office_context(),
+    )
 
     assert "<script" not in body
     assert "fonts.googleapis.com" not in body
@@ -1881,7 +1892,7 @@ def _panel_with_order():
 
 def test_next_step_targets_latest_version_when_no_candidate_set() -> None:
     panel, order, v1 = _panel_with_order()
-    action_html = panel._next_step_action(order)
+    action_html = panel._next_step_action(order, context=legacy_office_context())
     assert "Druck bestätigen" in action_html
     assert f'value="{v1.order_version_id}"' in action_html
 
@@ -1898,7 +1909,7 @@ def test_next_step_prefers_candidate_over_latest_version() -> None:
     )
     panel.order_service.set_candidate_order_version(order.order_id, v1.order_version_id)
     order = panel._orders.get_order(order.order_id)
-    action_html = panel._next_step_action(order)
+    action_html = panel._next_step_action(order, context=legacy_office_context())
     # Candidate is v1, not the higher version_number v2 -> v1 wins.
     assert f'value="{v1.order_version_id}"' in action_html
     assert v2.order_version_id not in action_html
@@ -1908,13 +1919,13 @@ def test_next_step_never_offers_effective_before_print_confirmed() -> None:
     """The real invariant this resolution exists to protect: Core itself
     refuses make_order_version_effective() for an unprinted version."""
     panel, order, v1 = _panel_with_order()
-    action_html = panel._next_step_action(order)
+    action_html = panel._next_step_action(order, context=legacy_office_context())
     assert "print-confirm" in action_html
     assert "effective" not in action_html
 
     panel.core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     order = panel._orders.get_order(order.order_id)
-    action_html = panel._next_step_action(order)
+    action_html = panel._next_step_action(order, context=legacy_office_context())
     assert "Wirksam machen" in action_html
     assert f'action="/order/{order.order_id}/effective"' in action_html
 
@@ -1926,7 +1937,7 @@ def test_next_step_falls_back_to_latest_when_candidate_is_foreign() -> None:
 
     panel, order, v1 = _panel_with_order()
     broken = replace(order, candidate_order_version_id="does-not-exist")
-    action_html = panel._next_step_action(broken)
+    action_html = panel._next_step_action(broken, context=legacy_office_context())
     assert f'value="{v1.order_version_id}"' in action_html
 
 
@@ -1935,7 +1946,7 @@ def test_next_step_empty_when_order_has_no_versions() -> None:
 
     panel, order, _v1 = _panel_with_order()
     fake_order = replace(order, order_id="unknown-order-id")
-    assert panel._next_step_action(fake_order) == ""
+    assert panel._next_step_action(fake_order, context=legacy_office_context()) == ""
 
 
 # -- proposal preview (CONFIGURATOR_OFFICE_MANUAL_HANDOFF_PACK_V1) --------

--- a/tests/unit/test_office_panel_auth_2d1.py
+++ b/tests/unit/test_office_panel_auth_2d1.py
@@ -564,3 +564,167 @@ def test_office_page_context_can_matches_authz_helper() -> None:
     assert context.can("orders.view") is False
     assert context.can("unknown.permission") is False
     assert can_access(None, "inquiries.view") is False
+
+
+def test_denied_anfragen_does_not_fetch_rueckruf_count(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="orders.only",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="orders.only", password="ReaderTemp1!")
+    with patch(
+        "catering_system.ui.office_panel_http.fetch_rueckruf_count",
+        autospec=True,
+    ) as count_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base, "/anfragen", jar=jar
+        )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+    count_mock.assert_not_called()
+
+
+def test_denied_offer_detail_does_not_fetch_rueckruf_count(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="orders.only.offer",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="orders.only.offer", password="ReaderTemp1!")
+    with patch(
+        "catering_system.ui.office_panel_http.fetch_rueckruf_count",
+        autospec=True,
+    ) as count_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base, "/offer/test-offer", jar=jar
+        )
+    assert status == 403
+    count_mock.assert_not_called()
+
+
+def test_denied_pdf_does_not_fetch_rueckruf_count_or_renderer(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="offers.view.only",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"offers.view"}),
+    )
+    jar = _login(employee_panel, username="offers.view.only", password="ReaderTemp1!")
+    with (
+        patch(
+            "catering_system.ui.office_panel_http.fetch_rueckruf_count",
+            autospec=True,
+        ) as count_mock,
+        patch.object(
+            OfficePanel,
+            "offer_document_pdf",
+            autospec=True,
+        ) as pdf_mock,
+    ):
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            "/offer/test-offer/offer-document/pdf?offer_version_id=v1",
+            jar=jar,
+        )
+    assert status == 403
+    count_mock.assert_not_called()
+    pdf_mock.assert_not_called()
+
+
+def test_allowed_anfragen_still_fetches_rueckruf_count_for_badge(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.reader.badge",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(
+        employee_panel, username="inquiry.reader.badge", password="ReaderTemp1!"
+    )
+    with patch(
+        "catering_system.ui.office_panel_http.fetch_rueckruf_count",
+        autospec=True,
+        return_value=3,
+    ) as count_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base, "/anfragen", jar=jar
+        )
+    assert status == 200
+    count_mock.assert_called_once()
+
+
+def test_aufgaben_hidden_without_queue_view(employee_panel: PanelHarness) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.only.tasks",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(employee_panel, username="inquiry.only.tasks", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/anfragen", jar=jar)
+    assert status == 200
+    assert 'href="/aufgaben"' not in body
+
+
+def test_aufgaben_visible_with_queue_view_without_inquiries_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="queue.only.tasks",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"queue.view"}),
+    )
+    jar = _login(employee_panel, username="queue.only.tasks", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert 'href="/aufgaben"' in body
+    assert 'href="/anfragen"' not in body
+
+
+def test_aufgaben_direct_url_requires_queue_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.only.tasks.direct",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(
+        employee_panel, username="inquiry.only.tasks.direct", password="ReaderTemp1!"
+    )
+    status, _url, body, _headers = _request(employee_panel.base, "/aufgaben", jar=jar)
+    assert status == 403

--- a/tests/unit/test_office_panel_auth_2d1.py
+++ b/tests/unit/test_office_panel_auth_2d1.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from catering_system.domain.inquiry import PLANNING_MODES
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
+from catering_system.ui.office_panel_authz import can_access
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@dataclass
+class PanelHarness:
+    base: str
+    server: object
+    thread: threading.Thread
+    service: EmployeeAuthService
+    repo: SQLiteEmployeeAuthRepository
+    password: str
+
+
+def _auth_header(password: str) -> str:
+    return "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _csrf(jar: http.cookiejar.CookieJar) -> str:
+    return _cookie_value(jar, "sl_employee_csrf")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = None
+    if data is not None:
+        payload = urllib.parse.urlencode(data).encode()
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    try:
+        with opener.open(request) as response:
+            return (
+                response.status,
+                response.url,
+                response.read().decode("utf-8"),
+                response.headers,
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8"), exc.headers
+
+
+def _create_panel(
+    tmp_path: Path,
+    *,
+    auth_mode: str,
+    password: str = "shared-office-password",
+) -> PanelHarness:
+    db = tmp_path / "core.db"
+    connection = sqlite3.connect(str(db), check_same_thread=False)
+    repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+    service = EmployeeAuthService(
+        repo, now=lambda: datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    )
+    service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "office-panel"},
+    )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        password,
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        auth_service=service,
+        secure_cookie=False,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return PanelHarness(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        service=service,
+        repo=repo,
+        password=password,
+    )
+
+
+def _shutdown(panel: PanelHarness) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+    panel.repo.close()
+
+
+def _login(
+    panel: PanelHarness, *, username: str, password: str
+) -> http.cookiejar.CookieJar:
+    jar = http.cookiejar.CookieJar()
+    status, _url, _body, _headers = _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": username, "password": password, "next": "/"},
+        jar=jar,
+    )
+    assert status == 303
+    return jar
+
+
+def _ready_superadmin(panel: PanelHarness) -> http.cookiejar.CookieJar:
+    jar = _login(panel, username="viktor.admin", password="TempPassw0rd!")
+    employee = panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    return _login(panel, username="viktor.admin", password="ChangedTemp1!")
+
+
+def _create_employee(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    password: str,
+    role: str,
+    permissions: frozenset[str] | None = None,
+) -> str:
+    super_employee = panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    account = panel.service.create_account(
+        super_employee,
+        username=username,
+        display_name=username,
+        password=password,
+        role=role,
+        explicit_permissions=set(permissions) if permissions is not None else None,
+        must_change_password=False,
+    )
+    return account.id
+
+
+def _seed_inquiry(panel_base: str, jar: http.cookiejar.CookieJar) -> str:
+    status, _url, _body, _headers = _request(
+        panel_base,
+        "/inquiry/new",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "event_date": "2026-09-01",
+            "inquiry_source": "manual",
+            "planning_mode": PLANNING_MODES[0],
+        },
+        jar=jar,
+    )
+    assert status == 303
+    inquiry_id = _url.rsplit("/", 1)[-1]
+    return inquiry_id
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def migration_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="migration")
+    yield panel
+    _shutdown(panel)
+
+
+def test_superadmin_can_open_protected_get_routes(employee_panel: PanelHarness) -> None:
+    jar = _ready_superadmin(employee_panel)
+    for path in (
+        "/",
+        "/anfragen",
+        "/angebote",
+        "/kontakte",
+        "/kalender",
+        "/auftraege",
+        "/gerichte",
+        "/settings/users",
+    ):
+        status, _url, _body, _headers = _request(employee_panel.base, path, jar=jar)
+        assert status == 200, path
+
+
+def test_user_with_inquiries_view_can_open_anfragen(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.reader",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(employee_panel, username="inquiry.reader", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/anfragen", jar=jar)
+    assert status == 200
+    assert "Anfragen" in body
+
+
+def test_user_without_inquiries_view_gets_german_403(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="no.inquiries",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="no.inquiries", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/anfragen", jar=jar)
+    assert status == 403
+    assert "Ihre Berechtigung reicht für diese Aktion nicht aus." in body
+
+
+def test_direct_inquiry_detail_denied_without_inquiries_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    inquiry_id = _seed_inquiry(employee_panel.base, super_jar)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="order.only",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="order.only", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(
+        employee_panel.base, f"/inquiry/{inquiry_id}", jar=jar
+    )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+
+
+def test_viewer_with_orders_view_can_read_order_pages(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="viewer.orders",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="viewer.orders", password="ViewerTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/auftraege", jar=jar)
+    assert status == 200
+
+
+def test_viewer_does_not_see_operational_order_buttons(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="viewer.readonly",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        permissions=frozenset({"orders.view"}),
+    )
+    jar = _login(employee_panel, username="viewer.readonly", password="ViewerTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/auftraege", jar=jar)
+    assert status == 200
+    assert "Druck bestätigen" not in body
+    assert "Auftrag stornieren" not in body
+
+
+def test_pdf_denied_without_permission_and_renderer_not_called(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="no.pdf",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"offers.view"}),
+    )
+    jar = _login(employee_panel, username="no.pdf", password="ReaderTemp1!")
+    with patch.object(
+        OfficePanel,
+        "offer_document_pdf",
+        autospec=True,
+    ) as pdf_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            "/offer/test-offer/offer-document/pdf?offer_version_id=v1",
+            jar=jar,
+        )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+    pdf_mock.assert_not_called()
+
+
+def test_catalog_list_allowed_with_catalog_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="catalog.reader",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"catalog.view"}),
+    )
+    jar = _login(employee_panel, username="catalog.reader", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/gerichte", jar=jar)
+    assert status == 200
+
+
+def test_catalog_edit_form_denied_without_catalog_edit(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="catalog.reader2",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"catalog.view"}),
+    )
+    jar = _login(employee_panel, username="catalog.reader2", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/gerichte/new", jar=jar
+    )
+    assert status == 403
+
+
+def test_dashboard_ok_without_calendar_view_and_widget_absent(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="queue.only",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"queue.view"}),
+    )
+    jar = _login(employee_panel, username="queue.only", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert 'id="diese-woche"' not in body
+    assert "Nächste Veranstaltungen" not in body
+
+
+def test_direct_kalender_denied_without_calendar_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="queue.only2",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"queue.view"}),
+    )
+    jar = _login(employee_panel, username="queue.only2", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/kalender", jar=jar)
+    assert status == 403
+
+
+def test_migration_basic_fallback_retains_business_get_access(
+    migration_panel: PanelHarness,
+) -> None:
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/anfragen",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+    )
+    assert status == 200
+
+
+def test_migration_basic_fallback_denied_for_settings_users(
+    migration_panel: PanelHarness,
+) -> None:
+    status, _url, body, _headers = _request(
+        migration_panel.base,
+        "/settings/users",
+        headers={"Authorization": _auth_header(migration_panel.password)},
+    )
+    assert status == 403
+
+
+def test_unauthenticated_get_redirects_to_login(employee_panel: PanelHarness) -> None:
+    status, _url, _body, headers = _request(employee_panel.base, "/anfragen")
+    assert status == 303
+    assert headers["Location"].startswith("/login")
+
+
+def test_sidebar_shows_only_permitted_sections(employee_panel: PanelHarness) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.only.nav",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(employee_panel, username="inquiry.only.nav", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/anfragen", jar=jar)
+    assert status == 200
+    assert "Anfragen" in body
+    assert 'href="/angebote"' not in body
+    assert 'href="/auftraege"' not in body
+
+
+def test_hidden_nav_item_still_denied_by_direct_url(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.only.direct",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    jar = _login(
+        employee_panel, username="inquiry.only.direct", password="ReaderTemp1!"
+    )
+    status, _url, body, _headers = _request(employee_panel.base, "/angebote", jar=jar)
+    assert status == 403
+
+
+def test_inquiry_create_link_hidden_without_permission(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="inquiry.reader.nav",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"inquiries.view", "queue.view"}),
+    )
+    jar = _login(employee_panel, username="inquiry.reader.nav", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert 'href="/inquiry/new"' not in body
+
+
+def test_catalog_edit_link_hidden_without_catalog_edit(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    _create_employee(
+        employee_panel,
+        super_jar,
+        username="catalog.view.nav",
+        password="ReaderTemp1!",
+        role="USER",
+        permissions=frozenset({"catalog.view"}),
+    )
+    jar = _login(employee_panel, username="catalog.view.nav", password="ReaderTemp1!")
+    status, _url, body, _headers = _request(employee_panel.base, "/gerichte", jar=jar)
+    assert status == 200
+    assert 'href="/gerichte/new"' not in body
+
+
+def test_csrf_still_required_for_existing_post_routes(
+    employee_panel: PanelHarness,
+) -> None:
+    jar = _ready_superadmin(employee_panel)
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/logout",
+        method="POST",
+        data={},
+        jar=jar,
+    )
+    assert status == 403
+    assert "CSRF-Sicherheitstoken" in body
+
+
+def test_office_page_context_can_matches_authz_helper() -> None:
+    from catering_system.ui.office_panel_views import OfficePageContext
+
+    context = OfficePageContext(
+        legacy_shared_access=False,
+        employee_effective_permissions=frozenset({"inquiries.view"}),
+    )
+    assert context.can("inquiries.view") is True
+    assert context.can("orders.view") is False
+    assert context.can("unknown.permission") is False
+    assert can_access(None, "inquiries.view") is False

--- a/tests/unit/test_office_panel_auth_2d1_legacy_controls.py
+++ b/tests/unit/test_office_panel_auth_2d1_legacy_controls.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date
+
+from catering_system.domain.inquiry import PLANNING_MODES
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.ui.office_panel import OfficePanel
+from catering_system.ui.office_panel_views import OfficePageContext
+from tests.helpers.office_panel_context import legacy_office_context
+from tests.helpers.order_seed import seed_order
+
+
+def _legacy_panel_with_order() -> tuple[OfficePanel, str]:
+    inquiry_repo = InMemoryInquiryRepository()
+    order_repo = InMemoryOrderRepository()
+    panel = OfficePanel(inquiry_repo, order_repo, ui_version="legacy")
+    inquiry = panel.inquiry_service.create_inquiry(
+        event_date=date(2026, 10, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode=PLANNING_MODES[0],
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="kunde@example.com",
+        contact_phone="+49301234567",
+    )
+    order, _version = seed_order(order_repo, inquiry)
+    return panel, order.order_id
+
+
+def _employee_context(*permissions: str) -> OfficePageContext:
+    return OfficePageContext(
+        legacy_shared_access=False,
+        employee_effective_permissions=frozenset(permissions),
+    )
+
+
+def test_legacy_order_hides_mutation_controls_for_viewer() -> None:
+    panel, order_id = _legacy_panel_with_order()
+    page = panel.render_order(
+        order_id,
+        context=_employee_context("orders.view"),
+    )
+    assert page is not None
+    assert "Druck bestätigen" not in page
+    assert "Wirksam machen" not in page
+    assert "Freigabe anfordern" not in page
+    assert "Auftrag stornieren" not in page
+    assert "Version anlegen" not in page
+
+
+def test_legacy_order_shows_print_confirm_with_permission() -> None:
+    panel, order_id = _legacy_panel_with_order()
+    page = panel.render_order(
+        order_id,
+        context=_employee_context("orders.view", "orders.print.confirm"),
+    )
+    assert page is not None
+    assert "Druck bestätigen" in page
+
+
+def test_legacy_order_shows_version_form_with_permission() -> None:
+    panel, order_id = _legacy_panel_with_order()
+    page = panel.render_order(
+        order_id,
+        context=_employee_context("orders.view", "orders.version.create"),
+    )
+    assert page is not None
+    assert "Version anlegen" in page
+    assert "Freigabe anfordern" not in page
+
+
+def test_legacy_order_shows_ready_and_cancel_with_permissions() -> None:
+    panel, order_id = _legacy_panel_with_order()
+    page = panel.render_order(
+        order_id,
+        context=_employee_context(
+            "orders.view",
+            "orders.ready.release",
+            "orders.cancel",
+        ),
+    )
+    assert page is not None
+    assert "Freigabe anfordern" in page
+    assert "Auftrag stornieren" in page
+    assert "Version anlegen" not in page
+
+
+def test_legacy_order_basic_fallback_retains_controls() -> None:
+    panel, order_id = _legacy_panel_with_order()
+    page = panel.render_order(order_id, context=legacy_office_context())
+    assert page is not None
+    assert "Druck bestätigen" in page
+    assert "Freigabe anfordern" in page
+    assert "Auftrag stornieren" in page
+    assert "Version anlegen" in page

--- a/tests/unit/test_office_panel_authz.py
+++ b/tests/unit/test_office_panel_authz.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+
+from catering_system.domain.employee_auth import AuthenticatedEmployee
+from catering_system.ui.office_panel_authz import (
+    BusinessAccessDenied,
+    can_access,
+    can_access_all,
+    require_all_business_permissions,
+    require_business_permission,
+)
+
+
+@dataclass(frozen=True)
+class _AuthStub:
+    kind: Literal["basic", "employee"]
+    legacy_shared_access: bool
+    employee: AuthenticatedEmployee | None = None
+
+
+def test_unknown_permission_code_fails_closed() -> None:
+    auth = _AuthStub(kind="employee", legacy_shared_access=False)
+    assert can_access(auth, "not.a.real.permission") is False
+    with pytest.raises(BusinessAccessDenied):
+        require_business_permission(auth, "not.a.real.permission")
+
+
+def test_legacy_basic_passes_without_employee_permissions() -> None:
+    auth = _AuthStub(kind="basic", legacy_shared_access=True, employee=None)
+    assert can_access(auth, "orders.view") is True
+    require_business_permission(auth, "orders.view")
+
+
+def test_employee_requires_effective_permission() -> None:
+    from catering_system.domain.employee_auth import EmployeeAccount, EmployeeSession
+    from datetime import UTC, datetime
+
+    account = EmployeeAccount(
+        id="acc-1",
+        username="worker",
+        email=None,
+        display_name="Worker",
+        password_hash="hash",
+        role="USER",
+        is_active=True,
+        must_change_password=False,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        deactivated_at=None,
+        last_login_at=None,
+        auth_version=1,
+    )
+    session = EmployeeSession(
+        id="sess-1",
+        account_id="acc-1",
+        token_hash="t",
+        csrf_token_hash="c",
+        created_at=datetime.now(UTC),
+        last_seen_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC),
+        revoked_at=None,
+        revoked_reason=None,
+        auth_version=1,
+    )
+    employee = AuthenticatedEmployee(
+        account=account,
+        session=session,
+        application_access_allowed=True,
+        effective_permissions=frozenset({"inquiries.view"}),
+    )
+    auth = _AuthStub(kind="employee", legacy_shared_access=False, employee=employee)
+    assert can_access(auth, "inquiries.view") is True
+    assert can_access(auth, "orders.view") is False
+    assert can_access_all(auth, ("inquiries.view", "orders.view")) is False
+    with pytest.raises(BusinessAccessDenied):
+        require_all_business_permissions(auth, ("inquiries.view", "orders.view"))

--- a/tests/unit/test_office_panel_dashboard.py
+++ b/tests/unit/test_office_panel_dashboard.py
@@ -14,7 +14,7 @@ from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
 from catering_system.services.inquiry_service import InquiryService
-from catering_system.ui.office_panel import OfficePageContext, OfficePanel
+from catering_system.ui.office_panel import OfficePanel
 from catering_system.ui.office_panel_dashboard import (
     ArbeitszentraleData,
     render_arbeitszentrale,

--- a/tests/unit/test_office_panel_dashboard.py
+++ b/tests/unit/test_office_panel_dashboard.py
@@ -19,6 +19,7 @@ from catering_system.ui.office_panel_dashboard import (
     ArbeitszentraleData,
     render_arbeitszentrale,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 
 
 def _snapshot(**overrides: int) -> WorkCenterSnapshot:
@@ -89,7 +90,7 @@ def _entry(
 
 def _data(**overrides: object) -> ArbeitszentraleData:
     values: dict[str, object] = {
-        "context": OfficePageContext(csrf_token="csrf-real"),
+        "context": legacy_office_context(csrf_token="csrf-real"),
         "today": date(2026, 7, 15),
         "snapshot": _snapshot(),
         "tasks": [],
@@ -315,7 +316,7 @@ def test_v2_panel_renders_new_dashboard() -> None:
     missed_calls = [{"call_id": f"c{i}", "phone": f"040{i}"} for i in range(15)]
     page = OfficePanel(inquiries, orders, ui_version="v2").render_queue(
         missed_calls,
-        context=OfficePageContext(rueckruf_count=15, csrf_token="csrf"),
+        context=legacy_office_context(rueckruf_count=15, csrf_token="csrf"),
     )
 
     assert "<h1>Heute im Büro</h1>" in page

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -61,6 +61,7 @@ from catering_system.ui.office_panel_views import (
     OfficePageContext,
     parse_datetime_local_berlin,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 from catering_system.ui.remote_core_client import RemoteCoreClient
 
 _PASSWORD = "test-pw"
@@ -805,7 +806,7 @@ def test_html_escaping_in_variant_label() -> None:
 
     html = render_offer_detail(
         detail,
-        context=OfficePageContext(csrf_token=_CSRF_TOKEN),
+        context=legacy_office_context(csrf_token=_CSRF_TOKEN),
         forms=OfferDetailFormFields(csrf_input="", command_fields=""),
     )
     assert "<script>" not in html
@@ -846,7 +847,7 @@ def test_expired_offer_detail_shows_prepare_next_without_link() -> None:
 
     html = render_offer_detail(
         detail,
-        context=OfficePageContext(csrf_token=_CSRF_TOKEN),
+        context=legacy_office_context(csrf_token=_CSRF_TOKEN),
         forms=OfferDetailFormFields(csrf_input="", command_fields=""),
         revision_prefill_url=None,
     )
@@ -889,7 +890,7 @@ def test_expired_offer_detail_shows_prepare_next_with_link() -> None:
 
     html = render_offer_detail(
         detail,
-        context=OfficePageContext(csrf_token=_CSRF_TOKEN),
+        context=legacy_office_context(csrf_token=_CSRF_TOKEN),
         forms=OfferDetailFormFields(csrf_input="", command_fields=""),
         revision_prefill_url="/configurator?offer=11111111-1111-4111-8111-111111111111",
     )

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -57,10 +57,7 @@ from catering_system.ui.office_panel_http import (
     inquiry_command_error_message,
 )
 from catering_system.ui.office_panel_offer_detail import render_offer_detail
-from catering_system.ui.office_panel_views import (
-    OfficePageContext,
-    parse_datetime_local_berlin,
-)
+from catering_system.ui.office_panel_views import parse_datetime_local_berlin
 from tests.helpers.office_panel_context import legacy_office_context
 from catering_system.ui.remote_core_client import RemoteCoreClient
 

--- a/tests/unit/test_office_panel_offer_prefill.py
+++ b/tests/unit/test_office_panel_offer_prefill.py
@@ -79,9 +79,7 @@ def test_payload_maps_labelled_context_without_creating_core_records() -> None:
         order_repo,
         configurator_url="http://127.0.0.1:5173",
     )
-    page = panel.render_inquiry(
-        inquiry.inquiry_id, context=legacy_office_context()
-    )
+    page = panel.render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
 
     assert page is not None
     assert "Angebot mit Anfragedaten vorbereiten" in page

--- a/tests/unit/test_office_panel_offer_prefill.py
+++ b/tests/unit/test_office_panel_offer_prefill.py
@@ -31,6 +31,7 @@ from catering_system.ui.office_panel_offer_prefill import (
     normalize_configurator_url,
     offer_prefill_payload,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 
 
 def _inquiry(*, guest_count: int | None = 42) -> Inquiry:
@@ -78,7 +79,9 @@ def test_payload_maps_labelled_context_without_creating_core_records() -> None:
         order_repo,
         configurator_url="http://127.0.0.1:5173",
     )
-    page = panel.render_inquiry(inquiry.inquiry_id)
+    page = panel.render_inquiry(
+        inquiry.inquiry_id, context=legacy_office_context()
+    )
 
     assert page is not None
     assert "Angebot mit Anfragedaten vorbereiten" in page
@@ -202,7 +205,8 @@ def test_empty_configurator_url_keeps_handoff_dormant() -> None:
     order_repo = InMemoryOrderRepository()
     inquiry_repo.save(_inquiry())
     page = OfficePanel(inquiry_repo, order_repo).render_inquiry(
-        "11111111-1111-1111-1111-111111111111"
+        "11111111-1111-1111-1111-111111111111",
+        context=legacy_office_context(),
     )
     assert page is not None
     assert "Angebot mit Anfragedaten vorbereiten" not in page
@@ -228,7 +232,7 @@ def test_v2_inquiry_detail_has_action_or_safe_unavailable_state(
         InMemoryOrderRepository(),
         configurator_url=configurator_url,
         ui_version="v2",
-    ).render_inquiry(inquiry.inquiry_id)
+    ).render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
 
     assert page is not None
     assert expected in page
@@ -247,7 +251,7 @@ def test_blocked_inquiry_never_renders_configurator_link() -> None:
         inquiry_repo,
         order_repo,
         configurator_url="https://angebote.example.test",
-    ).render_inquiry(inquiry.inquiry_id)
+    ).render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
 
     assert page is not None
     assert "https://angebote.example.test" not in page

--- a/tests/unit/test_office_panel_settings_users.py
+++ b/tests/unit/test_office_panel_settings_users.py
@@ -252,7 +252,7 @@ def test_users_nav_hidden_without_users_view(employee_panel: PanelHarness) -> No
         new_password="ViewerChanged1!",
     )
     jar = _login(employee_panel, username=viewer.username, password="ViewerChanged1!")
-    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    status, _url, body, _headers = _request(employee_panel.base, "/anfragen", jar=jar)
     assert status == 200
     assert "/settings/users" not in body
 


### PR DESCRIPTION
## Summary

- Add `office_panel_authz.py` with `can_access`, `require_business_permission`, and shared German 403 handling for employee sessions.
- Gate all existing business GET routes before panel/service/remote/Auerswald/PDF work; preserve Basic and migration rollback (settings/users remain employee-only via AUTH-2C).
- Extend `OfficePageContext` with `employee_effective_permissions` and `can()`; make sidebar, dashboard calendar widgets, and several read/action links permission-aware (presentation only — POST enforcement remains AUTH-2D2–2D5).

Closes #72.

## Auth-mode behavior

| Mode | Business GET | `/settings/users/*` |
|------|--------------|---------------------|
| Employee | Exact permission required; 403 DE on denial | Employee + `users.view`; Basic denied |
| Migration Basic fallback | Legacy pass | Denied (unchanged AUTH-2C) |
| Basic rollback | Legacy pass | Denied |
| Unauthenticated employee/migration | Login redirect | Login redirect |

## GET permission map (implemented)

- `/`, `/rueckruf`, `/aufgaben` → `queue.view`
- Dashboard calendar widget / `/kalender` → `calendar.view` (widget optional on `/`)
- Inquiries/email/proposal import → `inquiries.view` / `inquiries.create`
- Customers → `customers.view`
- Offers → `offers.view`; PDF → `offers.pdf.generate`
- Orders/print/buffet → `orders.view`; confirmation preview/outbox → `documents.view`
- Catalog list/detail → `catalog.view`; new/edit → `catalog.edit`

## Deferred product decisions (no new registry codes in this PR)

- inquiry→order: `inquiries.view` + `orders.version.create`
- offer→order: `offers.view` + `orders.version.create`
- POST `/rueckruf/resolve`: future `queue.resolve`
- payment reminder: future `orders.payment.reminder`
- confirmation document prepare/send: future `documents.prepare` / `documents.send`
- `offers.timing.acknowledge`: PR #63/DET integration
- catalog price values: `catalog.edit` + `prices.edit`
- Configurator/API: AUTH-2E

## Test plan

- [x] `tests/unit/test_office_panel_authz.py`
- [x] `tests/unit/test_office_panel_auth_2d1.py` (GET gates, nav, dashboard partial visibility, PDF not called on denial)
- [x] AUTH-2A/2C regressions updated where dashboard now requires `queue.view`
- [x] Full Core suite: 2561 passed locally
- [x] mypy + ruff clean on touched files

## Out of scope

- POST mutation enforcement
- Configurator auth (AUTH-2E)
- Production rollout / Tailscale / employee bootstrap
- PR #63 / DET-2

Made with [Cursor](https://cursor.com)