### PR TITLE
docs(architecture): record offer sent evidence boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,6 +154,21 @@ Accepted offers may be converted into Orders.
 Order operational states (READY_TO_SEND, kitchen, courier)
 are separate from commercial offer lifecycle.
 
+## Offer sent evidence
+
+Marking an offer as sent appends a SentEvidence record only.
+
+The OfferVersion snapshot is immutable after preparation:
+- positions are not rewritten;
+- prices are not changed;
+- snapshot_hash remains unchanged.
+
+Prepared → Sent is a commercial lifecycle transition represented
+by append-only evidence, not by modifying the OfferVersion itself.
+
+The sent actor, channel, recipient reference and timestamp are stored
+as evidence of the communication event.
+
 ## Trust boundaries
 
 | Surface | Exposure | Authentication | Writes production? |


### PR DESCRIPTION
## Summary
Documents Slice 2: Prepared → Sent is append-only `SentEvidence`, not an OfferVersion mutation.

Stacks on #85 (Configurator and Offer boundary).

## Changes
- add **Offer sent evidence** section to `docs/architecture.md`

## Validation
- docs-only change

Made with [Cursor](https://cursor.com)