### PR TITLE
AUTH-2D3: Office Panel POST authorization for offers and confirmation documents

### DIFF
--- a/src/catering_system/domain/employee_auth.py
+++ b/src/catering_system/domain/employee_auth.py
@@ -42,6 +42,8 @@ PERMISSION_REGISTRY: tuple[str, ...] = (
     "calendar.view",
     "queue.view",
     "documents.view",
+    "documents.prepare",
+    "documents.send",
     "users.view",
     "users.create",
     "users.edit",
@@ -88,6 +90,8 @@ ADMIN_ROLE_CEILING: frozenset[str] = frozenset(
         "calendar.view",
         "queue.view",
         "documents.view",
+        "documents.prepare",
+        "documents.send",
         "users.view",
         "users.create",
         "users.edit",
@@ -129,6 +133,8 @@ USER_ROLE_CEILING: frozenset[str] = frozenset(
         "calendar.view",
         "queue.view",
         "documents.view",
+        "documents.prepare",
+        "documents.send",
     }
 )
 

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3633,6 +3633,7 @@ class OfficePanel:
             confirmation,
             detail_forms,
             live_preview,
+            context=context,
         )
         outbound_card = render_confirmation_outbound_card(
             order,
@@ -3640,6 +3641,7 @@ class OfficePanel:
             outbound,
             detail_forms,
             operational_pause=pause_view,
+            context=context,
         )
         pause_card = render_operational_pause_card(order, pause_view, detail_forms)
         paused_header = (

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -631,6 +631,16 @@ def make_office_panel_handler(
                 return "inquiries"
             if len(parts) == 3 and parts[0] == "kontakt":
                 return "contacts"
+            if len(parts) == 3 and parts[0] == "offer":
+                return "offers"
+            if len(parts) == 3 and parts[0] == "order":
+                return "orders"
+            if (
+                len(parts) == 4
+                and parts[0] == "order"
+                and parts[2] == "confirmation-document"
+            ):
+                return "orders"
             return "home"
 
         def _auth2d2_post_permission_requirements(
@@ -661,6 +671,32 @@ def make_office_panel_handler(
                 return ("inquiries.create",)
             if len(parts) == 3 and parts[0] == "kontakt" and parts[2] == "notizen":
                 return ("customers.edit",)
+            if len(parts) == 3 and parts[0] == "offer":
+                action = parts[2]
+                if action == "mark-sent":
+                    return ("offers.send",)
+                if action in (
+                    "record-acceptance",
+                    "record-rejection",
+                    "record-withdrawal",
+                ):
+                    return ("offers.status.change",)
+                if action == "convert":
+                    return ("offers.view", "orders.version.create")
+                return None
+            if (
+                len(parts) == 3
+                and parts[0] == "order"
+                and parts[2] == "confirmation-document"
+            ):
+                return ("documents.prepare",)
+            if (
+                len(parts) == 4
+                and parts[0] == "order"
+                and parts[2] == "confirmation-document"
+                and parts[3] == "send"
+            ):
+                return ("documents.send",)
             return None
 
         def _require_auth2d2_post_permissions(

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -234,7 +234,11 @@ def _select_options(
     return "".join(options)
 
 
-def _mark_sent_form(offer_id: str, *, forms: OfferDetailFormFields) -> str:
+def _mark_sent_form(
+    offer_id: str, *, forms: OfferDetailFormFields, context: OfficePageContext
+) -> str:
+    if not context.can("offers.send"):
+        return ""
     default_at = default_datetime_local_berlin()
     return (
         '<section class="offer-detail-section offer-action-section">'
@@ -262,7 +266,10 @@ def _record_acceptance_form(
     variants: list[dict[str, object]],
     *,
     forms: OfferDetailFormFields,
+    context: OfficePageContext,
 ) -> str:
+    if not context.can("offers.status.change"):
+        return ""
     default_at = default_datetime_local_berlin()
     variant_options = "".join(
         f'<option value="{_e(str(variant["variant_id"]))}">'
@@ -295,7 +302,11 @@ def _record_acceptance_form(
     )
 
 
-def _record_rejection_form(offer_id: str, *, forms: OfferDetailFormFields) -> str:
+def _record_rejection_form(
+    offer_id: str, *, forms: OfferDetailFormFields, context: OfficePageContext
+) -> str:
+    if not context.can("offers.status.change"):
+        return ""
     default_at = default_datetime_local_berlin()
     return (
         '<section class="offer-detail-section offer-action-section">'
@@ -313,7 +324,11 @@ def _record_rejection_form(offer_id: str, *, forms: OfferDetailFormFields) -> st
     )
 
 
-def _record_withdrawal_form(offer_id: str, *, forms: OfferDetailFormFields) -> str:
+def _record_withdrawal_form(
+    offer_id: str, *, forms: OfferDetailFormFields, context: OfficePageContext
+) -> str:
+    if not context.can("offers.status.change"):
+        return ""
     return (
         '<section class="offer-detail-section offer-action-section">'
         "<h2>Angebot zurückziehen</h2>"
@@ -360,9 +375,9 @@ def _sent_offer_actions(
     context: OfficePageContext,
 ) -> str:
     return (
-        _record_acceptance_form(offer_id, variants, forms=forms)
-        + _record_rejection_form(offer_id, forms=forms)
-        + _record_withdrawal_form(offer_id, forms=forms)
+        _record_acceptance_form(offer_id, variants, forms=forms, context=context)
+        + _record_rejection_form(offer_id, forms=forms, context=context)
+        + _record_withdrawal_form(offer_id, forms=forms, context=context)
         + _prepare_next_version_cta(
             revision_prefill_url=revision_prefill_url, context=context
         )
@@ -375,7 +390,10 @@ def _convert_form(
     accepted_variant_id: str,
     acceptance_id: str,
     forms: OfferDetailFormFields,
+    context: OfficePageContext,
 ) -> str:
+    if not (context.can("offers.view") and context.can("orders.version.create")):
+        return ""
     return (
         '<section class="offer-detail-section offer-action-section">'
         "<h2>In Auftrag umwandeln</h2>"
@@ -430,7 +448,7 @@ def render_offer_detail(
     )
     action_section = ""
     if state == "Prepared":
-        action_section = _mark_sent_form(offer_id, forms=forms)
+        action_section = _mark_sent_form(offer_id, forms=forms, context=context)
     elif state == "Sent":
         action_section = _sent_offer_actions(
             offer_id,
@@ -456,6 +474,7 @@ def render_offer_detail(
                 accepted_variant_id=str(acceptance["accepted_variant_id"]),
                 acceptance_id=acceptance_id,
                 forms=forms,
+                context=context,
             )
     pdf_link = (
         f'<p><a href="{_e(pdf_download_url)}">PDF herunterladen</a></p>'

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -650,6 +650,8 @@ def _confirmation_card(
     confirmation: OrderConfirmationDocumentEligibility,
     forms: OrderDetailFormFields,
     live_preview: ConfirmationLivePreviewView,
+    *,
+    context: OfficePageContext,
 ) -> str:
     state_label = _confirmation_state_label(confirmation.state)
     facts: list[tuple[str, str]] = [("Status", state_label)]
@@ -679,7 +681,7 @@ def _confirmation_card(
         and live_preview.preview is not None
         and live_preview.preview.eligible
     )
-    if can_create:
+    if can_create and context.can("documents.prepare"):
         actions.append(
             f'<form method="post" action="/order/{_e(order.order_id)}/confirmation-document">'
             f"{forms.csrf_input}{forms.confirmation_command_fields}"
@@ -971,9 +973,14 @@ def render_confirmation_card(
     confirmation: OrderConfirmationDocumentEligibility,
     forms: OrderDetailFormFields,
     live_preview: ConfirmationLivePreviewView,
+    *,
+    context: OfficePageContext | None = None,
 ) -> str:
     """Shared Auftragsbestätigung card for v2 and legacy Order Detail."""
-    return _confirmation_card(order, confirmation, forms, live_preview)
+    page_context = context or OfficePageContext()
+    return _confirmation_card(
+        order, confirmation, forms, live_preview, context=page_context
+    )
 
 
 def render_confirmation_outbound_card(
@@ -983,8 +990,10 @@ def render_confirmation_outbound_card(
     forms: OrderDetailFormFields,
     *,
     operational_pause: Mapping[str, object] | None = None,
+    context: OfficePageContext | None = None,
 ) -> str:
     """Fake-outbox test send card — never implies real customer delivery."""
+    page_context = context or OfficePageContext()
     pause_view = operational_pause or {"active": False}
     state_label = _OUTBOUND_STATE_LABELS.get(outbound.state, outbound.state)
     facts: list[tuple[str, str]] = [("Status", state_label)]
@@ -1007,7 +1016,11 @@ def render_confirmation_outbound_card(
             '<p class="order-context-note blocked">'
             "Testversand blockiert: Auftrag pausiert</p>"
         )
-    elif outbound.can_send and confirmation.snapshot is not None:
+    elif (
+        outbound.can_send
+        and confirmation.snapshot is not None
+        and page_context.can("documents.send")
+    ):
         actions.append(
             '<p class="order-context-note">Es wird keine E-Mail an den Kunden gesendet.</p>'
         )
@@ -1298,9 +1311,16 @@ def render_order_detail(
         + render_customer_addresses_card(
             source_inquiry, order, forms, context=page_context
         )
-        + _confirmation_card(order, confirmation, forms, live_preview)
+        + _confirmation_card(
+            order, confirmation, forms, live_preview, context=page_context
+        )
         + render_confirmation_outbound_card(
-            order, confirmation, outbound, forms, operational_pause=pause_view
+            order,
+            confirmation,
+            outbound,
+            forms,
+            operational_pause=pause_view,
+            context=page_context,
         )
         + _payment_card(order, payment, forms)
         + _secondary_actions(order, forms, operational_pause=pause_view)

--- a/src/catering_system/ui/office_panel_settings_users.py
+++ b/src/catering_system/ui/office_panel_settings_users.py
@@ -82,6 +82,8 @@ PERMISSION_LABELS: dict[str, str] = {
     "calendar.view": "Kalender ansehen",
     "queue.view": "Warteschlange ansehen",
     "documents.view": "Dokumente ansehen",
+    "documents.prepare": "Dokumente vorbereiten",
+    "documents.send": "Dokumente versenden",
     "users.view": "Benutzer ansehen",
     "users.create": "Benutzer anlegen",
     "users.edit": "Benutzer bearbeiten",

--- a/tests/unit/test_office_panel_auth_2d2.py
+++ b/tests/unit/test_office_panel_auth_2d2.py
@@ -391,7 +391,7 @@ def _assert_post_forbidden(
             frozenset({"inquiries.view"}),
             {
                 "parse_proposal_payload": (
-                    "catering_system.ui.office_panel_proposal.parse_proposal_payload"
+                    "catering_system.ui.office_panel_http.parse_proposal_payload"
                 )
             },
             "denied.proposal.preview",
@@ -402,7 +402,7 @@ def _assert_post_forbidden(
             frozenset({"inquiries.view"}),
             {
                 "parse_proposal_payload": (
-                    "catering_system.ui.office_panel_proposal.parse_proposal_payload"
+                    "catering_system.ui.office_panel_http.parse_proposal_payload"
                 )
             },
             "denied.proposal.prepare",
@@ -499,6 +499,7 @@ def test_customer_addresses_requires_both_inquiries_view_and_customers_edit(
         "catering_system.ui.office_panel.OfficePanel.set_inquiry_customer_addresses"
     )
     for username, permissions in (
+        ("addresses.neither", frozenset({"inquiries.create"})),
         ("addresses.view.only", frozenset({"inquiries.view"})),
         ("addresses.edit.only", frozenset({"customers.edit"})),
     ):

--- a/tests/unit/test_office_panel_auth_2d3.py
+++ b/tests/unit/test_office_panel_auth_2d3.py
@@ -1,0 +1,811 @@
+from __future__ import annotations
+
+import base64
+import http.cookiejar
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from catering_system.domain.employee_auth import (
+    PERMISSION_REGISTRY,
+    PERMISSION_SET,
+    VIEW_PERMISSION_SET,
+    effective_permissions,
+    ensure_permissions_within_role,
+    role_ceiling,
+    validate_permission_code,
+)
+from catering_system.domain.order import Order
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_panel import OfficePanel, create_office_panel_server
+from catering_system.ui.office_panel_http import csrf_token_for_password
+from catering_system.ui.office_panel_offer_detail import (
+    OfferDetailFormFields,
+    render_offer_detail,
+)
+from catering_system.ui.office_panel_order_detail import (
+    OrderDetailFormFields,
+    render_confirmation_outbound_card,
+)
+from catering_system.ui.office_panel_settings_users import PERMISSION_LABELS
+from catering_system.ui.office_panel_views import OfficePageContext, _csrf_input
+from tests.helpers.office_panel_context import legacy_office_context
+
+_GERMAN_FORBIDDEN = "Ihre Berechtigung reicht für diese Aktion nicht aus."
+_GERMAN_CSRF = "Ungültiger oder fehlender CSRF-Sicherheitstoken."
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_ORDER_ID = "66666666-6666-6666-6666-666666666666"
+_VARIANT_ID = "44444444-4444-4444-8444-444444444441"
+_ACCEPTANCE_ID = "55555555-5555-5555-5555-555555555555"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+@dataclass
+class PanelHarness:
+    base: str
+    server: object
+    thread: threading.Thread
+    service: EmployeeAuthService
+    repo: SQLiteEmployeeAuthRepository
+    password: str
+
+
+def _auth_header(password: str) -> str:
+    return "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
+
+
+def _cookie_value(jar: http.cookiejar.CookieJar, name: str) -> str:
+    for cookie in jar:
+        if cookie.name == name:
+            return cookie.value
+    raise AssertionError(f"missing cookie {name}")
+
+
+def _csrf(jar: http.cookiejar.CookieJar) -> str:
+    return _cookie_value(jar, "sl_employee_csrf")
+
+
+def _request(
+    base: str,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    jar: http.cookiejar.CookieJar | None = None,
+) -> tuple[int, str, str, object]:
+    cookie_jar = jar if jar is not None else http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        _NoRedirect,
+        urllib.request.HTTPCookieProcessor(cookie_jar),
+    )
+    payload = None
+    if data is not None:
+        payload = urllib.parse.urlencode(data).encode()
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=payload,
+        method=method,
+    )
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+    try:
+        with opener.open(request) as response:
+            return (
+                response.status,
+                response.url,
+                response.read().decode("utf-8"),
+                response.headers,
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8"), exc.headers
+
+
+def _create_panel(
+    tmp_path: Path,
+    *,
+    auth_mode: str,
+    password: str = "shared-office-password",
+) -> PanelHarness:
+    db = tmp_path / "core.db"
+    connection = sqlite3.connect(str(db), check_same_thread=False)
+    repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+    service = EmployeeAuthService(
+        repo, now=lambda: datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    )
+    service.bootstrap_superadmin(
+        username="viktor.admin",
+        display_name="Viktor Johanson",
+        password="TempPassw0rd!",
+        metadata={"seed": "office-panel"},
+    )
+    server = create_office_panel_server(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        password,
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        auth_service=service,
+        secure_cookie=False,
+        ui_version="v2",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return PanelHarness(
+        base=f"http://{host}:{port}",
+        server=server,
+        thread=thread,
+        service=service,
+        repo=repo,
+        password=password,
+    )
+
+
+def _shutdown(panel: PanelHarness) -> None:
+    panel.server.shutdown()
+    panel.server.server_close()
+    panel.thread.join(timeout=5)
+    panel.repo.close()
+
+
+def _login(
+    panel: PanelHarness, *, username: str, password: str
+) -> http.cookiejar.CookieJar:
+    jar = http.cookiejar.CookieJar()
+    status, _url, _body, _headers = _request(
+        panel.base,
+        "/login",
+        method="POST",
+        data={"username": username, "password": password, "next": "/"},
+        jar=jar,
+    )
+    assert status == 303
+    return jar
+
+
+def _ready_superadmin(panel: PanelHarness) -> http.cookiejar.CookieJar:
+    jar = _login(panel, username="viktor.admin", password="TempPassw0rd!")
+    employee = panel.service.authenticate_session(
+        _cookie_value(jar, "sl_employee_session")
+    )
+    panel.service.change_password(
+        employee,
+        current_password="TempPassw0rd!",
+        new_password="ChangedTemp1!",
+    )
+    return _login(panel, username="viktor.admin", password="ChangedTemp1!")
+
+
+def _create_employee(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    password: str,
+    role: str,
+    permissions: frozenset[str] | None = None,
+) -> str:
+    super_employee = panel.service.authenticate_session(
+        _cookie_value(super_jar, "sl_employee_session")
+    )
+    account = panel.service.create_account(
+        super_employee,
+        username=username,
+        display_name=username,
+        password=password,
+        role=role,
+        explicit_permissions=set(permissions) if permissions is not None else None,
+        must_change_password=False,
+    )
+    return account.id
+
+
+def _employee_jar(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    password: str = "ReaderTemp1!",
+    permissions: frozenset[str],
+) -> http.cookiejar.CookieJar:
+    _create_employee(
+        panel,
+        super_jar,
+        username=username,
+        password=password,
+        role="USER",
+        permissions=permissions,
+    )
+    return _login(panel, username=username, password=password)
+
+
+def _employee_context(*permissions: str) -> OfficePageContext:
+    return OfficePageContext(
+        legacy_shared_access=False,
+        employee_effective_permissions=frozenset(permissions),
+        csrf_token="csrf-test",
+    )
+
+
+def _assert_post_forbidden(
+    panel: PanelHarness,
+    path: str,
+    *,
+    jar: http.cookiejar.CookieJar | None = None,
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    patches: dict[str, str] | None = None,
+) -> None:
+    patch_targets = patches or {}
+    with ExitStack() as stack:
+        mocks = {
+            name: stack.enter_context(patch(target, autospec=True))
+            for name, target in patch_targets.items()
+        }
+        status, _url, body, _headers = _request(
+            panel.base,
+            path,
+            method="POST",
+            data=data or {},
+            jar=jar,
+            headers=headers,
+        )
+    assert status == 403
+    assert _GERMAN_FORBIDDEN in body
+    for mock in mocks.values():
+        mock.assert_not_called()
+
+
+def _offer_detail(commercial_state: str) -> dict[str, object]:
+    detail: dict[str, object] = {
+        "offer_id": _OFFER_ID,
+        "inquiry_id": "22222222-2222-2222-2222-222222222222",
+        "commercial_state": commercial_state,
+        "offer_version_id": "33333333-3333-4333-8333-333333333331",
+        "versions": [
+            {
+                "offer_version_id": "33333333-3333-4333-8333-333333333331",
+                "version": 1,
+                "state": commercial_state,
+                "created_at": "2026-07-15T08:00:00+00:00",
+                "event_date": "2026-08-01",
+                "valid_until": "2026-07-31",
+                "time_window_text": "18:00",
+                "location_text": "Hamburg",
+                "guest_count": 50,
+                "planning_mode": "caterer_suggestion",
+                "variants": [
+                    {
+                        "variant_id": _VARIANT_ID,
+                        "name": "Variante A",
+                        "positions": [],
+                    }
+                ],
+            }
+        ],
+        "history": [],
+    }
+    if commercial_state == "Accepted":
+        detail["acceptance_id"] = _ACCEPTANCE_ID
+        detail["acceptance"] = {"accepted_variant_id": _VARIANT_ID}
+    return detail
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def migration_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="migration")
+    yield panel
+    _shutdown(panel)
+
+
+@pytest.fixture()
+def super_jar(employee_panel: PanelHarness) -> http.cookiejar.CookieJar:
+    return _ready_superadmin(employee_panel)
+
+
+def test_document_mutation_permissions_registered() -> None:
+    assert "documents.prepare" in PERMISSION_REGISTRY
+    assert "documents.send" in PERMISSION_REGISTRY
+    assert validate_permission_code("documents.prepare") == "documents.prepare"
+    assert validate_permission_code("documents.send") == "documents.send"
+    assert "documents.prepare" in PERMISSION_LABELS
+    assert "documents.send" in PERMISSION_LABELS
+
+
+def test_viewer_ceiling_excludes_document_mutations() -> None:
+    assert "documents.prepare" not in VIEW_PERMISSION_SET
+    assert "documents.send" not in VIEW_PERMISSION_SET
+    with pytest.raises(ValueError, match="permissions exceed VIEWER ceiling"):
+        ensure_permissions_within_role(
+            "VIEWER", {"documents.prepare", "documents.send"}
+        )
+
+
+def test_admin_and_user_may_receive_document_mutations_explicitly() -> None:
+    assert "documents.prepare" in role_ceiling("ADMIN")
+    assert "documents.send" in role_ceiling("ADMIN")
+    assert "documents.prepare" in role_ceiling("USER")
+    assert "documents.send" in role_ceiling("USER")
+    ensure_permissions_within_role("ADMIN", {"documents.prepare"})
+    ensure_permissions_within_role("USER", {"documents.send"})
+    assert effective_permissions(
+        "USER", {"documents.prepare", "documents.send"}
+    ) == frozenset({"documents.prepare", "documents.send"})
+
+
+def test_superadmin_ceiling_includes_document_mutations() -> None:
+    assert "documents.prepare" in PERMISSION_SET
+    assert "documents.send" in PERMISSION_SET
+
+
+@pytest.mark.parametrize(
+    ("action", "patch_target"),
+    [
+        (
+            "mark-sent",
+            "catering_system.ui.office_panel.OfficePanel.mark_offer_sent",
+        ),
+        (
+            "record-acceptance",
+            "catering_system.ui.office_panel.OfficePanel.record_offer_acceptance",
+        ),
+        (
+            "record-rejection",
+            "catering_system.ui.office_panel.OfficePanel.record_offer_rejection",
+        ),
+        (
+            "record-withdrawal",
+            "catering_system.ui.office_panel.OfficePanel.record_offer_withdrawal",
+        ),
+    ],
+)
+def test_offer_status_post_denied_without_required_permission(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    action: str,
+    patch_target: str,
+) -> None:
+    required = "offers.send" if action == "mark-sent" else "offers.status.change"
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username=f"denied.{action}",
+        permissions=frozenset({"offers.view"}),
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        f"/offer/{_OFFER_ID}/{action}",
+        jar=jar,
+        data={"_csrf_token": _csrf(jar)},
+        patches={action: patch_target},
+    )
+    assert required != "offers.view"
+
+
+def test_mark_sent_allowed_with_offers_send(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="sender.ok",
+        permissions=frozenset({"offers.send", "offers.view"}),
+    )
+    with patch.object(OfficePanel, "mark_offer_sent", autospec=True) as mark_mock:
+        status, _url, _body, _headers = _request(
+            employee_panel.base,
+            f"/offer/{_OFFER_ID}/mark-sent",
+            method="POST",
+            data={
+                "_csrf_token": _csrf(jar),
+                "sent_at": "2026-09-01T10:00",
+                "channel": "email",
+                "recipient_reference": "kunde@example.test",
+                "evidence_reference": "mail-1",
+            },
+            jar=jar,
+        )
+    assert status == 303
+    mark_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("permissions", "username"),
+    [
+        (frozenset({"inquiries.view"}), "convert.neither"),
+        (frozenset({"offers.view"}), "convert.view.only"),
+        (frozenset({"orders.version.create"}), "convert.create.only"),
+    ],
+)
+def test_offer_convert_requires_both_permissions(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    permissions: frozenset[str],
+    username: str,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username=username,
+        permissions=permissions,
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        f"/offer/{_OFFER_ID}/convert",
+        jar=jar,
+        data={
+            "_csrf_token": _csrf(jar),
+            "accepted_variant_id": _VARIANT_ID,
+            "acceptance_id": _ACCEPTANCE_ID,
+        },
+        patches={
+            "convert": "catering_system.ui.office_panel.OfficePanel.convert_accepted_offer"
+        },
+    )
+
+
+def test_offer_convert_allowed_with_both_permissions(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="convert.ok",
+        permissions=frozenset({"offers.view", "orders.version.create"}),
+    )
+    fake_order = Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id="22222222-2222-2222-2222-222222222222",
+        created_at=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 8, 1, 10, 0, tzinfo=UTC),
+    )
+    with patch.object(
+        OfficePanel, "convert_accepted_offer", autospec=True
+    ) as convert_mock:
+        convert_mock.return_value = (fake_order, object())
+        status, _url, _body, _headers = _request(
+            employee_panel.base,
+            f"/offer/{_OFFER_ID}/convert",
+            method="POST",
+            data={
+                "_csrf_token": _csrf(jar),
+                "accepted_variant_id": _VARIANT_ID,
+                "acceptance_id": _ACCEPTANCE_ID,
+            },
+            jar=jar,
+        )
+    assert status == 303
+    convert_mock.assert_called_once()
+
+
+def test_confirmation_prepare_denied_without_documents_prepare(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="doc.viewer",
+        permissions=frozenset({"documents.view", "orders.view"}),
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        f"/order/{_ORDER_ID}/confirmation-document",
+        jar=jar,
+        data={"_csrf_token": _csrf(jar)},
+        patches={
+            "prepare": (
+                "catering_system.ui.office_panel.OfficePanel.prepare_confirmation_document"
+            )
+        },
+    )
+
+
+def test_confirmation_send_denied_without_documents_send(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="doc.preparer",
+        permissions=frozenset({"documents.prepare", "documents.view", "orders.view"}),
+    )
+    _assert_post_forbidden(
+        employee_panel,
+        f"/order/{_ORDER_ID}/confirmation-document/send",
+        jar=jar,
+        data={
+            "_csrf_token": _csrf(jar),
+            "document_snapshot_id": "77777777-7777-4777-8777-777777777771",
+        },
+        patches={
+            "send": "catering_system.ui.office_panel.OfficePanel.send_confirmation_test"
+        },
+    )
+
+
+def test_csrf_required_for_authorized_offer_post(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="sender.no.csrf",
+        permissions=frozenset({"offers.send"}),
+    )
+    with patch.object(OfficePanel, "mark_offer_sent", autospec=True) as mark_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            f"/offer/{_OFFER_ID}/mark-sent",
+            method="POST",
+            data={
+                "sent_at": "2026-09-01T10:00",
+                "channel": "email",
+                "recipient_reference": "kunde@example.test",
+                "evidence_reference": "mail-1",
+            },
+            jar=jar,
+        )
+    assert status == 403
+    assert _GERMAN_CSRF in body
+    assert _GERMAN_FORBIDDEN not in body
+    mark_mock.assert_not_called()
+
+
+def test_valid_csrf_still_yields_permission_denied_for_offer_post(
+    employee_panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+) -> None:
+    jar = _employee_jar(
+        employee_panel,
+        super_jar,
+        username="viewer.with.csrf",
+        permissions=frozenset({"offers.view"}),
+    )
+    with patch.object(OfficePanel, "mark_offer_sent", autospec=True) as mark_mock:
+        status, _url, body, _headers = _request(
+            employee_panel.base,
+            f"/offer/{_OFFER_ID}/mark-sent",
+            method="POST",
+            data={"_csrf_token": _csrf(jar)},
+            jar=jar,
+        )
+    assert status == 403
+    assert _GERMAN_FORBIDDEN in body
+    assert _GERMAN_CSRF not in body
+    mark_mock.assert_not_called()
+
+
+def test_migration_basic_fallback_retains_offer_post(
+    migration_panel: PanelHarness,
+) -> None:
+    with patch.object(OfficePanel, "mark_offer_sent", autospec=True) as mark_mock:
+        status, _url, _body, _headers = _request(
+            migration_panel.base,
+            f"/offer/{_OFFER_ID}/mark-sent",
+            method="POST",
+            data={
+                "_csrf_token": csrf_token_for_password(migration_panel.password),
+                "sent_at": "2026-09-01T10:00",
+                "channel": "email",
+                "recipient_reference": "kunde@example.test",
+                "evidence_reference": "mail-1",
+            },
+            headers={"Authorization": _auth_header(migration_panel.password)},
+        )
+    assert status == 303
+    mark_mock.assert_called_once()
+
+
+def test_migration_employee_without_offers_send_gets_403(
+    migration_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(migration_panel)
+    jar = _employee_jar(
+        migration_panel,
+        super_jar,
+        username="migration.viewer",
+        permissions=frozenset({"offers.view"}),
+    )
+    _assert_post_forbidden(
+        migration_panel,
+        f"/offer/{_OFFER_ID}/mark-sent",
+        jar=jar,
+        data={"_csrf_token": _csrf(jar)},
+        patches={
+            "mark_offer_sent": (
+                "catering_system.ui.office_panel.OfficePanel.mark_offer_sent"
+            )
+        },
+    )
+
+
+def test_offer_mark_sent_hidden_without_offers_send() -> None:
+    forms = OfferDetailFormFields(
+        csrf_input=_csrf_input(_employee_context()), command_fields=""
+    )
+    page = render_offer_detail(
+        _offer_detail("Prepared"),
+        context=_employee_context("offers.view"),
+        forms=forms,
+    )
+    assert "Als gesendet markieren" not in page
+    assert "/mark-sent" not in page
+
+    allowed = render_offer_detail(
+        _offer_detail("Prepared"),
+        context=_employee_context("offers.view", "offers.send"),
+        forms=forms,
+    )
+    assert "Als gesendet markieren" in allowed
+    assert "/mark-sent" in allowed
+
+
+def test_offer_status_actions_hidden_without_offers_status_change() -> None:
+    forms = OfferDetailFormFields(
+        csrf_input=_csrf_input(_employee_context()), command_fields=""
+    )
+    page = render_offer_detail(
+        _offer_detail("Sent"),
+        context=_employee_context("offers.view"),
+        forms=forms,
+    )
+    assert "/record-acceptance" not in page
+    assert "/record-rejection" not in page
+    assert "/record-withdrawal" not in page
+
+    allowed = render_offer_detail(
+        _offer_detail("Sent"),
+        context=_employee_context("offers.view", "offers.status.change"),
+        forms=forms,
+    )
+    assert "/record-acceptance" in allowed
+    assert "/record-rejection" in allowed
+    assert "/record-withdrawal" in allowed
+
+
+def test_offer_convert_hidden_without_composite_permissions() -> None:
+    forms = OfferDetailFormFields(
+        csrf_input=_csrf_input(_employee_context()), command_fields=""
+    )
+    page = render_offer_detail(
+        _offer_detail("Accepted"),
+        context=_employee_context("offers.view"),
+        forms=forms,
+    )
+    assert "/convert" not in page
+    assert "In Auftrag umwandeln" not in page
+
+    page_create = render_offer_detail(
+        _offer_detail("Accepted"),
+        context=_employee_context("orders.version.create"),
+        forms=forms,
+    )
+    assert "/convert" not in page_create
+
+    allowed = render_offer_detail(
+        _offer_detail("Accepted"),
+        context=_employee_context("offers.view", "orders.version.create"),
+        forms=forms,
+    )
+    assert "/convert" in allowed
+    assert "In Auftrag umwandeln" in allowed
+
+
+def test_legacy_office_context_retains_offer_actions() -> None:
+    forms = OfferDetailFormFields(
+        csrf_input=_csrf_input(legacy_office_context(csrf_token="csrf")),
+        command_fields="",
+    )
+    page = render_offer_detail(
+        _offer_detail("Prepared"),
+        context=legacy_office_context(csrf_token="csrf"),
+        forms=forms,
+    )
+    assert "Als gesendet markieren" in page
+
+
+def test_confirmation_send_hidden_without_documents_send() -> None:
+    from catering_system.services.order_confirmation_document_service import (
+        OrderConfirmationDocumentEligibility,
+        OrderConfirmationDocumentSummary,
+    )
+    from catering_system.services.order_confirmation_outbound_service import (
+        OutboundSendEligibility,
+    )
+
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    order = Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id="22222222-2222-2222-2222-222222222222",
+        created_at=now,
+        updated_at=now,
+    )
+    snapshot = OrderConfirmationDocumentSummary(
+        document_snapshot_id="77777777-7777-4777-8777-777777777771",
+        order_id=_ORDER_ID,
+        order_version_id="33333333-3333-4333-8333-333333333331",
+        document_reference="AB-2026-0001",
+        created_at=now,
+        created_by="office-panel",
+        recipient_status="ready",
+        recipient_email_masked="k***@example.test",
+        document_hash_short="abc123",
+        net_total_cents=10000,
+        vat_total_cents=700,
+        gross_total_cents=10700,
+        effective_version_number=1,
+    )
+    confirmation = OrderConfirmationDocumentEligibility(
+        available=True,
+        state="created",
+        snapshot=snapshot,
+    )
+    outbound = OutboundSendEligibility(
+        state="testversand_bereit",
+        can_send=True,
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields="",
+        effective_command_fields="",
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        send_command_fields="",
+    )
+    hidden = render_confirmation_outbound_card(
+        order,
+        confirmation,
+        outbound,
+        forms,
+        context=_employee_context("documents.view", "documents.prepare"),
+    )
+    assert "/confirmation-document/send" not in hidden
+    assert "Testversand erzeugen" not in hidden
+
+    allowed = render_confirmation_outbound_card(
+        order,
+        confirmation,
+        outbound,
+        forms,
+        context=_employee_context("documents.send"),
+    )
+    assert "/confirmation-document/send" in allowed
+    assert "Testversand erzeugen" in allowed

--- a/tests/unit/test_office_panel_confirmation_document.py
+++ b/tests/unit/test_office_panel_confirmation_document.py
@@ -65,6 +65,7 @@ from catering_system.ui.office_panel_order_detail import (
     OrderDetailFormFields,
     render_confirmation_card,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 
 _PASSWORD = "panel-b1-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
@@ -297,7 +298,7 @@ def test_legacy_order_detail_before_snapshot_shows_prepare_action(
         ui_version="legacy",
     )
     eligibility = doc_service.eligibility(order_id)
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Auftragsbestätigung" in page
     assert (
@@ -332,7 +333,7 @@ def test_legacy_order_detail_after_snapshot_shows_created_facts(
         ),
         ui_version="legacy",
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Dokument erstellt" in page
     summary = doc_service.eligibility(order_id).snapshot
@@ -502,7 +503,7 @@ def test_pending_candidate_shows_blocked_state_without_prepare(tmp_path: Path) -
         ),
         ui_version="legacy",
     )
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Auftrag nicht bereit für Kundendokument" in page
     assert "Auftragsbestätigung erstellen" not in page

--- a/tests/unit/test_office_panel_confirmation_outbound.py
+++ b/tests/unit/test_office_panel_confirmation_outbound.py
@@ -43,6 +43,7 @@ from catering_system.ui.office_panel_order_detail import (
     OrderDetailFormFields,
     render_confirmation_outbound_card,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 from tests.unit.test_office_panel_confirmation_document import _sqlite_world
 
 _PASSWORD = "panel-b2-pw"
@@ -164,6 +165,7 @@ def test_outbound_card_before_send_shows_testversand_warning(tmp_path: Path) -> 
             confirmation_command_fields="",
             send_command_fields="",
         ),
+        context=legacy_office_context(),
     )
     assert "Testversand erzeugen" in card
     assert "Es wird keine E-Mail an den Kunden gesendet." in card
@@ -176,7 +178,7 @@ def test_legacy_order_detail_shows_outbound_block(tmp_path: Path) -> None:
     )
     doc_service.prepare_snapshot(order_id, order_version_id, "office-panel")
     panel = _panel_with_outbound(db, ui_version="legacy")
-    page = panel.render_order(order_id)
+    page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
     assert "Testversand erzeugen" in page
     assert "Es wird keine E-Mail an den Kunden gesendet." in page

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -67,6 +67,7 @@ from catering_system.ui.office_panel_order_detail import (
 from catering_system.services.order_confirmation_outbound_service import (
     OutboundSendEligibility,
 )
+from tests.helpers.office_panel_context import legacy_office_context
 from tests.unit.test_offer_service import (
     _INQUIRY_ID,
     _POSITION_ID,
@@ -843,6 +844,7 @@ def test_office_panel_confirmation_block_renders() -> None:
         live_preview=live,
         versions_total_count=1,
         versions_truncated=False,
+        context=legacy_office_context(),
     )
     assert "Auftragsbestätigung" in page.body
     assert "Auftragsbestätigung erstellen" in page.body
@@ -892,6 +894,7 @@ def test_office_panel_confirmation_block_renders() -> None:
         live_preview=live,
         versions_total_count=1,
         versions_truncated=False,
+        context=legacy_office_context(),
     )
     assert snapshot.document_reference in page_created.body
     assert "Vorschau öffnen" in page_created.body


### PR DESCRIPTION
## Summary

- Add `documents.prepare` and `documents.send` to the canonical permission registry with German labels and role ceilings
- Gate AUTH-2D3 POST routes: auth → permission → CSRF → payload → service (migration Basic fallback unchanged)
- Hide offer send/status/convert and confirmation prepare/send controls when employee lacks exact permissions (legacy + v2)

Closes #76

## Route / permission map

| Route | Permission(s) |
|-------|---------------|
| POST `/offer/{id}/mark-sent` | `offers.send` |
| POST `/offer/{id}/record-acceptance` | `offers.status.change` |
| POST `/offer/{id}/record-rejection` | `offers.status.change` |
| POST `/offer/{id}/record-withdrawal` | `offers.status.change` |
| POST `/offer/{id}/convert` | `offers.view` + `orders.version.create` |
| POST `/order/{id}/confirmation-document` | `documents.prepare` |
| POST `/order/{id}/confirmation-document/send` | `documents.send` |

## Test plan

- [x] AUTH-2D3 denial, allowed, composite, CSRF, auth-mode, UI visibility tests
- [x] Permission registry / VIEWER ceiling tests
- [x] AUTH-2D2 hardening (proposal patch call site, neither-permission composite)
- [x] Offer/document regressions updated with `legacy_office_context()` where needed
- [x] AUTH-2D1/2D2 regressions
- [x] Full Core suite: 2619 passed
- [x] mypy, ruff, git diff --check

## Deferred

- POST `/order/{id}/*` operational routes (AUTH-2D4)
- POST `/gerichte/*` (AUTH-2D5)
- AUTH-2E, PR #63, DET-2

## Validation notes

- Baseline: `7a6c587842831e592e6f5cc83ca78ad2018b85e3`
- Head: `f9f145f`
- No deploy, no merge in this PR

Made with [Cursor](https://cursor.com)