### PR TITLE
PHASE-3B: add atomic kitchen print claim

### DIFF
--- a/src/catering_system/repositories/in_memory_kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/in_memory_kitchen_print_job_repository.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import threading
 from dataclasses import replace
+from datetime import datetime
 
 from catering_system.domain.kitchen_print_job import (
     KitchenPrintJob,
+    KitchenPrintPolicy,
     validate_kitchen_print_job_transition,
 )
 from catering_system.domain.order import OrderVersion
@@ -16,6 +19,7 @@ class InMemoryKitchenPrintJobRepository:
     def __init__(self, order_repository: OrderRepository) -> None:
         self._orders = order_repository
         self._jobs: dict[str, KitchenPrintJob] = {}
+        self._claim_lock = threading.Lock()
 
     def save(self, job: KitchenPrintJob) -> None:
         self._validate_new_job(job)
@@ -108,6 +112,40 @@ class InMemoryKitchenPrintJobRepository:
         next_jobs = dict(self._jobs)
         next_jobs[job.print_job_id] = job
         self._jobs = next_jobs
+
+    def claim_next_eligible(
+        self, now: datetime, policy: KitchenPrintPolicy
+    ) -> KitchenPrintJob | None:
+        with self._claim_lock:
+            eligible = sorted(
+                (
+                    job
+                    for job in self._jobs.values()
+                    if job.accepted_at is None
+                    and job.rejected_at is None
+                    and job.superseded_at is None
+                    and job.acknowledged_at is None
+                    and now < job.accept_deadline_at
+                ),
+                key=lambda row: (
+                    row.accept_deadline_at,
+                    row.requested_at,
+                    row.print_job_id,
+                ),
+            )
+            if not eligible:
+                return None
+            target = eligible[0]
+            accepted = replace(
+                target,
+                accepted_at=now,
+                ack_deadline_at=now + policy.acknowledgment_timeout,
+            )
+            validate_kitchen_print_job_transition(target, accepted)
+            next_jobs = dict(self._jobs)
+            next_jobs[target.print_job_id] = accepted
+            self._jobs = next_jobs
+            return accepted
 
     def _validate_new_job(
         self, job: KitchenPrintJob, *, replacing: str | None = None

--- a/src/catering_system/repositories/kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/kitchen_print_job_repository.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Protocol
 
-from catering_system.domain.kitchen_print_job import KitchenPrintJob
+from catering_system.domain.kitchen_print_job import KitchenPrintJob, KitchenPrintPolicy
 from catering_system.domain.order import OrderVersion
 
 
@@ -29,3 +30,7 @@ class KitchenPrintJobRepository(Protocol):
     def acknowledge_and_confirm(
         self, job: KitchenPrintJob, confirmed_version: OrderVersion
     ) -> None: ...
+
+    def claim_next_eligible(
+        self, now: datetime, policy: KitchenPrintPolicy
+    ) -> KitchenPrintJob | None: ...

--- a/src/catering_system/repositories/sqlite_kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/sqlite_kitchen_print_job_repository.py
@@ -8,13 +8,16 @@ same SQLite transaction; no second store or status column is introduced.
 from __future__ import annotations
 
 import sqlite3
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
+from typing import Iterator
 
 from catering_system.domain.kitchen_print_job import (
     KITCHEN_PRINT_REJECTION_CODES,
     KitchenPrintJob,
+    KitchenPrintPolicy,
     validate_kitchen_print_job_transition,
 )
 from catering_system.domain.order import OrderVersion
@@ -217,6 +220,7 @@ class SQLiteKitchenPrintJobRepository:
     def __init__(self, db_path: str | Path) -> None:
         self._conn = sqlite3.connect(str(db_path))
         self._manage_transactions = True
+        self._transaction_depth = 0
         try:
             apply_migrations(self._conn, "kitchen_print", _MIGRATIONS)
         except Exception:
@@ -230,8 +234,28 @@ class SQLiteKitchenPrintJobRepository:
         repo = cls.__new__(cls)
         repo._conn = connection
         repo._manage_transactions = False
+        repo._transaction_depth = 0
         apply_migrations(connection, "kitchen_print", _MIGRATIONS)
         return repo
+
+    @contextmanager
+    def _immediate_transaction(self) -> Iterator[sqlite3.Connection]:
+        if not self._manage_transactions:
+            yield self._conn
+            return
+        self._transaction_depth += 1
+        if self._transaction_depth == 1:
+            self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield self._conn
+            if self._transaction_depth == 1:
+                self._conn.commit()
+        except Exception:
+            if self._transaction_depth == 1:
+                self._conn.rollback()
+            raise
+        finally:
+            self._transaction_depth -= 1
 
     def _write_scope(self):  # noqa: ANN202
         return self._conn if self._manage_transactions else nullcontext()
@@ -336,6 +360,49 @@ class SQLiteKitchenPrintJobRepository:
                 if updated != 1:
                     raise ValueError("stale kitchen print confirmation")
             self._update_facts(job)
+
+    def claim_next_eligible(
+        self, now: datetime, policy: KitchenPrintPolicy
+    ) -> KitchenPrintJob | None:
+        now_iso = now.isoformat()
+        ack_deadline_at = now + policy.acknowledgment_timeout
+        ack_deadline_iso = ack_deadline_at.isoformat()
+        with self._immediate_transaction():
+            row = self._conn.execute(
+                """
+                SELECT * FROM kitchen_print_jobs
+                WHERE acknowledged_at IS NULL
+                  AND rejected_at IS NULL
+                  AND superseded_at IS NULL
+                  AND accepted_at IS NULL
+                  AND julianday(accept_deadline_at) > julianday(?)
+                ORDER BY accept_deadline_at ASC, requested_at ASC, print_job_id ASC
+                LIMIT 1
+                """,
+                (now_iso,),
+            ).fetchone()
+            if row is None:
+                return None
+            job = self._row_to_job(row)
+            updated = self._conn.execute(
+                """
+                UPDATE kitchen_print_jobs
+                SET accepted_at = ?, ack_deadline_at = ?
+                WHERE print_job_id = ?
+                  AND accepted_at IS NULL
+                  AND rejected_at IS NULL
+                  AND superseded_at IS NULL
+                  AND acknowledged_at IS NULL
+                """,
+                (now_iso, ack_deadline_iso, job.print_job_id),
+            ).rowcount
+            if updated != 1:
+                return None
+        return replace(
+            job,
+            accepted_at=now,
+            ack_deadline_at=ack_deadline_at,
+        )
 
     def _insert(self, job: KitchenPrintJob) -> None:
         self._conn.execute(

--- a/src/catering_system/services/kitchen_print_service.py
+++ b/src/catering_system/services/kitchen_print_service.py
@@ -50,6 +50,33 @@ class KitchenPrintService:
     def get_print_job(self, print_job_id: str) -> KitchenPrintJob | None:
         return self._jobs.get(print_job_id)
 
+    def claim_next_eligible(self) -> KitchenPrintJob | None:
+        """Atomically accept the oldest repository-eligible print attempt.
+
+        Repository eligibility covers only open attempts inside the acceptance
+        window. Domain validation (order ownership, cancellation) runs here
+        after the atomic claim; a cancelled owner order becomes an explicit
+        ``accepted_at`` + ``rejected_at`` fact via ``order_cancelled``.
+        """
+
+        now = self._clock()
+        job = self._jobs.claim_next_eligible(now, self._policy)
+        if job is None:
+            return None
+        order = self._orders.get_order(job.order_id)
+        if order is None:
+            raise ValueError(f"no order with id {job.order_id!r}")
+        version = self._orders.get_order_version(job.order_version_id)
+        if version is None or version.order_id != job.order_id:
+            raise ValueError(
+                f"order_version_id {job.order_version_id!r} is not a version "
+                f"of order {job.order_id!r}"
+            )
+        if order.cancelled_at is not None:
+            self.reject_print_job(job.print_job_id, "order_cancelled")
+            return None
+        return job
+
     def list_print_jobs_for_version(
         self, order_version_id: str
     ) -> list[KitchenPrintJob]:
@@ -116,7 +143,9 @@ class KitchenPrintService:
     ) -> KitchenPrintJob:
         """Record a technical refusal with a narrow, non-PII reason code."""
 
-        job, _order, _version = self._active_job_context(print_job_id)
+        job, _order, _version = self._active_job_context(
+            print_job_id, allow_cancelled=True
+        )
         if rejection_code not in KITCHEN_PRINT_REJECTION_CODES:
             raise ValueError(f"unsupported rejection_code {rejection_code!r}")
         if job.rejected_at is not None:
@@ -223,21 +252,23 @@ class KitchenPrintService:
         return new_job
 
     def _active_job_context(
-        self, print_job_id: str
+        self, print_job_id: str, *, allow_cancelled: bool = False
     ) -> tuple[KitchenPrintJob, Order, OrderVersion]:
         job = self._jobs.get(print_job_id)
         if job is None:
             raise ValueError(f"no print job with id {print_job_id!r}")
-        order, version = self._active_owned_version(job.order_id, job.order_version_id)
+        order, version = self._active_owned_version(
+            job.order_id, job.order_version_id, allow_cancelled=allow_cancelled
+        )
         return job, order, version
 
     def _active_owned_version(
-        self, order_id: str, order_version_id: str
+        self, order_id: str, order_version_id: str, *, allow_cancelled: bool = False
     ) -> tuple[Order, OrderVersion]:
         order = self._orders.get_order(order_id)
         if order is None:
             raise ValueError(f"no order with id {order_id!r}")
-        if order.cancelled_at is not None:
+        if not allow_cancelled and order.cancelled_at is not None:
             raise ValueError(
                 f"order {order_id!r} is cancelled (Storno); print commands refused"
             )

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -14,7 +14,7 @@ import base64
 import hashlib
 import json
 import threading
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
@@ -31,6 +31,7 @@ from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
     PrintFlagsBlock,
@@ -39,7 +40,6 @@ from catering_system.services.order_print_projection_service import (
 
 _CLAIM_ROUTE = "POST /kitchen/v1/print-jobs/claim-next"
 _AGENT_CLIENT_ID = "kitchen-print-agent"
-_CLAIM_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -147,12 +147,6 @@ def is_eligible_for_claim(
     }
 
 
-def _all_jobs(job_repository: KitchenPrintJobRepository) -> tuple[KitchenPrintJob, ...]:
-    if hasattr(job_repository, "_jobs"):
-        return tuple(job_repository._jobs.values())  # type: ignore[attr-defined]
-    raise TypeError("contract claim requires in-memory job repository for reference scan")
-
-
 def claim_next_eligible(
     order_repository: OrderRepository,
     job_repository: KitchenPrintJobRepository,
@@ -161,29 +155,16 @@ def claim_next_eligible(
     policy: KitchenPrintPolicy,
     lock: threading.Lock | None = None,
 ) -> KitchenPrintJob | None:
-    """Reference atomic claim — production replaces with repo.claim_next_eligible()."""
+    """Delegate atomic claim to production KitchenPrintService."""
 
-    active_lock = lock or _CLAIM_LOCK
-    with active_lock:
-        eligible: list[KitchenPrintJob] = []
-        for job in sorted(
-            _all_jobs(job_repository),
-            key=lambda row: (row.accept_deadline_at, row.requested_at, row.print_job_id),
-        ):
-            order = order_repository.get_order(job.order_id)
-            if not is_eligible_for_claim(job, now=now, order=order):
-                continue
-            eligible.append(job)
-        if not eligible:
-            return None
-        target = eligible[0]
-        accepted = replace(
-            target,
-            accepted_at=now,
-            ack_deadline_at=now + policy.acknowledgment_timeout,
-        )
-        job_repository.update(accepted)
-        return accepted
+    del lock  # repository implementations own concurrency primitives
+    service = KitchenPrintService(
+        order_repository,
+        job_repository,
+        policy=policy,
+        clock=lambda: now,
+    )
+    return service.claim_next_eligible()
 
 
 def resolve_kitchen_job_projection(

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -15,8 +15,8 @@ import hashlib
 import json
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from typing import Any, Callable
+from datetime import datetime
+from typing import Callable
 
 from catering_system.domain.kitchen_print_job import (
     KitchenPrintJob,

--- a/tests/unit/test_kitchen_print_agent_contract.py
+++ b/tests/unit/test_kitchen_print_agent_contract.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import threading
 import uuid
-from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 
 from catering_system.domain.inquiry import (
@@ -116,7 +115,7 @@ def _eligible_job_setup() -> tuple[
     job_a = _requested_job(service, order_a.order_id, version_a.order_version_id, _JOB_A)
     job_b = _requested_job(service, order_b.order_id, version_b.order_version_id, _JOB_B)
     job_c = _requested_job(service, order_c.order_id, version_c.order_version_id, _JOB_C)
-    job_d = _requested_job(service, order_d.order_id, version_d.order_version_id, _JOB_D)
+    _requested_job(service, order_d.order_id, version_d.order_version_id, _JOB_D)
 
     service.accept_print_job(_JOB_B)
     service.reject_print_job(_JOB_C, "printer_unavailable")

--- a/tests/unit/test_kitchen_print_agent_contract.py
+++ b/tests/unit/test_kitchen_print_agent_contract.py
@@ -161,7 +161,6 @@ def test_claim_next_eligible_is_atomic_under_concurrency() -> None:
         service, second_order.order_id, second_version.order_version_id, _JOB_B
     )
 
-    lock = threading.Lock()
     barrier = threading.Barrier(2)
     results: list[KitchenPrintJob | None] = []
     errors: list[BaseException] = []
@@ -171,7 +170,7 @@ def test_claim_next_eligible_is_atomic_under_concurrency() -> None:
             barrier.wait(timeout=5)
             results.append(
                 claim_next_eligible(
-                    orders, jobs, now=_NOW, policy=_POLICY, lock=lock
+                    orders, jobs, now=_NOW, policy=_POLICY
                 )
             )
         except BaseException as exc:  # pragma: no cover - surfaced below

--- a/tests/unit/test_kitchen_print_claim_repository.py
+++ b/tests/unit/test_kitchen_print_claim_repository.py
@@ -1,0 +1,239 @@
+"""Repository boundary tests for Phase 3B atomic kitchen print claim."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+from catering_system.domain.inquiry import (
+    CALL_VERIFICATION_STATUSES,
+    CRM_PIPELINE,
+    Inquiry,
+    PLANNING_MODES,
+)
+from catering_system.domain.kitchen_print_job import KitchenPrintJob, KitchenPrintPolicy
+from catering_system.repositories.sqlite_kitchen_print_job_repository import (
+    SQLiteKitchenPrintJobRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.services.kitchen_print_service import KitchenPrintService
+from tests.helpers.order_seed import seed_order
+
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot as _CCSnapshot,
+)
+
+_NOW = datetime(2026, 8, 8, 10, 0, tzinfo=UTC)
+_POLICY = KitchenPrintPolicy(
+    acceptance_timeout=timedelta(seconds=30),
+    acknowledgment_timeout=timedelta(minutes=5),
+)
+
+_JOB_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_JOB_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_JOB_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+_JOB_EXPIRED = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+_JOB_ELIGIBLE = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+
+
+def _inquiry(*, location: str = "Hamburg") -> Inquiry:
+    now = datetime(2026, 8, 8, 8, 0, tzinfo=UTC)
+    return Inquiry(
+        inquiry_id=str(uuid.uuid4()),
+        event_date=date(2026, 10, 1),
+        created_at=now,
+        updated_at=now,
+        inquiry_source="manual",
+        crm_stage=CRM_PIPELINE[0],
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text=location,
+        guest_count_estimate=25,
+        planning_mode=PLANNING_MODES[0],
+        call_verification_required=False,
+        call_verification_status=CALL_VERIFICATION_STATUSES[0],
+        customer_snapshot=_CCSnapshot(email="kunde@example.com", phone="+49301234567"),
+    )
+
+
+def _sqlite_claim_world(
+    db: Path,
+) -> tuple[SQLiteOrderRepository, SQLiteKitchenPrintJobRepository, KitchenPrintService]:
+    orders = SQLiteOrderRepository(db)
+    jobs = SQLiteKitchenPrintJobRepository(db)
+    service = KitchenPrintService(
+        orders,
+        jobs,
+        policy=_POLICY,
+        clock=lambda: _NOW,
+    )
+    return orders, jobs, service
+
+
+def _save_open_job(
+    jobs: SQLiteKitchenPrintJobRepository,
+    *,
+    order_id: str,
+    order_version_id: str,
+    print_job_id: str,
+    requested_at: datetime,
+    accept_deadline_at: datetime,
+) -> KitchenPrintJob:
+    job = KitchenPrintJob(
+        print_job_id=print_job_id,
+        order_id=order_id,
+        order_version_id=order_version_id,
+        attempt_number=1,
+        requested_at=requested_at,
+        accept_deadline_at=accept_deadline_at,
+    )
+    jobs.save(job)
+    return job
+
+
+def test_sqlite_claim_skips_expired_accept_deadline(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, _service = _sqlite_claim_world(db)
+    expired_order, expired_version = seed_order(orders, _inquiry(location="expired"))
+    eligible_order, eligible_version = seed_order(orders, _inquiry(location="eligible"))
+
+    _save_open_job(
+        jobs,
+        order_id=expired_order.order_id,
+        order_version_id=expired_version.order_version_id,
+        print_job_id=_JOB_EXPIRED,
+        requested_at=_NOW - timedelta(minutes=5),
+        accept_deadline_at=_NOW - timedelta(seconds=1),
+    )
+    _save_open_job(
+        jobs,
+        order_id=eligible_order.order_id,
+        order_version_id=eligible_version.order_version_id,
+        print_job_id=_JOB_ELIGIBLE,
+        requested_at=_NOW - timedelta(minutes=1),
+        accept_deadline_at=_NOW + timedelta(seconds=10),
+    )
+
+    claimed = jobs.claim_next_eligible(_NOW, _POLICY)
+
+    assert claimed is not None
+    assert claimed.print_job_id == _JOB_ELIGIBLE
+    jobs.close()
+    orders.close()
+
+
+def test_sqlite_claim_orders_by_deadline_then_requested_at(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, _service = _sqlite_claim_world(db)
+    order_a, version_a = seed_order(orders, _inquiry(location="A"))
+    order_b, version_b = seed_order(orders, _inquiry(location="B"))
+    order_c, version_c = seed_order(orders, _inquiry(location="C"))
+
+    base_requested = datetime(2026, 8, 8, 9, 50, tzinfo=UTC)
+    _save_open_job(
+        jobs,
+        order_id=order_a.order_id,
+        order_version_id=version_a.order_version_id,
+        print_job_id=_JOB_A,
+        requested_at=base_requested,
+        accept_deadline_at=_NOW + timedelta(seconds=30),
+    )
+    _save_open_job(
+        jobs,
+        order_id=order_b.order_id,
+        order_version_id=version_b.order_version_id,
+        print_job_id=_JOB_B,
+        requested_at=base_requested + timedelta(minutes=1),
+        accept_deadline_at=_NOW + timedelta(seconds=30),
+    )
+    _save_open_job(
+        jobs,
+        order_id=order_c.order_id,
+        order_version_id=version_c.order_version_id,
+        print_job_id=_JOB_C,
+        requested_at=base_requested + timedelta(minutes=5),
+        accept_deadline_at=_NOW + timedelta(seconds=20),
+    )
+
+    first = jobs.claim_next_eligible(_NOW, _POLICY)
+    second = jobs.claim_next_eligible(_NOW, _POLICY)
+    third = jobs.claim_next_eligible(_NOW, _POLICY)
+
+    assert [row.print_job_id if row is not None else None for row in (first, second, third)] == [
+        _JOB_C,
+        _JOB_A,
+        _JOB_B,
+    ]
+    jobs.close()
+    orders.close()
+
+
+def test_sqlite_claim_sets_acceptance_facts_without_domain_confirmation(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, _service = _sqlite_claim_world(db)
+    order, version = seed_order(orders, _inquiry())
+
+    _save_open_job(
+        jobs,
+        order_id=order.order_id,
+        order_version_id=version.order_version_id,
+        print_job_id=_JOB_A,
+        requested_at=_NOW - timedelta(minutes=1),
+        accept_deadline_at=_NOW + timedelta(seconds=30),
+    )
+
+    claimed = jobs.claim_next_eligible(_NOW, _POLICY)
+    stored_version = orders.get_order_version(version.order_version_id)
+
+    assert claimed is not None
+    assert claimed.accepted_at == _NOW
+    assert claimed.ack_deadline_at == _NOW + _POLICY.acknowledgment_timeout
+    assert stored_version is not None
+    assert stored_version.kitchen_print_confirmed_at is None
+    jobs.close()
+    orders.close()
+
+
+def test_accept_print_job_after_claim_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, service = _sqlite_claim_world(db)
+    order, version = seed_order(orders, _inquiry())
+
+    service.request_print(order.order_id, version.order_version_id, print_job_id=_JOB_A)
+    claimed = jobs.claim_next_eligible(_NOW, _POLICY)
+    assert claimed is not None
+
+    accepted_again = service.accept_print_job(_JOB_A)
+    stored = jobs.get(_JOB_A)
+
+    assert accepted_again.accepted_at == claimed.accepted_at
+    assert accepted_again.ack_deadline_at == claimed.ack_deadline_at
+    assert stored == accepted_again
+    jobs.close()
+    orders.close()
+
+
+def test_sqlite_repository_claim_does_not_filter_cancelled_order(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, service = _sqlite_claim_world(db)
+    order, version = seed_order(orders, _inquiry())
+
+    service.request_print(order.order_id, version.order_version_id, print_job_id=_JOB_A)
+    cancelled = orders.get_order(order.order_id)
+    assert cancelled is not None
+    orders.update_order(
+        replace(cancelled, cancelled_at=_NOW, updated_at=_NOW)
+    )
+
+    claimed = jobs.claim_next_eligible(_NOW, _POLICY)
+
+    assert claimed is not None
+    assert claimed.print_job_id == _JOB_A
+    assert claimed.accepted_at == _NOW
+    assert claimed.rejected_at is None
+    jobs.close()
+    orders.close()

--- a/tests/unit/test_kitchen_print_service.py
+++ b/tests/unit/test_kitchen_print_service.py
@@ -286,3 +286,21 @@ def test_acceptance_deadline_and_cancelled_state_are_pure_derivations() -> None:
     )
     with pytest.raises(ValueError, match="deadline has passed"):
         service.accept_print_job(JOB_1)
+
+
+def test_claim_next_eligible_records_order_cancelled_after_atomic_accept() -> None:
+    orders, service, core, _clock, order_id, version_id, _events = _setup()
+    service.request_print(order_id, version_id, print_job_id=JOB_1)
+    core.cancel_order(order_id)
+
+    claimed = service.claim_next_eligible()
+    stored = service.get_print_job(JOB_1)
+    version = orders.get_order_version(version_id)
+
+    assert claimed is None
+    assert stored is not None
+    assert stored.accepted_at is not None
+    assert stored.rejected_at is not None
+    assert stored.rejection_code == "order_cancelled"
+    assert version is not None
+    assert version.kitchen_print_confirmed_at is None


### PR DESCRIPTION
## Summary

Adds atomic kitchen print job claiming for Phase 3B.

The implementation follows ADR-014:
- repository owns technical atomic selection only;
- service owns domain validation;
- technical acceptance remains separate from kitchen print confirmation.

## Included

- KitchenPrintJobRepository.claim_next_eligible()
- SQLite BEGIN IMMEDIATE claim transaction
- in-memory repository support
- KitchenPrintService.claim_next_eligible()
- cancelled-order post-claim rejection handling
- production-backed contract tests

## Guarantees

- no duplicate claim under concurrency;
- expired acceptance deadlines are ignored;
- cancelled orders become explicit rejection facts;
- claim never sets kitchen_print_confirmed_at.

## Not included

- HTTP API
- command ledger
- document generation
- renderer
- agent process
- printer adapter

Made with [Cursor](https://cursor.com)