### PR TITLE
docs: READY_TO_SEND operational release boundary (Slice 4)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,21 +191,21 @@ Order.source_inquiry_id.
 
 READY_TO_SEND is a derived operational state and is never stored.
 
-An order becomes ready only when operational facts allow release:
+An order is ready only when operational facts satisfy all release conditions:
 
-- the order is not cancelled;
+- order is not cancelled;
 - an effective OrderVersion exists;
 - the effective version has confirmed kitchen print;
-- no pending candidate version blocks release;
-- no operational pause blocks execution.
+- no pending candidate version blocks execution;
+- no operational pause blocks release.
 
-The `request_ready_to_send` operation evaluates current facts and emits
-the operational event. It does not mutate the order into a stored ready state.
+`request_ready_to_send` evaluates current operational facts and emits the
+corresponding event. It does not mutate the order into a stored ready state.
 
-Kitchen print projections are built from:
+Kitchen Print uses OrderPrintProjection:
 
-- OrderVersion for operational event facts;
-- OrderCommercialSnapshot for frozen accepted commercial facts.
+- OrderVersion provides operational event facts;
+- OrderCommercialSnapshot provides frozen accepted commercial facts.
 
 Operational consumers must not read live Offer data.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,28 @@ Offer and Order remain linked through ConversionLink.
 The originating Inquiry remains available through
 Order.source_inquiry_id.
 
+## Order operational release (READY_TO_SEND)
+
+READY_TO_SEND is a derived operational state and is never stored.
+
+An order becomes ready only when operational facts allow release:
+
+- the order is not cancelled;
+- an effective OrderVersion exists;
+- the effective version has confirmed kitchen print;
+- no pending candidate version blocks release;
+- no operational pause blocks execution.
+
+The `request_ready_to_send` operation evaluates current facts and emits
+the operational event. It does not mutate the order into a stored ready state.
+
+Kitchen print projections are built from:
+
+- OrderVersion for operational event facts;
+- OrderCommercialSnapshot for frozen accepted commercial facts.
+
+Operational consumers must not read live Offer data.
+
 ## Trust boundaries
 
 | Surface | Exposure | Authentication | Writes production? |


### PR DESCRIPTION
## Summary
- Adds **Order operational release (READY_TO_SEND)** section to `docs/architecture.md`.
- Documents that READY_TO_SEND is derived, never stored, and that `request_ready_to_send` emits events without mutating order state.
- Clarifies kitchen print projection sources: OrderVersion + OrderCommercialSnapshot, not live Offer.

## Test plan
- [ ] Review section placement after Offer acceptance / order conversion docs
- [ ] Confirm wording matches existing domain behavior (no new fields or APIs)


Made with [Cursor](https://cursor.com)