### PR TITLE
AUTH-2D2: Office Panel POST authorization for inquiries, customers, proposal import

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -2609,6 +2609,14 @@ class OfficePanel:
         # written anywhere — it's page context for the office worker, shown
         # once, not a prefilled form field bound to any Inquiry attribute.
         phone_hint = f'<p class="subtitle">Anruf von: {_e(phone)}</p>' if phone else ""
+        if not context.can("inquiries.create"):
+            return _page(
+                "Neue Anfrage",
+                phone_hint
+                + '<p class="blocked">Ihre Berechtigung reicht für diese Aktion nicht aus.</p>',
+                active_section="inquiries",
+                context=context,
+            )
         # event_date / guest_count_estimate / inquiry_source / intake_*:
         # optional prefill hints, from either the proposal preview's GET hint
         # (event_date/guest_count_estimate only, PROPOSAL_PREVIEW_MANUAL_
@@ -2669,23 +2677,25 @@ class OfficePanel:
                 f"{_e(CONTACT_COMPLETION_NEXT_ACTION)}. "
                 "Ohne vollständige Kontaktdaten sind Angebot und Auftrag blockiert.</p>"
             )
-            inputs = ""
-            if "email" in missing:
-                inputs += '<p><label>E-Mail</label><input type="email" name="contact_email"></p>'
-            if "phone" in missing:
-                inputs += '<p><label>Telefon</label><input type="tel" name="contact_phone"></p>'
-            form = (
-                f'<form method="post" action="/inquiry/{_e(inq.inquiry_id)}/contact-completion" '
-                'onsubmit="return confirm('
-                "'Fehlende Kontaktdaten werden ergänzt. "
-                "Vorhandene Angaben werden nicht überschrieben.'"
-                ');">'
-                f"{_csrf_input(context)}"
-                f"{self._command_fields({'updated_at': inq.updated_at.isoformat()})}"
-                f"<fieldset>{inputs}"
-                '<p><button type="submit">Kontaktdaten ergänzen</button></p>'
-                "</fieldset></form>"
-            )
+            form = ""
+            if context.can("inquiries.edit"):
+                inputs = ""
+                if "email" in missing:
+                    inputs += '<p><label>E-Mail</label><input type="email" name="contact_email"></p>'
+                if "phone" in missing:
+                    inputs += '<p><label>Telefon</label><input type="tel" name="contact_phone"></p>'
+                form = (
+                    f'<form method="post" action="/inquiry/{_e(inq.inquiry_id)}/contact-completion" '
+                    'onsubmit="return confirm('
+                    "'Fehlende Kontaktdaten werden ergänzt. "
+                    "Vorhandene Angaben werden nicht überschrieben.'"
+                    ');">'
+                    f"{_csrf_input(context)}"
+                    f"{self._command_fields({'updated_at': inq.updated_at.isoformat()})}"
+                    f"<fieldset>{inputs}"
+                    '<p><button type="submit">Kontaktdaten ergänzen</button></p>'
+                    "</fieldset></form>"
+                )
         return f"<h2>Kontaktdaten</h2>{status}<table>{rows}</table>{form}"
 
     def create_inquiry(self, form: dict[str, str]) -> Inquiry:
@@ -2847,7 +2857,7 @@ class OfficePanel:
         else:
             prog = '<p class="ok">Angebot kann vorbereitet werden.</p>'
         verify_btn = ""
-        if state.next_action == "verify":
+        if state.next_action == "verify" and context.can("inquiries.verify"):
             verify_btn = (
                 f'<form class="inline" method="post" action="/inquiry/{_e(inquiry_id)}/verify">'
                 f"{_csrf_input(context)}{self._command_fields()}"
@@ -2876,7 +2886,11 @@ class OfficePanel:
                     '<p class="muted">Auftrag bereits erstellt — '
                     "verknüpften Auftrag unten öffnen.</p>"
                 )
-            elif inquiry_shows_convert_accepted_button(state):
+            elif (
+                inquiry_shows_convert_accepted_button(state)
+                and context.can("offers.view")
+                and context.can("orders.version.create")
+            ):
                 convert += (
                     f'<form class="inline" method="post" '
                     f'action="/inquiry/{_e(inquiry_id)}/convert-accepted" '
@@ -2944,6 +2958,23 @@ class OfficePanel:
             else _crm_stage_select(inq.crm_stage)
         )
         contact_section = self._render_contact_section(inq, context)
+        update_form = ""
+        if context.can("inquiries.edit"):
+            update_form = f"""<h2>Anfrage bearbeiten</h2>
+<form method="post" action="/inquiry/{_e(inquiry_id)}/update">{_csrf_input(context)}{self._command_fields({"updated_at": inq.updated_at.isoformat()})}<fieldset>
+<p><label>Datum</label><input type="date" name="event_date" value="{_e(inq.event_date.isoformat())}"></p>
+<p><label>Zeitfenster</label><input name="time_window_text" value="{_e(inq.time_window_text)}"></p>
+<p><label>Ort</label><input name="location_text" value="{_e(inq.location_text)}"></p>
+<p><label>Gäste (ca.)</label><input name="guest_count_estimate" value="{_e(guests)}"></p>
+<p><label>Planungsmodus</label>{_planning_mode_select(inq.planning_mode)}</p>
+<p><label>CRM-Stufe</label>{crm_stage_field}</p>
+<p class="subtitle">Intake-Kontext — keine Auftrags-/Küchenfreigabe.</p>
+<p><label>Betreff</label><input name="intake_subject" value="{_e(inq.intake_subject or "")}"></p>
+<p><label>Nachricht</label><textarea name="intake_message" rows="4">{_e(inq.intake_message or "")}</textarea></p>
+<p><label>Zusammenfassung</label><textarea name="intake_summary" rows="3">{_e(inq.intake_summary or "")}</textarea></p>
+<p><label>Externe Referenz</label><input name="intake_external_ref" value="{_e(inq.intake_external_ref or "")}"></p>
+<p><button type="submit">Speichern</button></p>
+</fieldset></form>"""
         body = (
             inquiry_truncation_warning
             + website_banner
@@ -2960,21 +2991,7 @@ class OfficePanel:
 <h2>Vorgangsprüfung (Progression)</h2>{prog}
 <p>{verify_btn}{convert}</p>
 {offer_prefill}
-<h2>Anfrage bearbeiten</h2>
-<form method="post" action="/inquiry/{_e(inquiry_id)}/update">{_csrf_input(context)}{self._command_fields({"updated_at": inq.updated_at.isoformat()})}<fieldset>
-<p><label>Datum</label><input type="date" name="event_date" value="{_e(inq.event_date.isoformat())}"></p>
-<p><label>Zeitfenster</label><input name="time_window_text" value="{_e(inq.time_window_text)}"></p>
-<p><label>Ort</label><input name="location_text" value="{_e(inq.location_text)}"></p>
-<p><label>Gäste (ca.)</label><input name="guest_count_estimate" value="{_e(guests)}"></p>
-<p><label>Planungsmodus</label>{_planning_mode_select(inq.planning_mode)}</p>
-<p><label>CRM-Stufe</label>{crm_stage_field}</p>
-<p class="subtitle">Intake-Kontext — keine Auftrags-/Küchenfreigabe.</p>
-<p><label>Betreff</label><input name="intake_subject" value="{_e(inq.intake_subject or "")}"></p>
-<p><label>Nachricht</label><textarea name="intake_message" rows="4">{_e(inq.intake_message or "")}</textarea></p>
-<p><label>Zusammenfassung</label><textarea name="intake_summary" rows="3">{_e(inq.intake_summary or "")}</textarea></p>
-<p><label>Externe Referenz</label><input name="intake_external_ref" value="{_e(inq.intake_external_ref or "")}"></p>
-<p><button type="submit">Speichern</button></p>
-</fieldset></form>"""
+{update_form}"""
         )
         return _page(
             f"Anfrage {inq.inquiry_id[:8]}",
@@ -3350,6 +3367,7 @@ class OfficePanel:
                 operational_pause=pause_view,
                 versions_total_count=versions_total_count,
                 versions_truncated=versions_truncated,
+                context=context,
             )
             return _page(
                 detail.title,
@@ -3602,11 +3620,13 @@ class OfficePanel:
             source_inquiry,
             order,
             detail_forms,
+            context=context,
         )
         addresses_card = render_customer_addresses_card(
             source_inquiry,
             order,
             detail_forms,
+            context=context,
         )
         confirmation_card = render_confirmation_card(
             order,

--- a/src/catering_system/ui/office_panel_authz.py
+++ b/src/catering_system/ui/office_panel_authz.py
@@ -64,3 +64,18 @@ def require_all_business_permissions(
 ) -> None:
     for permission_code in permission_codes:
         require_business_permission(auth, permission_code)
+
+
+def require_business_permission_post(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_code: str,
+) -> None:
+    """POST alias — same employee/Basic semantics as GET (AUTH-2D2)."""
+    require_business_permission(auth, permission_code)
+
+
+def require_all_business_permissions_post(
+    auth: BusinessAuthRequest | "OfficePanelRequestAuth" | None,
+    permission_codes: tuple[str, ...],
+) -> None:
+    require_all_business_permissions(auth, permission_codes)

--- a/src/catering_system/ui/office_panel_contact_detail.py
+++ b/src/catering_system/ui/office_panel_contact_detail.py
@@ -60,17 +60,20 @@ def _notes_section(detail: dict[str, object], context: OfficePageContext) -> str
         )
         or "<p>Keine internen Notizen.</p>"
     )
+    note_form = ""
+    if context.can("customers.edit"):
+        note_form = (
+            f'<form method="post" action="/kontakt/{_e(encoded)}/notizen">'
+            f"{_csrf_input(context)}"
+            f'<p><label>Kategorie</label><select name="category">{options}</select></p>'
+            "<p><label>Notiz</label>"
+            '<textarea name="note_text" rows="4" maxlength="4000" required></textarea></p>'
+            '<p><button type="submit">Notiz speichern</button></p>'
+            "</form>"
+        )
     return (
         '<section class="offer-detail-section">'
-        "<h2>Interne Notizen</h2>"
-        f'<form method="post" action="/kontakt/{_e(encoded)}/notizen">'
-        f"{_csrf_input(context)}"
-        f'<p><label>Kategorie</label><select name="category">{options}</select></p>'
-        "<p><label>Notiz</label>"
-        '<textarea name="note_text" rows="4" maxlength="4000" required></textarea></p>'
-        '<p><button type="submit">Notiz speichern</button></p>'
-        "</form>"
-        f"{note_rows}"
+        "<h2>Interne Notizen</h2>" + note_form + f"{note_rows}"
         "</section>"
     )
 

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -104,7 +104,9 @@ from catering_system.ui.office_panel_settings_users import (
 )
 from catering_system.ui.office_panel_authz import (
     BusinessAccessDenied,
+    require_all_business_permissions_post,
     require_business_permission,
+    require_business_permission_post,
 )
 from catering_system.ui.employee_auth_http import (
     CSRF_COOKIE_NAME,
@@ -612,6 +614,85 @@ def make_office_panel_handler(
         ) -> bool:
             try:
                 require_business_permission(auth, permission_code)
+            except BusinessAccessDenied:
+                self._business_forbidden(active_section=active_section)
+                return False
+            return True
+
+        def _post_active_section(self, parts: list[str]) -> OfficeSection:
+            if parts == ["proposal-preview"] or parts == [
+                "proposal-preview",
+                "prepare",
+            ]:
+                return "proposal"
+            if parts == ["inquiry", "new"] or (
+                len(parts) == 3 and parts[0] == "inquiry"
+            ):
+                return "inquiries"
+            if len(parts) == 3 and parts[0] == "kontakt":
+                return "contacts"
+            return "home"
+
+        def _auth2d2_post_permission_requirements(
+            self, parts: list[str]
+        ) -> tuple[str, ...] | None:
+            if parts == ["inquiry", "new"]:
+                return ("inquiries.create",)
+            if len(parts) == 3 and parts[0] == "inquiry":
+                action = parts[2]
+                if action == "update":
+                    return ("inquiries.edit",)
+                if action == "contact-completion":
+                    return ("inquiries.edit",)
+                if action == "fulfillment-mode":
+                    return ("inquiries.edit",)
+                if action == "customer-addresses":
+                    return ("inquiries.view", "customers.edit")
+                if action == "verify":
+                    return ("inquiries.verify",)
+                if action == "convert":
+                    return ("inquiries.view", "orders.version.create")
+                if action == "convert-accepted":
+                    return ("offers.view", "orders.version.create")
+                return None
+            if parts == ["proposal-preview"]:
+                return ("inquiries.create",)
+            if parts == ["proposal-preview", "prepare"]:
+                return ("inquiries.create",)
+            if len(parts) == 3 and parts[0] == "kontakt" and parts[2] == "notizen":
+                return ("customers.edit",)
+            return None
+
+        def _require_auth2d2_post_permissions(
+            self,
+            parts: list[str],
+            auth: OfficePanelRequestAuth | None,
+        ) -> bool:
+            requirements = self._auth2d2_post_permission_requirements(parts)
+            if requirements is None:
+                return True
+            if auth is None or auth.legacy_shared_access:
+                return True
+            if auth.kind != "employee" or auth.employee is None:
+                return True
+            try:
+                require_all_business_permissions_post(auth, requirements)
+            except BusinessAccessDenied:
+                self._business_forbidden(
+                    active_section=self._post_active_section(parts)
+                )
+                return False
+            return True
+
+        def _require_business_permission_post(
+            self,
+            auth: OfficePanelRequestAuth | None,
+            permission_code: str,
+            *,
+            active_section: OfficeSection = "home",
+        ) -> bool:
+            try:
+                require_business_permission_post(auth, permission_code)
             except BusinessAccessDenied:
                 self._business_forbidden(active_section=active_section)
                 return False
@@ -1282,15 +1363,15 @@ def make_office_panel_handler(
             parts = [part for part in urlparse(self.path).path.split("/") if part]
             auth = self._resolve_request_auth()
             self._request_auth = auth
-            try:
-                form = self._form()
-            except FormBodyTooLargeError as exc:
-                self._error_page(str(exc), status=413)
-                return
-            except (UnicodeDecodeError, ValueError) as exc:
-                self._error_page(str(exc), status=400)
-                return
             if parts == ["login"]:
+                try:
+                    form = self._form()
+                except FormBodyTooLargeError as exc:
+                    self._error_page(str(exc), status=413)
+                    return
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self._error_page(str(exc), status=400)
+                    return
                 if validated_auth_mode == "basic":
                     self.send_error(404)
                     return
@@ -1319,6 +1400,14 @@ def make_office_panel_handler(
                 )
                 return
             if parts == ["logout"]:
+                try:
+                    form = self._form()
+                except FormBodyTooLargeError as exc:
+                    self._error_page(str(exc), status=413)
+                    return
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self._error_page(str(exc), status=400)
+                    return
                 if auth is None or auth.kind != "employee" or auth.employee is None:
                     if validated_auth_mode == "basic":
                         self._deny()
@@ -1353,6 +1442,14 @@ def make_office_panel_handler(
                 )
                 return
             if parts == ["password-change"]:
+                try:
+                    form = self._form()
+                except FormBodyTooLargeError as exc:
+                    self._error_page(str(exc), status=413)
+                    return
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self._error_page(str(exc), status=400)
+                    return
                 if auth is None or auth.kind != "employee" or auth.employee is None:
                     if validated_auth_mode == "basic":
                         self._deny()
@@ -1409,6 +1506,16 @@ def make_office_panel_handler(
                 and not auth.employee.application_access_allowed
             ):
                 self._redirect("/password-change")
+                return
+            if not self._require_auth2d2_post_permissions(parts, auth):
+                return
+            try:
+                form = self._form()
+            except FormBodyTooLargeError as exc:
+                self._error_page(str(exc), status=413)
+                return
+            except (UnicodeDecodeError, ValueError) as exc:
+                self._error_page(str(exc), status=400)
                 return
             submitted_token = form.get("_csrf_token", "")
             if auth.kind == "employee":

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -191,6 +191,8 @@ def _primary_action(
             "</section>"
         )
     elif inquiry_shows_convert_accepted_button(state):
+        if not (context.can("offers.view") and context.can("orders.version.create")):
+            return ""
         return (
             '<section class="inquiry-next-step">'
             '<div class="inquiry-eyebrow">Nächster Schritt</div>'
@@ -305,7 +307,11 @@ def _contact_completion_form(
     inquiry: Inquiry,
     forms: InquiryDetailFormFields,
     missing: tuple[str, ...],
+    *,
+    context: OfficePageContext,
 ) -> str:
+    if not context.can("inquiries.edit"):
+        return ""
     """Inputs only for missing fields; stored values stay read-only above."""
     inputs = []
     if "email" in missing:
@@ -330,7 +336,9 @@ def _contact_completion_form(
     )
 
 
-def _contact_card(inquiry: Inquiry, forms: InquiryDetailFormFields) -> str:
+def _contact_card(
+    inquiry: Inquiry, forms: InquiryDetailFormFields, *, context: OfficePageContext
+) -> str:
     snapshot = inquiry.customer_snapshot
     completeness = derive_inquiry_contact_completeness(inquiry)
     missing = missing_contact_fields(completeness)
@@ -358,7 +366,7 @@ def _contact_card(inquiry: Inquiry, forms: InquiryDetailFormFields) -> str:
             "Ohne vollständige Kontaktdaten sind Angebot und Auftrag blockiert."
             "</div>"
         )
-        form = _contact_completion_form(inquiry, forms, missing)
+        form = _contact_completion_form(inquiry, forms, missing, context=context)
     return (
         '<section class="inquiry-card inquiry-content-card">'
         "<h2>Kontaktdaten</h2>"
@@ -545,7 +553,7 @@ def render_inquiry_detail(
         f"<strong>{_e(state_title)}</strong><p>{_e(state_description)}</p></div>"
         "</section>"
         '<div class="inquiry-detail-layout"><div class="inquiry-detail-main">'
-        + _contact_card(inquiry, forms)
+        + _contact_card(inquiry, forms, context=page_context)
         + '<section class="inquiry-card inquiry-content-card">'
         "<h2>Nachricht des Kunden</h2>"
         f'<p class="inquiry-message">{_e(message)}</p></section>'

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -31,6 +31,7 @@ from catering_system.services.order_confirmation_document_service import (
 from catering_system.services.order_confirmation_outbound_service import (
     OutboundSendEligibility,
 )
+from catering_system.ui.office_panel_views import OfficePageContext
 from catering_system.ui.operational_pause_labels import (
     PAUSE_REASON_LABELS,
     pause_reason_label,
@@ -850,8 +851,10 @@ def render_customer_addresses_card(
     forms: OrderDetailFormFields,
     *,
     editable: bool = True,
+    context: OfficePageContext | None = None,
 ) -> str:
     """Show stored vs effective delivery addresses for confirmation context."""
+    page_context = context or OfficePageContext()
     if inquiry is None:
         return (
             '<section class="order-card order-content-card order-addresses-card">'
@@ -884,7 +887,12 @@ def render_customer_addresses_card(
     )
     form = (
         _customer_addresses_form(inquiry, order, forms)
-        if editable and order.cancelled_at is None
+        if (
+            editable
+            and order.cancelled_at is None
+            and page_context.can("inquiries.view")
+            and page_context.can("customers.edit")
+        )
         else ""
     )
     return (
@@ -925,8 +933,10 @@ def render_fulfillment_mode_card(
     forms: OrderDetailFormFields,
     *,
     editable: bool = True,
+    context: OfficePageContext | None = None,
 ) -> str:
     """Auftragsart (Lieferung/Abholung) — never guessed, always explicit."""
+    page_context = context or OfficePageContext()
     if inquiry is None:
         return (
             '<section class="order-card order-content-card order-fulfillment-card">'
@@ -939,7 +949,11 @@ def render_fulfillment_mode_card(
     )
     form = (
         _fulfillment_mode_form(inquiry, order, forms)
-        if editable and order.cancelled_at is None
+        if (
+            editable
+            and order.cancelled_at is None
+            and page_context.can("inquiries.edit")
+        )
         else ""
     )
     return (
@@ -1200,8 +1214,10 @@ def render_order_detail(
     operational_pause: Mapping[str, object] | None = None,
     versions_total_count: int,
     versions_truncated: bool,
+    context: OfficePageContext | None = None,
 ) -> OrderDetailPage:
     """Render existing Order facts and actions without performing any reads."""
+    page_context = context or OfficePageContext()
 
     pause_view = operational_pause or {"active": False}
     target = _target_version(order, versions)
@@ -1276,8 +1292,12 @@ def render_order_detail(
         + "</div>"
         '<aside class="order-detail-side">'
         + _primary_action(order, target, next_action, forms)
-        + render_fulfillment_mode_card(source_inquiry, order, forms)
-        + render_customer_addresses_card(source_inquiry, order, forms)
+        + render_fulfillment_mode_card(
+            source_inquiry, order, forms, context=page_context
+        )
+        + render_customer_addresses_card(
+            source_inquiry, order, forms, context=page_context
+        )
         + _confirmation_card(order, confirmation, forms, live_preview)
         + render_confirmation_outbound_card(
             order, confirmation, outbound, forms, operational_pause=pause_view

--- a/tests/unit/test_customer_address_source_v1_b_panel.py
+++ b/tests/unit/test_customer_address_source_v1_b_panel.py
@@ -45,6 +45,7 @@ from catering_system.ui.office_panel_order_detail import (
     OrderDetailFormFields,
     render_customer_addresses_card,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 from tests.unit.test_offer_service import (
     _INQUIRY_ID,
     _acceptance_args,
@@ -105,7 +106,9 @@ def test_address_card_separate_shows_stored_and_effective() -> None:
         created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
         updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    card = render_customer_addresses_card(
+        inquiry, order, _empty_forms(), context=legacy_office_context()
+    )
     assert "Rechnungsadresse" in card
     assert "Bürostraße 1" in card
     assert "Abweichende Lieferadresse" in card
@@ -138,7 +141,9 @@ def test_address_card_same_as_invoice_distinguishes_stored_vs_effective() -> Non
         created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
         updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    card = render_customer_addresses_card(
+        inquiry, order, _empty_forms(), context=legacy_office_context()
+    )
     assert "Wie Rechnungsadresse" in card
     assert "keine separate Adresse" in card
     assert card.count("Bürostraße 1") >= 2
@@ -164,7 +169,9 @@ def test_address_card_unknown_has_no_effective_delivery() -> None:
         created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
         updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
-    card = render_customer_addresses_card(inquiry, order, _empty_forms())
+    card = render_customer_addresses_card(
+        inquiry, order, _empty_forms(), context=legacy_office_context()
+    )
     assert "Unbekannt" in card
     assert "keine separate Adresse" in card
     assert "nicht festgelegt" in card
@@ -252,7 +259,7 @@ def test_order_detail_shows_separate_addresses_after_service_write(
         delivery_address=_DELIVERY,
         delivery_address_mode="SEPARATE",
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Kundenadressen" in page
     assert "Bürostraße 1" in page
@@ -277,7 +284,7 @@ def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None
         delivery_address=_DELIVERY,
         delivery_address_mode="SAME_AS_INVOICE",
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Wie Rechnungsadresse" in page
     assert "keine separate Adresse" in page
@@ -289,7 +296,7 @@ def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None
         delivery_address=None,
         delivery_address_mode="UNKNOWN",
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Unbekannt" in page
     assert "nicht festgelegt" in page
@@ -327,7 +334,7 @@ def test_contact_completion_after_address_form_preserves_addresses(
     panel.complete_inquiry_contacts(
         inquiry_id, {"contact_email": "neu@example.invalid"}
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Eventplatz 9" in page
     assert "Abweichende Lieferadresse" in page

--- a/tests/unit/test_inquiry_contact_completeness.py
+++ b/tests/unit/test_inquiry_contact_completeness.py
@@ -911,11 +911,12 @@ def _panel_detail(inquiry: Inquiry, *, ui_version: str = "legacy") -> str:
         InMemoryOrderRepository as _Orders,
     )
     from catering_system.ui.office_panel import OfficePanel
+    from tests.helpers.office_panel_context import legacy_office_context
 
     inquiries = InMemoryInquiryRepository()
     inquiries.save(inquiry)
     panel = OfficePanel(inquiries, _Orders(), ui_version=ui_version)
-    html = panel.render_inquiry(inquiry.inquiry_id)
+    html = panel.render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
     assert html is not None
     return html
 
@@ -993,6 +994,7 @@ def test_ui_panel_completion_roundtrip() -> None:
         InMemoryOrderRepository as _Orders,
     )
     from catering_system.ui.office_panel import OfficePanel
+    from tests.helpers.office_panel_context import legacy_office_context
 
     inquiries = InMemoryInquiryRepository()
     inquiry = _inquiry(customer_snapshot=InquiryCustomerSnapshot(phone="+49301234567"))
@@ -1004,6 +1006,6 @@ def test_ui_panel_completion_roundtrip() -> None:
     assert updated.customer_snapshot == InquiryCustomerSnapshot(
         email="neu@example.com", phone="+49301234567"
     )
-    html = panel.render_inquiry(inquiry.inquiry_id)
+    html = panel.render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
     assert html is not None
     assert "Kontaktdaten vollständig" in html

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2505,7 +2505,9 @@ def test_website_intake_to_office_verification_and_conversion_workflow() -> None
     )
 
     queue = office.render_queue(None)
-    detail = office.render_inquiry(inquiry.inquiry_id)
+    from tests.helpers.office_panel_context import legacy_office_context
+
+    detail = office.render_inquiry(inquiry.inquiry_id, context=legacy_office_context())
     assert inquiry.inquiry_id[:8] in queue
     assert detail is not None
     assert "Website-Anfrage" in detail

--- a/tests/unit/test_office_panel_auth_2d2.py
+++ b/tests/unit/test_office_panel_auth_2d2.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import quote
+
+import pytest
+
+from catering_system.domain.inquiry import (
+    PLANNING_MODES,
+    Inquiry,
+    InquiryOfferProjection,
+    InquiryOfficeState,
+    inquiry_shows_convert_accepted_button,
+)
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
+from catering_system.ui.office_panel_contact_detail import render_kontakt_detail
+from catering_system.ui.office_panel_http import csrf_token_for_password
+from catering_system.ui.office_panel_inquiry_detail import (
+    InquiryDetailFormFields,
+    render_inquiry_detail,
+)
+from catering_system.ui.office_panel_views import OfficePageContext, _csrf_input
+from tests.helpers.office_panel_context import legacy_office_context
+
+_GERMAN_FORBIDDEN = "Ihre Berechtigung reicht für diese Aktion nicht aus."
+_GERMAN_CSRF = "Ungültiger oder fehlender CSRF-Sicherheitstoken."
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@dataclass
+class PanelHarness:
+    base: str
+    server: object
+    thread: threading.Thread
+    service: EmployeeAuthService
+    repo: SQLiteEmployeeAuthRepository
+    password: str
+
+
+def _auth_header(password: str) -> str:
+    return "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _csrf(jar: http.cookiejar.CookieJar) -> str:
+    return _cookie_value(jar, "sl_employee_csrf")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = None
+    if data is not None:
+        payload = urllib.parse.urlencode(data).encode()
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    try:
+        with opener.open(request) as response:
+            return (
+                response.status,
+                response.url,
+                response.read().decode("utf-8"),
+                response.headers,
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8"), exc.headers
+
+
+def _create_panel(
+    tmp_path: Path,
+    *,
+    auth_mode: str,
+    password: str = "shared-office-password",
+) -> PanelHarness:
+    db = tmp_path / "core.db"
+    connection = sqlite3.connect(str(db), check_same_thread=False)
+    repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+    service = EmployeeAuthService(
+        repo, now=lambda: datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    )
+    service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "office-panel"},
+    )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        password,
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        auth_service=service,
+        secure_cookie=False,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return PanelHarness(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        service=service,
+        repo=repo,
+        password=password,
+    )
+
+
+def _shutdown(panel: PanelHarness) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+    panel.repo.close()
+
+
+def _login(
+    panel: PanelHarness, *, username: str, password: str
+) -> http.cookiejar.CookieJar:
+    jar = http.cookiejar.CookieJar()
+    status, _url, _body, _headers = _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": username, "password": password, "next": "/"},
+        jar=jar,
+    )
+    assert status == 303
+    return jar
+
+
+def _ready_superadmin(panel: PanelHarness) -> http.cookiejar.CookieJar:
+    jar = _login(panel, username="viktor.admin", password="TempPassw0rd!")
+    employee = panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    return _login(panel, username="viktor.admin", password="ChangedTemp1!")
+
+
+def _create_employee(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    password: str,
+    role: str,
+    permissions: frozenset[str] | None = None,
+) -> str:
+    super_employee = panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    account = panel.service.create_account(
+        super_employee,
+        username=username,
+        display_name=username,
+        password=password,
+        role=role,
+        explicit_permissions=set(permissions) if permissions is not None else None,
+        must_change_password=False,
+    )
+    return account.id
+
+
+def _seed_inquiry(panel_base: str, jar: http.cookiejar.CookieJar) -> str:
+    status, _url, _body, _headers = _request(
+        panel_base,
+        "/inquiry/new",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "event_date": "2026-09-01",
+            "inquiry_source": "manual",
+            "planning_mode": PLANNING_MODES[0],
+        },
+        jar=jar,
+    )
+    assert status == 303
+    inquiry_id = _url.rsplit("/", 1)[-1]
+    return inquiry_id
+
+
+def _employee_jar(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    password: str = "ReaderTemp1!",
+    permissions: frozenset[str],
+) -> http.cookiejar.CookieJar:
+    _create_employee(
+        panel,
+        super_jar,
+        username=username,
+        password=password,
+        role="USER",
+        permissions=permissions,
+    )
+    return _login(panel, username=username, password=password)
+
+
+def _employee_context(*permissions: str) -> OfficePageContext:
+    return OfficePageContext(
+        legacy_shared_access=False,
+        employee_effective_permissions=frozenset(permissions),
+        csrf_token="csrf-test",
+    )
+
+
+def _accepted_inquiry_state() -> tuple[Inquiry, InquiryOfficeState]:
+    now = datetime(2026, 7, 14, 10, 0, tzinfo=UTC)
+    inquiry = Inquiry(
+        inquiry_id="22222222-2222-2222-2222-222222222222",
+        event_date=date(2026, 10, 1),
+        created_at=now,
+        updated_at=now,
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        customer_snapshot=InquiryCustomerSnapshot(
+            email="kunde@example.com",
+            phone="+49301234567",
+        ),
+    )
+    state = InquiryOfficeState(
+        is_open=True,
+        next_action="convert-accepted",
+        offer=InquiryOfferProjection(
+            offer_id="11111111-1111-1111-1111-111111111111",
+            offer_version_id="33333333-3333-3333-3333-333333333331",
+            commercial_state="Accepted",
+            accepted_variant_id="44444444-4444-4444-4444-444444444441",
+            acceptance_id="55555555-5555-5555-5555-555555555555",
+        ),
+    )
+    assert inquiry_shows_convert_accepted_button(state)
+    return inquiry, state
+
+
+def _inquiry_detail_page(context: OfficePageContext) -> str:
+    inquiry, state = _accepted_inquiry_state()
+    detail = render_inquiry_detail(
+        inquiry,
+        [],
+        state,
+        (),
+        forms=InquiryDetailFormFields(
+            csrf_input=_csrf_input(context),
+            primary_command_fields="",
+            update_command_fields="",
+        ),
+        context=context,
+    )
+    return detail.body
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def migration_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="migration")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def super_jar(employee_panel: PanelHarness) -> http.cookiejar.CookieJar:
+    return _ready_superadmin(employee_panel)
+
+
+@pytest.fixture()
+def seeded_inquiry_id(
+    employee_panel: PanelHarness, super_jar: http.cookiejar.CookieJar
+) -> str:
+    return _seed_inquiry(employee_panel.base, super_jar)
+
+
+def _assert_post_forbidden(
+    panel: PanelHarness,
+    path: str,
+    *,
+    jar: http.cookiejar.CookieJar | None = None,
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    patches: dict[str, str] | None = None,
+) -> None:
+    patch_targets = patches or {}
+    with ExitStack() as stack:
+        mocks = {
+            name: stack.enter_context(patch(target, autospec=True))
+            for name, target in patch_targets.items()
+        }
+        status, _url, body, _headers = _request(
+            panel.base,
+            path,
+            method="POST",
+            data=data or {},
+            jar=jar,
+            headers=headers,
+        )
+    assert status == 403
+    assert _GERMAN_FORBIDDEN in body
+    for mock in mocks.values():
+        mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("path", "data", "permissions", "patches", "username"),
+    [
+        (
+            "/inquiry/new",
+            {
+                "event_date": "2026-09-01",
+                "inquiry_source": "manual",
+                "planning_mode": PLANNING_MODES[0],
+            },
+            frozenset({"inquiries.view"}),
+            {
+                "create_inquiry": "catering_system.ui.office_panel.OfficePanel.create_inquiry"
+            },
+            "denied.inquiry.new",
+        ),
+        (
+            "/proposal-preview",
+            {"payload_json": "{}"},
+            frozenset({"inquiries.view"}),
+            {
+                "parse_proposal_payload": (
+                    "catering_system.ui.office_panel_proposal.parse_proposal_payload"
+                )
+            },
+            "denied.proposal.preview",
+        ),
+        (
+            "/proposal-preview/prepare",
+            {"payload_json": "{}"},
+            frozenset({"inquiries.view"}),
+            {
+                "parse_proposal_payload": (
+                    "catering_system.ui.office_panel_proposal.parse_proposal_payload"
+                )
+            },
+            "denied.proposal.prepare",
+        ),
+        (
+            "/kontakt/test%40example.invalid/notizen",
+            {"category": "Allgemein", "note_text": "Intern"},
+            frozenset({"customers.view"}),
+            {
+                "add_contact_note": "catering_system.ui.office_panel.OfficePanel.add_contact_note"
+            },
+            "denied.contact.notes",
+        ),
+    ],
+)
+def test_auth2d2_post_denied_without_required_permission(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    path: str,
+    data: dict[str, str],
+    permissions: frozenset[str],
+    patches: dict[str, str],
+    username: str,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username=username,
+        permissions=permissions,
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        path,
+        jar=jar,
+        data={**data, "_csrf_token": _csrf(jar)},
+        patches=patches,
+    )
+
+
+@pytest.mark.parametrize(
+    ("action", "permissions", "patch_target"),
+    [
+        (
+            "update",
+            frozenset({"inquiries.view"}),
+            "catering_system.ui.office_panel.OfficePanel.update_inquiry",
+        ),
+        (
+            "contact-completion",
+            frozenset({"inquiries.view"}),
+            "catering_system.ui.office_panel.OfficePanel.complete_inquiry_contacts",
+        ),
+        (
+            "fulfillment-mode",
+            frozenset({"inquiries.view"}),
+            "catering_system.ui.office_panel.OfficePanel.set_inquiry_fulfillment_mode",
+        ),
+        (
+            "verify",
+            frozenset({"inquiries.view"}),
+            "catering_system.services.inquiry_service.InquiryService.verify_customer_by_call",
+        ),
+    ],
+)
+def test_auth2d2_inquiry_action_denied_without_edit_or_verify_permission(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    seeded_inquiry_id: str,
+    action: str,
+    permissions: frozenset[str],
+    patch_target: str,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username=f"denied.{action}",
+        permissions=permissions,
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        f"/inquiry/{seeded_inquiry_id}/{action}",
+        jar=jar,
+        data={"_csrf_token": _csrf(jar)},
+        patches={action: patch_target},
+    )
+
+
+def test_customer_addresses_requires_both_inquiries_view_and_customers_edit(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    seeded_inquiry_id: str,
+) -> None:
+    patch_target = (
+        "catering_system.ui.office_panel.OfficePanel.set_inquiry_customer_addresses"
+    )
+    for username, permissions in (
+        ("addresses.view.only", frozenset({"inquiries.view"})),
+        ("addresses.edit.only", frozenset({"customers.edit"})),
+    ):
+        jar = _employee_jar(
+            employee_panel,
+            super_jar,
+            username=username,
+            permissions=permissions,
+        )
+        _assert_post_forbidden(
+            employee_panel,
+            f"/inquiry/{seeded_inquiry_id}/customer-addresses",
+            jar=jar,
+            data={"_csrf_token": _csrf(jar)},
+            patches={"set_inquiry_customer_addresses": patch_target},
+        )
+
+
+def test_convert_requires_inquiries_view_and_orders_version_create(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    seeded_inquiry_id: str,
+) -> None:
+    patch_target = (
+        "catering_system.ui.office_panel.OfficePanel.convert_inquiry_to_order"
+    )
+    for username, permissions in (
+        ("convert.view.only", frozenset({"inquiries.view"})),
+        ("convert.create.only", frozenset({"orders.version.create"})),
+    ):
+        jar = _employee_jar(
+            employee_panel,
+            super_jar,
+            username=username,
+            permissions=permissions,
+        )
+        _assert_post_forbidden(
+            employee_panel,
+            f"/inquiry/{seeded_inquiry_id}/convert",
+            jar=jar,
+            data={"_csrf_token": _csrf(jar)},
+            patches={"convert_inquiry_to_order": patch_target},
+        )
+
+
+def test_convert_accepted_requires_offers_view_and_orders_version_create(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    seeded_inquiry_id: str,
+) -> None:
+    patch_target = (
+        "catering_system.ui.office_panel.OfficePanel.convert_accepted_offer_for_inquiry"
+    )
+    for username, permissions in (
+        ("convertacc.view.only", frozenset({"offers.view"})),
+        ("convertacc.create.only", frozenset({"orders.version.create"})),
+    ):
+        jar = _employee_jar(
+            employee_panel,
+            super_jar,
+            username=username,
+            permissions=permissions,
+        )
+        _assert_post_forbidden(
+            employee_panel,
+            f"/inquiry/{seeded_inquiry_id}/convert-accepted",
+            jar=jar,
+            data={"_csrf_token": _csrf(jar)},
+            patches={"convert_accepted_offer_for_inquiry": patch_target},
+        )
+
+
+def test_migration_basic_fallback_post_inquiry_new_works_without_employee_permission(
+    migration_panel: PanelHarness,
+) -> None:
+    with patch.object(OfficePanel, "create_inquiry", autospec=True) as create_mock:
+        create_mock.side_effect = lambda self, form: InquiryService(
+            InMemoryInquiryRepository()
+        ).create_inquiry(
+            event_date=date(2026, 9, 1),
+            inquiry_source="manual",
+            crm_stage="Neue Anfrage",
+            customer_linkage={},
+            time_window_text="mittags",
+            location_text="Hamburg",
+            guest_count_estimate=10,
+            planning_mode=PLANNING_MODES[0],
+            call_verification_required=False,
+            call_verification_status="not_required",
+        )
+        status, _url, _body, _headers = _request(
+            migration_panel.base,
+            "/inquiry/new",
+            method="POST",
+            data={
+                "_csrf_token": csrf_token_for_password(migration_panel.password),
+                "event_date": "2026-09-01",
+                "inquiry_source": "manual",
+                "planning_mode": PLANNING_MODES[0],
+            },
+            headers={"Authorization": _auth_header(migration_panel.password)},
+        )
+    assert status == 303
+    create_mock.assert_called_once()
+
+
+def test_migration_employee_without_inquiries_create_gets_403(
+    migration_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(migration_panel)
+    jar = _employee_jar(
+        migration_panel,
+        super_jar,
+        username="migration.viewer",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    _assert_post_forbidden(
+        migration_panel,
+        "/inquiry/new",
+        jar=jar,
+        data={
+            "_csrf_token": _csrf(jar),
+            "event_date": "2026-09-01",
+            "inquiry_source": "manual",
+            "planning_mode": PLANNING_MODES[0],
+        },
+        patches={
+            "create_inquiry": "catering_system.ui.office_panel.OfficePanel.create_inquiry"
+        },
+    )
+
+
+def test_csrf_required_for_authorized_employee_post(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="creator.without.csrf",
+        permissions=frozenset({"inquiries.create"}),
+    )
+    with patch.object(OfficePanel, "create_inquiry", autospec=True) as create_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            "/inquiry/new",
+            method="POST",
+            data={
+                "event_date": "2026-09-01",
+                "inquiry_source": "manual",
+                "planning_mode": PLANNING_MODES[0],
+            },
+            jar=jar,
+        )
+    assert status == 403
+    assert _GERMAN_CSRF in body
+    assert _GERMAN_FORBIDDEN not in body
+    create_mock.assert_not_called()
+
+
+def test_valid_csrf_still_yields_permission_denied_without_required_permission(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="viewer.with.csrf",
+        permissions=frozenset({"inquiries.view"}),
+    )
+    with patch.object(OfficePanel, "create_inquiry", autospec=True) as create_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            "/inquiry/new",
+            method="POST",
+            data={
+                "_csrf_token": _csrf(jar),
+                "event_date": "2026-09-01",
+                "inquiry_source": "manual",
+                "planning_mode": PLANNING_MODES[0],
+            },
+            jar=jar,
+        )
+    assert status == 403
+    assert _GERMAN_FORBIDDEN in body
+    assert _GERMAN_CSRF not in body
+    create_mock.assert_not_called()
+
+
+def test_inquiry_create_link_hidden_without_inquiries_create(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="inquiry.reader.nav",
+        permissions=frozenset({"inquiries.view", "queue.view"}),
+    )
+    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    assert status == 200
+    assert 'href="/inquiry/new"' not in body
+    assert "+ Neue Anfrage" not in body
+
+
+def test_contact_note_form_hidden_without_customers_edit() -> None:
+    detail = {
+        "contact_key": "intake:email:jk@example.invalid",
+        "display_name": "JK-art",
+        "email": "jk@example.invalid",
+        "phone": "+4917642795029",
+        "inquiries": [],
+        "offers": [],
+        "orders": [],
+        "internal_notes": [],
+    }
+    page = render_kontakt_detail(
+        detail,
+        context=_employee_context("customers.view"),
+    )
+    assert "/notizen" not in page
+    assert "Notiz speichern" not in page
+
+    editable = render_kontakt_detail(
+        detail,
+        context=_employee_context("customers.view", "customers.edit"),
+    )
+    assert (
+        f"/kontakt/{quote('intake:email:jk@example.invalid', safe='')}/notizen"
+        in editable
+    )
+    assert "Notiz speichern" in editable
+
+
+def test_convert_accepted_hidden_without_composite_permissions() -> None:
+    body = _inquiry_detail_page(_employee_context("offers.view"))
+    assert "convert-accepted" not in body
+    assert "Angenommenes Angebot in Auftrag überführen" not in body
+
+    body_with_create = _inquiry_detail_page(
+        _employee_context("orders.version.create"),
+    )
+    assert "convert-accepted" not in body_with_create
+
+    body_allowed = _inquiry_detail_page(
+        _employee_context("offers.view", "orders.version.create"),
+    )
+    assert "convert-accepted" in body_allowed
+    assert "Angenommenes Angebot in Auftrag überführen" in body_allowed
+
+
+def test_legacy_office_context_retains_convert_accepted_control() -> None:
+    body = _inquiry_detail_page(legacy_office_context(csrf_token="csrf"))
+    assert "convert-accepted" in body
+    assert "Angenommenes Angebot in Auftrag überführen" in body

--- a/tests/unit/test_office_panel_authz.py
+++ b/tests/unit/test_office_panel_authz.py
@@ -11,7 +11,9 @@ from catering_system.ui.office_panel_authz import (
     can_access,
     can_access_all,
     require_all_business_permissions,
+    require_all_business_permissions_post,
     require_business_permission,
+    require_business_permission_post,
 )
 
 
@@ -78,3 +80,99 @@ def test_employee_requires_effective_permission() -> None:
     assert can_access_all(auth, ("inquiries.view", "orders.view")) is False
     with pytest.raises(BusinessAccessDenied):
         require_all_business_permissions(auth, ("inquiries.view", "orders.view"))
+
+
+def test_require_business_permission_post_matches_get_alias() -> None:
+    from catering_system.domain.employee_auth import EmployeeAccount, EmployeeSession
+    from datetime import UTC, datetime
+
+    account = EmployeeAccount(
+        id="acc-post",
+        username="worker",
+        email=None,
+        display_name="Worker",
+        password_hash="hash",
+        role="USER",
+        is_active=True,
+        must_change_password=False,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        deactivated_at=None,
+        last_login_at=None,
+        auth_version=1,
+    )
+    session = EmployeeSession(
+        id="sess-post",
+        account_id="acc-post",
+        token_hash="t",
+        csrf_token_hash="c",
+        created_at=datetime.now(UTC),
+        last_seen_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC),
+        revoked_at=None,
+        revoked_reason=None,
+        auth_version=1,
+    )
+    employee = AuthenticatedEmployee(
+        account=account,
+        session=session,
+        application_access_allowed=True,
+        effective_permissions=frozenset({"inquiries.view"}),
+    )
+    auth = _AuthStub(kind="employee", legacy_shared_access=False, employee=employee)
+
+    require_business_permission_post(auth, "inquiries.view")
+    with pytest.raises(BusinessAccessDenied):
+        require_business_permission_post(auth, "orders.view")
+
+
+def test_require_all_business_permissions_post_matches_get_alias() -> None:
+    from catering_system.domain.employee_auth import EmployeeAccount, EmployeeSession
+    from datetime import UTC, datetime
+
+    account = EmployeeAccount(
+        id="acc-all-post",
+        username="worker",
+        email=None,
+        display_name="Worker",
+        password_hash="hash",
+        role="USER",
+        is_active=True,
+        must_change_password=False,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        deactivated_at=None,
+        last_login_at=None,
+        auth_version=1,
+    )
+    session = EmployeeSession(
+        id="sess-all-post",
+        account_id="acc-all-post",
+        token_hash="t",
+        csrf_token_hash="c",
+        created_at=datetime.now(UTC),
+        last_seen_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC),
+        revoked_at=None,
+        revoked_reason=None,
+        auth_version=1,
+    )
+    employee = AuthenticatedEmployee(
+        account=account,
+        session=session,
+        application_access_allowed=True,
+        effective_permissions=frozenset({"inquiries.view", "customers.edit"}),
+    )
+    auth = _AuthStub(kind="employee", legacy_shared_access=False, employee=employee)
+
+    require_all_business_permissions_post(auth, ("inquiries.view", "customers.edit"))
+    with pytest.raises(BusinessAccessDenied):
+        require_all_business_permissions_post(auth, ("inquiries.view", "orders.view"))
+
+
+def test_post_aliases_preserve_legacy_basic_fallback() -> None:
+    auth = _AuthStub(kind="basic", legacy_shared_access=True, employee=None)
+    require_business_permission_post(auth, "inquiries.create")
+    require_all_business_permissions_post(
+        auth, ("offers.view", "orders.version.create")
+    )


### PR DESCRIPTION
## Summary

- Add POST authorization helpers (`require_business_permission_post`, `require_all_business_permissions_post`) reusing employee `effective_permissions` with fail-closed unknown codes
- Gate AUTH-2D2 Office Panel POST routes: auth → permission → CSRF → payload → business service (migration Basic fallback retains legacy access for ordinary business routes)
- Hide inquiry/customer/proposal/conversion UI controls when employee lacks exact permission codes (legacy + v2; Basic fallback unchanged)

Closes #74

## Route / permission map

| Route | Permission(s) |
|-------|---------------|
| POST `/inquiry/new` | `inquiries.create` |
| POST `/inquiry/{id}/update`, `/contact-completion`, `/fulfillment-mode` | `inquiries.edit` |
| POST `/inquiry/{id}/customer-addresses` | `inquiries.view` + `customers.edit` |
| POST `/inquiry/{id}/verify` | `inquiries.verify` |
| POST `/proposal-preview`, `/proposal-preview/prepare` | `inquiries.create` |
| POST `/kontakt/{key}/notizen` | `customers.edit` |
| POST `/inquiry/{id}/convert` | `inquiries.view` + `orders.version.create` |
| POST `/inquiry/{id}/convert-accepted` | `offers.view` + `orders.version.create` |

## Test plan

- [x] Permission-denial tests (11 routes + composite checks)
- [x] No-side-effect mocks for denied POST requests
- [x] Auth-mode: migration employee 403, Basic fallback legacy access, session precedence
- [x] CSRF ordering after permission gate
- [x] UI visibility (legacy + v2, Basic fallback)
- [x] AUTH-2D1 GET regressions unchanged
- [x] AUTH-2A/2B/2C regressions
- [x] Full Core suite: 2595 passed
- [x] ruff check + format, mypy `src/catering_system`, `git diff --check`

## Deferred

- POST `/offer/*` (AUTH-2D3), `/order/*` (AUTH-2D4), `/gerichte/*` (AUTH-2D5)
- `queue.resolve`, payment reminder, confirmation document POST permissions
- AUTH-2E, PR #63, DET-2

## Validation notes

- Baseline: `4cd287ad0b2cc73d0d6af48b2a1b8be4d9ed1339`
- Head: `52e204b`
- No deploy, no production restart/migration, no merge in this PR

Made with [Cursor](https://cursor.com)