### PR TITLE
feat: Delivery Execution implementation (Slice 6 PR C)

### DIFF
--- a/src/catering_system/domain/delivery_completion_evidence.py
+++ b/src/catering_system/domain/delivery_completion_evidence.py
@@ -1,0 +1,17 @@
+"""Append-only delivery completion facts — Slice 6."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class DeliveryCompletionEvidence:
+    delivery_completion_evidence_id: str
+    order_id: str
+    order_version_id: str
+    completed_at: datetime
+    recorded_at: datetime
+    recorded_by: str
+    evidence_reference: str

--- a/src/catering_system/domain/dispatch_evidence.py
+++ b/src/catering_system/domain/dispatch_evidence.py
@@ -1,0 +1,17 @@
+"""Append-only dispatch execution facts — Slice 6."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class DispatchEvidence:
+    dispatch_evidence_id: str
+    order_id: str
+    order_version_id: str
+    dispatched_at: datetime
+    recorded_at: datetime
+    recorded_by: str
+    evidence_reference: str

--- a/src/catering_system/domain/order_delivery_snapshot.py
+++ b/src/catering_system/domain/order_delivery_snapshot.py
@@ -1,0 +1,122 @@
+"""Frozen operational delivery facts at offer conversion — Slice 6."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry import FulfillmentMode, Inquiry
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.order import OrderVersion
+
+_CREATED_FROM = "accepted_order_conversion"
+_MAX_TEXT = 20_000
+
+
+class MissingDeliverySnapshotError(LookupError):
+    """Order/version has no OrderDeliverySnapshot."""
+
+    def __init__(self, order_id: str, order_version_id: str) -> None:
+        self.order_id = order_id
+        self.order_version_id = order_version_id
+        super().__init__(
+            "order delivery snapshot missing "
+            f"(order_id={order_id!r}, order_version_id={order_version_id!r})"
+        )
+
+
+def format_delivery_address(address: CustomerAddress | None) -> str | None:
+    if address is None:
+        return None
+    lines = [
+        value
+        for value in (
+            (address.street or "").strip(),
+            " ".join(
+                part
+                for part in (
+                    (address.postal_code or "").strip(),
+                    (address.city or "").strip(),
+                )
+                if part
+            ),
+            (address.country or "").strip(),
+        )
+        if value
+    ]
+    if not lines:
+        return None
+    text = "\n".join(lines)
+    if len(text) > _MAX_TEXT:
+        raise ValueError("delivery_address exceeds length limit")
+    return text
+
+
+def _resolved_delivery_address(
+    snapshot: InquiryCustomerSnapshot,
+) -> CustomerAddress | None:
+    if snapshot.delivery_address_mode == "SEPARATE":
+        return snapshot.delivery_address
+    if snapshot.delivery_address_mode == "SAME_AS_INVOICE":
+        return snapshot.invoice_address
+    return None
+
+
+def _delivery_contact(snapshot: InquiryCustomerSnapshot) -> str | None:
+    contact = snapshot.email or snapshot.phone or snapshot.contact_name
+    if contact is None:
+        return None
+    contact = contact.strip()
+    if not contact:
+        return None
+    if len(contact) > _MAX_TEXT:
+        raise ValueError("delivery_contact exceeds length limit")
+    return contact
+
+
+@dataclass(frozen=True)
+class OrderDeliverySnapshot:
+    snapshot_id: str
+    order_id: str
+    order_version_id: str
+    fulfillment_mode: FulfillmentMode
+    delivery_address: str | None
+    delivery_contact: str | None
+    time_window_text: str
+    location_text: str
+    created_from: str = _CREATED_FROM
+
+    def __post_init__(self) -> None:
+        if self.created_from != _CREATED_FROM:
+            raise ValueError("unsupported delivery snapshot source")
+        if not self.time_window_text.strip():
+            raise ValueError("time_window_text is required")
+        if not self.location_text.strip():
+            raise ValueError("location_text is required")
+        if self.fulfillment_mode == "PICKUP":
+            if self.delivery_address is not None:
+                raise ValueError("PICKUP must not store delivery_address")
+
+
+def build_order_delivery_snapshot(
+    *,
+    order_id: str,
+    order_version: OrderVersion,
+    inquiry: Inquiry,
+) -> OrderDeliverySnapshot:
+    customer = inquiry.customer_snapshot
+    fulfillment_mode = inquiry.fulfillment_mode
+    delivery_address: str | None = None
+    if fulfillment_mode == "DELIVERY":
+        delivery_address = format_delivery_address(_resolved_delivery_address(customer))
+    return OrderDeliverySnapshot(
+        snapshot_id=str(uuid.uuid4()),
+        order_id=order_id,
+        order_version_id=order_version.order_version_id,
+        fulfillment_mode=fulfillment_mode,
+        delivery_address=delivery_address,
+        delivery_contact=_delivery_contact(customer),
+        time_window_text=order_version.time_window_text,
+        location_text=order_version.location_text,
+    )

--- a/src/catering_system/repositories/delivery_completion_evidence_repository.py
+++ b/src/catering_system/repositories/delivery_completion_evidence_repository.py
@@ -1,0 +1,17 @@
+"""Delivery completion evidence persistence protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.delivery_completion_evidence import DeliveryCompletionEvidence
+
+
+class DeliveryCompletionEvidenceRepository(Protocol):
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DeliveryCompletionEvidence | None: ...
+
+    def append(self, evidence: DeliveryCompletionEvidence) -> None: ...

--- a/src/catering_system/repositories/dispatch_evidence_repository.py
+++ b/src/catering_system/repositories/dispatch_evidence_repository.py
@@ -1,0 +1,17 @@
+"""Dispatch evidence persistence protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.dispatch_evidence import DispatchEvidence
+
+
+class DispatchEvidenceRepository(Protocol):
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DispatchEvidence | None: ...
+
+    def append(self, evidence: DispatchEvidence) -> None: ...

--- a/src/catering_system/repositories/in_memory_delivery_completion_evidence_repository.py
+++ b/src/catering_system/repositories/in_memory_delivery_completion_evidence_repository.py
@@ -1,0 +1,26 @@
+"""In-memory delivery completion evidence for tests."""
+
+from __future__ import annotations
+
+from catering_system.domain.delivery_completion_evidence import DeliveryCompletionEvidence
+
+
+class InMemoryDeliveryCompletionEvidenceRepository:
+    def __init__(self) -> None:
+        self._by_version: dict[tuple[str, str], DeliveryCompletionEvidence] = {}
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DeliveryCompletionEvidence | None:
+        return self._by_version.get((order_id, order_version_id))
+
+    def append(self, evidence: DeliveryCompletionEvidence) -> None:
+        key = (evidence.order_id, evidence.order_version_id)
+        existing = self._by_version.get(key)
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("delivery completion evidence conflict")
+            return
+        self._by_version[key] = evidence

--- a/src/catering_system/repositories/in_memory_dispatch_evidence_repository.py
+++ b/src/catering_system/repositories/in_memory_dispatch_evidence_repository.py
@@ -1,0 +1,26 @@
+"""In-memory dispatch evidence for tests."""
+
+from __future__ import annotations
+
+from catering_system.domain.dispatch_evidence import DispatchEvidence
+
+
+class InMemoryDispatchEvidenceRepository:
+    def __init__(self) -> None:
+        self._by_version: dict[tuple[str, str], DispatchEvidence] = {}
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DispatchEvidence | None:
+        return self._by_version.get((order_id, order_version_id))
+
+    def append(self, evidence: DispatchEvidence) -> None:
+        key = (evidence.order_id, evidence.order_version_id)
+        existing = self._by_version.get(key)
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("dispatch evidence conflict")
+            return
+        self._by_version[key] = evidence

--- a/src/catering_system/repositories/in_memory_order_delivery_snapshot_repository.py
+++ b/src/catering_system/repositories/in_memory_order_delivery_snapshot_repository.py
@@ -1,0 +1,23 @@
+"""In-memory OrderDeliverySnapshot repository for tests."""
+
+from __future__ import annotations
+
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
+
+
+class InMemoryOrderDeliverySnapshotRepository:
+    def __init__(self) -> None:
+        self._by_version: dict[tuple[str, str], OrderDeliverySnapshot] = {}
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> OrderDeliverySnapshot | None:
+        return self._by_version.get((order_id, order_version_id))
+
+    def create(self, snapshot: OrderDeliverySnapshot) -> None:
+        key = (snapshot.order_id, snapshot.order_version_id)
+        if key in self._by_version:
+            raise ValueError("order delivery snapshot already exists")
+        self._by_version[key] = snapshot

--- a/src/catering_system/repositories/order_delivery_snapshot_repository.py
+++ b/src/catering_system/repositories/order_delivery_snapshot_repository.py
@@ -1,0 +1,17 @@
+"""OrderDeliverySnapshot persistence protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
+
+
+class OrderDeliverySnapshotRepository(Protocol):
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> OrderDeliverySnapshot | None: ...
+
+    def create(self, snapshot: OrderDeliverySnapshot) -> None: ...

--- a/src/catering_system/repositories/sqlite_delivery_completion_evidence_repository.py
+++ b/src/catering_system/repositories/sqlite_delivery_completion_evidence_repository.py
@@ -1,0 +1,157 @@
+"""SQLite persistence for append-only delivery completion evidence."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+
+from catering_system.domain.delivery_completion_evidence import DeliveryCompletionEvidence
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE delivery_completion_evidence (
+            delivery_completion_evidence_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            order_version_id TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            recorded_by TEXT NOT NULL,
+            evidence_reference TEXT NOT NULL,
+            UNIQUE (order_id, order_version_id)
+        );
+        CREATE INDEX idx_delivery_completion_evidence_order_id
+            ON delivery_completion_evidence (order_id);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_delivery_completion_evidence_owner_insert
+        BEFORE INSERT ON delivery_completion_evidence
+        WHEN NOT EXISTS (
+            SELECT 1 FROM orders o
+            JOIN order_versions v ON v.order_version_id = NEW.order_version_id
+            JOIN dispatch_evidence d
+              ON d.order_id = o.order_id
+             AND d.order_version_id = NEW.order_version_id
+            WHERE o.order_id = NEW.order_id
+              AND v.order_id = NEW.order_id
+              AND o.effective_order_version_id = NEW.order_version_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'delivery completion evidence owner is invalid');
+        END;
+        CREATE TRIGGER trg_delivery_completion_evidence_immutable_update
+        BEFORE UPDATE ON delivery_completion_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'delivery completion evidence is immutable');
+        END;
+        CREATE TRIGGER trg_delivery_completion_evidence_immutable_delete
+        BEFORE DELETE ON delivery_completion_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'delivery completion evidence is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = (
+    (1, "create_delivery_completion_evidence", _migration_1_create_tables),
+)
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _row_to_evidence(row: tuple) -> DeliveryCompletionEvidence:
+    return DeliveryCompletionEvidence(
+        delivery_completion_evidence_id=row[0],
+        order_id=row[1],
+        order_version_id=row[2],
+        completed_at=_parse_datetime(row[3]),
+        recorded_at=_parse_datetime(row[4]),
+        recorded_by=row[5],
+        evidence_reference=row[6],
+    )
+
+
+class SQLiteDeliveryCompletionEvidenceRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(
+                self._conn,
+                "delivery_completion_evidence",
+                _MIGRATIONS,
+            )
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteDeliveryCompletionEvidenceRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "delivery_completion_evidence", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DeliveryCompletionEvidence | None:
+        row = self._conn.execute(
+            """
+            SELECT delivery_completion_evidence_id, order_id, order_version_id,
+                   completed_at, recorded_at, recorded_by, evidence_reference
+            FROM delivery_completion_evidence
+            WHERE order_id = ? AND order_version_id = ?
+            """,
+            (order_id, order_version_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_evidence(row)
+
+    def append(self, evidence: DeliveryCompletionEvidence) -> None:
+        existing = self.get_by_order_version_id(
+            evidence.order_id,
+            evidence.order_version_id,
+        )
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("delivery completion evidence conflict")
+            return
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO delivery_completion_evidence (
+                    delivery_completion_evidence_id, order_id, order_version_id,
+                    completed_at, recorded_at, recorded_by, evidence_reference
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evidence.delivery_completion_evidence_id,
+                    evidence.order_id,
+                    evidence.order_version_id,
+                    evidence.completed_at.isoformat(),
+                    evidence.recorded_at.isoformat(),
+                    evidence.recorded_by,
+                    evidence.evidence_reference,
+                ),
+            )

--- a/src/catering_system/repositories/sqlite_dispatch_evidence_repository.py
+++ b/src/catering_system/repositories/sqlite_dispatch_evidence_repository.py
@@ -1,0 +1,151 @@
+"""SQLite persistence for append-only dispatch evidence."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+
+from catering_system.domain.dispatch_evidence import DispatchEvidence
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE dispatch_evidence (
+            dispatch_evidence_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            order_version_id TEXT NOT NULL,
+            dispatched_at TEXT NOT NULL,
+            recorded_at TEXT NOT NULL,
+            recorded_by TEXT NOT NULL,
+            evidence_reference TEXT NOT NULL,
+            UNIQUE (order_id, order_version_id)
+        );
+        CREATE INDEX idx_dispatch_evidence_order_id
+            ON dispatch_evidence (order_id);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_dispatch_evidence_owner_insert
+        BEFORE INSERT ON dispatch_evidence
+        WHEN NOT EXISTS (
+            SELECT 1 FROM orders o
+            JOIN order_versions v ON v.order_version_id = NEW.order_version_id
+            JOIN kitchen_completion_evidence k
+              ON k.order_id = o.order_id
+             AND k.order_version_id = NEW.order_version_id
+            WHERE o.order_id = NEW.order_id
+              AND v.order_id = NEW.order_id
+              AND o.effective_order_version_id = NEW.order_version_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'dispatch evidence owner is invalid');
+        END;
+        CREATE TRIGGER trg_dispatch_evidence_immutable_update
+        BEFORE UPDATE ON dispatch_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'dispatch evidence is immutable');
+        END;
+        CREATE TRIGGER trg_dispatch_evidence_immutable_delete
+        BEFORE DELETE ON dispatch_evidence
+        BEGIN
+            SELECT RAISE(ABORT, 'dispatch evidence is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = ((1, "create_dispatch_evidence", _migration_1_create_tables),)
+
+
+def _parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _row_to_evidence(row: tuple) -> DispatchEvidence:
+    return DispatchEvidence(
+        dispatch_evidence_id=row[0],
+        order_id=row[1],
+        order_version_id=row[2],
+        dispatched_at=_parse_datetime(row[3]),
+        recorded_at=_parse_datetime(row[4]),
+        recorded_by=row[5],
+        evidence_reference=row[6],
+    )
+
+
+class SQLiteDispatchEvidenceRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "dispatch_evidence", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteDispatchEvidenceRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "dispatch_evidence", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> DispatchEvidence | None:
+        row = self._conn.execute(
+            """
+            SELECT dispatch_evidence_id, order_id, order_version_id,
+                   dispatched_at, recorded_at, recorded_by, evidence_reference
+            FROM dispatch_evidence
+            WHERE order_id = ? AND order_version_id = ?
+            """,
+            (order_id, order_version_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_evidence(row)
+
+    def append(self, evidence: DispatchEvidence) -> None:
+        existing = self.get_by_order_version_id(
+            evidence.order_id,
+            evidence.order_version_id,
+        )
+        if existing is not None:
+            if existing != evidence:
+                raise ValueError("dispatch evidence conflict")
+            return
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO dispatch_evidence (
+                    dispatch_evidence_id, order_id, order_version_id,
+                    dispatched_at, recorded_at, recorded_by, evidence_reference
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    evidence.dispatch_evidence_id,
+                    evidence.order_id,
+                    evidence.order_version_id,
+                    evidence.dispatched_at.isoformat(),
+                    evidence.recorded_at.isoformat(),
+                    evidence.recorded_by,
+                    evidence.evidence_reference,
+                ),
+            )

--- a/src/catering_system/repositories/sqlite_order_delivery_snapshot_repository.py
+++ b/src/catering_system/repositories/sqlite_order_delivery_snapshot_repository.py
@@ -1,0 +1,143 @@
+"""SQLite persistence for immutable OrderDeliverySnapshot rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from pathlib import Path
+
+from catering_system.domain.inquiry import validate_fulfillment_mode
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE order_delivery_snapshots (
+            snapshot_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            order_version_id TEXT NOT NULL,
+            fulfillment_mode TEXT NOT NULL,
+            delivery_address TEXT,
+            delivery_contact TEXT,
+            time_window_text TEXT NOT NULL,
+            location_text TEXT NOT NULL,
+            created_from TEXT NOT NULL,
+            UNIQUE (order_id, order_version_id)
+        );
+        CREATE INDEX idx_order_delivery_snapshots_order_id
+            ON order_delivery_snapshots (order_id);
+        """
+    )
+    connection.executescript(
+        """
+        CREATE TRIGGER trg_order_delivery_snapshot_owner_insert
+        BEFORE INSERT ON order_delivery_snapshots
+        WHEN NOT EXISTS (
+            SELECT 1 FROM orders o
+            JOIN order_versions v ON v.order_version_id = NEW.order_version_id
+            WHERE o.order_id = NEW.order_id
+              AND v.order_id = NEW.order_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'order delivery snapshot owner is invalid');
+        END;
+        CREATE TRIGGER trg_order_delivery_snapshot_immutable_update
+        BEFORE UPDATE ON order_delivery_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order delivery snapshot is immutable');
+        END;
+        CREATE TRIGGER trg_order_delivery_snapshot_immutable_delete
+        BEFORE DELETE ON order_delivery_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order delivery snapshot is immutable');
+        END;
+        """
+    )
+
+
+_MIGRATIONS = ((1, "create_order_delivery_snapshots", _migration_1_create_tables),)
+
+
+def _row_to_snapshot(row: tuple) -> OrderDeliverySnapshot:
+    return OrderDeliverySnapshot(
+        snapshot_id=row[0],
+        order_id=row[1],
+        order_version_id=row[2],
+        fulfillment_mode=validate_fulfillment_mode(row[3]),
+        delivery_address=row[4],
+        delivery_contact=row[5],
+        time_window_text=row[6],
+        location_text=row[7],
+        created_from=row[8],
+    )
+
+
+class SQLiteOrderDeliverySnapshotRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "order_delivery_snapshots", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteOrderDeliverySnapshotRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "order_delivery_snapshots", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get_by_order_version_id(
+        self,
+        order_id: str,
+        order_version_id: str,
+    ) -> OrderDeliverySnapshot | None:
+        row = self._conn.execute(
+            """
+            SELECT snapshot_id, order_id, order_version_id, fulfillment_mode,
+                   delivery_address, delivery_contact, time_window_text,
+                   location_text, created_from
+            FROM order_delivery_snapshots
+            WHERE order_id = ? AND order_version_id = ?
+            """,
+            (order_id, order_version_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_snapshot(row)
+
+    def create(self, snapshot: OrderDeliverySnapshot) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO order_delivery_snapshots (
+                    snapshot_id, order_id, order_version_id, fulfillment_mode,
+                    delivery_address, delivery_contact, time_window_text,
+                    location_text, created_from
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot.snapshot_id,
+                    snapshot.order_id,
+                    snapshot.order_version_id,
+                    snapshot.fulfillment_mode,
+                    snapshot.delivery_address,
+                    snapshot.delivery_contact,
+                    snapshot.time_window_text,
+                    snapshot.location_text,
+                    snapshot.created_from,
+                ),
+            )

--- a/src/catering_system/services/delivery_execution_service.py
+++ b/src/catering_system/services/delivery_execution_service.py
@@ -1,0 +1,172 @@
+"""Delivery execution commands — dispatch and completion evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from catering_system.domain.delivery_completion_evidence import DeliveryCompletionEvidence
+from catering_system.domain.dispatch_evidence import DispatchEvidence
+from catering_system.repositories.delivery_completion_evidence_repository import (
+    DeliveryCompletionEvidenceRepository,
+)
+from catering_system.repositories.dispatch_evidence_repository import (
+    DispatchEvidenceRepository,
+)
+from catering_system.repositories.kitchen_completion_evidence_repository import (
+    KitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.order_delivery_snapshot_repository import (
+    OrderDeliverySnapshotRepository,
+)
+from catering_system.repositories.order_operational_pause_repository import (
+    OrderOperationalPauseRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.delivery_queue_projection_service import (
+    DeliveryQueueProjectionService,
+)
+
+
+class DeliveryExecutionBlockedError(ValueError):
+    """Dispatch or completion rejected because delivery eligibility is unsatisfied."""
+
+
+class DeliveryEvidenceConflictError(ValueError):
+    """Evidence already exists with different facts."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class DeliveryEvidenceRecordResult:
+    evidence: DispatchEvidence | DeliveryCompletionEvidence
+    replay: bool
+
+
+class DeliveryExecutionService:
+    def __init__(
+        self,
+        order_repository: OrderRepository,
+        kitchen_completion_repository: KitchenCompletionEvidenceRepository,
+        delivery_snapshot_repository: OrderDeliverySnapshotRepository,
+        dispatch_repository: DispatchEvidenceRepository,
+        delivery_completion_repository: DeliveryCompletionEvidenceRepository,
+        *,
+        pause_repository: OrderOperationalPauseRepository | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._orders = order_repository
+        self._dispatch = dispatch_repository
+        self._delivery_completion = delivery_completion_repository
+        self._queue = DeliveryQueueProjectionService(
+            order_repository,
+            kitchen_completion_repository,
+            delivery_snapshot_repository,
+            pause_repository=pause_repository,
+        )
+        self._clock = clock or _utc_now
+
+    def _assert_delivery_eligible(self, order_id: str, order_version_id: str) -> None:
+        eligible = {
+            (entry.order_id, entry.order_version_id) for entry in self._queue.list_queue()
+        }
+        if (order_id, order_version_id) not in eligible:
+            raise DeliveryExecutionBlockedError()
+
+    def record_dispatch(
+        self,
+        order_id: str,
+        order_version_id: str,
+        *,
+        dispatched_at: datetime,
+        recorded_by: str,
+        evidence_reference: str,
+    ) -> DeliveryEvidenceRecordResult:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise ValueError("order not found")
+        if order.cancelled_at is not None:
+            raise ValueError("order cancelled")
+        version = self._orders.get_order_version(order_version_id)
+        if version is None or version.order_id != order_id:
+            raise ValueError("order version not owned")
+        if order.effective_order_version_id != order_version_id:
+            raise ValueError("order version is not effective")
+
+        self._assert_delivery_eligible(order_id, order_version_id)
+
+        existing = self._dispatch.get_by_order_version_id(order_id, order_version_id)
+        candidate = DispatchEvidence(
+            dispatch_evidence_id=(
+                existing.dispatch_evidence_id if existing is not None else str(uuid4())
+            ),
+            order_id=order_id,
+            order_version_id=order_version_id,
+            dispatched_at=dispatched_at,
+            recorded_at=existing.recorded_at if existing is not None else self._clock(),
+            recorded_by=recorded_by,
+            evidence_reference=evidence_reference,
+        )
+        if existing is not None:
+            if existing != candidate:
+                raise DeliveryEvidenceConflictError()
+            return DeliveryEvidenceRecordResult(evidence=existing, replay=True)
+
+        self._dispatch.append(candidate)
+        return DeliveryEvidenceRecordResult(evidence=candidate, replay=False)
+
+    def record_delivery_completion(
+        self,
+        order_id: str,
+        order_version_id: str,
+        *,
+        completed_at: datetime,
+        recorded_by: str,
+        evidence_reference: str,
+    ) -> DeliveryEvidenceRecordResult:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise ValueError("order not found")
+        if order.cancelled_at is not None:
+            raise ValueError("order cancelled")
+        version = self._orders.get_order_version(order_version_id)
+        if version is None or version.order_id != order_id:
+            raise ValueError("order version not owned")
+        if order.effective_order_version_id != order_version_id:
+            raise ValueError("order version is not effective")
+
+        if (
+            self._dispatch.get_by_order_version_id(order_id, order_version_id)
+            is None
+        ):
+            raise DeliveryExecutionBlockedError()
+
+        existing = self._delivery_completion.get_by_order_version_id(
+            order_id,
+            order_version_id,
+        )
+        candidate = DeliveryCompletionEvidence(
+            delivery_completion_evidence_id=(
+                existing.delivery_completion_evidence_id
+                if existing is not None
+                else str(uuid4())
+            ),
+            order_id=order_id,
+            order_version_id=order_version_id,
+            completed_at=completed_at,
+            recorded_at=existing.recorded_at if existing is not None else self._clock(),
+            recorded_by=recorded_by,
+            evidence_reference=evidence_reference,
+        )
+        if existing is not None:
+            if existing != candidate:
+                raise DeliveryEvidenceConflictError()
+            return DeliveryEvidenceRecordResult(evidence=existing, replay=True)
+
+        self._delivery_completion.append(candidate)
+        return DeliveryEvidenceRecordResult(evidence=candidate, replay=False)

--- a/src/catering_system/services/delivery_queue_projection_service.py
+++ b/src/catering_system/services/delivery_queue_projection_service.py
@@ -1,0 +1,83 @@
+"""Derived delivery queue from kitchen completion + frozen delivery snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
+from catering_system.repositories.kitchen_completion_evidence_repository import (
+    KitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.order_delivery_snapshot_repository import (
+    OrderDeliverySnapshotRepository,
+)
+from catering_system.repositories.order_operational_pause_repository import (
+    OrderOperationalPauseRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.operational_core_service import OperationalCoreService
+
+
+@dataclass(frozen=True)
+class DeliveryQueueProjectionEntry:
+    order_id: str
+    order_version_id: str
+    delivery_snapshot: OrderDeliverySnapshot
+
+
+class DeliveryQueueProjectionService:
+    def __init__(
+        self,
+        order_repository: OrderRepository,
+        kitchen_completion_repository: KitchenCompletionEvidenceRepository,
+        delivery_snapshot_repository: OrderDeliverySnapshotRepository,
+        *,
+        pause_repository: OrderOperationalPauseRepository | None = None,
+    ) -> None:
+        self._orders = order_repository
+        self._kitchen_completion = kitchen_completion_repository
+        self._delivery_snapshots = delivery_snapshot_repository
+        self._core = OperationalCoreService(
+            order_repository,
+            pause_repository=pause_repository,
+        )
+
+    def list_queue(self) -> tuple[DeliveryQueueProjectionEntry, ...]:
+        entries: list[DeliveryQueueProjectionEntry] = []
+        for order in self._orders.list_orders():
+            if order.cancelled_at is not None:
+                continue
+            evaluation = self._core.evaluate_ready_to_send(order.order_id)
+            if "operational_pause" in evaluation.reasons:
+                continue
+            effective_id = order.effective_order_version_id
+            if effective_id is None:
+                continue
+            if (
+                self._kitchen_completion.get_by_order_version_id(
+                    order.order_id,
+                    effective_id,
+                )
+                is None
+            ):
+                continue
+            snapshot = self._delivery_snapshots.get_by_order_version_id(
+                order.order_id,
+                effective_id,
+            )
+            if snapshot is None or snapshot.fulfillment_mode != "DELIVERY":
+                continue
+            entries.append(
+                DeliveryQueueProjectionEntry(
+                    order_id=order.order_id,
+                    order_version_id=effective_id,
+                    delivery_snapshot=snapshot,
+                )
+            )
+        entries.sort(
+            key=lambda entry: (
+                entry.delivery_snapshot.time_window_text,
+                entry.order_id,
+            )
+        )
+        return tuple(entries)

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -51,15 +51,24 @@ from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
     InMemoryOrderCommercialSnapshotRepository,
 )
+from catering_system.repositories.in_memory_order_delivery_snapshot_repository import (
+    InMemoryOrderDeliverySnapshotRepository,
+)
 from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_delivery_snapshot_repository import (
+    OrderDeliverySnapshotRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
 from catering_system.services.order_service import OrderService
 from catering_system.services.offer_snapshot_validation import validate_offer_snapshot
 from catering_system.domain.order_commercial_snapshot import (
     build_order_commercial_snapshot,
+)
+from catering_system.domain.order_delivery_snapshot import (
+    build_order_delivery_snapshot,
 )
 
 _log = logging.getLogger(__name__)
@@ -99,6 +108,7 @@ class OfferService:
         inquiry_repository: InquiryRepository,
         order_repository: OrderRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
+        delivery_snapshot_repository: OrderDeliverySnapshotRepository | None = None,
         *,
         now: Callable[[], datetime] | None = None,
         today: Callable[[], date] | None = None,
@@ -109,6 +119,10 @@ class OfferService:
         self._commercial_snapshots = (
             commercial_snapshot_repository
             or InMemoryOrderCommercialSnapshotRepository()
+        )
+        self._delivery_snapshots = (
+            delivery_snapshot_repository
+            or InMemoryOrderDeliverySnapshotRepository()
         )
         self._order_service = OrderService(order_repository)
         self._now = now or (lambda: datetime.now(UTC))
@@ -599,6 +613,12 @@ class OfferService:
             created_at=created_at,
         )
         self._commercial_snapshots.create(snapshot)
+        delivery_snapshot = build_order_delivery_snapshot(
+            order_id=order.order_id,
+            order_version=order_version,
+            inquiry=inquiry,
+        )
+        self._delivery_snapshots.create(delivery_snapshot)
         conversion_link = ConversionLink(
             offer_id=offer_id,
             offer_version_id=offer_version_id,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -132,6 +132,15 @@ from catering_system.repositories.sqlite_order_operational_pause_repository impo
 from catering_system.repositories.sqlite_kitchen_completion_evidence_repository import (
     SQLiteKitchenCompletionEvidenceRepository,
 )
+from catering_system.repositories.sqlite_dispatch_evidence_repository import (
+    SQLiteDispatchEvidenceRepository,
+)
+from catering_system.repositories.sqlite_delivery_completion_evidence_repository import (
+    SQLiteDeliveryCompletionEvidenceRepository,
+)
+from catering_system.repositories.sqlite_order_delivery_snapshot_repository import (
+    SQLiteOrderDeliverySnapshotRepository,
+)
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
@@ -171,6 +180,14 @@ from catering_system.services.kitchen_execution_service import (
 )
 from catering_system.services.kitchen_queue_projection_service import (
     KitchenQueueProjectionService,
+)
+from catering_system.services.delivery_execution_service import (
+    DeliveryEvidenceConflictError,
+    DeliveryExecutionBlockedError,
+    DeliveryExecutionService,
+)
+from catering_system.services.delivery_queue_projection_service import (
+    DeliveryQueueProjectionService,
 )
 from catering_system.services.offer_document_snapshot_service import (
     OfferDocumentNotFoundError,
@@ -523,6 +540,9 @@ class OfficeApi:
         self.commercial_snapshots = (
             SQLiteOrderCommercialSnapshotRepository.from_connection(connection)
         )
+        self.delivery_snapshots = SQLiteOrderDeliverySnapshotRepository.from_connection(
+            connection
+        )
         self.confirmation_outbound = (
             SQLiteOrderConfirmationOutboundRepository.from_connection(connection)
         )
@@ -531,6 +551,12 @@ class OfficeApi:
         )
         self.kitchen_completion_evidence = (
             SQLiteKitchenCompletionEvidenceRepository.from_connection(connection)
+        )
+        self.dispatch_evidence = SQLiteDispatchEvidenceRepository.from_connection(
+            connection
+        )
+        self.delivery_completion_evidence = (
+            SQLiteDeliveryCompletionEvidenceRepository.from_connection(connection)
         )
         self.offer_documents = SQLiteOfferDocumentSnapshotRepository.from_connection(
             connection
@@ -546,6 +572,7 @@ class OfficeApi:
             self.inquiries,
             self.orders,
             self.commercial_snapshots,
+            self.delivery_snapshots,
             today=views.berlin_today,
         )
         self.offer_document_service = OfferDocumentSnapshotService(
@@ -635,6 +662,20 @@ class OfficeApi:
         self.kitchen_execution_service = KitchenExecutionService(
             self.orders,
             self.kitchen_completion_evidence,
+            pause_repository=self.operational_pauses,
+        )
+        self.delivery_queue_projection_service = DeliveryQueueProjectionService(
+            self.orders,
+            self.kitchen_completion_evidence,
+            self.delivery_snapshots,
+            pause_repository=self.operational_pauses,
+        )
+        self.delivery_execution_service = DeliveryExecutionService(
+            self.orders,
+            self.kitchen_completion_evidence,
+            self.delivery_snapshots,
+            self.dispatch_evidence,
+            self.delivery_completion_evidence,
             pause_repository=self.operational_pauses,
         )
         self.catalog_dish_service = CatalogDishService(self.catalog)
@@ -1999,6 +2040,98 @@ class OfficeApi:
             "evidence": views.kitchen_completion_evidence_shape(result.evidence),
         }
 
+    def delivery_queue(self) -> dict[str, object]:
+        entries = self.delivery_queue_projection_service.list_queue()
+        return views.delivery_queue_view(entries)
+
+    def cmd_dispatch(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        order = self._require_active_order(path_ids["id"])
+        expected = expect["current_effective_order_version_id"]
+        if expected is not None and not isinstance(expected, str):
+            raise _invalid()
+        if expected != order.effective_order_version_id:
+            raise ApiError(409, "stale_state")
+        version = self._owned_version(
+            order.order_id,
+            _v_uuid(args["order_version_id"]),
+        )
+        dispatched_at = (
+            _v_datetime(args["dispatched_at"])
+            if "dispatched_at" in args
+            else datetime.now(UTC)
+        )
+        try:
+            result = self.delivery_execution_service.record_dispatch(
+                order.order_id,
+                version.order_version_id,
+                dispatched_at=dispatched_at,
+                recorded_by=_v_str(args["recorded_by"], 200),
+                evidence_reference=_v_str(args["evidence_reference"], 500),
+            )
+        except DeliveryExecutionBlockedError as exc:
+            raise ApiError(422, "dispatch_blocked") from exc
+        except DeliveryEvidenceConflictError as exc:
+            raise ApiError(409, "dispatch_conflict") from exc
+        except ValueError as exc:
+            message = str(exc)
+            if message == "order version is not effective":
+                raise ApiError(422, "order_version_not_effective") from exc
+            if message == "order version not owned":
+                raise ApiError(422, "version_not_owned") from exc
+            raise ApiError(422, "dispatch_blocked") from exc
+        status = 200 if result.replay else 201
+        return status, {
+            "order_id": order.order_id,
+            "order_version_id": version.order_version_id,
+            "evidence": views.dispatch_evidence_shape(result.evidence),
+        }
+
+    def cmd_delivery_completion(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        order = self._require_active_order(path_ids["id"])
+        expected = expect["current_effective_order_version_id"]
+        if expected is not None and not isinstance(expected, str):
+            raise _invalid()
+        if expected != order.effective_order_version_id:
+            raise ApiError(409, "stale_state")
+        version = self._owned_version(
+            order.order_id,
+            _v_uuid(args["order_version_id"]),
+        )
+        completed_at = (
+            _v_datetime(args["completed_at"])
+            if "completed_at" in args
+            else datetime.now(UTC)
+        )
+        try:
+            result = self.delivery_execution_service.record_delivery_completion(
+                order.order_id,
+                version.order_version_id,
+                completed_at=completed_at,
+                recorded_by=_v_str(args["recorded_by"], 200),
+                evidence_reference=_v_str(args["evidence_reference"], 500),
+            )
+        except DeliveryExecutionBlockedError as exc:
+            raise ApiError(422, "delivery_completion_blocked") from exc
+        except DeliveryEvidenceConflictError as exc:
+            raise ApiError(409, "delivery_completion_conflict") from exc
+        except ValueError as exc:
+            message = str(exc)
+            if message == "order version is not effective":
+                raise ApiError(422, "order_version_not_effective") from exc
+            if message == "order version not owned":
+                raise ApiError(422, "version_not_owned") from exc
+            raise ApiError(422, "delivery_completion_blocked") from exc
+        status = 200 if result.replay else 201
+        return status, {
+            "order_id": order.order_id,
+            "order_version_id": version.order_version_id,
+            "evidence": views.delivery_completion_evidence_shape(result.evidence),
+        }
+
     def _pause_actor_reference(self, args: dict[str, object]) -> str:
         if "actor_reference" in args:
             return _v_str(args["actor_reference"], 200)
@@ -2440,6 +2573,18 @@ _KITCHEN_COMPLETION_ARGS = _ArgKeys(
     ),
     optional=frozenset({"completed_at"}),
 )
+_DISPATCH_ARGS = _ArgKeys(
+    required=frozenset(
+        {"order_version_id", "recorded_by", "evidence_reference"},
+    ),
+    optional=frozenset({"dispatched_at"}),
+)
+_DELIVERY_COMPLETION_ARGS = _ArgKeys(
+    required=frozenset(
+        {"order_version_id", "recorded_by", "evidence_reference"},
+    ),
+    optional=frozenset({"completed_at"}),
+)
 _CONFIRMATION_DOCUMENT_SEND_ARGS = _ArgKeys(
     required=frozenset({"document_snapshot_id", "requested_by"})
 )
@@ -2533,6 +2678,16 @@ _COMMANDS: dict[str, _CommandSpec] = {
         _KITCHEN_COMPLETION_ARGS,
         {"current_effective_order_version_id"},
     ),
+    "dispatch": _CommandSpec(
+        "cmd_dispatch",
+        _DISPATCH_ARGS,
+        {"current_effective_order_version_id"},
+    ),
+    "delivery-completion": _CommandSpec(
+        "cmd_delivery_completion",
+        _DELIVERY_COMPLETION_ARGS,
+        {"current_effective_order_version_id"},
+    ),
     "pause": _CommandSpec(
         "cmd_pause",
         _PAUSE_ARGS,
@@ -2587,6 +2742,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/kitchen-queue$"),
         "/office/v1/kitchen-queue",
         {"GET": "kitchen_queue"},
+    ),
+    (
+        re.compile(r"^/office/v1/delivery-queue$"),
+        "/office/v1/delivery-queue",
+        {"GET": "delivery_queue"},
     ),
     (
         re.compile(r"^/office/v1/work-center$"),
@@ -2812,6 +2972,16 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/kitchen-completion$"),
         "/office/v1/orders/{id}/kitchen-completion",
         {"POST": "kitchen-completion"},
+    ),
+    (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/dispatch$"),
+        "/office/v1/orders/{id}/dispatch",
+        {"POST": "dispatch"},
+    ),
+    (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/delivery-completion$"),
+        "/office/v1/orders/{id}/delivery-completion",
+        {"POST": "delivery-completion"},
     ),
     (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/pause$"),
@@ -3247,6 +3417,9 @@ def make_office_api_handler(
             elif kind == "kitchen_queue":
                 self._query(set())
                 self._respond(200, api.kitchen_queue())
+            elif kind == "delivery_queue":
+                self._query(set())
+                self._respond(200, api.delivery_queue())
             elif kind == "work_center":
                 self._query(set())
                 self._respond(200, api.work_center())

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -23,6 +23,9 @@ from catering_system.domain.inquiry_customer_snapshot import (
 )
 from catering_system.domain.email_intake_projection import EmailIntakeProjection
 from catering_system.domain.kitchen_completion_evidence import KitchenCompletionEvidence
+from catering_system.domain.dispatch_evidence import DispatchEvidence
+from catering_system.domain.delivery_completion_evidence import DeliveryCompletionEvidence
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
 from catering_system.domain.inquiry import (
     Inquiry,
     InquiryOfferProjection,
@@ -57,6 +60,9 @@ from catering_system.services.order_print_projection_service import (
 from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
 from catering_system.services.kitchen_queue_projection_service import (
     KitchenQueueProjectionEntry,
+)
+from catering_system.services.delivery_queue_projection_service import (
+    DeliveryQueueProjectionEntry,
 )
 from catering_system.domain.catalog import allergen_labels
 from catering_system.services.catalog_dish_service import (
@@ -1301,6 +1307,65 @@ def kitchen_queue_view(
                 "order_id": entry.order_id,
                 "order_version_id": entry.order_version_id,
                 "projection": order_print_projection_shape(entry.projection),
+            }
+            for entry in entries
+        ]
+    }
+
+
+def order_delivery_snapshot_shape(
+    snapshot: OrderDeliverySnapshot,
+) -> dict[str, object]:
+    return {
+        "snapshot_id": snapshot.snapshot_id,
+        "order_id": snapshot.order_id,
+        "order_version_id": snapshot.order_version_id,
+        "fulfillment_mode": snapshot.fulfillment_mode,
+        "delivery_address": snapshot.delivery_address,
+        "delivery_contact": snapshot.delivery_contact,
+        "time_window_text": snapshot.time_window_text,
+        "location_text": snapshot.location_text,
+        "created_from": snapshot.created_from,
+    }
+
+
+def dispatch_evidence_shape(evidence: DispatchEvidence) -> dict[str, object]:
+    return {
+        "dispatch_evidence_id": evidence.dispatch_evidence_id,
+        "order_id": evidence.order_id,
+        "order_version_id": evidence.order_version_id,
+        "dispatched_at": evidence.dispatched_at.isoformat(),
+        "recorded_at": evidence.recorded_at.isoformat(),
+        "recorded_by": evidence.recorded_by,
+        "evidence_reference": evidence.evidence_reference,
+    }
+
+
+def delivery_completion_evidence_shape(
+    evidence: DeliveryCompletionEvidence,
+) -> dict[str, object]:
+    return {
+        "delivery_completion_evidence_id": evidence.delivery_completion_evidence_id,
+        "order_id": evidence.order_id,
+        "order_version_id": evidence.order_version_id,
+        "completed_at": evidence.completed_at.isoformat(),
+        "recorded_at": evidence.recorded_at.isoformat(),
+        "recorded_by": evidence.recorded_by,
+        "evidence_reference": evidence.evidence_reference,
+    }
+
+
+def delivery_queue_view(
+    entries: tuple[DeliveryQueueProjectionEntry, ...],
+) -> dict[str, object]:
+    return {
+        "entries": [
+            {
+                "order_id": entry.order_id,
+                "order_version_id": entry.order_version_id,
+                "delivery_snapshot": order_delivery_snapshot_shape(
+                    entry.delivery_snapshot
+                ),
             }
             for entry in entries
         ]

--- a/tests/helpers/delivery_queue_contract.py
+++ b/tests/helpers/delivery_queue_contract.py
@@ -1,81 +1,38 @@
-"""Slice 6 delivery queue contract — reference for PR C DeliveryQueueProjectionService.
-
-Eligibility requires KitchenCompletionEvidence plus frozen OrderDeliverySnapshot.
-Production modules must use only operational delivery snapshot facts.
-"""
+"""Slice 6 delivery queue contract — delegates to DeliveryQueueProjectionService."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from catering_system.repositories.kitchen_completion_evidence_repository import (
     KitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.order_delivery_snapshot_repository import (
+    OrderDeliverySnapshotRepository,
 )
 from catering_system.repositories.order_operational_pause_repository import (
     OrderOperationalPauseRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
-from catering_system.services.operational_core_service import OperationalCoreService
-from tests.helpers.delivery_snapshot_contract import (
-    InMemoryOrderDeliverySnapshotRepository,
-    OrderDeliverySnapshotContract,
+from catering_system.services.delivery_queue_projection_service import (
+    DeliveryQueueProjectionEntry,
+    DeliveryQueueProjectionService,
 )
 
-
-@dataclass(frozen=True)
-class DeliveryQueueProjectionEntry:
-    order_id: str
-    order_version_id: str
-    delivery_snapshot: OrderDeliverySnapshotContract
+__all__ = (
+    "DeliveryQueueProjectionEntry",
+    "build_delivery_queue_projection",
+)
 
 
 def build_delivery_queue_projection(
     order_repository: OrderRepository,
     kitchen_completion_repository: KitchenCompletionEvidenceRepository,
-    delivery_snapshot_repository: InMemoryOrderDeliverySnapshotRepository,
+    delivery_snapshot_repository: OrderDeliverySnapshotRepository,
     *,
     pause_repository: OrderOperationalPauseRepository | None = None,
 ) -> tuple[DeliveryQueueProjectionEntry, ...]:
-    """Derived delivery queue: kitchen completion handoff + frozen delivery snapshot."""
-    core = OperationalCoreService(
+    return DeliveryQueueProjectionService(
         order_repository,
+        kitchen_completion_repository,
+        delivery_snapshot_repository,
         pause_repository=pause_repository,
-    )
-    entries: list[DeliveryQueueProjectionEntry] = []
-    for order in order_repository.list_orders():
-        if order.cancelled_at is not None:
-            continue
-        pause = core.evaluate_ready_to_send(order.order_id)
-        if "operational_pause" in pause.reasons:
-            continue
-        effective_id = order.effective_order_version_id
-        if effective_id is None:
-            continue
-        if (
-            kitchen_completion_repository.get_by_order_version_id(
-                order.order_id,
-                effective_id,
-            )
-            is None
-        ):
-            continue
-        snapshot = delivery_snapshot_repository.get_by_order_version_id(
-            order.order_id,
-            effective_id,
-        )
-        if snapshot is None or snapshot.fulfillment_mode != "DELIVERY":
-            continue
-        entries.append(
-            DeliveryQueueProjectionEntry(
-                order_id=order.order_id,
-                order_version_id=effective_id,
-                delivery_snapshot=snapshot,
-            )
-        )
-    entries.sort(
-        key=lambda entry: (
-            entry.delivery_snapshot.time_window_text,
-            entry.order_id,
-        )
-    )
-    return tuple(entries)
+    ).list_queue()

--- a/tests/helpers/delivery_snapshot_contract.py
+++ b/tests/helpers/delivery_snapshot_contract.py
@@ -1,52 +1,14 @@
-"""Slice 6 OrderDeliverySnapshot contract — reference for PR C.
-
-Test-only frozen operational delivery read model. Production code must match
-this contract using only frozen operational delivery facts at conversion.
-"""
+"""Slice 6 OrderDeliverySnapshot test seeding helpers."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal
+import uuid
 
-DeliveryFulfillmentMode = Literal["DELIVERY", "PICKUP"]
-
-_CREATED_FROM = "accepted_order_conversion"
-
-
-@dataclass(frozen=True)
-class OrderDeliverySnapshotContract:
-    order_id: str
-    order_version_id: str
-    fulfillment_mode: DeliveryFulfillmentMode
-    delivery_address: str | None
-    delivery_contact: str | None
-    time_window_text: str
-    location_text: str
-    created_from: str = _CREATED_FROM
-
-    def __post_init__(self) -> None:
-        if self.created_from != _CREATED_FROM:
-            raise ValueError("unsupported delivery snapshot source")
-
-
-class InMemoryOrderDeliverySnapshotRepository:
-    def __init__(self) -> None:
-        self._by_version: dict[tuple[str, str], OrderDeliverySnapshotContract] = {}
-
-    def get_by_order_version_id(
-        self,
-        order_id: str,
-        order_version_id: str,
-    ) -> OrderDeliverySnapshotContract | None:
-        return self._by_version.get((order_id, order_version_id))
-
-    def save(self, snapshot: OrderDeliverySnapshotContract) -> None:
-        key = (snapshot.order_id, snapshot.order_version_id)
-        existing = self._by_version.get(key)
-        if existing is not None and existing != snapshot:
-            raise ValueError("order delivery snapshot conflict")
-        self._by_version[key] = snapshot
+from catering_system.domain.inquiry import FulfillmentMode
+from catering_system.domain.order_delivery_snapshot import OrderDeliverySnapshot
+from catering_system.repositories.in_memory_order_delivery_snapshot_repository import (
+    InMemoryOrderDeliverySnapshotRepository,
+)
 
 
 def seed_delivery_snapshot(
@@ -54,13 +16,14 @@ def seed_delivery_snapshot(
     *,
     order_id: str,
     order_version_id: str,
-    fulfillment_mode: DeliveryFulfillmentMode = "DELIVERY",
+    fulfillment_mode: FulfillmentMode = "DELIVERY",
     time_window_text: str = "mittags",
     location_text: str = "Hamburg",
     delivery_address: str | None = "Musterstraße 1, Hamburg",
     delivery_contact: str | None = "kunde@example.com",
-) -> OrderDeliverySnapshotContract:
-    snapshot = OrderDeliverySnapshotContract(
+) -> OrderDeliverySnapshot:
+    snapshot = OrderDeliverySnapshot(
+        snapshot_id=str(uuid.uuid4()),
         order_id=order_id,
         order_version_id=order_version_id,
         fulfillment_mode=fulfillment_mode,
@@ -69,5 +32,5 @@ def seed_delivery_snapshot(
         time_window_text=time_window_text,
         location_text=location_text,
     )
-    repository.save(snapshot)
+    repository.create(snapshot)
     return snapshot

--- a/tests/unit/test_delivery_execution_contract.py
+++ b/tests/unit/test_delivery_execution_contract.py
@@ -22,8 +22,10 @@ from catering_system.repositories.in_memory_order_repository import (
 from catering_system.services.kitchen_execution_service import KitchenExecutionService
 from catering_system.services.operational_core_service import OperationalCoreService
 from tests.helpers.delivery_queue_contract import build_delivery_queue_projection
-from tests.helpers.delivery_snapshot_contract import (
+from catering_system.repositories.in_memory_order_delivery_snapshot_repository import (
     InMemoryOrderDeliverySnapshotRepository,
+)
+from tests.helpers.delivery_snapshot_contract import (
     seed_delivery_snapshot,
 )
 from tests.helpers.kitchen_queue_contract import build_kitchen_queue_projection

--- a/tests/unit/test_delivery_execution_flow.py
+++ b/tests/unit/test_delivery_execution_flow.py
@@ -1,0 +1,219 @@
+"""Integration test: kitchen completion → delivery queue → dispatch → completion."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.sqlite_delivery_completion_evidence_repository import (
+    SQLiteDeliveryCompletionEvidenceRepository,
+)
+from catering_system.repositories.sqlite_dispatch_evidence_repository import (
+    SQLiteDispatchEvidenceRepository,
+)
+from catering_system.repositories.sqlite_order_delivery_snapshot_repository import (
+    SQLiteOrderDeliverySnapshotRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from tests.unit.test_office_api import (
+    _MARK_SENT_ARGS,
+    _RECORD_ACCEPTANCE_ARGS,
+    _VARIANT_ID,
+    _convert_accepted_url,
+    _get,
+    _mark_sent_url,
+    _post,
+    _prepare_offer_url,
+    _record_acceptance_url,
+    _seed,
+    _seed_employee_auth,
+    _start_api_server,
+    _valid_offer_snapshot,
+)
+
+_DISPATCHED_AT = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)
+_COMPLETED_AT = datetime(2026, 8, 7, 16, 0, tzinfo=UTC)
+
+
+@pytest.fixture()
+def office_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from catering_system.ui import office_api_views
+
+    monkeypatch.setattr(
+        office_api_views,
+        "berlin_today",
+        lambda: date(2026, 7, 15),
+    )
+    db = tmp_path / "core.db"
+    ids = _seed(db)
+    _seed_employee_auth(db)
+    server, thread, base = _start_api_server(db)
+    yield base, ids, db
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+    assert thread.is_alive() is False
+
+
+def _release_and_complete_kitchen(
+    office_api: tuple[str, dict[str, str], Path],
+) -> tuple[str, str, str]:
+    base, ids, _db = office_api
+    inquiry_id = ids["inquiry_offer_ready"]
+
+    detail = _get(f"{base}/office/v1/inquiries/{inquiry_id}")[1]
+    assert (
+        _post(
+            f"{base}/office/v1/inquiries/{inquiry_id}/fulfillment-mode",
+            args={"fulfillment_mode": "DELIVERY"},
+            expect={"updated_at": detail["updated_at"]},
+        )[0]
+        == 200
+    )
+
+    prepare_status, prepare_body, _headers = _post(
+        _prepare_offer_url(base, inquiry_id),
+        args={"snapshot": _valid_offer_snapshot(inquiry_id=inquiry_id)},
+    )
+    assert prepare_status == 201
+    offer_id = prepare_body["offer_id"]
+    version_id = prepare_body["offer_version_id"]
+
+    assert (
+        _post(_mark_sent_url(base, offer_id, version_id), args=_MARK_SENT_ARGS)[0]
+        == 200
+    )
+    accept_status, accept_body, _headers = _post(
+        _record_acceptance_url(base, offer_id, version_id),
+        args=_RECORD_ACCEPTANCE_ARGS,
+    )
+    assert accept_status == 200
+
+    convert_status, convert_body, _headers = _post(
+        _convert_accepted_url(base, offer_id, version_id),
+        args={
+            "accepted_variant_id": _VARIANT_ID,
+            "acceptance_id": accept_body["acceptance_id"],
+        },
+    )
+    assert convert_status == 201
+    order_id = convert_body["order_id"]
+    order_version_id = convert_body["order_version_id"]
+
+    assert (
+        _post(
+            f"{base}/office/v1/orders/{order_id}/print-confirm",
+            args={"order_version_id": order_version_id},
+        )[0]
+        == 200
+    )
+    assert (
+        _post(
+            f"{base}/office/v1/orders/{order_id}/effective",
+            args={"order_version_id": order_version_id},
+            expect={
+                "current_effective_order_version_id": None,
+                "current_candidate_order_version_id": None,
+            },
+        )[0]
+        == 200
+    )
+    assert (
+        _post(
+            f"{base}/office/v1/orders/{order_id}/kitchen-completion",
+            args={
+                "order_version_id": order_version_id,
+                "recorded_by": "kitchen-panel",
+                "evidence_reference": "kitchen-ticket-42",
+                "completed_at": _DISPATCHED_AT.isoformat(),
+            },
+            expect={"current_effective_order_version_id": order_version_id},
+        )[0]
+        in {200, 201}
+    )
+    return base, order_id, order_version_id
+
+
+def test_delivery_execution_cycle_from_kitchen_completion(
+    office_api: tuple[str, dict[str, str], Path],
+) -> None:
+    base, order_id, order_version_id = _release_and_complete_kitchen(office_api)
+    _base, _ids, db = office_api
+
+    queue_status, queue_body, _headers = _get(f"{base}/office/v1/delivery-queue")
+    assert queue_status == 200
+    matching = [entry for entry in queue_body["entries"] if entry["order_id"] == order_id]
+    assert len(matching) == 1
+    entry = matching[0]
+    assert entry["order_version_id"] == order_version_id
+    assert entry["delivery_snapshot"]["fulfillment_mode"] == "DELIVERY"
+    assert entry["delivery_snapshot"]["created_from"] == "accepted_order_conversion"
+
+    dispatch_args = {
+        "order_version_id": order_version_id,
+        "recorded_by": "office-dispatch",
+        "evidence_reference": "dispatch-77",
+        "dispatched_at": _DISPATCHED_AT.isoformat(),
+    }
+    dispatch_status, dispatch_body, _headers = _post(
+        f"{base}/office/v1/orders/{order_id}/dispatch",
+        args=dispatch_args,
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert dispatch_status == 201
+    dispatch_id = dispatch_body["evidence"]["dispatch_evidence_id"]
+
+    completion_status, completion_body, _headers = _post(
+        f"{base}/office/v1/orders/{order_id}/delivery-completion",
+        args={
+            "order_version_id": order_version_id,
+            "recorded_by": "office-dispatch",
+            "evidence_reference": "delivered-88",
+            "completed_at": _COMPLETED_AT.isoformat(),
+        },
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert completion_status == 201
+
+    replay_status, replay_body, _headers = _post(
+        f"{base}/office/v1/orders/{order_id}/delivery-completion",
+        args={
+            "order_version_id": order_version_id,
+            "recorded_by": "office-dispatch",
+            "evidence_reference": "delivered-88",
+            "completed_at": _COMPLETED_AT.isoformat(),
+        },
+        expect={"current_effective_order_version_id": order_version_id},
+    )
+    assert replay_status == 200
+    assert (
+        replay_body["evidence"]["delivery_completion_evidence_id"]
+        == completion_body["evidence"]["delivery_completion_evidence_id"]
+    )
+
+    orders = SQLiteOrderRepository(db)
+    order_before = orders.get_order(order_id)
+    version_before = orders.get_order_version(order_version_id)
+    orders.close()
+
+    dispatch_repo = SQLiteDispatchEvidenceRepository(db)
+    assert dispatch_repo.get_by_order_version_id(order_id, order_version_id) is not None
+    dispatch_repo.close()
+
+    completion_repo = SQLiteDeliveryCompletionEvidenceRepository(db)
+    assert completion_repo.get_by_order_version_id(order_id, order_version_id) is not None
+    completion_repo.close()
+
+    delivery_repo = SQLiteOrderDeliverySnapshotRepository(db)
+    snapshot = delivery_repo.get_by_order_version_id(order_id, order_version_id)
+    delivery_repo.close()
+    assert snapshot is not None
+
+    orders = SQLiteOrderRepository(db)
+    assert orders.get_order(order_id) == order_before
+    assert orders.get_order_version(order_version_id) == version_before
+    orders.close()
+
+    assert dispatch_id

--- a/tests/unit/test_delivery_execution_service.py
+++ b/tests/unit/test_delivery_execution_service.py
@@ -1,0 +1,379 @@
+"""Unit tests — DeliveryExecutionService dispatch and completion evidence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from catering_system.repositories.in_memory_delivery_completion_evidence_repository import (
+    InMemoryDeliveryCompletionEvidenceRepository,
+)
+from catering_system.repositories.in_memory_dispatch_evidence_repository import (
+    InMemoryDispatchEvidenceRepository,
+)
+from catering_system.repositories.in_memory_kitchen_completion_evidence_repository import (
+    InMemoryKitchenCompletionEvidenceRepository,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_delivery_snapshot_repository import (
+    InMemoryOrderDeliverySnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.delivery_execution_service import (
+    DeliveryEvidenceConflictError,
+    DeliveryExecutionBlockedError,
+    DeliveryExecutionService,
+)
+from catering_system.services.delivery_queue_projection_service import (
+    DeliveryQueueProjectionService,
+)
+from catering_system.services.kitchen_execution_service import KitchenExecutionService
+from catering_system.services.operational_core_service import OperationalCoreService
+from tests.helpers.delivery_snapshot_contract import seed_delivery_snapshot
+from tests.unit.test_offer_service import _accepted_offer_state
+
+_NOW = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)
+_COMPLETED_AT = datetime(2026, 8, 7, 16, 0, tzinfo=UTC)
+
+
+def _delivery_eligible_order() -> tuple[
+    InMemoryOrderRepository,
+    InMemoryKitchenCompletionEvidenceRepository,
+    InMemoryOrderDeliverySnapshotRepository,
+    InMemoryDispatchEvidenceRepository,
+    InMemoryDeliveryCompletionEvidenceRepository,
+    str,
+    str,
+]:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+
+    delivery_snapshots = InMemoryOrderDeliverySnapshotRepository()
+    seed_delivery_snapshot(
+        delivery_snapshots,
+        order_id=order.order_id,
+        order_version_id=order_version.order_version_id,
+        time_window_text=order_version.time_window_text,
+        location_text=order_version.location_text,
+    )
+    kitchen_evidence = InMemoryKitchenCompletionEvidenceRepository()
+    KitchenExecutionService(
+        orders,
+        kitchen_evidence,
+        clock=lambda: _NOW,
+    ).record_kitchen_completion(
+        order.order_id,
+        order_version.order_version_id,
+        completed_at=_NOW,
+        recorded_by="kitchen-panel",
+        evidence_reference="ticket-42",
+    )
+    return (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        InMemoryDispatchEvidenceRepository(),
+        InMemoryDeliveryCompletionEvidenceRepository(),
+        order.order_id,
+        order_version.order_version_id,
+    )
+
+
+def _service(
+    orders: InMemoryOrderRepository,
+    kitchen_evidence: InMemoryKitchenCompletionEvidenceRepository,
+    delivery_snapshots: InMemoryOrderDeliverySnapshotRepository,
+    dispatch_repo: InMemoryDispatchEvidenceRepository,
+    completion_repo: InMemoryDeliveryCompletionEvidenceRepository,
+) -> DeliveryExecutionService:
+    return DeliveryExecutionService(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        clock=lambda: _NOW,
+    )
+
+
+def test_record_dispatch_persists_append_only_evidence() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+
+    result = service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    assert result.replay is False
+    stored = dispatch_repo.get_by_order_version_id(order_id, version_id)
+    assert stored == result.evidence
+
+
+def test_record_dispatch_replay_is_idempotent() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+    first = service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    second = service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    assert first.evidence == second.evidence
+    assert second.replay is True
+
+
+def test_record_dispatch_rejects_conflicting_replay() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+    service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    with pytest.raises(DeliveryEvidenceConflictError):
+        service.record_dispatch(
+            order_id,
+            version_id,
+            dispatched_at=_NOW,
+            recorded_by="office-dispatch",
+            evidence_reference="dispatch-99",
+        )
+
+
+def test_record_dispatch_blocked_without_kitchen_completion() -> None:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+
+    delivery_snapshots = InMemoryOrderDeliverySnapshotRepository()
+    seed_delivery_snapshot(
+        delivery_snapshots,
+        order_id=order.order_id,
+        order_version_id=order_version.order_version_id,
+    )
+    dispatch_repo = InMemoryDispatchEvidenceRepository()
+    service = _service(
+        orders,
+        InMemoryKitchenCompletionEvidenceRepository(),
+        delivery_snapshots,
+        dispatch_repo,
+        InMemoryDeliveryCompletionEvidenceRepository(),
+    )
+
+    with pytest.raises(DeliveryExecutionBlockedError):
+        service.record_dispatch(
+            order.order_id,
+            order_version.order_version_id,
+            dispatched_at=_NOW,
+            recorded_by="office-dispatch",
+            evidence_reference="dispatch-77",
+        )
+
+
+def test_record_delivery_completion_requires_dispatch() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+
+    with pytest.raises(DeliveryExecutionBlockedError):
+        service.record_delivery_completion(
+            order_id,
+            version_id,
+            completed_at=_COMPLETED_AT,
+            recorded_by="office-dispatch",
+            evidence_reference="delivered-88",
+        )
+
+
+def test_record_delivery_completion_replay_is_idempotent() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+    service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    first = service.record_delivery_completion(
+        order_id,
+        version_id,
+        completed_at=_COMPLETED_AT,
+        recorded_by="office-dispatch",
+        evidence_reference="delivered-88",
+    )
+    second = service.record_delivery_completion(
+        order_id,
+        version_id,
+        completed_at=_COMPLETED_AT,
+        recorded_by="office-dispatch",
+        evidence_reference="delivered-88",
+    )
+    assert first.evidence == second.evidence
+    assert second.replay is True
+
+
+def test_delivery_queue_and_evidence_do_not_mutate_order_version() -> None:
+    (
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+        order_id,
+        version_id,
+    ) = _delivery_eligible_order()
+    before = orders.get_order_version(version_id)
+    assert before is not None
+
+    queue = DeliveryQueueProjectionService(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+    ).list_queue()
+    assert len(queue) == 1
+
+    service = _service(
+        orders,
+        kitchen_evidence,
+        delivery_snapshots,
+        dispatch_repo,
+        completion_repo,
+    )
+    service.record_dispatch(
+        order_id,
+        version_id,
+        dispatched_at=_NOW,
+        recorded_by="office-dispatch",
+        evidence_reference="dispatch-77",
+    )
+    service.record_delivery_completion(
+        order_id,
+        version_id,
+        completed_at=_COMPLETED_AT,
+        recorded_by="office-dispatch",
+        evidence_reference="delivered-88",
+    )
+
+    after = orders.get_order_version(version_id)
+    assert after == before
+
+
+def test_delivery_execution_services_must_not_depend_on_offer_or_catalog() -> None:
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "src" / "catering_system" / "services"
+    for name in (
+        "delivery_queue_projection_service.py",
+        "delivery_execution_service.py",
+    ):
+        text = (root / name).read_text(encoding="utf-8")
+        assert "OfferRepository" not in text, name
+        assert "offer_repository" not in text, name
+        assert "CatalogRepository" not in text, name


### PR DESCRIPTION
## Summary

- Add frozen `OrderDeliverySnapshot` at accepted-offer conversion and `DeliveryQueueProjectionService` gated on `KitchenCompletionEvidence` + `fulfillment_mode = DELIVERY`.
- Add append-only `DispatchEvidence` and `DeliveryCompletionEvidence` (completion requires dispatch) with Office API endpoints.
- Wire contract test helpers to production projection service; add flow + service unit tests.

Completes the first Core delivery execution cycle:

```text
Order → READY_TO_SEND → KitchenCompletionEvidence
  → DeliveryQueueProjection → DispatchEvidence → DeliveryCompletionEvidence
```

Explicitly out of scope: courier assignment, routes/GPS/ETA, and changes to `courier-app` / Wochenübersicht (Variant A preserved).

## Test plan

- [x] `pytest tests/unit/test_delivery_execution_contract.py`
- [x] `pytest tests/unit/test_delivery_execution_flow.py`
- [x] `pytest tests/unit/test_delivery_execution_service.py`
- [x] Full suite: `2739 passed`
- [x] Boundary grep: no `OfferRepository` / `InquiryRepository` / `Configurator` / `OrderCommercialSnapshot` in delivery services/domain


Made with [Cursor](https://cursor.com)