### PR TITLE
feat: Kitchen Execution implementation (Slice 5 PR C)

### DIFF
--- a/src/catering_system/domain/kitchen_completion_evidence.py
+++ b/src/catering_system/domain/kitchen_completion_evidence.py
@@ -1,0 +1,17 @@
+"""Append-only kitchen execution completion facts — Slice 5."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class KitchenCompletionEvidence:
+    kitchen_completion_evidence_id: str
+    order_id: str
+    order_version_id: str
+    completed_at: datetime
+    recorded_at: datetime
+    recorded_by: str
+    evidence_reference: str

--- a/src/catering_system/repositories/in_memory_kitchen_completion_evidence_repository.py
+++ b/src/catering_system/repositories/in_memory_kitchen_completion_evidence_repository.py
@@ -1,0 +1,26 @@
+"""In-memory kitchen completion evidence for tests."""
+
+from __future__ import annotations
+
+from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
+
+
+class InMemoryKitchenCompletionEvidenceRepository:
+    def __init__(self) -> None:
+        self._by_version: dict[tuple[str, str], KitchenCompletionEvidence] = {}
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> KitchenCompletionEvidence | None:
+        return self._by_version.get((order_id, order_version_id))
+
+    def append(self, evidence: KitchenCompletionEvidence) -> None:
+        key = (evidence.order_id, evidence.order_version_id)
+        existing = self._by_version.get(key)
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("kitchen completion evidence conflict")
+            return
+        self._by_version[key] = evidence

--- a/src/catering_system/repositories/kitchen_completion_evidence_repository.py
+++ b/src/catering_system/repositories/kitchen_completion_evidence_repository.py
@@ -1,0 +1,17 @@
+"""Kitchen completion evidence persistence protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
+
+
+class KitchenCompletionEvidenceRepository(Protocol):
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> KitchenCompletionEvidence | None: ...
+
+    def append(self, evidence: KitchenCompletionEvidence) -> None: ...

--- a/src/catering_system/repositories/sqlite_kitchen_completion_evidence_repository.py
+++ b/src/catering_system/repositories/sqlite_kitchen_completion_evidence_repository.py
@@ -1,0 +1,159 @@
+"""SQLite persistence for append-only kitchen completion evidence."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+
+from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE kitchen_completion_evidence (
+            kitchen_completion_evidence_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            order_version_id TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            recorded_by TEXT NOT NULL,
+            evidence_reference TEXT NOT NULL,
+            UNIQUE (order_id, order_version_id)
+        );
+        CREATE INDEX idx_kitchen_completion_evidence_order_id
+            ON kitchen_completion_evidence (order_id);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_kitchen_completion_evidence_owner_insert
+        BEFORE INSERT ON kitchen_completion_evidence
+        WHEN NOT EXISTS (
+            SELECT 1 FROM orders o
+            JOIN order_versions v ON v.order_version_id = NEW.order_version_id
+            WHERE o.order_id = NEW.order_id
+              AND v.order_id = NEW.order_id
+              AND o.effective_order_version_id = NEW.order_version_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'kitchen completion owner is invalid');
+        END;
+        CREATE TRIGGER trg_kitchen_completion_evidence_immutable_update
+        BEFORE UPDATE ON kitchen_completion_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'kitchen completion evidence is immutable');
+        END;
+        CREATE TRIGGER trg_kitchen_completion_evidence_immutable_delete
+        BEFORE DELETE ON kitchen_completion_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'kitchen completion evidence is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = (
+    (1, "create_kitchen_completion_evidence", _migration_1_create_tables),
+)
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _row_to_evidence(row: tuple) -> KitchenCompletionEvidence:
+    return KitchenCompletionEvidence(
+        kitchen_completion_evidence_id=row[0],
+        order_id=row[1],
+        order_version_id=row[2],
+        completed_at=_parse_datetime(row[3]),
+        recorded_at=_parse_datetime(row[4]),
+        recorded_by=row[5],
+        evidence_reference=row[6],
+    )
+
+
+class SQLiteKitchenCompletionEvidenceRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(
+                self._conn,
+                "kitchen_completion_evidence",
+                _MIGRATIONS,
+            )
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteKitchenCompletionEvidenceRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "kitchen_completion_evidence", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> KitchenCompletionEvidence | None:
+        row = self._conn.execute(
+            """
+            SELECT kitchen_completion_evidence_id, order_id, order_version_id,
+                   completed_at, recorded_at, recorded_by, evidence_reference
+            FROM kitchen_completion_evidence
+            WHERE order_id = ? AND order_version_id = ?
+            """,
+            (order_id, order_version_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_evidence(row)
+
+    def append(self, evidence: KitchenCompletionEvidence) -> None:
+        existing = self.get_by_order_version_id(
+            evidence.order_id,
+            evidence.order_version_id,
+        )
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("kitchen completion evidence conflict")
+            return
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO kitchen_completion_evidence (
+                    kitchen_completion_evidence_id,
+                    order_id,
+                    order_version_id,
+                    completed_at,
+                    recorded_at,
+                    recorded_by,
+                    evidence_reference
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evidence.kitchen_completion_evidence_id,
+                    evidence.order_id,
+                    evidence.order_version_id,
+                    evidence.completed_at.isoformat(),
+                    evidence.recorded_at.isoformat(),
+                    evidence.recorded_by,
+                    evidence.evidence_reference,
+                ),
+            )

--- a/src/catering_system/services/kitchen_execution_service.py
+++ b/src/catering_system/services/kitchen_execution_service.py
@@ -1,0 +1,105 @@
+"""Kitchen execution commands — queue eligibility and completion evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Callable
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
+from catering_system.repositories.kitchen_completion_evidence_repository import (
+    KitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.order_operational_pause_repository import (
+    OrderOperationalPauseRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.operational_core_service import OperationalCoreService
+
+
+class KitchenCompletionBlockedError(ValueError):
+    """Completion rejected because operational release facts are unsatisfied."""
+
+    def __init__(self, reasons: tuple[str, ...]) -> None:
+        super().__init__("kitchen completion blocked")
+        self.reasons = reasons
+
+
+class KitchenCompletionConflictError(ValueError):
+    """Completion evidence already exists with different facts."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class KitchenCompletionRecordResult:
+    evidence: KitchenCompletionEvidence
+    replay: bool
+
+
+class KitchenExecutionService:
+    def __init__(
+        self,
+        order_repository: OrderRepository,
+        evidence_repository: KitchenCompletionEvidenceRepository,
+        *,
+        pause_repository: OrderOperationalPauseRepository | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._orders = order_repository
+        self._evidence = evidence_repository
+        self._core = OperationalCoreService(
+            order_repository,
+            pause_repository=pause_repository,
+        )
+        self._clock = clock or _utc_now
+
+    def record_kitchen_completion(
+        self,
+        order_id: str,
+        order_version_id: str,
+        *,
+        completed_at: datetime,
+        recorded_by: str,
+        evidence_reference: str,
+    ) -> KitchenCompletionRecordResult:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise ValueError("order not found")
+        if order.cancelled_at is not None:
+            raise ValueError("order cancelled")
+        version = self._orders.get_order_version(order_version_id)
+        if version is None or version.order_id != order_id:
+            raise ValueError("order version not owned")
+
+        evaluation = self._core.evaluate_ready_to_send(order_id)
+        if not evaluation.ready:
+            raise KitchenCompletionBlockedError(evaluation.reasons)
+
+        if order.effective_order_version_id != order_version_id:
+            raise ValueError("order version is not effective")
+
+        existing = self._evidence.get_by_order_version_id(order_id, order_version_id)
+        candidate = KitchenCompletionEvidence(
+            kitchen_completion_evidence_id=(
+                existing.kitchen_completion_evidence_id
+                if existing is not None
+                else str(uuid4())
+            ),
+            order_id=order_id,
+            order_version_id=order_version_id,
+            completed_at=completed_at,
+            recorded_at=existing.recorded_at if existing is not None else self._clock(),
+            recorded_by=recorded_by,
+            evidence_reference=evidence_reference,
+        )
+        if existing is not None:
+            if existing != candidate:
+                raise KitchenCompletionConflictError()
+            return KitchenCompletionRecordResult(evidence=existing, replay=True)
+
+        self._evidence.append(candidate)
+        return KitchenCompletionRecordResult(evidence=candidate, replay=False)

--- a/src/catering_system/services/kitchen_queue_projection_service.py
+++ b/src/catering_system/services/kitchen_queue_projection_service.py
@@ -1,0 +1,71 @@
+"""Derived kitchen queue from READY_TO_SEND facts + OrderPrintProjection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_operational_pause_repository import (
+    OrderOperationalPauseRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    OrderPrintProjectionService,
+)
+
+
+@dataclass(frozen=True)
+class KitchenQueueProjectionEntry:
+    order_id: str
+    order_version_id: str
+    projection: OrderPrintProjection
+
+
+class KitchenQueueProjectionService:
+    def __init__(
+        self,
+        order_repository: OrderRepository,
+        snapshot_repository: OrderCommercialSnapshotRepository,
+        *,
+        pause_repository: OrderOperationalPauseRepository | None = None,
+    ) -> None:
+        self._orders = order_repository
+        self._snapshots = snapshot_repository
+        self._core = OperationalCoreService(
+            order_repository,
+            pause_repository=pause_repository,
+        )
+        self._print_projection = OrderPrintProjectionService(
+            order_repository,
+            snapshot_repository,
+        )
+
+    def list_queue(self) -> tuple[KitchenQueueProjectionEntry, ...]:
+        entries: list[KitchenQueueProjectionEntry] = []
+        for order in self._orders.list_orders():
+            evaluation = self._core.evaluate_ready_to_send(order.order_id)
+            if not evaluation.ready:
+                continue
+            effective_id = order.effective_order_version_id
+            if effective_id is None:
+                continue
+            projection = self._print_projection.resolve(
+                order.order_id,
+                effective_id,
+                intent="final",
+            )
+            entries.append(
+                KitchenQueueProjectionEntry(
+                    order_id=order.order_id,
+                    order_version_id=effective_id,
+                    projection=projection,
+                )
+            )
+        entries.sort(
+            key=lambda entry: (entry.projection.event.event_date, entry.order_id)
+        )
+        return tuple(entries)

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -129,6 +129,9 @@ from catering_system.repositories.sqlite_order_confirmation_outbound_repository 
 from catering_system.repositories.sqlite_order_operational_pause_repository import (
     SQLiteOrderOperationalPauseRepository,
 )
+from catering_system.repositories.sqlite_kitchen_completion_evidence_repository import (
+    SQLiteKitchenCompletionEvidenceRepository,
+)
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
@@ -160,6 +163,14 @@ from catering_system.services.employee_auth_service import (
 from catering_system.services.inquiry_service import (
     InquiryService,
     validate_inquiry_source,
+)
+from catering_system.services.kitchen_execution_service import (
+    KitchenCompletionBlockedError,
+    KitchenCompletionConflictError,
+    KitchenExecutionService,
+)
+from catering_system.services.kitchen_queue_projection_service import (
+    KitchenQueueProjectionService,
 )
 from catering_system.services.offer_document_snapshot_service import (
     OfferDocumentNotFoundError,
@@ -518,6 +529,9 @@ class OfficeApi:
         self.operational_pauses = SQLiteOrderOperationalPauseRepository.from_connection(
             connection
         )
+        self.kitchen_completion_evidence = (
+            SQLiteKitchenCompletionEvidenceRepository.from_connection(connection)
+        )
         self.offer_documents = SQLiteOfferDocumentSnapshotRepository.from_connection(
             connection
         )
@@ -612,6 +626,16 @@ class OfficeApi:
         self.buffet_cards_service = BuffetCardsService(
             self.orders,
             self.print_projection_service,
+        )
+        self.kitchen_queue_projection_service = KitchenQueueProjectionService(
+            self.orders,
+            self.commercial_snapshots,
+            pause_repository=self.operational_pauses,
+        )
+        self.kitchen_execution_service = KitchenExecutionService(
+            self.orders,
+            self.kitchen_completion_evidence,
+            pause_repository=self.operational_pauses,
         )
         self.catalog_dish_service = CatalogDishService(self.catalog)
         self.catalog_dish_write_service = CatalogDishWriteService(self.catalog)
@@ -1923,6 +1947,58 @@ class OfficeApi:
             }
         }
 
+    def kitchen_queue(self) -> dict[str, object]:
+        entries = self.kitchen_queue_projection_service.list_queue()
+        return views.kitchen_queue_view(entries)
+
+    def cmd_kitchen_completion(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        order = self._require_active_order(path_ids["id"])
+        expected = expect["current_effective_order_version_id"]
+        if expected is not None and not isinstance(expected, str):
+            raise _invalid()
+        if expected != order.effective_order_version_id:
+            raise ApiError(409, "stale_state")
+        version = self._owned_version(
+            order.order_id,
+            _v_uuid(args["order_version_id"]),
+        )
+        completed_at = (
+            _v_datetime(args["completed_at"])
+            if "completed_at" in args
+            else datetime.now(UTC)
+        )
+        try:
+            result = self.kitchen_execution_service.record_kitchen_completion(
+                order.order_id,
+                version.order_version_id,
+                completed_at=completed_at,
+                recorded_by=_v_str(args["recorded_by"], 200),
+                evidence_reference=_v_str(args["evidence_reference"], 500),
+            )
+        except KitchenCompletionBlockedError as exc:
+            raise ApiError(
+                422,
+                "kitchen_completion_blocked",
+                reasons=list(exc.reasons),
+            ) from exc
+        except KitchenCompletionConflictError as exc:
+            raise ApiError(409, "kitchen_completion_conflict") from exc
+        except ValueError as exc:
+            message = str(exc)
+            if message == "order version is not effective":
+                raise ApiError(422, "order_version_not_effective") from exc
+            if message == "order version not owned":
+                raise ApiError(422, "version_not_owned") from exc
+            raise ApiError(422, "kitchen_completion_blocked") from exc
+        status = 200 if result.replay else 201
+        return status, {
+            "order_id": order.order_id,
+            "order_version_id": version.order_version_id,
+            "evidence": views.kitchen_completion_evidence_shape(result.evidence),
+        }
+
     def _pause_actor_reference(self, args: dict[str, object]) -> str:
         if "actor_reference" in args:
             return _v_str(args["actor_reference"], 200)
@@ -2358,6 +2434,12 @@ _PAYMENT_REMINDER_ARGS = _ArgKeys(
     )
 )
 _CONFIRMATION_DOCUMENT_ARGS = _ArgKeys(required=frozenset({"created_by"}))
+_KITCHEN_COMPLETION_ARGS = _ArgKeys(
+    required=frozenset(
+        {"order_version_id", "recorded_by", "evidence_reference"},
+    ),
+    optional=frozenset({"completed_at"}),
+)
 _CONFIRMATION_DOCUMENT_SEND_ARGS = _ArgKeys(
     required=frozenset({"document_snapshot_id", "requested_by"})
 )
@@ -2446,6 +2528,11 @@ _COMMANDS: dict[str, _CommandSpec] = {
         },
     ),
     "ready": _CommandSpec("cmd_ready", _NO_ARGS, set()),
+    "kitchen-completion": _CommandSpec(
+        "cmd_kitchen_completion",
+        _KITCHEN_COMPLETION_ARGS,
+        {"current_effective_order_version_id"},
+    ),
     "pause": _CommandSpec(
         "cmd_pause",
         _PAUSE_ARGS,
@@ -2496,6 +2583,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         {"POST": "configurator-handoff-exchange"},
     ),
     (re.compile(r"^/office/v1/queue$"), "/office/v1/queue", {"GET": "queue"}),
+    (
+        re.compile(r"^/office/v1/kitchen-queue$"),
+        "/office/v1/kitchen-queue",
+        {"GET": "kitchen_queue"},
+    ),
     (
         re.compile(r"^/office/v1/work-center$"),
         "/office/v1/work-center",
@@ -2715,6 +2807,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/ready$"),
         "/office/v1/orders/{id}/ready",
         {"POST": "ready"},
+    ),
+    (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/kitchen-completion$"),
+        "/office/v1/orders/{id}/kitchen-completion",
+        {"POST": "kitchen-completion"},
     ),
     (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/pause$"),
@@ -3147,6 +3244,9 @@ def make_office_api_handler(
             if kind == "queue":
                 self._query(set())
                 self._respond(200, api.queue_view())
+            elif kind == "kitchen_queue":
+                self._query(set())
+                self._respond(200, api.kitchen_queue())
             elif kind == "work_center":
                 self._query(set())
                 self._respond(200, api.work_center())

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -22,6 +22,7 @@ from catering_system.domain.inquiry_customer_snapshot import (
     customer_snapshot_to_mapping,
 )
 from catering_system.domain.email_intake_projection import EmailIntakeProjection
+from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
 from catering_system.domain.inquiry import (
     Inquiry,
     InquiryOfferProjection,
@@ -54,6 +55,9 @@ from catering_system.services.order_print_projection_service import (
     PrintPositionLine,
 )
 from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
+from catering_system.services.kitchen_queue_projection_service import (
+    KitchenQueueProjectionEntry,
+)
 from catering_system.domain.catalog import allergen_labels
 from catering_system.services.catalog_dish_service import (
     AllergenCodeDefinition,
@@ -1270,5 +1274,34 @@ def allergen_codes_view(
     return {
         "allergen_codes": [
             {"code": item.code, "label": item.label} for item in definitions
+        ]
+    }
+
+
+def kitchen_completion_evidence_shape(
+    evidence: KitchenCompletionEvidence,
+) -> dict[str, object]:
+    return {
+        "kitchen_completion_evidence_id": evidence.kitchen_completion_evidence_id,
+        "order_id": evidence.order_id,
+        "order_version_id": evidence.order_version_id,
+        "completed_at": evidence.completed_at.isoformat(),
+        "recorded_at": evidence.recorded_at.isoformat(),
+        "recorded_by": evidence.recorded_by,
+        "evidence_reference": evidence.evidence_reference,
+    }
+
+
+def kitchen_queue_view(
+    entries: tuple[KitchenQueueProjectionEntry, ...],
+) -> dict[str, object]:
+    return {
+        "entries": [
+            {
+                "order_id": entry.order_id,
+                "order_version_id": entry.order_version_id,
+                "projection": order_print_projection_shape(entry.projection),
+            }
+            for entry in entries
         ]
     }

--- a/tests/helpers/kitchen_queue_contract.py
+++ b/tests/helpers/kitchen_queue_contract.py
@@ -1,12 +1,6 @@
-"""Slice 5 kitchen queue contract — reference for PR C KitchenQueueProjectionService.
-
-This module defines the eligibility + projection boundary only. Production code
-must match this contract without reading live Offer or catalog write models.
-"""
+"""Slice 5 kitchen queue contract — delegates to KitchenQueueProjectionService."""
 
 from __future__ import annotations
-
-from dataclasses import dataclass
 
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
@@ -15,18 +9,15 @@ from catering_system.repositories.order_operational_pause_repository import (
     OrderOperationalPauseRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
-from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.services.order_print_projection_service import (
-    OrderPrintProjection,
-    OrderPrintProjectionService,
+from catering_system.services.kitchen_queue_projection_service import (
+    KitchenQueueProjectionEntry,
+    KitchenQueueProjectionService,
 )
 
-
-@dataclass(frozen=True)
-class KitchenQueueProjectionEntry:
-    order_id: str
-    order_version_id: str
-    projection: OrderPrintProjection
+__all__ = (
+    "KitchenQueueProjectionEntry",
+    "build_kitchen_queue_projection",
+)
 
 
 def build_kitchen_queue_projection(
@@ -35,34 +26,9 @@ def build_kitchen_queue_projection(
     *,
     pause_repository: OrderOperationalPauseRepository | None = None,
 ) -> tuple[KitchenQueueProjectionEntry, ...]:
-    """Derived kitchen queue: READY_TO_SEND gate + OrderPrintProjection only."""
-    core = OperationalCoreService(
-        order_repository,
-        pause_repository=pause_repository,
-    )
-    print_projection = OrderPrintProjectionService(
+    """Contract helper used by Slice 5 tests."""
+    return KitchenQueueProjectionService(
         order_repository,
         snapshot_repository,
-    )
-    entries: list[KitchenQueueProjectionEntry] = []
-    for order in order_repository.list_orders():
-        evaluation = core.evaluate_ready_to_send(order.order_id)
-        if not evaluation.ready:
-            continue
-        effective_id = order.effective_order_version_id
-        if effective_id is None:
-            continue
-        projection = print_projection.resolve(
-            order.order_id,
-            effective_id,
-            intent="final",
-        )
-        entries.append(
-            KitchenQueueProjectionEntry(
-                order_id=order.order_id,
-                order_version_id=effective_id,
-                projection=projection,
-            )
-        )
-    entries.sort(key=lambda entry: (entry.projection.event.event_date, entry.order_id))
-    return tuple(entries)
+        pause_repository=pause_repository,
+    ).list_queue()

--- a/tests/helpers/kitchen_queue_contract.py
+++ b/tests/helpers/kitchen_queue_contract.py
@@ -1,0 +1,68 @@
+"""Slice 5 kitchen queue contract — reference for PR C KitchenQueueProjectionService.
+
+This module defines the eligibility + projection boundary only. Production code
+must match this contract without reading live Offer or catalog write models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_operational_pause_repository import (
+    OrderOperationalPauseRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    OrderPrintProjectionService,
+)
+
+
+@dataclass(frozen=True)
+class KitchenQueueProjectionEntry:
+    order_id: str
+    order_version_id: str
+    projection: OrderPrintProjection
+
+
+def build_kitchen_queue_projection(
+    order_repository: OrderRepository,
+    snapshot_repository: OrderCommercialSnapshotRepository,
+    *,
+    pause_repository: OrderOperationalPauseRepository | None = None,
+) -> tuple[KitchenQueueProjectionEntry, ...]:
+    """Derived kitchen queue: READY_TO_SEND gate + OrderPrintProjection only."""
+    core = OperationalCoreService(
+        order_repository,
+        pause_repository=pause_repository,
+    )
+    print_projection = OrderPrintProjectionService(
+        order_repository,
+        snapshot_repository,
+    )
+    entries: list[KitchenQueueProjectionEntry] = []
+    for order in order_repository.list_orders():
+        evaluation = core.evaluate_ready_to_send(order.order_id)
+        if not evaluation.ready:
+            continue
+        effective_id = order.effective_order_version_id
+        if effective_id is None:
+            continue
+        projection = print_projection.resolve(
+            order.order_id,
+            effective_id,
+            intent="final",
+        )
+        entries.append(
+            KitchenQueueProjectionEntry(
+                order_id=order.order_id,
+                order_version_id=effective_id,
+                projection=projection,
+            )
+        )
+    entries.sort(key=lambda entry: (entry.projection.event.event_date, entry.order_id))
+    return tuple(entries)

--- a/tests/unit/test_kitchen_execution_contract.py
+++ b/tests/unit/test_kitchen_execution_contract.py
@@ -1,0 +1,189 @@
+"""Slice 5 contract tests — Kitchen Execution boundary (docs-only PR B).
+
+Proves READY_TO_SEND eligibility drives kitchen queue membership and that queue
+payload comes from OrderPrintProjection only. No domain/service/API changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+
+from catering_system.domain.ready_to_send import (
+    READY_REASON_KITCHEN_PRINT_NOT_CONFIRMED,
+    READY_REASON_NO_EFFECTIVE_VERSION,
+    READY_REASON_PENDING_ORDER_VERSION_CHANGE,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_service import OrderService
+from catering_system.ui.office_panel_views import render_print_sheet
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+from tests.helpers.kitchen_queue_contract import build_kitchen_queue_projection
+from tests.helpers.order_seed import seed_order
+from tests.unit.test_effective_order_version_change_gate import _effective_v1
+from tests.unit.test_offer_service import _accepted_offer_state, _sample_inquiry
+
+
+def _queue_order_ids(
+    orders: InMemoryOrderRepository,
+    snapshots: InMemoryOrderCommercialSnapshotRepository,
+) -> set[str]:
+    return {entry.order_id for entry in build_kitchen_queue_projection(orders, snapshots)}
+
+
+def test_kitchen_queue_excludes_order_without_effective_version() -> None:
+    orders = InMemoryOrderRepository()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
+    order, _version = seed_order(orders, _sample_inquiry())
+    seed_commercial_snapshot(snapshots, order.order_id)
+
+    core = OperationalCoreService(orders)
+    evaluation = core.evaluate_ready_to_send(order.order_id)
+    assert evaluation.ready is False
+    assert evaluation.reasons == (READY_REASON_NO_EFFECTIVE_VERSION,)
+
+    assert order.order_id not in _queue_order_ids(orders, snapshots)
+
+
+def test_kitchen_queue_excludes_order_without_kitchen_print_confirmation() -> None:
+    orders = InMemoryOrderRepository()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
+    order, version = seed_order(orders, _sample_inquiry())
+    seed_commercial_snapshot(snapshots, order.order_id)
+    orders.update_order(
+        replace(order, effective_order_version_id=version.order_version_id),
+    )
+
+    core = OperationalCoreService(orders)
+    evaluation = core.evaluate_ready_to_send(order.order_id)
+    assert evaluation.ready is False
+    assert evaluation.reasons == (READY_REASON_KITCHEN_PRINT_NOT_CONFIRMED,)
+
+    assert order.order_id not in _queue_order_ids(orders, snapshots)
+
+
+def test_kitchen_queue_excludes_order_with_pending_candidate_change() -> None:
+    repository, order_service, core, _events, order, v1 = _effective_v1()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
+    seed_commercial_snapshot(snapshots, order.order_id)
+
+    order_service.propose_order_version_change(
+        order.order_id,
+        event_date=date(2026, 10, 2),
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=v1.guest_count_estimate,
+        planning_mode=v1.planning_mode,
+        actor_reference="office-panel",
+        change_reason="Termin verschoben",
+    )
+
+    evaluation = core.evaluate_ready_to_send(order.order_id)
+    assert evaluation.ready is False
+    assert evaluation.reasons == (READY_REASON_PENDING_ORDER_VERSION_CHANGE,)
+
+    assert order.order_id not in _queue_order_ids(repository, snapshots)
+
+
+def test_ready_order_appears_in_kitchen_queue_from_order_print_projection() -> None:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = service._commercial_snapshots
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+
+    assert core.evaluate_ready_to_send(order.order_id).ready is True
+
+    queue = build_kitchen_queue_projection(orders, snapshots)
+    assert len(queue) == 1
+    entry = queue[0]
+    assert entry.order_id == order.order_id
+    assert entry.order_version_id == order_version.order_version_id
+    assert entry.projection.commercial.source == "offer_conversion"
+    assert entry.projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert render_print_sheet(entry.projection)
+
+
+def test_kitchen_queue_projection_ignores_live_offer_mutations() -> None:
+    offer, version_id, variant_id, acceptance_id, offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = service._commercial_snapshots
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    version = stored.versions[0]
+    variant = version.variants[0]
+    offers._offers[stored.offer_id] = replace(
+        stored,
+        versions=(
+            replace(
+                version,
+                variants=(
+                    replace(
+                        variant,
+                        positions=(
+                            replace(variant.positions[0], name="MUTATED LIVE OFFER"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    entry = build_kitchen_queue_projection(orders, snapshots)[0]
+    assert entry.projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert "MUTATED LIVE OFFER" not in render_print_sheet(entry.projection)
+
+
+def test_kitchen_queue_contract_must_not_depend_on_offer_or_catalog() -> None:
+    contract_path = (
+        Path(__file__).resolve().parents[1] / "helpers" / "kitchen_queue_contract.py"
+    )
+    text = contract_path.read_text(encoding="utf-8")
+    forbidden = (
+        "OfferRepository",
+        "offer_repository",
+        "conversion_link",
+        "Configurator",
+        "catalog_repository",
+        "CatalogRepository",
+    )
+    for token in forbidden:
+        assert token not in text, token
+
+    services_root = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "catering_system"
+        / "services"
+    )
+    production_module = services_root / "kitchen_queue_projection_service.py"
+    if production_module.exists():
+        production_text = production_module.read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in production_text, production_module.name

--- a/tests/unit/test_kitchen_execution_flow.py
+++ b/tests/unit/test_kitchen_execution_flow.py
@@ -1,0 +1,166 @@
+"""Integration test: READY_TO_SEND → kitchen queue → completion evidence."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.sqlite_kitchen_completion_evidence_repository import (
+    SQLiteKitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from tests.unit.test_office_api import (
+    _MARK_SENT_ARGS,
+    _RECORD_ACCEPTANCE_ARGS,
+    _VARIANT_ID,
+    _convert_accepted_url,
+    _get,
+    _mark_sent_url,
+    _post,
+    _prepare_offer_url,
+    _record_acceptance_url,
+    _seed,
+    _seed_employee_auth,
+    _start_api_server,
+    _valid_offer_snapshot,
+)
+
+_COMPLETED_AT = datetime(2026, 8, 7, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture()
+def office_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from catering_system.ui import office_api_views
+
+    monkeypatch.setattr(
+        office_api_views,
+        "berlin_today",
+        lambda: date(2026, 7, 15),
+    )
+    db = tmp_path / "core.db"
+    ids = _seed(db)
+    _seed_employee_auth(db)
+    server, thread, base = _start_api_server(db)
+    yield base, ids, db
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+
+
+def _release_order(
+    office_api: tuple[str, dict[str, str], Path],
+) -> tuple[str, str, str]:
+    base, ids, _db = office_api
+    inquiry_id = ids["inquiry_offer_ready"]
+
+    prepare_status, prepare_body, _headers = _post(
+        _prepare_offer_url(base, inquiry_id),
+        args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
+    )
+    assert prepare_status == 201
+    offer_id = prepare_body["offer_id"]
+    version_id = prepare_body["offer_version_id"]
+
+    assert (
+        _post(_mark_sent_url(base, offer_id, version_id), args=_MARK_SENT_ARGS)[0]
+        == 200
+    )
+    accept_status, accept_body, _headers = _post(
+        _record_acceptance_url(base, offer_id, version_id),
+        args=_RECORD_ACCEPTANCE_ARGS,
+    )
+    assert accept_status == 200
+
+    convert_status, convert_body, _headers = _post(
+        _convert_accepted_url(base, offer_id, version_id),
+        args={
+            "accepted_variant_id": _VARIANT_ID,
+            "acceptance_id": accept_body["acceptance_id"],
+        },
+    )
+    assert convert_status == 201
+    order_id = convert_body["order_id"]
+    order_version_id = convert_body["order_version_id"]
+
+    assert (
+        _post(
+            f"{base}/office/v1/orders/{order_id}/print-confirm",
+            args={"order_version_id": order_version_id},
+        )[0]
+        == 200
+    )
+    assert (
+        _post(
+            f"{base}/office/v1/orders/{order_id}/effective",
+            args={"order_version_id": order_version_id},
+            expect={
+                "current_effective_order_version_id": None,
+                "current_candidate_order_version_id": None,
+            },
+        )[0]
+        == 200
+    )
+    assert (
+        _post(f"{base}/office/v1/orders/{order_id}/ready")[1]["evaluation"]["ready"]
+        is True
+    )
+    return base, order_id, order_version_id
+
+
+def test_released_order_flows_through_kitchen_queue_to_completion_evidence(
+    office_api: tuple[str, dict[str, str], Path],
+) -> None:
+    base, order_id, order_version_id = _release_order(office_api)
+    _base, _ids, db = office_api
+
+    queue_status, queue_body, _headers = _get(f"{base}/office/v1/kitchen-queue")
+    assert queue_status == 200
+    matching = [entry for entry in queue_body["entries"] if entry["order_id"] == order_id]
+    assert len(matching) == 1
+    entry = matching[0]
+    assert entry["order_id"] == order_id
+    assert entry["order_version_id"] == order_version_id
+    assert entry["projection"]["commercial"]["source"] == "offer_conversion"
+
+    completion_args = {
+        "order_version_id": order_version_id,
+        "recorded_by": "kitchen-panel",
+        "evidence_reference": "ticket-42",
+        "completed_at": _COMPLETED_AT.isoformat(),
+    }
+    first_status, first_body, _headers = _post(
+        f"{base}/office/v1/orders/{order_id}/kitchen-completion",
+        args=completion_args,
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert first_status == 201
+    evidence_id = first_body["evidence"]["kitchen_completion_evidence_id"]
+
+    second_status, second_body, _headers = _post(
+        f"{base}/office/v1/orders/{order_id}/kitchen-completion",
+        args=completion_args,
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert second_status == 200
+    assert (
+        second_body["evidence"]["kitchen_completion_evidence_id"] == evidence_id
+    )
+
+    orders = SQLiteOrderRepository(db)
+    order_before = orders.get_order(order_id)
+    version_before = orders.get_order_version(order_version_id)
+    orders.close()
+
+    evidence_repo = SQLiteKitchenCompletionEvidenceRepository(db)
+    stored = evidence_repo.get_by_order_version_id(order_id, order_version_id)
+    evidence_repo.close()
+    assert stored is not None
+    assert stored.evidence_reference == "ticket-42"
+
+    orders = SQLiteOrderRepository(db)
+    assert orders.get_order(order_id) == order_before
+    assert orders.get_order_version(order_version_id) == version_before
+    orders.close()

--- a/tests/unit/test_kitchen_execution_service.py
+++ b/tests/unit/test_kitchen_execution_service.py
@@ -1,0 +1,183 @@
+"""Unit tests — KitchenExecutionService completion evidence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from catering_system.domain.ready_to_send import READY_REASON_NO_EFFECTIVE_VERSION
+from catering_system.repositories.in_memory_kitchen_completion_evidence_repository import (
+    InMemoryKitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.kitchen_execution_service import (
+    KitchenCompletionBlockedError,
+    KitchenCompletionConflictError,
+    KitchenExecutionService,
+)
+from catering_system.services.kitchen_queue_projection_service import (
+    KitchenQueueProjectionService,
+)
+from catering_system.services.operational_core_service import OperationalCoreService
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+from tests.helpers.order_seed import seed_order
+from tests.unit.test_offer_service import _accepted_offer_state, _sample_inquiry
+
+_NOW = datetime(2026, 8, 7, 9, 0, tzinfo=UTC)
+
+
+def _ready_order() -> tuple[
+    InMemoryOrderRepository,
+    InMemoryOrderCommercialSnapshotRepository,
+    str,
+    str,
+]:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = service._commercial_snapshots
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+    assert core.evaluate_ready_to_send(order.order_id).ready is True
+    return orders, snapshots, order.order_id, order_version.order_version_id
+
+
+def test_record_kitchen_completion_persists_append_only_evidence() -> None:
+    orders, _snapshots, order_id, version_id = _ready_order()
+    evidence_repo = InMemoryKitchenCompletionEvidenceRepository()
+    service = KitchenExecutionService(
+        orders,
+        evidence_repo,
+        clock=lambda: _NOW,
+    )
+
+    result = service.record_kitchen_completion(
+        order_id,
+        version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+    assert result.replay is False
+    stored = evidence_repo.get_by_order_version_id(order_id, version_id)
+    assert stored == result.evidence
+
+
+def test_record_kitchen_completion_replay_is_idempotent() -> None:
+    orders, _snapshots, order_id, version_id = _ready_order()
+    evidence_repo = InMemoryKitchenCompletionEvidenceRepository()
+    service = KitchenExecutionService(
+        orders,
+        evidence_repo,
+        clock=lambda: _NOW,
+    )
+    first = service.record_kitchen_completion(
+        order_id,
+        version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+    second = service.record_kitchen_completion(
+        order_id,
+        version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+    assert first.evidence == second.evidence
+    assert second.replay is True
+
+
+def test_record_kitchen_completion_rejects_conflicting_replay() -> None:
+    orders, _snapshots, order_id, version_id = _ready_order()
+    evidence_repo = InMemoryKitchenCompletionEvidenceRepository()
+    service = KitchenExecutionService(
+        orders,
+        evidence_repo,
+        clock=lambda: _NOW,
+    )
+    service.record_kitchen_completion(
+        order_id,
+        version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+    with pytest.raises(KitchenCompletionConflictError):
+        service.record_kitchen_completion(
+            order_id,
+            version_id,
+            completed_at=_NOW,
+            recorded_by="kitchen-panel",
+            evidence_reference="ticket-99",
+        )
+
+
+def test_record_kitchen_completion_blocked_when_not_ready() -> None:
+    orders = InMemoryOrderRepository()
+    snapshots = InMemoryOrderCommercialSnapshotRepository()
+    order, version = seed_order(orders, _sample_inquiry())
+    seed_commercial_snapshot(snapshots, order.order_id)
+    service = KitchenExecutionService(orders, InMemoryKitchenCompletionEvidenceRepository())
+
+    with pytest.raises(KitchenCompletionBlockedError) as exc_info:
+        service.record_kitchen_completion(
+            order.order_id,
+            version.order_version_id,
+            completed_at=_NOW,
+            recorded_by="kitchen-panel",
+            evidence_reference="ticket-1",
+        )
+    assert exc_info.value.reasons == (READY_REASON_NO_EFFECTIVE_VERSION,)
+
+
+def test_kitchen_queue_and_completion_do_not_mutate_order_version() -> None:
+    orders, snapshots, order_id, version_id = _ready_order()
+    before = orders.get_order_version(version_id)
+    assert before is not None
+
+    queue = KitchenQueueProjectionService(orders, snapshots).list_queue()
+    assert len(queue) == 1
+
+    KitchenExecutionService(
+        orders,
+        InMemoryKitchenCompletionEvidenceRepository(),
+        clock=lambda: _NOW,
+    ).record_kitchen_completion(
+        order_id,
+        version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+
+    after = orders.get_order_version(version_id)
+    assert after == before
+
+
+def test_kitchen_execution_services_must_not_depend_on_offer_or_catalog() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system" / "services"
+    for name in (
+        "kitchen_queue_projection_service.py",
+        "kitchen_execution_service.py",
+    ):
+        text = (root / name).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, name
+        assert "offer_repository" not in text, name
+        assert "CatalogRepository" not in text, name


### PR DESCRIPTION
## Summary
- Implements `KitchenQueueProjectionService` — derived queue from `evaluate_ready_to_send()` + `OrderPrintProjectionService` (no stored queue status, no Offer reads).
- Adds append-only `KitchenCompletionEvidence` with SQLite/in-memory repositories and `KitchenExecutionService.record_kitchen_completion()` (idempotent replay, conflict on mismatched facts).
- Wires minimal Office API: `GET /office/v1/kitchen-queue`, `POST /office/v1/orders/{id}/kitchen-completion`.
- Includes PR B contract tests (delegating to production service), service unit tests, and end-to-end integration test.

## Architectural guarantees
- Kitchen queue eligibility = fresh READY_TO_SEND facts
- Queue payload only from OrderPrintProjection (OrderVersion + OrderCommercialSnapshot)
- Completion evidence does not mutate OrderVersion or commercial snapshot
- Static guards prevent Offer/catalog coupling in kitchen services

## Explicitly out of scope
- ProductionTask, kitchen statuses, employee assignment, SLA, courier

## Test plan
- [x] `pytest tests/unit/test_kitchen_execution_contract.py -v`
- [x] `pytest tests/unit/test_kitchen_execution_service.py -v`
- [x] `pytest tests/unit/test_kitchen_execution_flow.py -v`


Made with [Cursor](https://cursor.com)