### PR TITLE
docs(architecture): record configurator integration boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,15 @@ flowchart TD
   SQLite indexes and triggers.
 - Take a verified backup before deploying code that may open the database.
 
+## Configurator integration boundary
+
+Configurator ↔ Core communication uses trusted handoff only.
+
+The former manual JSON proposal export/import workflow
+(`proposal_payload_v1` / `proposal-preview`) has been removed.
+
+Core remains the source of truth for inquiries, offers, and orders.
+
 ## Trust boundaries
 
 | Surface | Exposure | Authentication | Writes production? |


### PR DESCRIPTION
## Summary
Documents the architectural boundary after removal of the legacy proposal preview workflow (PR #83).

Configurator ↔ Core communication uses trusted handoff only. The former manual JSON export/import path (`proposal_payload_v1` / `proposal-preview`) must not be reintroduced.

## Changes
- add **Configurator integration boundary** section to `docs/architecture.md`

Made with [Cursor](https://cursor.com)