### PR TITLE
PHASE-3B: add kitchen_job print intent

### DIFF
--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -19,7 +19,7 @@ from catering_system.repositories.order_commercial_snapshot_repository import (
 )
 from catering_system.repositories.order_repository import OrderRepository
 
-PrintIntent = Literal["preview", "change_preview", "final"]
+PrintIntent = Literal["preview", "change_preview", "final", "kitchen_job"]
 PrintWatermark = Literal["ENTWURF", "VERALTET", "ÄNDERUNG – NOCH NICHT WIRKSAM"]
 
 
@@ -176,6 +176,15 @@ class OrderPrintProjectionService:
         *,
         intent: PrintIntent,
     ) -> PrintFlagsBlock:
+        if intent == "kitchen_job":
+            return PrintFlagsBlock(
+                intent=intent,
+                is_preview=False,
+                is_final_allowed=False,
+                is_stale=False,
+                watermark=None,
+            )
+
         is_effective = version.order_version_id == order.effective_order_version_id
         if intent == "final":
             return PrintFlagsBlock(

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -215,7 +215,9 @@ def _canonical_projection_json(projection: OrderPrintProjection) -> str:
             "is_stale": flags.is_stale,
         },
     }
-    return json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return json.dumps(
+        payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    )
 
 
 def create_kitchen_print_document(

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -34,8 +34,7 @@ from catering_system.repositories.order_repository import OrderRepository
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
-    PrintFlagsBlock,
-    PrintProjectionNotFoundError,
+    OrderPrintProjectionService,
 )
 
 _CLAIM_ROUTE = "POST /kitchen/v1/print-jobs/claim-next"
@@ -174,33 +173,12 @@ def resolve_kitchen_job_projection(
     order_id: str,
     order_version_id: str,
 ) -> OrderPrintProjection:
-    """Reference kitchen_job intent — production uses intent='kitchen_job'."""
+    """Delegate kitchen_job intent to production OrderPrintProjectionService."""
 
-    order = order_repository.get_order(order_id)
-    version = order_repository.get_order_version(order_version_id)
-    if order is None or version is None or version.order_id != order_id:
-        raise PrintProjectionNotFoundError(order_version_id)
-
-    snapshot = commercial_snapshot_repository.get_by_order_id(order_id)
-    if snapshot is None:
-        raise PrintProjectionNotFoundError(order_id)
-
-    from catering_system.services.order_print_projection_service import (
-        _commercial_from_snapshot,
-        _event_block,
-    )
-
-    return OrderPrintProjection(
-        event=_event_block(order, version),
-        commercial=_commercial_from_snapshot(snapshot, version.guest_count_estimate),
-        flags=PrintFlagsBlock(
-            intent="kitchen_job",  # type: ignore[arg-type]
-            is_preview=False,
-            is_final_allowed=False,
-            is_stale=False,
-            watermark=None,
-        ),
-    )
+    return OrderPrintProjectionService(
+        order_repository,
+        commercial_snapshot_repository,
+    ).resolve(order_id, order_version_id, intent="kitchen_job")
 
 
 def _canonical_projection_json(projection: OrderPrintProjection) -> str:

--- a/tests/unit/test_kitchen_print_agent_contract.py
+++ b/tests/unit/test_kitchen_print_agent_contract.py
@@ -112,9 +112,15 @@ def _eligible_job_setup() -> tuple[
     jobs = InMemoryKitchenPrintJobRepository(orders)
     service = _print_service(orders, jobs)
 
-    job_a = _requested_job(service, order_a.order_id, version_a.order_version_id, _JOB_A)
-    job_b = _requested_job(service, order_b.order_id, version_b.order_version_id, _JOB_B)
-    job_c = _requested_job(service, order_c.order_id, version_c.order_version_id, _JOB_C)
+    job_a = _requested_job(
+        service, order_a.order_id, version_a.order_version_id, _JOB_A
+    )
+    job_b = _requested_job(
+        service, order_b.order_id, version_b.order_version_id, _JOB_B
+    )
+    job_c = _requested_job(
+        service, order_c.order_id, version_c.order_version_id, _JOB_C
+    )
     _requested_job(service, order_d.order_id, version_d.order_version_id, _JOB_D)
 
     service.accept_print_job(_JOB_B)
@@ -155,7 +161,9 @@ def test_claim_next_eligible_is_atomic_under_concurrency() -> None:
     second_order, second_version = seed_order(orders, _inquiry(location="second"))
     jobs = InMemoryKitchenPrintJobRepository(orders)
     service = _print_service(orders, jobs)
-    _requested_job(service, first_order.order_id, first_version.order_version_id, _JOB_A)
+    _requested_job(
+        service, first_order.order_id, first_version.order_version_id, _JOB_A
+    )
     _requested_job(
         service, second_order.order_id, second_version.order_version_id, _JOB_B
     )
@@ -167,11 +175,7 @@ def test_claim_next_eligible_is_atomic_under_concurrency() -> None:
     def worker() -> None:
         try:
             barrier.wait(timeout=5)
-            results.append(
-                claim_next_eligible(
-                    orders, jobs, now=_NOW, policy=_POLICY
-                )
-            )
+            results.append(claim_next_eligible(orders, jobs, now=_NOW, policy=_POLICY))
         except BaseException as exc:  # pragma: no cover - surfaced below
             errors.append(exc)
 
@@ -377,10 +381,7 @@ def test_only_acknowledge_print_job_sets_kitchen_print_confirmed_at() -> None:
 
     assert acknowledged.acknowledged_at == _NOW
     assert confirmed_version.kitchen_print_confirmed_at == _NOW
-    assert (
-        orders.get_order_version(job_a.order_version_id)
-        == confirmed_version
-    )
+    assert orders.get_order_version(job_a.order_version_id) == confirmed_version
 
 
 def test_kitchen_print_agent_contract_must_not_import_offer_or_catalog() -> None:

--- a/tests/unit/test_kitchen_print_claim_repository.py
+++ b/tests/unit/test_kitchen_print_claim_repository.py
@@ -161,7 +161,9 @@ def test_sqlite_claim_orders_by_deadline_then_requested_at(tmp_path: Path) -> No
     second = jobs.claim_next_eligible(_NOW, _POLICY)
     third = jobs.claim_next_eligible(_NOW, _POLICY)
 
-    assert [row.print_job_id if row is not None else None for row in (first, second, third)] == [
+    assert [
+        row.print_job_id if row is not None else None for row in (first, second, third)
+    ] == [
         _JOB_C,
         _JOB_A,
         _JOB_B,
@@ -217,7 +219,9 @@ def test_accept_print_job_after_claim_is_idempotent(tmp_path: Path) -> None:
     orders.close()
 
 
-def test_sqlite_repository_claim_does_not_filter_cancelled_order(tmp_path: Path) -> None:
+def test_sqlite_repository_claim_does_not_filter_cancelled_order(
+    tmp_path: Path,
+) -> None:
     db = tmp_path / "core.db"
     orders, jobs, service = _sqlite_claim_world(db)
     order, version = seed_order(orders, _inquiry())
@@ -225,9 +229,7 @@ def test_sqlite_repository_claim_does_not_filter_cancelled_order(tmp_path: Path)
     service.request_print(order.order_id, version.order_version_id, print_job_id=_JOB_A)
     cancelled = orders.get_order(order.order_id)
     assert cancelled is not None
-    orders.update_order(
-        replace(cancelled, cancelled_at=_NOW, updated_at=_NOW)
-    )
+    orders.update_order(replace(cancelled, cancelled_at=_NOW, updated_at=_NOW))
 
     claimed = jobs.claim_next_eligible(_NOW, _POLICY)
 

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -642,3 +642,151 @@ def test_print_and_confirmation_services_must_not_depend_on_offer_or_conversion_
         text = (root / name).read_text(encoding="utf-8")
         assert "OfferRepository" not in text, name
         assert "conversion_link" not in text, name
+
+
+def _kitchen_job_setup():
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, v1 = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    order_service = OrderService(orders)
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, v1.order_version_id)
+    core.make_order_version_effective(order.order_id, v1.order_version_id)
+    v2 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 9, 1),
+        time_window_text="abends",
+        location_text="Lübeck",
+        guest_count_estimate=40,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order.order_id, v2.order_version_id)
+    service = _projection_service(orders, offer_service._commercial_snapshots)
+    return offer, order, v1, v2, offers, service
+
+
+def test_kitchen_job_intent_uses_requested_version_not_effective() -> None:
+    _offer, order, v1, v2, _offers, service = _kitchen_job_setup()
+
+    projection = service.resolve(
+        order.order_id,
+        v2.order_version_id,
+        intent="kitchen_job",
+    )
+
+    assert projection.event.order_version_id == v2.order_version_id
+    assert projection.event.version_number == 2
+    assert projection.event.location_text == "Lübeck"
+    assert projection.event.is_effective is False
+    assert projection.event.is_candidate is True
+
+
+def test_kitchen_job_intent_has_no_ui_watermarks() -> None:
+    _offer, order, _v1, v2, _offers, service = _kitchen_job_setup()
+
+    projection = service.resolve(
+        order.order_id,
+        v2.order_version_id,
+        intent="kitchen_job",
+    )
+
+    assert projection.flags.intent == "kitchen_job"
+    assert projection.flags.watermark is None
+    assert projection.flags.is_preview is False
+    assert projection.flags.is_stale is False
+    assert projection.flags.is_final_allowed is False
+    assert "ENTWURF" not in render_print_sheet(projection)
+    assert "VERALTET" not in render_print_sheet(projection)
+    assert "ÄNDERUNG" not in render_print_sheet(projection)
+
+
+def test_kitchen_job_intent_keeps_frozen_commercial_snapshot() -> None:
+    from dataclasses import replace
+
+    offer, order, _v1, v2, offers, service = _kitchen_job_setup()
+    stored = offers.get(offer.offer_id)
+    assert stored is not None
+    version = stored.versions[0]
+    variant = version.variants[0]
+    mutated = replace(
+        stored,
+        versions=(
+            replace(
+                version,
+                variants=(
+                    replace(
+                        variant,
+                        positions=(
+                            replace(variant.positions[0], name="MUTATED LIVE OFFER"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    offers._offers[stored.offer_id] = mutated
+
+    projection = service.resolve(
+        order.order_id,
+        v2.order_version_id,
+        intent="kitchen_job",
+    )
+
+    assert projection.commercial.positions[0].name == "Fingerfood Paket"
+    assert "MUTATED LIVE OFFER" not in render_print_sheet(projection)
+
+
+def test_kitchen_job_does_not_change_preview_change_preview_or_final_intents() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inq,
+        offer_service,
+    ) = _accepted_offer_state()
+    _converted, order, v1 = offer_service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    core = OperationalCoreService(orders)
+    core.confirm_kitchen_print(order.order_id, v1.order_version_id)
+    core.make_order_version_effective(order.order_id, v1.order_version_id)
+    v2 = OrderService(orders).propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text="18:00",
+        location_text=v1.location_text,
+        guest_count_estimate=v1.guest_count_estimate,
+        planning_mode=v1.planning_mode,
+        actor_reference="office-panel",
+        change_reason="Beginn verschoben",
+    )
+    service = _projection_service(orders, offer_service._commercial_snapshots)
+
+    preview = service.resolve(order.order_id, v2.order_version_id, intent="preview")
+    change_preview = service.resolve(order.order_id, v2.order_version_id)
+    final = service.resolve(order.order_id, v1.order_version_id, intent="final")
+
+    assert preview.flags.intent == "change_preview"
+    assert preview.flags.watermark == "ÄNDERUNG – NOCH NICHT WIRKSAM"
+    assert change_preview.flags.intent == "change_preview"
+    assert final.flags.intent == "final"
+    assert final.flags.is_final_allowed is True


### PR DESCRIPTION
## Summary

Adds production `kitchen_job` print intent to `OrderPrintProjectionService`.

The resolver uses the requested `order_version_id` directly and applies kitchen-specific flag semantics without Office UI watermarks or effective-version selection.

## Included

- `PrintIntent.kitchen_job`
- kitchen-specific `_resolve_flags()` semantics
- production-backed `resolve_kitchen_job_projection()` contract helper
- focused projection tests for requested version, flags, frozen snapshot, and existing intent regression

## Guarantees

- requested `OrderVersion` wins over effective/candidate selection;
- no `ENTWURF` / `VERALTET` / change-preview watermarks for kitchen jobs;
- commercial snapshot remains frozen;
- `preview`, `change_preview`, and `final` behavior unchanged.

## Not included

- `KitchenPrintDocument`
- DocumentStore
- HTTP routes
- command ledger
- agent process
- renderer extraction

Made with [Cursor](https://cursor.com)