### PR TITLE
PHASE-3B: Add kitchen print agent contract tests

### DIFF
--- a/docs/decisions/PHASE_3B_KITCHEN_PRINT_AGENT_V1.md
+++ b/docs/decisions/PHASE_3B_KITCHEN_PRINT_AGENT_V1.md
@@ -1,0 +1,393 @@
+# PHASE_3B_KITCHEN_PRINT_AGENT_V1
+
+Status: **accepted ADR — implementation not started**
+
+Depends on: Slice 3A (`KitchenPrintJob` facts, repository, service) — **frozen**
+
+Related: `PHASE_3_PRINT_ACK_ATTENTION_PACK_V1.md`, `PRINT_PROJECTION_SCOPE_V1.md`
+
+Scope: Core API kitchen-agent contract, claim idempotency, immutable print
+document delivery. No agent process, CUPS adapter, or Office UX in this slice.
+
+---
+
+## 1. Purpose
+
+Slice 3B adds the **kitchen print agent API boundary** on top of existing
+Phase 3A job facts. It answers:
+
+1. Which job may the agent take?
+2. How does the agent obtain an **immutable** print artifact?
+3. How does the agent report technical rejection?
+4. How does command replay return the same result?
+
+It does **not** change Slice 3A domain facts, SQLite job triggers, or
+`acknowledge_print_job()` / `kitchen_print_confirmed_at` semantics.
+
+---
+
+## 2. Layering
+
+```text
+Domain
+ └── KitchenPrintJob              facts only (Slice 3A, frozen)
+
+Application
+ ├── KitchenPrintService          claim / accept / reject orchestration
+ ├── KitchenPrintDocument         immutable claim snapshot (DTO)
+ └── KitchenPrintDocumentFactory  resolve + render + hash
+
+Infrastructure
+ ├── KitchenPrintJobRepository    atomic claim_next_eligible()
+ ├── Command ledger               idempotency (reuse office_api pattern)
+ └── DocumentStore                persisted artifact by document_ref
+```
+
+### 2.1 `KitchenPrintDocument` — application DTO, not domain entity
+
+The frozen print artifact is **not** a domain aggregate and **not** the primary
+ledger object. Responsibilities stay separate:
+
+| Concern | Owner |
+|---|---|
+| Command idempotency | `office_api_ledger` (`command_id`, fingerprint, stored response) |
+| Print artifact lifecycle | `KitchenPrintDocument` + `DocumentStore` |
+
+Suggested shape:
+
+```python
+@dataclass(frozen=True)
+class KitchenPrintDocument:
+    document_ref: str          # stable content address, e.g. sha256 hex
+    print_job_id: str
+    projection_hash: str       # canonical hash of resolved projection JSON
+    content_type: str          # e.g. text/html; charset=utf-8
+    body: bytes
+    created_at: datetime
+```
+
+The ledger stores **references** (`document_ref`, job IDs, timestamps) in the
+replay response body. Full `body` bytes live in `DocumentStore` keyed by
+`document_ref`.
+
+---
+
+## 3. Mandatory invariants
+
+```text
+Invariant 1:
+  Agent never confirms a business fact.
+  Agent must not call acknowledge_print_job() or mutate
+  OrderVersion.kitchen_print_confirmed_at.
+
+Invariant 2:
+  Every accepted print job has exactly one immutable print document
+  once document creation completes.
+
+Invariant 3:
+  Replaying a claim command returns identical document_ref and payload
+  (via command ledger + DocumentStore lookup).
+
+Invariant 4:
+  Kitchen print resolution never selects candidate/effective versions.
+  Target is always the job's immutable order_version_id.
+
+Invariant 5:
+  OrderVersion.kitchen_print_confirmed_at changes only through
+  acknowledge_print_job() (Office/human path).
+```
+
+---
+
+## 4. Atomic claim — repository use case
+
+Do **not** implement claim as `list_open_jobs()` followed by
+`accept_print_job()`. That introduces a race window.
+
+Add one repository operation:
+
+```text
+KitchenPrintJobRepository.claim_next_eligible(now, policy) -> KitchenPrintJob | None
+
+BEGIN IMMEDIATE
+  SELECT oldest eligible job
+    WHERE acknowledged_at IS NULL
+      AND rejected_at IS NULL
+      AND superseded_at IS NULL
+      AND accepted_at IS NULL
+      AND accept_deadline_at > now
+    ORDER BY accept_deadline_at ASC, requested_at ASC
+    LIMIT 1
+  IF none: COMMIT; return None
+  UPDATE SET accepted_at = now, ack_deadline_at = now + acknowledgment_timeout
+COMMIT
+```
+
+Cancellation is checked in the service layer before/after claim (owner Order
+`cancelled_at`). Rejected path uses existing `reject_print_job()`.
+
+---
+
+## 5. Idempotency — command ledger only
+
+Reuse the existing Office API pattern:
+
+```text
+command_id + command_fingerprint → ledger.get / ledger.record
+```
+
+Agent routes (`POST /kitchen/v1/print-jobs/claim-next`,
+`POST /kitchen/v1/print-jobs/{id}/reject`) use the same envelope.
+
+Do **not** add `claimed_by` or `agent_id` to `KitchenPrintJob`. Agent identity
+is transport/auth (`KITCHEN_PRINT_AGENT_TOKEN`), not a persisted job fact.
+
+Replay flow:
+
+```text
+Agent --command_id=abc--> Core API
+                              |
+                              +-- ledger hit → return stored response
+                              +-- ledger miss → claim + document → record → return
+```
+
+---
+
+## 6. Print resolution — `PrintIntent.kitchen_job`
+
+Existing intents (`preview`, `change_preview`, `final`) are Office UI semantics.
+Kitchen agent needs a distinct contract:
+
+```text
+"Production sheet for this exact OrderVersion"
+```
+
+```python
+OrderPrintProjectionService.resolve(
+    order_id,
+    order_version_id,
+    intent="kitchen_job",
+)
+```
+
+### 6.1 Must use
+
+- Requested `OrderVersion` event facts (date, time, location, guests, stand #)
+- Frozen `OrderCommercialSnapshot` (positions, variant label)
+- Order cancellation fact (`order_cancelled_at`) for STORNIERT banner only
+
+### 6.2 Must not use
+
+- Candidate / effective version **selection** (no "print the effective stand")
+- UI watermark logic (`ENTWURF`, `VERALTET`, `ÄNDERUNG – NOCH NICHT WIRKSAM`)
+- Preview semantics (`is_preview`, stale flags derived from live effective switch)
+
+Implementation: extend `_resolve_flags()` with a `kitchen_job` branch that
+returns stable flags for the job-bound version. Only operational safety banners
+(e.g. cancelled order) remain.
+
+---
+
+## 7. Immutable document — flags hazard
+
+`PrintFlagsBlock` today depends on **live** Order state. Re-fetching projection
+after an effective-version switch can change watermarks for the same
+`order_version_id`.
+
+Therefore:
+
+```text
+claim-next
+  → resolve(intent="kitchen_job")     # once
+  → render → bytes                    # once
+  → projection_hash + document_ref    # once
+  → DocumentStore.save
+  → ledger.record(response with refs)
+```
+
+Subsequent reads (replay, optional `GET .../document`) load from
+`DocumentStore` by `document_ref`. Never re-render from live projection for an
+accepted job.
+
+---
+
+## 8. Transaction boundary — MVP (Variant A)
+
+Rendering inside a SQLite `BEGIN IMMEDIATE` is too slow (HTML/PDF generation).
+
+**Slice 3B MVP:**
+
+```text
+BEGIN IMMEDIATE
+  claim_next_eligible()   # sets accepted_at + ack_deadline_at
+COMMIT
+
+resolve(intent="kitchen_job")
+render document
+DocumentStore.save(document)
+ledger.record(full response)
+```
+
+### 8.1 Attention state: accepted without document
+
+Between COMMIT and DocumentStore.save, a crash leaves:
+
+```text
+accepted_at != null
+document_ref == null
+```
+
+This is a **derived attention condition** (not a new persisted status column):
+
+```text
+derive: document_pending = accepted_at IS NOT NULL AND no DocumentStore entry
+```
+
+Office print-attention read (Slice 3C) surfaces this. Agent retry with the
+same `command_id` completes idempotently once ledger + store exist.
+
+### 8.2 Deferred (Variant B — later slice)
+
+Explicit artifact lifecycle facts (`document_created_at`, `ready_for_print_at`)
+or a separate `KitchenPrintArtifact` table. Not required for 3B MVP.
+
+---
+
+## 9. API contract (Slice 3B)
+
+Auth: `KITCHEN_PRINT_AGENT_TOKEN` bearer. Office token cannot call agent routes.
+
+### 9.1 Claim
+
+```http
+POST /kitchen/v1/print-jobs/claim-next
+```
+
+Request:
+
+```json
+{
+  "command_id": "uuid"
+}
+```
+
+Success response (first call and replay):
+
+```json
+{
+  "command_id": "uuid",
+  "print_job_id": "uuid",
+  "order_id": "uuid",
+  "order_version_id": "uuid",
+  "accepted_at": "2026-08-08T11:00:00+00:00",
+  "ack_deadline_at": "2026-08-08T11:05:00+00:00",
+  "document_ref": "sha256:…",
+  "document": {
+    "content_type": "text/html; charset=utf-8",
+    "body_base64": "…"
+  }
+}
+```
+
+Empty queue: `204` or structured `{ "job": null }` — pick one in contract tests
+and freeze.
+
+Optional later: `GET /kitchen/v1/print-jobs/{id}/document` for crash recovery
+without replaying full body in ledger.
+
+### 9.2 Reject
+
+```http
+POST /kitchen/v1/print-jobs/{print_job_id}/reject
+```
+
+```json
+{
+  "command_id": "uuid",
+  "rejection_code": "printer_unavailable"
+}
+```
+
+Allowlisted codes unchanged from Slice 3A domain.
+
+### 9.3 ACK — explicitly out of agent scope
+
+```text
+Agent → physical print result → reject OR (success, no domain ACK)
+Office → human confirmation → POST .../ack → acknowledge_print_job()
+       → kitchen_print_confirmed_at
+```
+
+---
+
+## 10. Application flow (3B)
+
+```text
+POST /kitchen/v1/print-jobs/claim-next
+        |
+        v
+KitchenPrintService
+        |
+        +-- claim_next_eligible()          [repo, atomic]
+        |
+        +-- OrderPrintProjectionService
+        |         .resolve(..., intent="kitchen_job")
+        |
+        +-- KitchenPrintDocumentFactory
+        |         .create(projection) → KitchenPrintDocument
+        |
+        +-- DocumentStore.save(document)
+        |
+        +-- ledger.record(response)
+        v
+Agent → CUPS / lp adapter (Slice 3D, out of scope here)
+```
+
+Renderer for MVP: extract `render_print_sheet()` logic to an application-layer
+function callable from Core API (HTML bytes). PDF rendering is a later deployment
+slice.
+
+---
+
+## 11. Explicitly out of scope (3B)
+
+- `kitchen_print_agent` systemd process (Slice 3D)
+- CUPS / physical printer adapter (Slice 3F)
+- Office Panel attention UX (Slice 3C)
+- Changes to Slice 3A `KitchenPrintJob` fields or SQLite triggers
+- Agent-side domain ACK or `kitchen_print_confirmed_at` mutation
+- `claimed_by` / `agent_id` on job rows
+- Heartbeat persistence to SQLite (in-process memory only, per Phase 3 pack)
+
+---
+
+## 12. Implementation order (PR: PHASE-3B-PRINT-AGENT-CONTRACT)
+
+0. **Contract tests** — `tests/unit/test_kitchen_print_agent_contract.py` +
+   `tests/helpers/kitchen_print_agent_contract.py` (reference boundary; 9 tests)
+1. ADR + contract tests green against reference boundary
+2. `claim_next_eligible()` on repository (+ in-memory mirror)
+3. `PrintIntent.kitchen_job` + tests (no UI watermarks)
+4. `KitchenPrintDocument` DTO + `KitchenPrintDocumentFactory` + `DocumentStore`
+5. Kitchen-agent HTTP routes wired through command ledger
+6. Integration tests: claim → document immutable on replay; accepted-without-
+   document attention derivable
+
+Contract helpers delegate to production once each slice lands; until then the
+reference boundary encodes ADR invariants and must stay green.
+
+No Slice 3A code changes unless a test-only seam is required.
+
+---
+
+## 13. Test obligations
+
+| Test | Proves |
+|---|---|
+| `claim_next_eligible` atomic under contention | no double-accept |
+| `kitchen_job` intent stable flags | Invariant 4 |
+| same `command_id` → same `document_ref` + body | Invariant 3 |
+| agent token cannot call office routes / vice versa | capability separation |
+| agent cannot reach `acknowledge_print_job` | Invariant 1 |
+| replay after crash mid-document-create | idempotent completion |
+| `flags` not re-derived on document fetch | §7 immutability |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,6 +18,7 @@ review that updates architecture, tests, runbooks, and this register.
 | ADR-011 | Core Office API supersedes the panel's in-process Core access | After cutover exactly three Lenovo processes touch `core.db`: Core Office API (read+command), kiosk (read), website-intake receiver (Inquiry create) |
 | ADR-012 | Payment method is agreed in the accepted offer; Office tracks reminders only | Keep commercial terms explicit without turning Office or operational Core into accounting software |
 | ADR-013 | Commercial Offer is a separate aggregate between Inquiry and Order | Preserve commercial history and accepted variants without mixing pricing with operational OrderVersion truth |
+| ADR-014 | Kitchen print agent gets immutable documents via claim + ledger; agent never domain-ACKs | Separates technical delivery from business confirmation; Slice 3B contract |
 
 ## ADR-001 — Core on Lenovo
 
@@ -330,6 +331,28 @@ boundaries remain unchanged until separately accepted implementation slices are
 deployed. Future storage must be additive, tolerate records without an Offer,
 and permit rollback to the legacy conversion path without altering existing
 Order or OrderVersion history.
+
+## ADR-014 — Kitchen print agent contract (Slice 3B)
+
+Full detail: [PHASE_3B_KITCHEN_PRINT_AGENT_V1.md](PHASE_3B_KITCHEN_PRINT_AGENT_V1.md)
+
+The kitchen print agent is a narrow Core API client. It claims durable
+`KitchenPrintJob` rows, receives a **frozen** print document, and may record
+technical rejection. It never opens `core.db`, never confirms
+`kitchen_print_confirmed_at`, and never selects candidate/effective versions.
+
+Consequences:
+
+- claim is one atomic repository use case (`claim_next_eligible`), not
+  list-then-accept;
+- command idempotency reuses the office command ledger; job rows store no
+  `claimed_by`;
+- `KitchenPrintDocument` is an application DTO; ledger stores refs, DocumentStore
+  stores bytes;
+- `PrintIntent.kitchen_job` resolves production sheets without UI watermarks;
+- accepted-without-document is an attention state (MVP Variant A), not a new
+  status column;
+- domain ACK remains Office/human via `acknowledge_print_job()`.
 
 ## How to add a decision
 

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -1,0 +1,389 @@
+"""Slice 3B kitchen print agent contract — reference boundary for ADR tests.
+
+CONTRACT REFERENCE: these functions encode PHASE_3B_KITCHEN_PRINT_AGENT_V1
+invariants. When production Slice 3B lands, each entry point should delegate
+to the real service/repository and drop the inline reference logic.
+
+Tests import only from this module (and existing Slice 3A types), never from
+future production agent modules directly.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from catering_system.domain.kitchen_print_job import (
+    KitchenPrintJob,
+    KitchenPrintPolicy,
+    derive_kitchen_print_job_state,
+)
+from catering_system.domain.order import Order
+from catering_system.repositories.kitchen_print_job_repository import (
+    KitchenPrintJobRepository,
+)
+from catering_system.repositories.order_commercial_snapshot_repository import (
+    OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    PrintFlagsBlock,
+    PrintProjectionNotFoundError,
+)
+
+_CLAIM_ROUTE = "POST /kitchen/v1/print-jobs/claim-next"
+_AGENT_CLIENT_ID = "kitchen-print-agent"
+_CLAIM_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class KitchenPrintDocument:
+    """Application DTO — immutable print artifact at claim time (ADR §2.1)."""
+
+    document_ref: str
+    print_job_id: str
+    projection_hash: str
+    content_type: str
+    body: bytes
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class AgentClaimResult:
+    job: KitchenPrintJob
+    document: KitchenPrintDocument
+
+
+@dataclass(frozen=True)
+class RecordedAgentCommand:
+    command_id: str
+    fingerprint: str
+    result_status: int
+    result_body: str
+
+
+def command_fingerprint(
+    *,
+    command_id: str,
+    route_template: str = _CLAIM_ROUTE,
+    args: dict[str, object] | None = None,
+) -> str:
+    canonical = json.dumps(
+        {
+            "route_template": route_template,
+            "command_id": command_id,
+            "args": args or {},
+            "client_id": _AGENT_CLIENT_ID,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class InMemoryDocumentStore:
+    def __init__(self) -> None:
+        self._by_ref: dict[str, KitchenPrintDocument] = {}
+
+    def save(self, document: KitchenPrintDocument) -> None:
+        if document.document_ref in self._by_ref:
+            existing = self._by_ref[document.document_ref]
+            if existing != document:
+                raise ValueError("document_ref conflict")
+            return
+        self._by_ref[document.document_ref] = document
+
+    def get(self, document_ref: str) -> KitchenPrintDocument | None:
+        return self._by_ref.get(document_ref)
+
+
+class InMemoryAgentCommandLedger:
+    def __init__(self) -> None:
+        self._rows: dict[str, RecordedAgentCommand] = {}
+
+    def get(self, command_id: str) -> RecordedAgentCommand | None:
+        return self._rows.get(command_id)
+
+    def record(
+        self,
+        command_id: str,
+        fingerprint: str,
+        result_status: int,
+        result_body: str,
+    ) -> None:
+        self._rows[command_id] = RecordedAgentCommand(
+            command_id=command_id,
+            fingerprint=fingerprint,
+            result_status=result_status,
+            result_body=result_body,
+        )
+
+
+def is_eligible_for_claim(
+    job: KitchenPrintJob,
+    *,
+    now: datetime,
+    order: Order | None,
+) -> bool:
+    if order is not None and order.cancelled_at is not None:
+        return False
+    if job.accepted_at is not None:
+        return False
+    if job.rejected_at is not None or job.superseded_at is not None:
+        return False
+    if job.acknowledged_at is not None:
+        return False
+    if now >= job.accept_deadline_at:
+        return False
+    return derive_kitchen_print_job_state(job, now=now, order_cancelled=False) in {
+        "awaiting_acceptance",
+    }
+
+
+def _all_jobs(job_repository: KitchenPrintJobRepository) -> tuple[KitchenPrintJob, ...]:
+    if hasattr(job_repository, "_jobs"):
+        return tuple(job_repository._jobs.values())  # type: ignore[attr-defined]
+    raise TypeError("contract claim requires in-memory job repository for reference scan")
+
+
+def claim_next_eligible(
+    order_repository: OrderRepository,
+    job_repository: KitchenPrintJobRepository,
+    *,
+    now: datetime,
+    policy: KitchenPrintPolicy,
+    lock: threading.Lock | None = None,
+) -> KitchenPrintJob | None:
+    """Reference atomic claim — production replaces with repo.claim_next_eligible()."""
+
+    active_lock = lock or _CLAIM_LOCK
+    with active_lock:
+        eligible: list[KitchenPrintJob] = []
+        for job in sorted(
+            _all_jobs(job_repository),
+            key=lambda row: (row.accept_deadline_at, row.requested_at, row.print_job_id),
+        ):
+            order = order_repository.get_order(job.order_id)
+            if not is_eligible_for_claim(job, now=now, order=order):
+                continue
+            eligible.append(job)
+        if not eligible:
+            return None
+        target = eligible[0]
+        accepted = replace(
+            target,
+            accepted_at=now,
+            ack_deadline_at=now + policy.acknowledgment_timeout,
+        )
+        job_repository.update(accepted)
+        return accepted
+
+
+def resolve_kitchen_job_projection(
+    order_repository: OrderRepository,
+    commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+    *,
+    order_id: str,
+    order_version_id: str,
+) -> OrderPrintProjection:
+    """Reference kitchen_job intent — production uses intent='kitchen_job'."""
+
+    order = order_repository.get_order(order_id)
+    version = order_repository.get_order_version(order_version_id)
+    if order is None or version is None or version.order_id != order_id:
+        raise PrintProjectionNotFoundError(order_version_id)
+
+    snapshot = commercial_snapshot_repository.get_by_order_id(order_id)
+    if snapshot is None:
+        raise PrintProjectionNotFoundError(order_id)
+
+    from catering_system.services.order_print_projection_service import (
+        _commercial_from_snapshot,
+        _event_block,
+    )
+
+    return OrderPrintProjection(
+        event=_event_block(order, version),
+        commercial=_commercial_from_snapshot(snapshot, version.guest_count_estimate),
+        flags=PrintFlagsBlock(
+            intent="kitchen_job",  # type: ignore[arg-type]
+            is_preview=False,
+            is_final_allowed=False,
+            is_stale=False,
+            watermark=None,
+        ),
+    )
+
+
+def _canonical_projection_json(projection: OrderPrintProjection) -> str:
+    event = projection.event
+    commercial = projection.commercial
+    flags = projection.flags
+    payload = {
+        "event": {
+            "order_id": event.order_id,
+            "order_version_id": event.order_version_id,
+            "version_number": event.version_number,
+            "event_date": event.event_date.isoformat(),
+            "time_window_text": event.time_window_text,
+            "location_text": event.location_text,
+            "guest_count_estimate": event.guest_count_estimate,
+            "planning_mode": event.planning_mode,
+        },
+        "commercial": {
+            "source": commercial.source,
+            "variant_label": commercial.variant_label,
+            "positions": [
+                {
+                    "position_id": line.position_id,
+                    "name": line.name,
+                    "quantity_display": line.quantity_display,
+                }
+                for line in commercial.positions
+            ],
+        },
+        "flags": {
+            "intent": flags.intent,
+            "watermark": flags.watermark,
+            "is_preview": flags.is_preview,
+            "is_stale": flags.is_stale,
+        },
+    }
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def create_kitchen_print_document(
+    projection: OrderPrintProjection,
+    job: KitchenPrintJob,
+    *,
+    now: datetime,
+    render_html: Callable[[OrderPrintProjection], str] | None = None,
+) -> KitchenPrintDocument:
+    projection_hash = hashlib.sha256(
+        _canonical_projection_json(projection).encode("utf-8")
+    ).hexdigest()
+    if render_html is not None:
+        body = render_html(projection).encode("utf-8")
+    else:
+        body = _minimal_kitchen_html(projection).encode("utf-8")
+    document_ref = f"sha256:{hashlib.sha256(body).hexdigest()}"
+    return KitchenPrintDocument(
+        document_ref=document_ref,
+        print_job_id=job.print_job_id,
+        projection_hash=projection_hash,
+        content_type="text/html; charset=utf-8",
+        body=body,
+        created_at=now,
+    )
+
+
+def _minimal_kitchen_html(projection: OrderPrintProjection) -> str:
+    event = projection.event
+    lines = [
+        "<html><body>",
+        f"<p>order_version_id={event.order_version_id}</p>",
+        f"<p>version_number={event.version_number}</p>",
+        f"<p>location={event.location_text}</p>",
+    ]
+    for position in projection.commercial.positions:
+        lines.append(f"<p>{position.name}</p>")
+    lines.append("</body></html>")
+    return "".join(lines)
+
+
+def claim_with_document(
+    order_repository: OrderRepository,
+    job_repository: KitchenPrintJobRepository,
+    commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+    document_store: InMemoryDocumentStore,
+    *,
+    now: datetime,
+    policy: KitchenPrintPolicy,
+) -> AgentClaimResult | None:
+    job = claim_next_eligible(
+        order_repository,
+        job_repository,
+        now=now,
+        policy=policy,
+    )
+    if job is None:
+        return None
+    projection = resolve_kitchen_job_projection(
+        order_repository,
+        commercial_snapshot_repository,
+        order_id=job.order_id,
+        order_version_id=job.order_version_id,
+    )
+    document = create_kitchen_print_document(projection, job, now=now)
+    document_store.save(document)
+    return AgentClaimResult(job=job, document=document)
+
+
+def execute_claim_command(
+    *,
+    command_id: str,
+    order_repository: OrderRepository,
+    job_repository: KitchenPrintJobRepository,
+    commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+    document_store: InMemoryDocumentStore,
+    ledger: InMemoryAgentCommandLedger,
+    now: datetime,
+    policy: KitchenPrintPolicy,
+) -> tuple[int, str]:
+    fingerprint = command_fingerprint(command_id=command_id)
+    recorded = ledger.get(command_id)
+    if recorded is not None:
+        if recorded.fingerprint != fingerprint:
+            raise ValueError("command_id_conflict")
+        return recorded.result_status, recorded.result_body
+
+    result = claim_with_document(
+        order_repository,
+        job_repository,
+        commercial_snapshot_repository,
+        document_store,
+        now=now,
+        policy=policy,
+    )
+    if result is None:
+        body = json.dumps({"command_id": command_id, "job": None}, sort_keys=True)
+        ledger.record(command_id, fingerprint, 204, body)
+        return 204, body
+
+    payload = {
+        "command_id": command_id,
+        "print_job_id": result.job.print_job_id,
+        "order_id": result.job.order_id,
+        "order_version_id": result.job.order_version_id,
+        "accepted_at": result.job.accepted_at.isoformat()
+        if result.job.accepted_at is not None
+        else None,
+        "ack_deadline_at": result.job.ack_deadline_at.isoformat()
+        if result.job.ack_deadline_at is not None
+        else None,
+        "document_ref": result.document.document_ref,
+        "document": {
+            "content_type": result.document.content_type,
+            "body_base64": base64.b64encode(result.document.body).decode("ascii"),
+        },
+    }
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    ledger.record(command_id, fingerprint, 200, body)
+    return 200, body
+
+
+def load_document_by_ref(
+    document_store: InMemoryDocumentStore,
+    document_ref: str,
+) -> KitchenPrintDocument:
+    document = document_store.get(document_ref)
+    if document is None:
+        raise LookupError(document_ref)
+    return document

--- a/tests/unit/test_kitchen_print_agent_contract.py
+++ b/tests/unit/test_kitchen_print_agent_contract.py
@@ -1,0 +1,398 @@
+"""Slice 3B contract tests — Kitchen Print Agent boundary (PR: PHASE-3B-PRINT-CONTRACT-TESTS).
+
+Proves claim eligibility, atomicity, technical-vs-domain separation, kitchen_job
+intent, document immutability, ledger replay, reject path, and human-only ACK.
+No production Slice 3B implementation required — tests encode ADR invariants via
+tests.helpers.kitchen_print_agent_contract reference boundary.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta
+
+from catering_system.domain.inquiry import (
+    CALL_VERIFICATION_STATUSES,
+    CRM_PIPELINE,
+    Inquiry,
+    PLANNING_MODES,
+)
+from catering_system.domain.kitchen_print_job import KitchenPrintJob, KitchenPrintPolicy
+from catering_system.repositories.in_memory_kitchen_print_job_repository import (
+    InMemoryKitchenPrintJobRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.kitchen_print_service import KitchenPrintService
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_service import OrderService
+from tests.helpers.kitchen_print_agent_contract import (
+    InMemoryAgentCommandLedger,
+    InMemoryDocumentStore,
+    claim_next_eligible,
+    claim_with_document,
+    execute_claim_command,
+    is_eligible_for_claim,
+    load_document_by_ref,
+    resolve_kitchen_job_projection,
+)
+from tests.helpers.order_seed import seed_order
+from tests.unit.test_offer_service import _accepted_offer_state
+
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot as _CCSnapshot,
+)
+
+_NOW = datetime(2026, 8, 8, 11, 0, tzinfo=UTC)
+_POLICY = KitchenPrintPolicy(
+    acceptance_timeout=timedelta(seconds=30),
+    acknowledgment_timeout=timedelta(minutes=5),
+)
+
+_JOB_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_JOB_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_JOB_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+_JOB_D = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+
+
+def _inquiry(*, location: str = "Hamburg") -> Inquiry:
+    now = datetime(2026, 8, 8, 8, 0, tzinfo=UTC)
+    return Inquiry(
+        inquiry_id=str(uuid.uuid4()),
+        event_date=date(2026, 10, 1),
+        created_at=now,
+        updated_at=now,
+        inquiry_source="manual",
+        crm_stage=CRM_PIPELINE[0],
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text=location,
+        guest_count_estimate=25,
+        planning_mode=PLANNING_MODES[0],
+        call_verification_required=False,
+        call_verification_status=CALL_VERIFICATION_STATUSES[0],
+        customer_snapshot=_CCSnapshot(email="kunde@example.com", phone="+49301234567"),
+    )
+
+
+def _print_service(
+    orders: InMemoryOrderRepository,
+    jobs: InMemoryKitchenPrintJobRepository,
+) -> KitchenPrintService:
+    return KitchenPrintService(
+        orders,
+        jobs,
+        policy=_POLICY,
+        clock=lambda: _NOW,
+    )
+
+
+def _requested_job(
+    service: KitchenPrintService,
+    order_id: str,
+    version_id: str,
+    print_job_id: str,
+) -> KitchenPrintJob:
+    return service.request_print(order_id, version_id, print_job_id=print_job_id)
+
+
+def _eligible_job_setup() -> tuple[
+    InMemoryOrderRepository,
+    InMemoryKitchenPrintJobRepository,
+    KitchenPrintService,
+    KitchenPrintJob,
+]:
+    orders = InMemoryOrderRepository()
+    order_a, version_a = seed_order(orders, _inquiry(location="A"))
+    order_b, version_b = seed_order(orders, _inquiry(location="B"))
+    order_c, version_c = seed_order(orders, _inquiry(location="C"))
+    order_d, version_d = seed_order(orders, _inquiry(location="D"))
+    jobs = InMemoryKitchenPrintJobRepository(orders)
+    service = _print_service(orders, jobs)
+
+    job_a = _requested_job(service, order_a.order_id, version_a.order_version_id, _JOB_A)
+    job_b = _requested_job(service, order_b.order_id, version_b.order_version_id, _JOB_B)
+    job_c = _requested_job(service, order_c.order_id, version_c.order_version_id, _JOB_C)
+    job_d = _requested_job(service, order_d.order_id, version_d.order_version_id, _JOB_D)
+
+    service.accept_print_job(_JOB_B)
+    service.reject_print_job(_JOB_C, "printer_unavailable")
+    service.accept_print_job(_JOB_D)
+    service.reprint(_JOB_D, new_print_job_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+
+    assert is_eligible_for_claim(
+        job_a, now=_NOW, order=orders.get_order(order_a.order_id)
+    )
+    assert not is_eligible_for_claim(
+        jobs.get(_JOB_B) or job_b, now=_NOW, order=orders.get_order(order_b.order_id)
+    )
+    assert not is_eligible_for_claim(
+        jobs.get(_JOB_C) or job_c, now=_NOW, order=orders.get_order(order_c.order_id)
+    )
+    superseded = jobs.get(_JOB_D)
+    assert superseded is not None and superseded.superseded_at is not None
+
+    return orders, jobs, service, job_a
+
+
+def test_claim_next_eligible_returns_only_awaiting_acceptance_job() -> None:
+    orders, jobs, _service, job_a = _eligible_job_setup()
+
+    claimed = claim_next_eligible(orders, jobs, now=_NOW, policy=_POLICY)
+
+    assert claimed is not None
+    assert claimed.print_job_id == job_a.print_job_id
+    assert claimed.order_version_id == job_a.order_version_id
+    assert claimed.accepted_at == _NOW
+    assert claimed.ack_deadline_at == _NOW + _POLICY.acknowledgment_timeout
+
+
+def test_claim_next_eligible_is_atomic_under_concurrency() -> None:
+    orders = InMemoryOrderRepository()
+    first_order, first_version = seed_order(orders, _inquiry(location="first"))
+    second_order, second_version = seed_order(orders, _inquiry(location="second"))
+    jobs = InMemoryKitchenPrintJobRepository(orders)
+    service = _print_service(orders, jobs)
+    _requested_job(service, first_order.order_id, first_version.order_version_id, _JOB_A)
+    _requested_job(
+        service, second_order.order_id, second_version.order_version_id, _JOB_B
+    )
+
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+    results: list[KitchenPrintJob | None] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=5)
+            results.append(
+                claim_next_eligible(
+                    orders, jobs, now=_NOW, policy=_POLICY, lock=lock
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert len(results) == 2
+    claimed_ids = {job.print_job_id for job in results if job is not None}
+    assert len(claimed_ids) == 2
+    assert claimed_ids == {_JOB_A, _JOB_B}
+
+
+def test_claim_does_not_set_kitchen_print_confirmed_at() -> None:
+    orders, jobs, _service, job_a = _eligible_job_setup()
+
+    claimed = claim_next_eligible(orders, jobs, now=_NOW, policy=_POLICY)
+    assert claimed is not None
+    assert claimed.accepted_at == _NOW
+
+    version = orders.get_order_version(job_a.order_version_id)
+    assert version is not None
+    assert version.kitchen_print_confirmed_at is None
+
+
+def test_kitchen_job_intent_resolves_requested_version_not_effective() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, v1 = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    order_service = OrderService(orders)
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, v1.order_version_id)
+    core.make_order_version_effective(order.order_id, v1.order_version_id)
+
+    v2 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 9, 1),
+        time_window_text="abends",
+        location_text="Lübeck",
+        guest_count_estimate=40,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order.order_id, v2.order_version_id)
+
+    projection = resolve_kitchen_job_projection(
+        orders,
+        offer_service._commercial_snapshots,
+        order_id=order.order_id,
+        order_version_id=v2.order_version_id,
+    )
+
+    assert projection.event.order_version_id == v2.order_version_id
+    assert projection.event.version_number == 2
+    assert projection.event.location_text == "Lübeck"
+    assert projection.flags.intent == "kitchen_job"
+    assert projection.flags.watermark is None
+    assert projection.flags.is_preview is False
+
+
+def test_kitchen_print_document_is_immutable_after_order_mutations() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    jobs = InMemoryKitchenPrintJobRepository(orders)
+    service = _print_service(orders, jobs)
+    service.request_print(
+        order.order_id,
+        order_version.order_version_id,
+        print_job_id=_JOB_A,
+    )
+    store = InMemoryDocumentStore()
+
+    result = claim_with_document(
+        orders,
+        jobs,
+        offer_service._commercial_snapshots,
+        store,
+        now=_NOW,
+        policy=_POLICY,
+    )
+    assert result is not None
+    first_ref = result.document.document_ref
+    first_bytes = result.document.body
+
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, order_version.order_version_id)
+    core.make_order_version_effective(order.order_id, order_version.order_version_id)
+
+    stored = load_document_by_ref(store, first_ref)
+    assert stored.document_ref == first_ref
+    assert stored.body == first_bytes
+
+
+def test_claim_command_replay_returns_byte_identical_response() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    jobs = InMemoryKitchenPrintJobRepository(orders)
+    service = _print_service(orders, jobs)
+    service.request_print(
+        order.order_id,
+        order_version.order_version_id,
+        print_job_id=_JOB_A,
+    )
+    store = InMemoryDocumentStore()
+    ledger = InMemoryAgentCommandLedger()
+    command_id = "11111111-1111-4111-8111-111111111111"
+
+    first_status, first_body = execute_claim_command(
+        command_id=command_id,
+        order_repository=orders,
+        job_repository=jobs,
+        commercial_snapshot_repository=offer_service._commercial_snapshots,
+        document_store=store,
+        ledger=ledger,
+        now=_NOW,
+        policy=_POLICY,
+    )
+    second_status, second_body = execute_claim_command(
+        command_id=command_id,
+        order_repository=orders,
+        job_repository=jobs,
+        commercial_snapshot_repository=offer_service._commercial_snapshots,
+        document_store=store,
+        ledger=ledger,
+        now=_NOW,
+        policy=_POLICY,
+    )
+
+    assert first_status == 200
+    assert second_status == first_status
+    assert second_body == first_body
+
+
+def test_agent_reject_after_claim_leaves_domain_confirmation_unset() -> None:
+    orders, jobs, service, _job_a = _eligible_job_setup()
+
+    claimed = claim_next_eligible(orders, jobs, now=_NOW, policy=_POLICY)
+    assert claimed is not None
+
+    rejected = service.reject_print_job(claimed.print_job_id, "printer_unavailable")
+    version = orders.get_order_version(claimed.order_version_id)
+    assert version is not None
+
+    assert rejected.rejected_at == _NOW
+    assert rejected.rejection_code == "printer_unavailable"
+    assert rejected.acknowledged_at is None
+    assert version.kitchen_print_confirmed_at is None
+
+
+def test_only_acknowledge_print_job_sets_kitchen_print_confirmed_at() -> None:
+    orders, jobs, service, job_a = _eligible_job_setup()
+
+    claimed = claim_next_eligible(orders, jobs, now=_NOW, policy=_POLICY)
+    assert claimed is not None
+    version_before_ack = orders.get_order_version(job_a.order_version_id)
+    assert version_before_ack is not None
+    assert version_before_ack.kitchen_print_confirmed_at is None
+
+    acknowledged, confirmed_version = service.acknowledge_print_job(job_a.print_job_id)
+
+    assert acknowledged.acknowledged_at == _NOW
+    assert confirmed_version.kitchen_print_confirmed_at == _NOW
+    assert (
+        orders.get_order_version(job_a.order_version_id)
+        == confirmed_version
+    )
+
+
+def test_kitchen_print_agent_contract_must_not_import_offer_or_catalog() -> None:
+    from pathlib import Path
+
+    helper = (
+        Path(__file__).resolve().parents[1]
+        / "helpers"
+        / "kitchen_print_agent_contract.py"
+    )
+    text = helper.read_text(encoding="utf-8")
+    assert "OfferRepository" not in text
+    assert "CatalogRepository" not in text


### PR DESCRIPTION
## Summary

Adds executable contract tests for Phase 3B Kitchen Print Agent boundary.

The tests encode ADR-014 and
[PHASE_3B_KITCHEN_PRINT_AGENT_V1.md](docs/decisions/PHASE_3B_KITCHEN_PRINT_AGENT_V1.md) decisions.

## Covered invariants

- atomic claim selects only eligible print jobs
- concurrent agents cannot claim the same job
- technical acceptance is separated from domain confirmation
- kitchen_job intent ignores effective version selection
- kitchen print document remains immutable
- command replay returns identical response
- agent rejection never confirms kitchen print
- only human ACK sets kitchen_print_confirmed_at

## Design notes

The current contract helper is intentionally a reference boundary.
Production implementations will replace the helper behavior incrementally
during PR 2-5.

## Scope

No production code changes.
No schema changes.
No API changes.

## Test plan

- [x] `pytest tests/unit/test_kitchen_print_agent_contract.py -q` — 9 passed
- [x] `pytest -q` — 2721 passed
- [x] `git diff origin/main --stat` — docs + tests only


Made with [Cursor](https://cursor.com)