### PR TITLE
AUTH-2E1: add employee session introspection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ PICKUP_SIGNAL_TOKEN=
 # Core Office API (Phase 1, dormant until the panel is configured against it).
 OFFICE_API_TOKEN=
 
+# Trusted service clients for POST /office/v1/auth/employee/introspect only.
+# Example (placeholder — generate a long random secret per client):
+# EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON={"configurator":"<secret>"}
+EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON=
+
 # Office panel Phase 2 dual mode: leave both empty for direct mode (opens
 # core.db locally, unchanged). Set BOTH together to run the panel against the
 # Core Office API instead — it then never opens core.db. Half-configured

--- a/docs/contracts/employee-introspection.md
+++ b/docs/contracts/employee-introspection.md
@@ -1,0 +1,131 @@
+# Employee session introspection (AUTH-2E1)
+
+Private Core Office API contract for trusted backend callers (Configurator BFF
+in AUTH-2E2). Not for browser use.
+
+## Endpoint
+
+```http
+POST /office/v1/auth/employee/introspect
+```
+
+## Service authentication
+
+Required on every request:
+
+```http
+Authorization: Bearer <service-token>
+```
+
+Tokens are configured server-side only:
+
+- `OFFICE_API_TOKEN` — existing office-panel bearer; **not** authorized for this
+  route (`403 forbidden`).
+- `EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON` — JSON object mapping trusted
+  service client ids to bearer secrets, for example:
+
+```json
+{"configurator": "<long-random-secret>"}
+```
+
+Rules:
+
+- missing / invalid bearer → `401 {"error":"unauthorized"}` even when the request
+  body or `X-Employee-Session` would otherwise be invalid
+- valid office-panel bearer → `403 {"error":"forbidden"}`
+- ambiguous bearer identity → `403 {"error":"forbidden"}`
+- valid configurator bearer → allowed, then request validation runs
+- secrets compared with constant-time `hmac.compare_digest`
+- never log bearer values
+
+## Employee session input
+
+```http
+X-Employee-Session: <opaque session token>
+```
+
+Rules:
+
+- header absent or blank → `200`, `authenticated=false`
+- malformed or longer than 256 characters → `400 {"error":"invalid_request"}`
+- valid token → resolved through existing `EmployeeAuthService` session validation
+- the endpoint does **not** read browser `Cookie` headers
+- request body must be empty (non-zero body → `400`)
+
+## Response
+
+Always `200` after successful service authentication (except header/body
+validation errors):
+
+Authenticated with application access:
+
+```json
+{
+  "authenticated": true,
+  "application_access_allowed": true,
+  "principal": {
+    "account_id": "...",
+    "username": "...",
+    "display_name": "...",
+    "role": "SUPERADMIN",
+    "effective_permissions": ["..."]
+  }
+}
+```
+
+Missing/invalid session:
+
+```json
+{
+  "authenticated": false,
+  "application_access_allowed": false,
+  "principal": null
+}
+```
+
+`must_change_password` sessions return `authenticated=true`,
+`application_access_allowed=false`, and an empty permission list on `principal`.
+
+Never returned: raw session token, token hash, password hash, session repository
+id, CSRF token, email, or detailed auth-failure reasons.
+
+Permissions are sorted lexicographically.
+
+## Trust boundary
+
+- Server-to-server only over trusted network (Tailscale / loopback).
+- No CORS, no browser exposure, no CSRF (opaque session arrives only from an
+  authenticated service caller).
+- No security audit row per introspection (operational log only: service client
+  id, booleans, account id on success).
+- Read-only: no session touch, no expiry extension, no business mutations.
+
+## Credential redaction
+
+Do not log `Authorization`, `X-Employee-Session`, `Cookie`, or full principal
+payloads.
+
+## Caching
+
+AUTH-2E1 defines no server-side cache. Callers may use a short-lived cache in
+AUTH-2E2; invalidate on logout/password change via conservative TTL until
+`auth_version` is exposed.
+
+## Deferred work
+
+- **AUTH-2E2** — Configurator BFF integration
+- **AUTH-2E3** — signed handoff ticket for inquiry/offer operation binding
+
+## Production activation
+
+1. Add `EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON` to `/etc/catering/office-api.env`
+   (mode `600`).
+2. Deploy Core with this endpoint.
+3. Configure the same secret on the Configurator backend (AUTH-2E2).
+4. Restrict `:8084` to trusted backends only (existing Tailscale bind).
+
+## Rollback
+
+Stop Configurator from calling the route. The endpoint remains dormant until a
+caller uses it; removing the env JSON disables configurator authorization while
+keeping office-panel API behavior unchanged.

--- a/src/catering_system/domain/employee_introspection.py
+++ b/src/catering_system/domain/employee_introspection.py
@@ -1,0 +1,66 @@
+"""Office API employee-session introspection response contract (AUTH-2E1)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.domain.employee_auth import AuthenticatedEmployee, EmployeeRole
+
+
+@dataclass(frozen=True)
+class EmployeeIntrospectionPrincipal:
+    account_id: str
+    username: str
+    display_name: str
+    role: EmployeeRole
+    effective_permissions: tuple[str, ...]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "account_id": self.account_id,
+            "username": self.username,
+            "display_name": self.display_name,
+            "role": self.role,
+            "effective_permissions": list(self.effective_permissions),
+        }
+
+
+@dataclass(frozen=True)
+class EmployeeIntrospectionResponse:
+    authenticated: bool
+    application_access_allowed: bool
+    principal: EmployeeIntrospectionPrincipal | None
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "authenticated": self.authenticated,
+            "application_access_allowed": self.application_access_allowed,
+            "principal": self.principal.to_json()
+            if self.principal is not None
+            else None,
+        }
+
+
+def employee_introspection_from_session(
+    employee: AuthenticatedEmployee | None,
+) -> EmployeeIntrospectionResponse:
+    if employee is None:
+        return EmployeeIntrospectionResponse(
+            authenticated=False,
+            application_access_allowed=False,
+            principal=None,
+        )
+    permissions: tuple[str, ...] = ()
+    if employee.application_access_allowed:
+        permissions = tuple(sorted(employee.effective_permissions))
+    return EmployeeIntrospectionResponse(
+        authenticated=True,
+        application_access_allowed=employee.application_access_allowed,
+        principal=EmployeeIntrospectionPrincipal(
+            account_id=employee.account.id,
+            username=employee.account.username,
+            display_name=employee.account.display_name,
+            role=employee.account.role,
+            effective_permissions=permissions,
+        ),
+    )

--- a/src/catering_system/services/employee_auth_service.py
+++ b/src/catering_system/services/employee_auth_service.py
@@ -630,6 +630,31 @@ class EmployeeAuthService:
         )
 
     def authenticate_session(self, session_token: str) -> AuthenticatedEmployee:
+        return self._resolve_authenticated_session(
+            session_token,
+            touch_last_seen=True,
+            revoke_on_invalid=True,
+        )
+
+    def resolve_session_for_introspection(
+        self, session_token: str
+    ) -> AuthenticatedEmployee | None:
+        try:
+            return self._resolve_authenticated_session(
+                session_token,
+                touch_last_seen=False,
+                revoke_on_invalid=False,
+            )
+        except AuthenticationError:
+            return None
+
+    def _resolve_authenticated_session(
+        self,
+        session_token: str,
+        *,
+        touch_last_seen: bool,
+        revoke_on_invalid: bool,
+    ) -> AuthenticatedEmployee:
         session = self.repository.get_session_by_token_hash(_token_hash(session_token))
         if session is None:
             raise AuthenticationError("session not found")
@@ -637,26 +662,28 @@ class EmployeeAuthService:
         if session.revoked_at is not None:
             raise AuthenticationError("session revoked")
         if session.expires_at <= now:
-            revoked = replace(
-                session,
-                revoked_at=now,
-                revoked_reason="expired",
-            )
-            self.repository.update_session(revoked)
+            if revoke_on_invalid:
+                revoked = replace(
+                    session,
+                    revoked_at=now,
+                    revoked_reason="expired",
+                )
+                self.repository.update_session(revoked)
             raise AuthenticationError("session expired")
         account = self._require_account(session.account_id)
         if not account.is_active:
             raise AuthenticationError("account is inactive")
         if session.auth_version != account.auth_version:
-            revoked = replace(
-                session,
-                revoked_at=now,
-                revoked_reason="auth_version_changed",
-            )
-            self.repository.update_session(revoked)
+            if revoke_on_invalid:
+                revoked = replace(
+                    session,
+                    revoked_at=now,
+                    revoked_reason="auth_version_changed",
+                )
+                self.repository.update_session(revoked)
             raise AuthenticationError("session invalidated")
         touched = session
-        if now - session.last_seen_at >= _LAST_SEEN_WRITE_INTERVAL:
+        if touch_last_seen and now - session.last_seen_at >= _LAST_SEEN_WRITE_INTERVAL:
             touched = replace(session, last_seen_at=now)
             self.repository.update_session(touched)
         resolved_permissions = self.repository.get_explicit_permissions(account.id)

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -27,6 +27,19 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TypeVar
 from urllib.parse import parse_qsl, unquote, urlparse
 
+from catering_system.domain.catalog import (
+    AllergenCode,
+    CatalogDishAlreadyExistsError,
+    CatalogDishCreatePayload,
+    CatalogDishNotFoundError,
+    CatalogDishStaleError,
+    CatalogDishUpdatePayload,
+    validate_allergen_codes,
+    validate_pricing_unit,
+)
+from catering_system.domain.customer_document_eligibility import (
+    CustomerDocumentCreationBlocked,
+)
 from catering_system.domain.inquiry import (
     ACTIVE_ORDER_CRM_STAGE,
     CRM_PIPELINE,
@@ -67,6 +80,9 @@ from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
     validate_payment_method,
 )
+from catering_system.repositories.bootstrap_customer_identity_schema import (
+    bootstrap_customer_identity_schema,
+)
 from catering_system.repositories.core_transaction import (
     CoreBusyError,
     CoreCommandExecutor,
@@ -80,6 +96,12 @@ from catering_system.repositories.office_api_ledger import (
     OfficeCommandLedger,
     command_fingerprint,
 )
+from catering_system.repositories.sqlite_catalog_repository import (
+    SQLiteCatalogRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
@@ -89,30 +111,39 @@ from catering_system.repositories.sqlite_offer_document_snapshot_repository impo
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
 )
-from catering_system.repositories.sqlite_catalog_repository import (
-    SQLiteCatalogRepository,
-)
-from catering_system.repositories.bootstrap_customer_identity_schema import (
-    bootstrap_customer_identity_schema,
-)
-from catering_system.repositories.sqlite_order_repository import (
-    SQLiteOrderRepository,
-)
-from catering_system.repositories.sqlite_order_operational_pause_repository import (
-    SQLiteOrderOperationalPauseRepository,
-)
-from catering_system.repositories.sqlite_payment_reminder_repository import (
-    SQLitePaymentReminderRepository,
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.sqlite_order_confirmation_document_repository import (
     SQLiteOrderConfirmationDocumentRepository,
 )
-from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
-    SQLiteOrderCommercialSnapshotRepository,
-)
 from catering_system.repositories.sqlite_order_confirmation_outbound_repository import (
     SQLiteOrderConfirmationOutboundRepository,
 )
+from catering_system.repositories.sqlite_order_operational_pause_repository import (
+    SQLiteOrderOperationalPauseRepository,
+)
+from catering_system.repositories.sqlite_order_repository import (
+    SQLiteOrderRepository,
+)
+from catering_system.repositories.sqlite_payment_reminder_repository import (
+    SQLitePaymentReminderRepository,
+)
+from catering_system.services.buffet_cards_service import BuffetCardsService
+from catering_system.services.calendar_projection_service import (
+    CalendarProjectionService,
+)
+from catering_system.services.catalog_dish_service import CatalogDishService
+from catering_system.services.catalog_dish_write_service import CatalogDishWriteService
+from catering_system.services.contact_projection_service import ContactProjectionService
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewNotFoundError,
+    CustomerDocumentPreviewService,
+)
+from catering_system.services.email_intake_projection_service import (
+    EmailIntakeProjectionService,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
 from catering_system.services.inquiry_service import (
     InquiryService,
     validate_inquiry_source,
@@ -125,19 +156,17 @@ from catering_system.services.offer_pdf_renderer import (
     offer_document_pdf_filename,
     render_offer_document_pdf,
 )
+from catering_system.services.offer_queue_projection_service import (
+    OfferQueueProjectionService,
+)
 from catering_system.services.offer_service import (
     OfferPreparationBlockedError,
     OfferService,
 )
 from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_service import OrderService
-from catering_system.services.payment_reminder_service import PaymentReminderService
-from catering_system.domain.customer_document_eligibility import (
-    CustomerDocumentCreationBlocked,
-)
-from catering_system.services.customer_document_preview import (
-    CustomerDocumentPreviewNotFoundError,
-    CustomerDocumentPreviewService,
+from catering_system.services.order_confirmation_document_preview import (
+    build_preview,
+    render_preview_html,
 )
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentBlockedError,
@@ -154,42 +183,25 @@ from catering_system.services.order_confirmation_outbound_service import (
     OrderConfirmationOutboundService,
     OrderConfirmationOutboundStaleVersionError,
 )
-from catering_system.services.order_confirmation_document_preview import (
-    build_preview,
-    render_preview_html,
-)
-from catering_system.services.wochenuebersicht_service import WochenuebersichtService
-from catering_system.services.contact_projection_service import ContactProjectionService
-from catering_system.services.email_intake_projection_service import (
-    EmailIntakeProjectionService,
-)
-from catering_system.services.calendar_projection_service import (
-    CalendarProjectionService,
-)
-from catering_system.services.task_projection_service import TaskProjectionService
-from catering_system.services.offer_queue_projection_service import (
-    OfferQueueProjectionService,
-)
-from catering_system.services.work_center_service import WorkCenterService
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjectionService,
     PrintFinalRequiresEffectiveError,
     PrintProjectionNotFoundError,
 )
-from catering_system.services.buffet_cards_service import BuffetCardsService
-from catering_system.services.catalog_dish_service import CatalogDishService
-from catering_system.services.catalog_dish_write_service import CatalogDishWriteService
-from catering_system.domain.catalog import (
-    AllergenCode,
-    CatalogDishAlreadyExistsError,
-    CatalogDishCreatePayload,
-    CatalogDishNotFoundError,
-    CatalogDishStaleError,
-    CatalogDishUpdatePayload,
-    validate_allergen_codes,
-    validate_pricing_unit,
-)
+from catering_system.services.order_service import OrderService
+from catering_system.services.payment_reminder_service import PaymentReminderService
+from catering_system.services.task_projection_service import TaskProjectionService
+from catering_system.services.wochenuebersicht_service import WochenuebersichtService
+from catering_system.services.work_center_service import WorkCenterService
 from catering_system.ui import office_api_views as views
+from catering_system.ui.office_api_employee_introspect import (
+    EMPLOYEE_INTROSPECT_PATH,
+    perform_employee_introspection,
+)
+from catering_system.ui.office_api_service_auth import (
+    OfficeApiServiceAuth,
+    read_introspection_service_tokens_from_env,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -447,6 +459,7 @@ class OfficeApi:
         connection: sqlite3.Connection,
         *,
         offer_pdf_static_content: OfferPdfStaticContent,
+        employee_auth_now: Callable[[], datetime] | None = None,
     ) -> None:
         self._conn = connection
         self.offer_pdf_static_content = offer_pdf_static_content
@@ -567,6 +580,14 @@ class OfficeApi:
         )
         self.catalog_dish_service = CatalogDishService(self.catalog)
         self.catalog_dish_write_service = CatalogDishWriteService(self.catalog)
+        employee_auth_repo = SQLiteEmployeeAuthRepository.from_connection(connection)
+        if employee_auth_now is not None:
+            self.employee_auth_service = EmployeeAuthService(
+                employee_auth_repo,
+                now=employee_auth_now,
+            )
+        else:
+            self.employee_auth_service = EmployeeAuthService(employee_auth_repo)
 
     # -- reads -----------------------------------------------------------
 
@@ -1051,7 +1072,7 @@ class OfficeApi:
 
     # -- command helpers ---------------------------------------------------
 
-    def _require_inquiry(self, inquiry_id: str):  # noqa: ANN202
+    def _require_inquiry(self, inquiry_id: str):
         inquiry = self.inquiries.get_by_id(inquiry_id)
         if inquiry is None:
             raise ApiError(404, "not_found")
@@ -2669,8 +2690,17 @@ def _resolve_route(path: str) -> tuple[str, dict[str, str], dict[str, str]] | No
     return None
 
 
-def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestHandler]:
+def make_office_api_handler(
+    api: OfficeApi,
+    token: str,
+    *,
+    introspection_service_tokens: dict[str, str] | None = None,
+) -> type[BaseHTTPRequestHandler]:
     expected_auth = f"Bearer {token}"
+    service_auth = OfficeApiServiceAuth(
+        office_panel_token=token,
+        introspection_clients=introspection_service_tokens or {},
+    )
 
     class OfficeApiHandler(BaseHTTPRequestHandler):
         server_version = "CoreOfficeAPI/1.0"
@@ -2678,7 +2708,7 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
         # undrained, which under keep-alive corrupts the next request on the
         # same connection (observed in the courier repo); 1.0 closes it.
 
-        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        def log_message(self, format: str, *args: object) -> None:
             pass
 
         # -- plumbing --------------------------------------------------
@@ -2776,6 +2806,36 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
             self._error(401, "unauthorized")
             return False
 
+        def _is_introspect_path(self, path: str) -> bool:
+            return path == EMPLOYEE_INTROSPECT_PATH
+
+        def _employee_introspect(self) -> None:
+            status, response, error_code = perform_employee_introspection(
+                service_auth=service_auth,
+                authorization=self.headers.get("Authorization"),
+                content_length=self.headers.get("Content-Length"),
+                transfer_encoding=self.headers.get("Transfer-Encoding"),
+                session_header_values=self.headers.get_all("X-Employee-Session"),
+                employee_auth=api.employee_auth_service,
+            )
+            if error_code is not None:
+                self._error(status, error_code)
+                return
+            assert response is not None
+            self._respond(status, response.to_json())
+
+        def _introspect_service_auth_or_respond(self) -> bool:
+            result = service_auth.authenticate_introspection(
+                self.headers.get("Authorization")
+            )
+            if result.outcome == "allowed":
+                return True
+            if result.outcome in {"forbidden", "ambiguous"}:
+                self._error(403, "forbidden")
+            else:
+                self._error(401, "unauthorized")
+            return False
+
         def _read_command_body(self, max_bytes: int) -> bytes:
             content_type = self.headers.get("Content-Type", "")
             if content_type.split(";")[0].strip() != "application/json":
@@ -2823,24 +2883,42 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
 
         # -- HTTP methods ----------------------------------------------
 
-        def do_GET(self) -> None:  # noqa: N802
+        def do_GET(self) -> None:
             self._handle("GET")
 
-        def do_POST(self) -> None:  # noqa: N802
+        def do_POST(self) -> None:
             self._handle("POST")
 
-        def do_PUT(self) -> None:  # noqa: N802
+        def do_PUT(self) -> None:
             self._method_not_allowed_or_404()
 
-        def do_DELETE(self) -> None:  # noqa: N802
+        def do_DELETE(self) -> None:
             self._method_not_allowed_or_404()
 
-        def do_PATCH(self) -> None:  # noqa: N802
+        def do_PATCH(self) -> None:
             self._method_not_allowed_or_404()
 
-        def do_HEAD(self) -> None:  # noqa: N802
+        def do_HEAD(self) -> None:
             # Explicit handler (pack §4.0): auth first, then 405/404 with
             # full headers; body suppressed but Content-Length preserved.
+            path = urlparse(self.path).path
+            if self._is_introspect_path(path):
+                if not self._introspect_service_auth_or_respond():
+                    return
+                payload = json.dumps(
+                    {
+                        "authenticated": False,
+                        "application_access_allowed": False,
+                        "principal": None,
+                    }
+                ).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(payload)))
+                self.send_header("Cache-Control", "no-store")
+                self.send_header("X-Content-Type-Options", "nosniff")
+                self.end_headers()
+                return
             if not self._authorized():
                 payload = json.dumps({"error": "unauthorized"}).encode("utf-8")
                 self.send_response(401)
@@ -2855,7 +2933,13 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
             error = "method_not_allowed" if code == 405 else "not_found"
             self._respond(code, {"error": error}, suppress_body=True)
 
-        def do_OPTIONS(self) -> None:  # noqa: N802
+        def do_OPTIONS(self) -> None:
+            path = urlparse(self.path).path
+            if self._is_introspect_path(path):
+                if not self._introspect_service_auth_or_respond():
+                    return
+                self._error(405, "method_not_allowed")
+                return
             if not self._auth_or_401():
                 return
             path = urlparse(self.path).path
@@ -2874,9 +2958,15 @@ def make_office_api_handler(api: OfficeApi, token: str) -> type[BaseHTTPRequestH
                 self._error(404, "not_found")
 
         def _handle(self, method: str) -> None:
+            path = urlparse(self.path).path
+            if self._is_introspect_path(path):
+                if method != "POST":
+                    self._error(405, "method_not_allowed")
+                    return
+                self._employee_introspect()
+                return
             if not self._auth_or_401():
                 return
-            path = urlparse(self.path).path
             resolved = _resolve_route(path)
             if resolved is None:
                 self._error(404, "not_found")
@@ -3163,14 +3253,24 @@ def create_office_api_server(
     port: int = 0,
     *,
     offer_pdf_static_content: OfferPdfStaticContent,
+    introspection_service_tokens: dict[str, str] | None = None,
+    employee_auth_now: Callable[[], datetime] | None = None,
 ) -> HTTPServer:
     """Build connection, repositories and server in the calling thread —
     single-threaded on purpose (sqlite3 thread affinity, Entry 048)."""
     api = OfficeApi(
         open_core_connection(db_path),
         offer_pdf_static_content=offer_pdf_static_content,
+        employee_auth_now=employee_auth_now,
     )
-    return HTTPServer((host, port), make_office_api_handler(api, token))
+    return HTTPServer(
+        (host, port),
+        make_office_api_handler(
+            api,
+            token,
+            introspection_service_tokens=introspection_service_tokens,
+        ),
+    )
 
 
 def main() -> None:
@@ -3198,12 +3298,17 @@ def main() -> None:
 
     offer_pdf_static_content = offer_pdf_static_content_from_env()
 
+    introspection_tokens = read_introspection_service_tokens_from_env(
+        office_panel_token=token,
+    )
+
     server = create_office_api_server(
         args.db,
         token,
         args.host,
         args.port,
         offer_pdf_static_content=offer_pdf_static_content,
+        introspection_service_tokens=introspection_tokens,
     )
     print(f"Core Office API on http://{args.host}:{args.port}/office/v1/")
     server.serve_forever()

--- a/src/catering_system/ui/office_api_employee_introspect.py
+++ b/src/catering_system/ui/office_api_employee_introspect.py
@@ -1,0 +1,126 @@
+"""Private employee-session introspection route for trusted backends (AUTH-2E1)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Literal
+
+from catering_system.domain.employee_introspection import (
+    EmployeeIntrospectionResponse,
+    employee_introspection_from_session,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_api_service_auth import (
+    OfficeApiServiceAuth,
+    ServiceAuthResult,
+)
+
+_log = logging.getLogger(__name__)
+
+EMPLOYEE_INTROSPECT_PATH = "/office/v1/auth/employee/introspect"
+EMPLOYEE_SESSION_HEADER = "X-Employee-Session"
+_MAX_EMPLOYEE_SESSION_LEN = 256
+_SESSION_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+ParseSessionHeader = str | None | Literal["malformed"]
+
+
+def parse_employee_session_header(raw: str | None) -> ParseSessionHeader:
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value:
+        return None
+    if (
+        len(value) > _MAX_EMPLOYEE_SESSION_LEN
+        or _SESSION_TOKEN_RE.fullmatch(value) is None
+    ):
+        return "malformed"
+    return value
+
+
+def parse_employee_session_header_values(
+    values: list[str] | None,
+) -> ParseSessionHeader:
+    if not values:
+        return None
+    if len(values) != 1:
+        return "malformed"
+    return parse_employee_session_header(values[0])
+
+
+def validate_introspection_request_body(
+    *,
+    content_length: str | None,
+    transfer_encoding: str | None,
+) -> bool:
+    """Return True when the request body must be rejected with 400."""
+    if transfer_encoding is not None:
+        encodings = [
+            part.strip().lower()
+            for part in transfer_encoding.split(",")
+            if part.strip()
+        ]
+        if "chunked" in encodings:
+            return True
+    if content_length is None or content_length in ("", "0"):
+        return False
+    try:
+        length = int(content_length)
+    except ValueError:
+        return True
+    if length < 0:
+        return True
+    return length > 0
+
+
+def perform_employee_introspection(
+    *,
+    service_auth: OfficeApiServiceAuth,
+    authorization: str | None,
+    content_length: str | None,
+    transfer_encoding: str | None,
+    session_header_values: list[str] | None,
+    employee_auth: EmployeeAuthService,
+) -> tuple[int, EmployeeIntrospectionResponse | None, str | None]:
+    """Return HTTP status, response body, or error code for service-auth failures."""
+    auth_result = service_auth.authenticate_introspection(authorization)
+    status, error_code = _service_auth_status(auth_result)
+    if status != 200:
+        return status, None, error_code
+
+    if validate_introspection_request_body(
+        content_length=content_length,
+        transfer_encoding=transfer_encoding,
+    ):
+        return 400, None, "invalid_request"
+
+    parsed = parse_employee_session_header_values(session_header_values)
+    if parsed == "malformed":
+        return 400, None, "invalid_request"
+
+    employee = (
+        None
+        if parsed is None
+        else employee_auth.resolve_session_for_introspection(parsed)
+    )
+    response = employee_introspection_from_session(employee)
+    _log.info(
+        "employee_introspect client=%s authenticated=%s application_access_allowed=%s account_id=%s",
+        auth_result.client_id,
+        response.authenticated,
+        response.application_access_allowed,
+        response.principal.account_id if response.principal is not None else "-",
+    )
+    return 200, response, None
+
+
+def _service_auth_status(result: ServiceAuthResult) -> tuple[int, str | None]:
+    if result.outcome == "allowed":
+        return 200, None
+    if result.outcome == "forbidden":
+        return 403, "forbidden"
+    if result.outcome == "ambiguous":
+        return 403, "forbidden"
+    return 401, "unauthorized"

--- a/src/catering_system/ui/office_api_service_auth.py
+++ b/src/catering_system/ui/office_api_service_auth.py
@@ -1,0 +1,125 @@
+"""Service bearer authentication for Core Office API privileged routes."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+ServiceAuthOutcome = Literal["allowed", "forbidden", "missing", "invalid", "ambiguous"]
+
+
+@dataclass(frozen=True)
+class ServiceAuthResult:
+    outcome: ServiceAuthOutcome
+    client_id: str | None = None
+
+
+class IntrospectionServiceTokenConfigError(Exception):
+    """Invalid EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON configuration."""
+
+
+class OfficeApiServiceAuth:
+    """Distinguishes the office-panel bearer from introspection-capable clients."""
+
+    def __init__(
+        self,
+        *,
+        office_panel_token: str,
+        introspection_clients: dict[str, str],
+    ) -> None:
+        self._office_panel_token = office_panel_token
+        self._introspection_clients = dict(introspection_clients)
+
+    def authenticate_introspection(
+        self, authorization: str | None
+    ) -> ServiceAuthResult:
+        if authorization is None or not authorization.startswith("Bearer "):
+            return ServiceAuthResult(outcome="missing")
+        token = authorization.removeprefix("Bearer ").strip()
+        if not token:
+            return ServiceAuthResult(outcome="missing")
+        office_match = hmac.compare_digest(token, self._office_panel_token)
+        matched_clients = [
+            client_id
+            for client_id, expected in self._introspection_clients.items()
+            if hmac.compare_digest(token, expected)
+        ]
+        if office_match and matched_clients:
+            return ServiceAuthResult(outcome="ambiguous")
+        if office_match:
+            return ServiceAuthResult(outcome="forbidden", client_id="office-panel")
+        if len(matched_clients) > 1:
+            return ServiceAuthResult(outcome="ambiguous")
+        if len(matched_clients) == 1:
+            return ServiceAuthResult(
+                outcome="allowed",
+                client_id=matched_clients[0],
+            )
+        return ServiceAuthResult(outcome="invalid")
+
+
+def parse_introspection_service_tokens(
+    raw: str,
+    *,
+    office_panel_token: str,
+) -> dict[str, str]:
+    """Parse introspection client tokens; empty raw keeps the route fail-closed."""
+    value = raw.strip()
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise IntrospectionServiceTokenConfigError(
+            "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON must be valid JSON"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise IntrospectionServiceTokenConfigError(
+            "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON must be a JSON object"
+        )
+    tokens: dict[str, str] = {}
+    seen_values: dict[str, str] = {}
+    for key, token_value in parsed.items():
+        if not isinstance(key, str) or not key.strip():
+            raise IntrospectionServiceTokenConfigError(
+                "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON client id must be a "
+                "non-empty string"
+            )
+        if not isinstance(token_value, str) or not token_value.strip():
+            raise IntrospectionServiceTokenConfigError(
+                "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON token must be a "
+                "non-empty string"
+            )
+        client_id = key.strip()
+        token = token_value.strip()
+        if hmac.compare_digest(token, office_panel_token):
+            raise IntrospectionServiceTokenConfigError(
+                "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON must not reuse "
+                "OFFICE_API_TOKEN"
+            )
+        previous_client = seen_values.get(token)
+        if previous_client is not None:
+            raise IntrospectionServiceTokenConfigError(
+                "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON contains duplicate "
+                "service tokens"
+            )
+        tokens[client_id] = token
+        seen_values[token] = client_id
+    return tokens
+
+
+def read_introspection_service_tokens_from_env(
+    *,
+    office_panel_token: str,
+) -> dict[str, str]:
+    raw = os.environ.get("EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON", "")
+    try:
+        return parse_introspection_service_tokens(
+            raw,
+            office_panel_token=office_panel_token,
+        )
+    except IntrospectionServiceTokenConfigError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/tests/unit/test_office_api_employee_introspect.py
+++ b/tests/unit/test_office_api_employee_introspect.py
@@ -1,0 +1,796 @@
+"""Core Office API employee-session introspection contract (AUTH-2E1)."""
+
+from __future__ import annotations
+
+import socket
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.employee_auth import PERMISSION_SET
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.office_api_employee_introspect import (
+    EMPLOYEE_INTROSPECT_PATH,
+    perform_employee_introspection,
+    validate_introspection_request_body,
+)
+from catering_system.ui.office_api_service_auth import (
+    IntrospectionServiceTokenConfigError,
+    OfficeApiServiceAuth,
+    parse_introspection_service_tokens,
+    read_introspection_service_tokens_from_env,
+)
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+
+_PANEL_TOKEN = "test-office-api-token"
+_CONFIGURATOR_TOKEN = "test-configurator-introspect-token"
+_INTROSPECT_PATH = EMPLOYEE_INTROSPECT_PATH
+_PANEL_AUTH = {"Authorization": f"Bearer {_PANEL_TOKEN}"}
+_CONFIGURATOR_AUTH = {
+    "Authorization": f"Bearer {_CONFIGURATOR_TOKEN}",
+}
+
+
+class Clock:
+    def __init__(self, value: datetime) -> None:
+        self.value = value
+
+    def now(self) -> datetime:
+        return self.value
+
+
+def _start_api_server(
+    db: Path,
+    *,
+    introspection_tokens: dict[str, str] | None = None,
+    employee_auth_now: Callable[[], datetime] | None = None,
+) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.office_api import create_office_api_server
+
+        server = create_office_api_server(
+            str(db),
+            _PANEL_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+            introspection_service_tokens=(
+                {"configurator": _CONFIGURATOR_TOKEN}
+                if introspection_tokens is None
+                else introspection_tokens
+            ),
+            employee_auth_now=employee_auth_now,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+def _auth_service(
+    db: Path, clock: Clock
+) -> tuple[EmployeeAuthService, SQLiteEmployeeAuthRepository]:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(repo, now=clock.now)
+    service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "test"},
+    )
+    return service, repo
+
+
+def _ready_session(
+    service: EmployeeAuthService,
+    *,
+    username: str = "super.admin",
+    password: str = "TempPassw0rd!",
+) -> tuple[str, object]:
+    login = service.authenticate(username=username, password=password)
+    service.change_password(
+        service.authenticate_session(login.session_token),
+        current_password=password,
+        new_password="ChangedTemp1!",
+    )
+    relogin = service.authenticate(username=username, password="ChangedTemp1!")
+    return relogin.session_token, relogin
+
+
+@pytest.fixture()
+def introspect_api(tmp_path: Path):
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    db = tmp_path / f"introspect-{uuid.uuid4().hex}.sqlite3"
+    auth_service, repo = _auth_service(db, clock)
+    server, thread, base = _start_api_server(
+        db,
+        employee_auth_now=clock.now,
+    )
+    yield {
+        "base": base,
+        "db": db,
+        "clock": clock,
+        "auth_service": auth_service,
+        "repo": repo,
+    }
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+    repo.close()
+
+
+def _introspect_post(
+    base: str,
+    *,
+    headers: dict[str, str] | None = None,
+    session_token: str | None = None,
+    body: bytes | None = b"",
+) -> tuple[int, dict, dict]:
+    all_headers = dict(_CONFIGURATOR_AUTH)
+    if headers is not None:
+        all_headers.update(headers)
+    if session_token is not None:
+        all_headers["X-Employee-Session"] = session_token
+    req = urllib.request.Request(
+        f"{base}{_INTROSPECT_PATH}",
+        data=body,
+        headers=all_headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode()), dict(resp.headers)
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}"), dict(exc.headers)
+
+
+def _introspect_raw_post(base: str, raw_request: bytes) -> tuple[int, dict]:
+    host_port = base.removeprefix("http://")
+    host, port_text = host_port.split(":", 1)
+    port = int(port_text)
+    with socket.create_connection((host, port), timeout=5) as sock:
+        sock.sendall(raw_request)
+        chunks: list[bytes] = []
+        while True:
+            part = sock.recv(4096)
+            if not part:
+                break
+            chunks.append(part)
+    raw_response = b"".join(chunks)
+    header_block, _body = raw_response.split(b"\r\n\r\n", 1)
+    status_line = header_block.split(b"\r\n", 1)[0]
+    status = int(status_line.split(b" ", 2)[1])
+    body_start = raw_response.find(b"\r\n\r\n") + 4
+    payload = json.loads(raw_response[body_start:].decode() or "{}")
+    return status, payload
+
+
+def _introspect_post_header_list(
+    base: str,
+    header_items: list[tuple[str, str]],
+    *,
+    body: bytes = b"",
+) -> tuple[int, dict]:
+    header_lines = "".join(f"{name}: {value}\r\n" for name, value in header_items)
+    raw_request = (
+        f"POST {_INTROSPECT_PATH} HTTP/1.0\r\n"
+        f"{header_lines}"
+        f"Content-Length: {len(body)}\r\n"
+        f"\r\n"
+    ).encode("utf-8") + body
+    return _introspect_raw_post(base, raw_request)
+
+
+def test_missing_bearer_returns_401(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": ""},
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+def test_invalid_bearer_returns_401(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+def test_office_panel_bearer_returns_403(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers=_PANEL_AUTH,
+    )
+    assert status == 403
+    assert body == {"error": "forbidden"}
+
+
+@pytest.mark.parametrize(
+    "extra_headers",
+    [
+        {"Content-Length": "12"},
+        {"Content-Length": "not-a-number"},
+        {"Transfer-Encoding": "chunked"},
+    ],
+    ids=["non_empty_body", "invalid_content_length", "chunked_body"],
+)
+def test_missing_bearer_returns_401_before_body_validation(
+    introspect_api, extra_headers: dict[str, str]
+) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": "Bearer wrong-token", **extra_headers},
+        body=b'{"account_id":"x"}'
+        if extra_headers.get("Content-Length") == "12"
+        else b"",
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+@pytest.mark.parametrize(
+    "session_token",
+    ["not valid!", "a" * 300],
+    ids=["malformed_session", "oversized_session"],
+)
+def test_missing_bearer_returns_401_before_session_validation(
+    introspect_api, session_token: str
+) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": "Bearer wrong-token"},
+        session_token=session_token,
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+def test_missing_bearer_with_client_identity_body_returns_401(introspect_api) -> None:
+    payload = json.dumps(
+        {"account_id": str(uuid.uuid4()), "effective_permissions": ["offers.prepare"]}
+    ).encode("utf-8")
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": "Bearer wrong-token"},
+        body=payload,
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+def test_missing_session_header_returns_unauthenticated(introspect_api) -> None:
+    status, body, headers = _introspect_post(introspect_api["base"])
+    assert status == 200
+    assert body == {
+        "authenticated": False,
+        "application_access_allowed": False,
+        "principal": None,
+    }
+    assert headers["Content-Type"] == "application/json; charset=utf-8"
+    assert "Access-Control-Allow-Origin" not in headers
+
+
+def test_empty_session_header_returns_unauthenticated(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token="   ",
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+    assert body["principal"] is None
+
+
+def test_malformed_session_header_returns_400(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token="not valid token!",
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_oversized_session_header_returns_400(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token="a" * 300,
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_valid_superadmin_session_returns_permissions(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    session_token, _login = _ready_session(service)
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is True
+    assert body["application_access_allowed"] is True
+    principal = body["principal"]
+    assert isinstance(principal, dict)
+    assert principal["role"] == "SUPERADMIN"
+    assert principal["effective_permissions"] == sorted(PERMISSION_SET)
+    assert "session" not in json.dumps(body)
+    assert "csrf" not in json.dumps(body).lower()
+    assert "email" not in principal
+
+
+def test_viewer_session_returns_view_permissions_only(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    superadmin_token, _super_login = _ready_session(service)
+    superadmin = service.authenticate_session(superadmin_token)
+    viewer = service.create_account(
+        superadmin,
+        username="viewer.user",
+        display_name="Viewer User",
+        password="ViewerTemp1!",
+        role="VIEWER",
+        explicit_permissions={"inquiries.view"},
+    )
+    login = service.authenticate(username=viewer.username, password="ViewerTemp1!")
+    service.change_password(
+        service.authenticate_session(login.session_token),
+        current_password="ViewerTemp1!",
+        new_password="ViewerChanged1!",
+    )
+    relogin = service.authenticate(username=viewer.username, password="ViewerChanged1!")
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=relogin.session_token,
+    )
+    assert status == 200
+    principal = body["principal"]
+    assert principal["role"] == "VIEWER"
+    assert principal["effective_permissions"] == ["inquiries.view"]
+
+
+def test_must_change_password_blocks_application_access(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    login = service.authenticate(username="super.admin", password="TempPassw0rd!")
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=login.session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is True
+    assert body["application_access_allowed"] is False
+    assert body["principal"]["effective_permissions"] == []
+
+
+def test_expired_session_returns_unauthenticated(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    clock: Clock = introspect_api["clock"]
+    session_token, _login = _ready_session(service)
+    clock.value = clock.value + timedelta(hours=13)
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+
+
+def test_revoked_session_returns_unauthenticated(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    session_token, _login = _ready_session(service)
+    employee = service.authenticate_session(session_token)
+    service.logout(employee)
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+
+
+def test_deactivated_employee_returns_unauthenticated(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    superadmin_token, _super_login = _ready_session(service)
+    superadmin = service.authenticate_session(superadmin_token)
+    worker = service.create_account(
+        superadmin,
+        username="worker.user",
+        display_name="Worker User",
+        password="WorkerTemp1!",
+        role="USER",
+    )
+    login = service.authenticate(username=worker.username, password="WorkerTemp1!")
+    service.change_password(
+        service.authenticate_session(login.session_token),
+        current_password="WorkerTemp1!",
+        new_password="WorkerChanged1!",
+    )
+    relogin = service.authenticate(username=worker.username, password="WorkerChanged1!")
+    service.deactivate_account(superadmin, worker.id)
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=relogin.session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+
+
+def test_auth_version_mismatch_returns_unauthenticated(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    session_token, _login = _ready_session(service)
+    employee = service.authenticate_session(session_token)
+    service.change_password(
+        employee,
+        current_password="ChangedTemp1!",
+        new_password="AnotherTemp1!",
+    )
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+
+
+def test_permission_change_reflected_without_new_session(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    superadmin_token, _super_login = _ready_session(service)
+    superadmin = service.authenticate_session(superadmin_token)
+    worker = service.create_account(
+        superadmin,
+        username="worker.user",
+        display_name="Worker User",
+        password="WorkerTemp1!",
+        role="USER",
+        explicit_permissions={"inquiries.view"},
+    )
+    login = service.authenticate(username=worker.username, password="WorkerTemp1!")
+    service.change_password(
+        service.authenticate_session(login.session_token),
+        current_password="WorkerTemp1!",
+        new_password="WorkerChanged1!",
+    )
+    relogin = service.authenticate(username=worker.username, password="WorkerChanged1!")
+    session_token = relogin.session_token
+
+    _status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert body["principal"]["effective_permissions"] == ["inquiries.view"]
+
+    service.set_account_permissions(
+        superadmin,
+        worker.id,
+        {"offers.view", "inquiries.view"},
+    )
+    _status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        session_token=session_token,
+    )
+    assert sorted(body["principal"]["effective_permissions"]) == [
+        "inquiries.view",
+        "offers.view",
+    ]
+
+
+def test_request_body_with_client_identity_is_rejected(introspect_api) -> None:
+    payload = json.dumps({"account_id": str(uuid.uuid4())}).encode("utf-8")
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        body=payload,
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_chunked_transfer_encoding_rejected_after_service_auth(
+    introspect_api,
+) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Transfer-Encoding": "chunked"},
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_duplicate_session_headers_rejected(introspect_api) -> None:
+    status, body = _introspect_post_header_list(
+        introspect_api["base"],
+        [
+            ("Authorization", f"Bearer {_CONFIGURATOR_TOKEN}"),
+            ("X-Employee-Session", "valid-session-token"),
+            ("X-Employee-Session", "other-session-token"),
+        ],
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_introspection_endpoint_fail_closed_without_configured_clients(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / f"introspect-dormant-{uuid.uuid4().hex}.sqlite3"
+    SQLiteEmployeeAuthRepository(db).close()
+    server, thread, base = _start_api_server(db, introspection_tokens={})
+    try:
+        status, body, _headers = _introspect_post(base)
+        assert status == 401
+        assert body == {"error": "unauthorized"}
+        req = urllib.request.Request(
+            f"{base}/office/v1/queue",
+            headers=_PANEL_AUTH,
+        )
+        with urllib.request.urlopen(req) as resp:
+            assert resp.status == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_cookie_header_does_not_authenticate(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    session_token, _login = _ready_session(service)
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Cookie": f"sl_employee_session={session_token}"},
+    )
+    assert status == 200
+    assert body["authenticated"] is False
+
+
+def test_basic_auth_does_not_substitute_session_header(introspect_api) -> None:
+    import base64
+
+    basic = base64.b64encode(b"office:secret").decode()
+    status, _body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": f"Basic {basic}"},
+    )
+    assert status == 401
+
+
+def test_introspection_does_not_mutate_session_state(introspect_api) -> None:
+    service: EmployeeAuthService = introspect_api["auth_service"]
+    repo: SQLiteEmployeeAuthRepository = introspect_api["repo"]
+    session_token, login = _ready_session(service)
+    session_before = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session_before is not None
+    before_seen = session_before.last_seen_at
+    before_expires = session_before.expires_at
+    audit_before = repo.list_audit_events()
+
+    for _ in range(3):
+        status, body, _headers = _introspect_post(
+            introspect_api["base"],
+            session_token=session_token,
+        )
+        assert status == 200
+        assert body["authenticated"] is True
+
+    session_after = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session_after is not None
+    assert session_after.last_seen_at == before_seen
+    assert session_after.expires_at == before_expires
+    assert repo.list_audit_events() == audit_before
+
+
+def test_get_method_not_allowed(introspect_api) -> None:
+    req = urllib.request.Request(
+        f"{introspect_api['base']}{_INTROSPECT_PATH}",
+        headers=_CONFIGURATOR_AUTH,
+        method="GET",
+    )
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(req)
+    assert exc_info.value.code == 405
+    body = json.loads(exc_info.value.read().decode())
+    assert body == {"error": "method_not_allowed"}
+
+
+def test_existing_office_api_routes_unchanged(introspect_api) -> None:
+    req = urllib.request.Request(
+        f"{introspect_api['base']}/office/v1/queue",
+        headers=_PANEL_AUTH,
+    )
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 200
+
+
+def test_bearer_with_empty_token_returns_401(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Authorization": "Bearer "},
+    )
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+
+
+def test_invalid_content_length_header_returns_400(introspect_api) -> None:
+    status, body, _headers = _introspect_post(
+        introspect_api["base"],
+        headers={"Content-Length": "not-a-number"},
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+
+def test_read_introspection_service_tokens_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON", raising=False)
+    assert (
+        read_introspection_service_tokens_from_env(office_panel_token="panel-token")
+        == {}
+    )
+    monkeypatch.setenv(
+        "EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON",
+        '{"configurator":"secret-token"}',
+    )
+    assert read_introspection_service_tokens_from_env(
+        office_panel_token="panel-token"
+    ) == {"configurator": "secret-token"}
+
+
+def test_parse_introspection_service_tokens_rejects_invalid_config() -> None:
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="valid JSON"):
+        parse_introspection_service_tokens("{", office_panel_token="panel")
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="JSON object"):
+        parse_introspection_service_tokens("[]", office_panel_token="panel")
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="client id"):
+        parse_introspection_service_tokens('{"": "token"}', office_panel_token="panel")
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="token must"):
+        parse_introspection_service_tokens(
+            '{"configurator": ""}', office_panel_token="panel"
+        )
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="non-empty string"):
+        parse_introspection_service_tokens(
+            '{"configurator": 1}', office_panel_token="panel"
+        )
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="OFFICE_API_TOKEN"):
+        parse_introspection_service_tokens(
+            '{"configurator": "panel"}', office_panel_token="panel"
+        )
+    with pytest.raises(IntrospectionServiceTokenConfigError, match="duplicate"):
+        parse_introspection_service_tokens(
+            '{"a": "same-token", "b": "same-token"}',
+            office_panel_token="panel",
+        )
+
+
+def test_ambiguous_bearer_matching_office_and_introspection_returns_403(
+    tmp_path: Path,
+) -> None:
+    auth = OfficeApiServiceAuth(
+        office_panel_token="shared-token",
+        introspection_clients={"configurator": "shared-token"},
+    )
+    assert auth.authenticate_introspection("Bearer shared-token").outcome == "ambiguous"
+    service = EmployeeAuthService(SQLiteEmployeeAuthRepository(tmp_path / "ambig.db"))
+    status, _response, error = perform_employee_introspection(
+        service_auth=auth,
+        authorization="Bearer shared-token",
+        content_length=None,
+        transfer_encoding=None,
+        session_header_values=None,
+        employee_auth=service,
+    )
+    assert status == 403
+    assert error == "forbidden"
+
+
+def test_service_auth_helpers(tmp_path: Path) -> None:
+    auth = OfficeApiServiceAuth(
+        office_panel_token="panel-token",
+        introspection_clients={"configurator": "cfg-token"},
+    )
+    assert auth.authenticate_introspection(None).outcome == "missing"
+    assert auth.authenticate_introspection("Basic x").outcome == "missing"
+    assert auth.authenticate_introspection("Bearer panel-token").outcome == "forbidden"
+    assert auth.authenticate_introspection("Bearer cfg-token").outcome == "allowed"
+    assert (
+        auth.authenticate_introspection("Bearer cfg-token").client_id == "configurator"
+    )
+    assert auth.authenticate_introspection("Bearer unknown").outcome == "invalid"
+    assert (
+        validate_introspection_request_body(content_length=None, transfer_encoding=None)
+        is False
+    )
+    assert (
+        validate_introspection_request_body(content_length="0", transfer_encoding=None)
+        is False
+    )
+    assert (
+        validate_introspection_request_body(content_length="12", transfer_encoding=None)
+        is True
+    )
+    assert (
+        validate_introspection_request_body(
+            content_length="bad", transfer_encoding=None
+        )
+        is True
+    )
+    assert (
+        validate_introspection_request_body(
+            content_length=None, transfer_encoding="chunked"
+        )
+        is True
+    )
+
+    db = tmp_path / "helper.db"
+    service = EmployeeAuthService(SQLiteEmployeeAuthRepository(db))
+    status, response, error = perform_employee_introspection(
+        service_auth=auth,
+        authorization="Bearer cfg-token",
+        content_length=None,
+        transfer_encoding=None,
+        session_header_values=None,
+        employee_auth=service,
+    )
+    assert status == 200
+    assert error is None
+    assert response is not None
+    assert response.authenticated is False
+
+
+def test_resolve_session_for_introspection_skips_last_seen(tmp_path: Path) -> None:
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    repo = SQLiteEmployeeAuthRepository(tmp_path / "core.db")
+    service = EmployeeAuthService(repo, now=clock.now)
+    service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "test"},
+    )
+    login = service.authenticate(username="super.admin", password="TempPassw0rd!")
+    session = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session is not None
+    first_seen = session.last_seen_at
+    clock.value = clock.value + timedelta(minutes=6)
+    resolved = service.resolve_session_for_introspection(login.session_token)
+    assert resolved is not None
+    session = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session is not None
+    assert session.last_seen_at == first_seen
+
+
+def test_resolve_session_for_introspection_does_not_revoke_expired(
+    tmp_path: Path,
+) -> None:
+    clock = Clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    repo = SQLiteEmployeeAuthRepository(tmp_path / "core.db")
+    service = EmployeeAuthService(repo, now=clock.now)
+    service.bootstrap_superadmin(
+        username="super.admin",
+        display_name="Super Admin",
+        password="TempPassw0rd!",
+        metadata={"seed": "test"},
+    )
+    login = service.authenticate(username="super.admin", password="TempPassw0rd!")
+    clock.value = clock.value + timedelta(hours=13)
+    assert service.resolve_session_for_introspection(login.session_token) is None
+    session = repo.get_session_by_token_hash(login.session.token_hash)
+    assert session is not None
+    assert session.revoked_at is None


### PR DESCRIPTION
## Summary

- add private employee-session introspection endpoint to Core Office API
- require a dedicated introspection service token
- keep OFFICE_API_TOKEN forbidden for introspection
- return current Core-derived employee principal and effective permissions
- preserve session revocation, expiry, deactivation, auth_version, and live permission changes
- add focused security tests and contract documentation

## Endpoint

POST /office/v1/auth/employee/introspect

Required headers:

- Authorization: Bearer <introspection service token>
- X-Employee-Session: <opaque employee session token>

## Scope

- Core only
- no Configurator integration
- no handoff ticket
- no production activation
- no DET changes

## Verification

- 38 focused tests passed
- 22 employee-auth regression tests passed
- 2723 full-suite tests passed
- coverage 90.0%
- ruff, format, mypy, PDF runtime, and Node tests passed

Made with [Cursor](https://cursor.com)