### PR TITLE
PHASE-3B: add kitchen print HTTP API and command ledger

### DIFF
--- a/src/catering_system/repositories/kitchen_api_ledger.py
+++ b/src/catering_system/repositories/kitchen_api_ledger.py
@@ -1,0 +1,124 @@
+"""Idempotency ledger for the Kitchen Print Agent HTTP API (Phase 3B)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+KITCHEN_AGENT_CLIENT_ID = "kitchen-print-agent"
+
+_CREATE_LEDGER = """
+CREATE TABLE IF NOT EXISTS kitchen_api_commands (
+    command_id TEXT PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    result_status INTEGER NOT NULL,
+    result_body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+)
+"""
+
+
+def _migration_1_create_kitchen_api_ledger(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE_LEDGER)
+
+
+_MIGRATIONS = (
+    (1, "create_kitchen_api_ledger", _migration_1_create_kitchen_api_ledger),
+)
+
+
+def kitchen_command_fingerprint(
+    *,
+    route_template: str,
+    command_id: str,
+    args: dict[str, object] | None = None,
+    client_id: str = KITCHEN_AGENT_CLIENT_ID,
+) -> str:
+    canonical = json.dumps(
+        {
+            "route_template": route_template,
+            "command_id": command_id,
+            "args": args or {},
+            "client_id": client_id,
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class RecordedKitchenCommand:
+    command_id: str
+    fingerprint: str
+    result_status: int
+    result_body: str
+
+
+class KitchenCommandLedger:
+    """Reads/writes kitchen command rows on a shared SQLite connection."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._conn = connection
+        apply_migrations(connection, "kitchen_api", _MIGRATIONS)
+
+    def get(self, command_id: str) -> RecordedKitchenCommand | None:
+        row = self._conn.execute(
+            "SELECT command_id, fingerprint, result_status, result_body "
+            "FROM kitchen_api_commands WHERE command_id = ?",
+            (command_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return RecordedKitchenCommand(
+            command_id=row[0],
+            fingerprint=row[1],
+            result_status=row[2],
+            result_body=row[3],
+        )
+
+    def record(
+        self,
+        command_id: str,
+        fingerprint: str,
+        result_status: int,
+        result_body: str,
+    ) -> None:
+        self._conn.execute(
+            "INSERT INTO kitchen_api_commands VALUES (?, ?, ?, ?, ?)",
+            (
+                command_id,
+                fingerprint,
+                result_status,
+                result_body,
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+
+
+class InMemoryKitchenCommandLedger:
+    def __init__(self) -> None:
+        self._rows: dict[str, RecordedKitchenCommand] = {}
+
+    def get(self, command_id: str) -> RecordedKitchenCommand | None:
+        return self._rows.get(command_id)
+
+    def record(
+        self,
+        command_id: str,
+        fingerprint: str,
+        result_status: int,
+        result_body: str,
+    ) -> None:
+        self._rows[command_id] = RecordedKitchenCommand(
+            command_id=command_id,
+            fingerprint=fingerprint,
+            result_status=result_status,
+            result_body=result_body,
+        )

--- a/src/catering_system/services/kitchen_print_application_service.py
+++ b/src/catering_system/services/kitchen_print_application_service.py
@@ -1,0 +1,42 @@
+"""Kitchen print agent application orchestration (Phase 3B transport boundary)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from catering_system.domain.kitchen_print_job import KitchenPrintJob
+from catering_system.services.kitchen_print_document import KitchenPrintDocument
+from catering_system.services.kitchen_print_document_factory import (
+    KitchenPrintDocumentFactory,
+)
+from catering_system.services.kitchen_print_service import KitchenPrintService
+
+
+@dataclass(frozen=True)
+class KitchenClaimResult:
+    job: KitchenPrintJob
+    document: KitchenPrintDocument
+
+
+class KitchenPrintApplicationService:
+    """Domain orchestration for agent transport — no HTTP or ledger concerns."""
+
+    def __init__(
+        self,
+        print_service: KitchenPrintService,
+        document_factory: KitchenPrintDocumentFactory,
+    ) -> None:
+        self._print_service = print_service
+        self._document_factory = document_factory
+
+    def claim_next_with_document(self) -> KitchenClaimResult | None:
+        job = self._print_service.claim_next_eligible()
+        if job is None:
+            return None
+        document = self._document_factory.create_for_print_job(job)
+        return KitchenClaimResult(job=job, document=document)
+
+    def reject_print_job(
+        self, print_job_id: str, rejection_code: str
+    ) -> KitchenPrintJob:
+        return self._print_service.reject_print_job(print_job_id, rejection_code)

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -1,0 +1,334 @@
+"""Kitchen Print Agent HTTP API — transport-only layer (Phase 3B).
+
+Logs carry route, status, command_id and opaque Core IDs only — never PII.
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import logging
+import re
+from collections.abc import Callable
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Protocol
+from uuid import UUID
+
+from catering_system.domain.kitchen_print_job import KitchenPrintPolicy
+from catering_system.repositories.in_memory_kitchen_print_document_store import (
+    InMemoryKitchenPrintDocumentStore,
+)
+from catering_system.repositories.kitchen_api_ledger import (
+    KitchenCommandLedger,
+    RecordedKitchenCommand,
+    kitchen_command_fingerprint,
+)
+from catering_system.repositories.kitchen_print_document_store import (
+    KitchenPrintDocumentStore,
+)
+from catering_system.repositories.sqlite_kitchen_print_job_repository import (
+    SQLiteKitchenPrintJobRepository,
+)
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.services.kitchen_print_application_service import (
+    KitchenPrintApplicationService,
+)
+from catering_system.services.kitchen_print_document_factory import (
+    KitchenPrintDocumentFactory,
+)
+from catering_system.services.kitchen_print_service import KitchenPrintService
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjectionService,
+)
+from catering_system.ui.office_api import ApiError, strict_json_loads
+
+_log = logging.getLogger(__name__)
+
+_MAX_BODY_BYTES = 4096
+_CLAIM_ROUTE = "POST /kitchen/v1/print-jobs/claim-next"
+_REJECT_ROUTE = "POST /kitchen/v1/print-jobs/{print_job_id}/reject"
+_UUID4 = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+class _KitchenLedger(Protocol):
+    def get(self, command_id: str) -> RecordedKitchenCommand | None: ...
+
+    def record(
+        self,
+        command_id: str,
+        fingerprint: str,
+        result_status: int,
+        result_body: str,
+    ) -> None: ...
+
+
+def _invalid() -> ApiError:
+    return ApiError(422, "invalid_request")
+
+
+def _v_uuid(value: object) -> str:
+    if not isinstance(value, str) or not _UUID4.match(value):
+        raise _invalid()
+    parsed = UUID(value)
+    if parsed.version != 4 or str(parsed) != value:
+        raise _invalid()
+    return value
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class KitchenApi:
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        ledger: _KitchenLedger | None = None,
+        document_store: KitchenPrintDocumentStore | None = None,
+        policy: KitchenPrintPolicy | None = None,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._db_path = db_path
+        self._ledger = ledger
+        self._document_store = (
+            document_store
+            if document_store is not None
+            else InMemoryKitchenPrintDocumentStore()
+        )
+        self._policy = policy if policy is not None else KitchenPrintPolicy()
+        self._clock = clock
+        self._orders = SQLiteOrderRepository(db_path)
+        self._jobs = SQLiteKitchenPrintJobRepository(db_path)
+        self._snapshots = SQLiteOrderCommercialSnapshotRepository(db_path)
+        self._print_service = KitchenPrintService(
+            self._orders,
+            self._jobs,
+            policy=self._policy,
+            clock=self._clock,
+        )
+        projection_service = OrderPrintProjectionService(self._orders, self._snapshots)
+        self._document_factory = KitchenPrintDocumentFactory(
+            projection_service,
+            self._document_store,
+            clock=self._clock,
+        )
+        self.application = KitchenPrintApplicationService(
+            self._print_service,
+            self._document_factory,
+        )
+
+    @property
+    def ledger(self) -> _KitchenLedger:
+        if self._ledger is None:
+            raise RuntimeError("kitchen ledger is not configured")
+        return self._ledger
+
+    def close(self) -> None:
+        self._jobs.close()
+        self._snapshots.close()
+        self._orders.close()
+
+    def execute_claim(self, command_id: str) -> tuple[int, str]:
+        fingerprint = kitchen_command_fingerprint(
+            route_template=_CLAIM_ROUTE,
+            command_id=command_id,
+        )
+        recorded = self.ledger.get(command_id)
+        if recorded is not None:
+            if not hmac.compare_digest(recorded.fingerprint, fingerprint):
+                raise ApiError(409, "command_id_conflict")
+            return recorded.result_status, recorded.result_body
+
+        result = self.application.claim_next_with_document()
+        if result is None:
+            body = json.dumps({"command_id": command_id, "job": None}, sort_keys=True)
+            self.ledger.record(command_id, fingerprint, 204, body)
+            return 204, body
+
+        job = result.job
+        document = result.document
+        payload = {
+            "command_id": command_id,
+            "print_job_id": job.print_job_id,
+            "order_id": job.order_id,
+            "order_version_id": job.order_version_id,
+            "accepted_at": job.accepted_at.isoformat()
+            if job.accepted_at is not None
+            else None,
+            "ack_deadline_at": job.ack_deadline_at.isoformat()
+            if job.ack_deadline_at is not None
+            else None,
+            "document_ref": document.document_ref,
+            "document": {
+                "content_type": document.content_type,
+                "body_base64": base64.b64encode(document.body).decode("ascii"),
+            },
+        }
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        self.ledger.record(command_id, fingerprint, 200, body)
+        return 200, body
+
+    def execute_reject(
+        self, print_job_id: str, *, command_id: str, rejection_code: str
+    ) -> tuple[int, str]:
+        fingerprint = kitchen_command_fingerprint(
+            route_template=_REJECT_ROUTE,
+            command_id=command_id,
+            args={"print_job_id": print_job_id, "rejection_code": rejection_code},
+        )
+        recorded = self.ledger.get(command_id)
+        if recorded is not None:
+            if not hmac.compare_digest(recorded.fingerprint, fingerprint):
+                raise ApiError(409, "command_id_conflict")
+            return recorded.result_status, recorded.result_body
+
+        rejected = self.application.reject_print_job(print_job_id, rejection_code)
+        payload = {
+            "command_id": command_id,
+            "print_job_id": rejected.print_job_id,
+            "rejected_at": rejected.rejected_at.isoformat()
+            if rejected.rejected_at is not None
+            else None,
+            "rejection_code": rejected.rejection_code,
+        }
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        self.ledger.record(command_id, fingerprint, 200, body)
+        return 200, body
+
+
+def make_kitchen_api_handler(
+    api: KitchenApi,
+    token: str,
+) -> type[BaseHTTPRequestHandler]:
+    class KitchenApiHandler(BaseHTTPRequestHandler):
+        server_version = "KitchenApi/1.0"
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            _log.info(format, *args)
+
+        def _authorized(self) -> bool:
+            header = self.headers.get("Authorization", "")
+            if not header.startswith("Bearer "):
+                return False
+            supplied = header[7:]
+            return hmac.compare_digest(supplied, token)
+
+        def _error(self, status: int, error: str) -> None:
+            payload = json.dumps({"error": error}, ensure_ascii=False).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _respond_json(self, status: int, body: str) -> None:
+            payload = body.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _read_json_body(self) -> dict[str, object]:
+            content_type = self.headers.get("Content-Type", "")
+            if content_type.split(";")[0].strip() != "application/json":
+                raise ApiError(415, "unsupported_media_type")
+            raw_length = self.headers.get("Content-Length")
+            if raw_length is None:
+                raise _invalid()
+            try:
+                length = int(raw_length)
+            except ValueError as exc:
+                raise _invalid() from exc
+            if length <= 0 or length > _MAX_BODY_BYTES:
+                raise _invalid()
+            raw = self.rfile.read(length)
+            if len(raw) != length:
+                raise _invalid()
+            return strict_json_loads(raw)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if not self._authorized():
+                self._error(401, "unauthorized")
+                return
+            try:
+                if self.path == "/kitchen/v1/print-jobs/claim-next":
+                    body = self._read_json_body()
+                    if set(body) != {"command_id"}:
+                        raise _invalid()
+                    command_id = _v_uuid(body["command_id"])
+                    status, response_body = api.execute_claim(command_id)
+                    self._respond_json(status, response_body)
+                    return
+
+                reject_prefix = "/kitchen/v1/print-jobs/"
+                reject_suffix = "/reject"
+                if self.path.startswith(reject_prefix) and self.path.endswith(
+                    reject_suffix
+                ):
+                    print_job_id = self.path[len(reject_prefix) : -len(reject_suffix)]
+                    _v_uuid(print_job_id)
+                    body = self._read_json_body()
+                    if set(body) != {"command_id", "rejection_code"}:
+                        raise _invalid()
+                    command_id = _v_uuid(body["command_id"])
+                    rejection_code = body["rejection_code"]
+                    if not isinstance(rejection_code, str) or not rejection_code:
+                        raise _invalid()
+                    status, response_body = api.execute_reject(
+                        print_job_id,
+                        command_id=command_id,
+                        rejection_code=rejection_code,
+                    )
+                    self._respond_json(status, response_body)
+                    return
+
+                self._error(404, "not_found")
+            except ApiError as exc:
+                self._error(exc.status, exc.code)
+            except ValueError:
+                self._error(422, "invalid_request")
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._error(404, "not_found")
+
+    return KitchenApiHandler
+
+
+def create_kitchen_api_server(
+    db_path: str,
+    token: str,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    *,
+    ledger: _KitchenLedger | None = None,
+    document_store: KitchenPrintDocumentStore | None = None,
+    clock: Callable[[], datetime] | None = None,
+) -> tuple[HTTPServer, KitchenApi]:
+    from catering_system.repositories.core_transaction import open_core_connection
+
+    connection = open_core_connection(db_path)
+    effective_ledger = (
+        ledger if ledger is not None else KitchenCommandLedger(connection)
+    )
+    api = KitchenApi(
+        db_path,
+        ledger=effective_ledger,
+        document_store=document_store,
+        clock=clock or _utc_now,
+    )
+    server = HTTPServer((host, port), make_kitchen_api_handler(api, token))
+    server.kitchen_connection = connection  # type: ignore[attr-defined]
+    return server, api

--- a/tests/unit/test_kitchen_api.py
+++ b/tests/unit/test_kitchen_api.py
@@ -1,0 +1,293 @@
+"""Kitchen Print Agent HTTP API transport tests (Phase 3B)."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.kitchen_print_job import KitchenPrintPolicy
+from catering_system.repositories.in_memory_kitchen_print_document_store import (
+    InMemoryKitchenPrintDocumentStore,
+)
+from catering_system.domain.inquiry import (
+    CALL_VERIFICATION_STATUSES,
+    CRM_PIPELINE,
+    Inquiry,
+    PLANNING_MODES,
+)
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot as _CCSnapshot,
+)
+from catering_system.repositories.kitchen_api_ledger import InMemoryKitchenCommandLedger
+from catering_system.repositories.sqlite_kitchen_print_job_repository import (
+    SQLiteKitchenPrintJobRepository,
+)
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.services.kitchen_print_service import KitchenPrintService
+from catering_system.ui.kitchen_api import KitchenApi, make_kitchen_api_handler
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+from tests.helpers.order_seed import seed_order
+
+_TOKEN = "test-kitchen-agent-token"
+_AUTH = {"Authorization": f"Bearer {_TOKEN}"}
+_NOW = datetime(2026, 8, 8, 11, 0, tzinfo=UTC)
+_POLICY = KitchenPrintPolicy(
+    acceptance_timeout=timedelta(seconds=30),
+    acknowledgment_timeout=timedelta(minutes=5),
+)
+_JOB_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_JOB_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def _post(url: str, payload: dict[str, object]) -> tuple[int, dict[str, object], bytes]:
+    data = json.dumps(payload, sort_keys=True).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            **_AUTH,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        status = exc.code
+    body = json.loads(raw.decode("utf-8")) if raw else {}
+    return status, body, raw
+
+
+@pytest.fixture
+def kitchen_api(
+    tmp_path: Path,
+) -> tuple[str, Path, InMemoryKitchenCommandLedger]:
+    db = tmp_path / "core.db"
+    ledger = InMemoryKitchenCommandLedger()
+    store = InMemoryKitchenPrintDocumentStore()
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        api = KitchenApi(
+            str(db),
+            ledger=ledger,
+            document_store=store,
+            policy=_POLICY,
+            clock=lambda: _NOW,
+        )
+        server = HTTPServer(("127.0.0.1", 0), make_kitchen_api_handler(api, _TOKEN))
+        ready.put(server)
+        try:
+            server.serve_forever()
+        finally:
+            api.close()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address
+    base = f"http://{host}:{port}"
+    try:
+        yield base, db, ledger
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _seed_claimable_job(
+    db: Path,
+    *,
+    print_job_id: str = _JOB_A,
+    inquiry_id: str | None = None,
+) -> tuple[str, str]:
+    now = datetime(2026, 8, 8, 8, 0, tzinfo=UTC)
+    inquiry = Inquiry(
+        inquiry_id=inquiry_id or str(uuid.uuid4()),
+        event_date=date(2026, 10, 1),
+        created_at=now,
+        updated_at=now,
+        inquiry_source="manual",
+        crm_stage=CRM_PIPELINE[0],
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode=PLANNING_MODES[0],
+        call_verification_required=False,
+        call_verification_status=CALL_VERIFICATION_STATUSES[0],
+        customer_snapshot=_CCSnapshot(email="kunde@example.com", phone="+49301234567"),
+    )
+    orders = SQLiteOrderRepository(db)
+    order, order_version = seed_order(orders, inquiry)
+    orders.close()
+    seed_commercial_snapshot(
+        SQLiteOrderCommercialSnapshotRepository(db),
+        order.order_id,
+    )
+    jobs = SQLiteKitchenPrintJobRepository(db)
+    orders = SQLiteOrderRepository(db)
+    print_service = KitchenPrintService(
+        orders,
+        jobs,
+        policy=_POLICY,
+        clock=lambda: _NOW,
+    )
+    print_service.request_print(
+        order.order_id,
+        order_version.order_version_id,
+        print_job_id=print_job_id,
+    )
+    jobs.close()
+    orders.close()
+    return order.order_id, order_version.order_version_id
+
+
+def test_claim_returns_artifact_happy_path(kitchen_api) -> None:
+    base, db, _ledger = kitchen_api
+    _seed_claimable_job(db)
+    command_id = str(uuid.uuid4())
+
+    status, body, _raw = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": command_id},
+    )
+
+    assert status == 200
+    assert body["command_id"] == command_id
+    assert body["print_job_id"] == _JOB_A
+    assert body["document_ref"].startswith("sha256:")
+    assert body["document"]["content_type"] == "text/html; charset=utf-8"
+    assert body["document"]["body_base64"]
+
+
+def test_repeated_command_id_replays_without_new_claim(kitchen_api) -> None:
+    base, db, ledger = kitchen_api
+    _seed_claimable_job(db)
+    command_id = str(uuid.uuid4())
+
+    status1, body1, raw1 = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": command_id},
+    )
+    status2, body2, raw2 = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": command_id},
+    )
+
+    assert status1 == 200
+    assert (status2, body2) == (status1, body1)
+    assert raw2 == raw1
+    assert len(ledger._rows) == 1
+    jobs = SQLiteKitchenPrintJobRepository(db)
+    claimed = jobs.get(_JOB_A)
+    jobs.close()
+    assert claimed is not None
+    assert claimed.accepted_at == _NOW
+
+
+def test_two_command_ids_can_claim_two_jobs_when_queue_allows(kitchen_api) -> None:
+    base, db, ledger = kitchen_api
+    _seed_claimable_job(db, print_job_id=_JOB_A)
+    _seed_claimable_job(db, print_job_id=_JOB_B)
+
+    status_a, body_a, _raw_a = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": str(uuid.uuid4())},
+    )
+    status_b, body_b, _raw_b = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": str(uuid.uuid4())},
+    )
+
+    assert status_a == 200
+    assert status_b == 200
+    assert body_a["print_job_id"] != body_b["print_job_id"]
+    assert len(ledger._rows) == 2
+
+
+def test_reject_replay_is_idempotent(kitchen_api) -> None:
+    base, db, ledger = kitchen_api
+    _seed_claimable_job(db)
+    claim_command = str(uuid.uuid4())
+    _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": claim_command},
+    )
+    reject_command = str(uuid.uuid4())
+    url = f"{base}/kitchen/v1/print-jobs/{_JOB_A}/reject"
+    payload = {
+        "command_id": reject_command,
+        "rejection_code": "printer_unavailable",
+    }
+    status1, body1, raw1 = _post(url, payload)
+    status2, body2, raw2 = _post(url, payload)
+
+    assert status1 == 200
+    assert (status2, body2) == (status1, body1)
+    assert raw2 == raw1
+    assert len(ledger._rows) == 2
+
+
+def test_reject_unknown_code_returns_domain_validation_error(kitchen_api) -> None:
+    base, db, _ledger = kitchen_api
+    _seed_claimable_job(db)
+    _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": str(uuid.uuid4())},
+    )
+    status, body, _raw = _post(
+        f"{base}/kitchen/v1/print-jobs/{_JOB_A}/reject",
+        {
+            "command_id": str(uuid.uuid4()),
+            "rejection_code": "not_a_real_code",
+        },
+    )
+    assert status == 422
+    assert body["error"] == "invalid_request"
+
+
+def test_claim_does_not_set_kitchen_print_confirmed_at(kitchen_api) -> None:
+    base, db, _ledger = kitchen_api
+    order_id, version_id = _seed_claimable_job(db)
+    status, body, _raw = _post(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        {"command_id": str(uuid.uuid4())},
+    )
+    assert status == 200
+    orders = SQLiteOrderRepository(db)
+    version = orders.get_order_version(version_id)
+    orders.close()
+    assert version is not None
+    assert version.kitchen_print_confirmed_at is None
+    assert body["print_job_id"] == _JOB_A
+
+
+def test_unauthorized_request_is_rejected(kitchen_api) -> None:
+    base, db, _ledger = kitchen_api
+    _seed_claimable_job(db)
+    data = json.dumps({"command_id": str(uuid.uuid4())}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base}/kitchen/v1/print-jobs/claim-next",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(request, timeout=5)
+    assert exc_info.value.code == 401


### PR DESCRIPTION
## Summary

- Add transport-only Kitchen API: `POST /kitchen/v1/print-jobs/claim-next` and `POST /kitchen/v1/print-jobs/{id}/reject` with Bearer auth.
- Introduce command ledger (`command_id` + fingerprint) so replay returns stored responses byte-for-byte — no repeated claim, render, or document creation.
- Wire `KitchenPrintApplicationService` as the domain boundary between HTTP/ledger and existing claim + immutable document layers.

Stacked on #102 (`feature/phase-3b-kitchen-print-document`).

## Architecture

```text
HTTP → Command Ledger → KitchenPrintApplicationService
                              ├─ atomic claim
                              ├─ KitchenPrintDocumentFactory
                              └─ DocumentStore
```

Out of scope: agent daemon, heartbeat, CUPS, printer adapter, ACK endpoint.

## Test plan

- [x] `pytest tests/unit/test_kitchen_api.py -q` — claim happy path, ledger replay (`raw2 == raw1`), two command_ids, reject replay, unknown rejection code, claim does not set `kitchen_print_confirmed_at`, unauthorized
- [x] Full suite green (`pytest -q`)
- [x] `ruff check src tests infra` + `ruff format --check src tests infra`


Made with [Cursor](https://cursor.com)