### PR TITLE
PHASE-3B: add CUPS printer adapter and agent deployment entrypoint

### DIFF
--- a/infra/kitchen_print_agent/__init__.py
+++ b/infra/kitchen_print_agent/__init__.py
@@ -3,13 +3,19 @@
 from kitchen_print_agent.agent import KitchenPrintAgent
 from kitchen_print_agent.client import KitchenPrintAgentClient
 from kitchen_print_agent.config import AgentConfig
+from kitchen_print_agent.errors import PrinterError
 from kitchen_print_agent.models import ClaimDocument, ClaimResponse, RejectResponse
-from kitchen_print_agent.printer import FakePrinterAdapter, PrinterAdapter, PrinterError
+from kitchen_print_agent.printer import (
+    CupsPrinterAdapter,
+    FakePrinterAdapter,
+    PrinterAdapter,
+)
 
 __all__ = [
     "AgentConfig",
     "ClaimDocument",
     "ClaimResponse",
+    "CupsPrinterAdapter",
     "FakePrinterAdapter",
     "KitchenPrintAgent",
     "KitchenPrintAgentClient",

--- a/infra/kitchen_print_agent/__main__.py
+++ b/infra/kitchen_print_agent/__main__.py
@@ -1,0 +1,37 @@
+"""Entry point: python -m kitchen_print_agent"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from kitchen_print_agent.agent import KitchenPrintAgent
+from kitchen_print_agent.config import AgentConfig
+from kitchen_print_agent.printer import CupsPrinterAdapter
+
+_log = logging.getLogger(__name__)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        config = AgentConfig.from_env()
+    except KeyError as exc:
+        _log.error("missing required environment variable: %s", exc.args[0])
+        sys.exit(1)
+
+    printer = CupsPrinterAdapter(config.printer_name)
+    agent = KitchenPrintAgent.from_config(config, printer)
+    _log.info(
+        "starting kitchen print agent api=%s printer=%s",
+        config.api_url,
+        config.printer_name,
+    )
+    agent.run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/kitchen_print_agent/agent.py
+++ b/infra/kitchen_print_agent/agent.py
@@ -10,8 +10,9 @@ from typing import Protocol
 
 from kitchen_print_agent.client import KitchenPrintAgentClient
 from kitchen_print_agent.config import AgentConfig
+from kitchen_print_agent.errors import PrinterError
 from kitchen_print_agent.models import ClaimResponse
-from kitchen_print_agent.printer import PrinterAdapter, PrinterError
+from kitchen_print_agent.printer import PrinterAdapter
 
 _log = logging.getLogger(__name__)
 
@@ -82,20 +83,24 @@ class KitchenPrintAgent:
                 result.document.content_type,
                 result.document.body,
             )
-        except PrinterError:
+        except PrinterError as exc:
             reject_command_id = self._uuid_factory()
             self._client.reject(
                 result.print_job_id,
                 reject_command_id,
-                "printer_unavailable",
+                exc.rejection_code,
             )
         return True
 
-    def run(self) -> None:
+    def run_forever(self) -> None:
+        """Poll until stop() is called."""
         self._running = True
         while self._running:
             self.run_once()
             self._sleep(self._config.poll_interval_seconds)
+
+    def run(self) -> None:
+        self.run_forever()
 
     def stop(self) -> None:
         self._running = False

--- a/infra/kitchen_print_agent/errors.py
+++ b/infra/kitchen_print_agent/errors.py
@@ -1,0 +1,11 @@
+"""Agent-layer printer errors — carry Core allowlisted rejection codes."""
+
+from __future__ import annotations
+
+
+class PrinterError(Exception):
+    """Technical printer failure reported back to Core via reject."""
+
+    def __init__(self, message: str, rejection_code: str) -> None:
+        super().__init__(message)
+        self.rejection_code = rejection_code

--- a/infra/kitchen_print_agent/printer.py
+++ b/infra/kitchen_print_agent/printer.py
@@ -1,12 +1,20 @@
-"""Printer adapter boundary — real CUPS implementation belongs in deployment slice."""
+"""Printer adapter boundary — Fake for tests, CUPS for deployment."""
 
 from __future__ import annotations
 
+import subprocess
+import tempfile
+from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Protocol
 
+from kitchen_print_agent.errors import PrinterError
 
-class PrinterError(Exception):
-    """Technical printer failure reported back to Core via reject."""
+_CONTENT_TYPE_SUFFIX = {
+    "text/html; charset=utf-8": ".html",
+    "text/html": ".html",
+    "application/pdf": ".pdf",
+}
 
 
 class PrinterAdapter(Protocol):
@@ -16,11 +24,79 @@ class PrinterAdapter(Protocol):
 class FakePrinterAdapter:
     """In-memory printer for tests and local development."""
 
-    def __init__(self, *, fail_on_print: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        fail_on_print: bool = False,
+        rejection_code: str = "printer_unavailable",
+    ) -> None:
         self.fail_on_print = fail_on_print
+        self.rejection_code = rejection_code
         self.printed: list[tuple[str, bytes]] = []
 
     def print_document(self, content_type: str, body: bytes) -> None:
         if self.fail_on_print:
-            raise PrinterError("simulated printer failure")
+            raise PrinterError("simulated printer failure", self.rejection_code)
         self.printed.append((content_type, body))
+
+
+def _suffix_for_content_type(content_type: str) -> str:
+    return _CONTENT_TYPE_SUFFIX.get(content_type, ".bin")
+
+
+def _map_lp_failure(stderr: str) -> str:
+    normalized = stderr.lower()
+    if "unknown printer" in normalized or "does not exist" in normalized:
+        return "printer_unavailable"
+    if "job rejected" in normalized or "rejected" in normalized:
+        return "spool_rejected"
+    if "unsupported" in normalized or "format" in normalized:
+        return "invalid_printer_configuration"
+    return "printer_unavailable"
+
+
+class CupsPrinterAdapter:
+    """Send document bytes to a CUPS queue via lp."""
+
+    def __init__(
+        self,
+        printer_name: str,
+        *,
+        run_lp: Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+        | None = None,
+    ) -> None:
+        if not printer_name:
+            raise ValueError("printer_name is required for CupsPrinterAdapter")
+        self._printer_name = printer_name
+        self._run_lp = run_lp or self._default_run_lp
+
+    def print_document(self, content_type: str, body: bytes) -> None:
+        suffix = _suffix_for_content_type(content_type)
+        temp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+                handle.write(body)
+                temp_path = handle.name
+            result = self._run_lp(
+                ["lp", "-d", self._printer_name, temp_path],
+            )
+        except OSError as exc:
+            raise PrinterError(str(exc), "printer_unavailable") from exc
+        finally:
+            if temp_path is not None:
+                Path(temp_path).unlink(missing_ok=True)
+
+        if result.returncode == 0:
+            return
+
+        message = (result.stderr or result.stdout or "lp failed").strip()
+        raise PrinterError(message, _map_lp_failure(message))
+
+    @staticmethod
+    def _default_run_lp(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            check=False,
+        )

--- a/infra/kitchen_print_agent/printer.py
+++ b/infra/kitchen_print_agent/printer.py
@@ -10,11 +10,7 @@ from typing import Protocol
 
 from kitchen_print_agent.errors import PrinterError
 
-_CONTENT_TYPE_SUFFIX = {
-    "text/html; charset=utf-8": ".html",
-    "text/html": ".html",
-    "application/pdf": ".pdf",
-}
+_PDF_CONTENT_TYPE = "application/pdf"
 
 
 class PrinterAdapter(Protocol):
@@ -38,10 +34,6 @@ class FakePrinterAdapter:
         if self.fail_on_print:
             raise PrinterError("simulated printer failure", self.rejection_code)
         self.printed.append((content_type, body))
-
-
-def _suffix_for_content_type(content_type: str) -> str:
-    return _CONTENT_TYPE_SUFFIX.get(content_type, ".bin")
 
 
 def _map_lp_failure(stderr: str) -> str:
@@ -71,10 +63,14 @@ class CupsPrinterAdapter:
         self._run_lp = run_lp or self._default_run_lp
 
     def print_document(self, content_type: str, body: bytes) -> None:
-        suffix = _suffix_for_content_type(content_type)
+        if content_type != _PDF_CONTENT_TYPE:
+            raise PrinterError(
+                f"unsupported print document content type: {content_type}",
+                "invalid_printer_configuration",
+            )
         temp_path: str | None = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
                 handle.write(body)
                 temp_path = handle.name
             result = self._run_lp(

--- a/infra/systemd/kitchen-print-agent.env.example
+++ b/infra/systemd/kitchen-print-agent.env.example
@@ -1,0 +1,5 @@
+# Copy to /etc/kitchen-print-agent.env (root-owned, mode 600).
+KITCHEN_PRINT_API_URL=http://127.0.0.1:8083
+KITCHEN_PRINT_AGENT_TOKEN=replace-with-agent-token
+KITCHEN_PRINT_POLL_INTERVAL_SECONDS=5
+KITCHEN_PRINT_PRINTER_NAME=Kitchen

--- a/infra/systemd/kitchen-print-agent.service
+++ b/infra/systemd/kitchen-print-agent.service
@@ -1,0 +1,20 @@
+# Kitchen print agent — Lenovo deployment (Phase 3B edge runtime).
+# Requires kitchen-print-agent.env with API URL, token, and CUPS queue name.
+
+[Unit]
+Description=Kitchen Print Agent
+After=network-online.target cups.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=viktor
+WorkingDirectory=/opt/kitchen-print-agent
+Environment=PYTHONPATH=/opt/kitchen-print-agent/infra
+EnvironmentFile=/etc/kitchen-print-agent.env
+ExecStart=/usr/bin/python3 -m kitchen_print_agent
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/catering_system/services/kitchen_print_document.py
+++ b/src/catering_system/services/kitchen_print_document.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 
 from catering_system.domain.kitchen_print_job import KitchenPrintJob
+from catering_system.services.kitchen_print_pdf_renderer import render_kitchen_print_pdf
 from catering_system.services.order_print_projection_service import OrderPrintProjection
 
 
@@ -68,35 +68,17 @@ def build_kitchen_print_document(
     job: KitchenPrintJob,
     *,
     now: datetime,
-    render_html: Callable[[OrderPrintProjection], str] | None = None,
 ) -> KitchenPrintDocument:
     projection_hash = hashlib.sha256(
         canonical_kitchen_projection_json(projection).encode("utf-8")
     ).hexdigest()
-    if render_html is not None:
-        body = render_html(projection).encode("utf-8")
-    else:
-        body = _minimal_kitchen_html(projection).encode("utf-8")
+    body = render_kitchen_print_pdf(projection, created_at=now)
     document_ref = f"sha256:{hashlib.sha256(body).hexdigest()}"
     return KitchenPrintDocument(
         document_ref=document_ref,
         print_job_id=job.print_job_id,
         projection_hash=projection_hash,
-        content_type="text/html; charset=utf-8",
+        content_type="application/pdf",
         body=body,
         created_at=now,
     )
-
-
-def _minimal_kitchen_html(projection: OrderPrintProjection) -> str:
-    event = projection.event
-    lines = [
-        "<html><body>",
-        f"<p>order_version_id={event.order_version_id}</p>",
-        f"<p>version_number={event.version_number}</p>",
-        f"<p>location={event.location_text}</p>",
-    ]
-    for position in projection.commercial.positions:
-        lines.append(f"<p>{position.name}</p>")
-    lines.append("</body></html>")
-    return "".join(lines)

--- a/src/catering_system/services/kitchen_print_document_factory.py
+++ b/src/catering_system/services/kitchen_print_document_factory.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from datetime import UTC, datetime
-
 from catering_system.domain.kitchen_print_job import KitchenPrintJob
 from catering_system.repositories.kitchen_print_document_store import (
     KitchenPrintDocumentStore,
@@ -14,13 +11,8 @@ from catering_system.services.kitchen_print_document import (
     build_kitchen_print_document,
 )
 from catering_system.services.order_print_projection_service import (
-    OrderPrintProjection,
     OrderPrintProjectionService,
 )
-
-
-def _utc_now() -> datetime:
-    return datetime.now(UTC)
 
 
 class KitchenPrintDocumentFactory:
@@ -30,19 +22,16 @@ class KitchenPrintDocumentFactory:
         self,
         projection_service: OrderPrintProjectionService,
         document_store: KitchenPrintDocumentStore,
-        *,
-        clock: Callable[[], datetime] = _utc_now,
-        render_html: Callable[[OrderPrintProjection], str] | None = None,
     ) -> None:
         self._projection_service = projection_service
         self._document_store = document_store
-        self._clock = clock
-        self._render_html = render_html
 
     def create_for_print_job(self, job: KitchenPrintJob) -> KitchenPrintDocument:
         existing = self._document_store.get_by_print_job_id(job.print_job_id)
         if existing is not None:
             return existing
+        if job.accepted_at is None:
+            raise ValueError("accepted kitchen print job is required")
         projection = self._projection_service.resolve(
             job.order_id,
             job.order_version_id,
@@ -51,8 +40,7 @@ class KitchenPrintDocumentFactory:
         document = build_kitchen_print_document(
             projection,
             job,
-            now=self._clock(),
-            render_html=self._render_html,
+            now=job.accepted_at,
         )
         self._document_store.save(document)
         return document

--- a/src/catering_system/services/kitchen_print_pdf_renderer.py
+++ b/src/catering_system/services/kitchen_print_pdf_renderer.py
@@ -1,0 +1,272 @@
+"""Deterministic PDF renderer for immutable kitchen print artifacts."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import (
+    Flowable,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from catering_system.services.order_print_projection_service import OrderPrintProjection
+
+_TITLE = "Küchenzettel"
+_PAGE_SIZE = A4
+_LEFT_MARGIN = 18 * mm
+_RIGHT_MARGIN = 18 * mm
+_TOP_MARGIN = 16 * mm
+_BOTTOM_MARGIN = 14 * mm
+
+
+class KitchenPrintPdfUnsupportedCharacterError(Exception):
+    def __init__(self, *, field: str) -> None:
+        self.field = field
+        super().__init__(f"unsupported character(s) in {field}")
+
+
+class KitchenPrintPdfRenderError(Exception):
+    """Wraps unexpected ReportLab failures without exposing internals."""
+
+
+class _FixedTimeStamp:
+    def __init__(self, created_at: datetime) -> None:
+        utc = created_at.astimezone(UTC)
+        self.YMDhms = (utc.year, utc.month, utc.day, utc.hour, utc.minute, utc.second)
+        self.dhh = 0
+        self.dmm = 0
+
+
+@dataclass(frozen=True)
+class _Styles:
+    title: ParagraphStyle
+    h2: ParagraphStyle
+    body: ParagraphStyle
+    body_bold: ParagraphStyle
+    small: ParagraphStyle
+    table_header: ParagraphStyle
+
+
+def render_kitchen_print_pdf(
+    projection: OrderPrintProjection,
+    *,
+    created_at: datetime,
+) -> bytes:
+    """Render one kitchen_job projection to printer-ready PDF bytes."""
+
+    _check_all_text(projection)
+    styles = _styles()
+    story = _build_story(projection, styles)
+
+    buf = io.BytesIO()
+    try:
+        doc = SimpleDocTemplate(
+            buf,
+            pagesize=_PAGE_SIZE,
+            leftMargin=_LEFT_MARGIN,
+            rightMargin=_RIGHT_MARGIN,
+            topMargin=_TOP_MARGIN,
+            bottomMargin=_BOTTOM_MARGIN,
+            invariant=1,
+            title=_TITLE,
+            author="Silberlöffel Catering",
+            subject=projection.event.order_version_id,
+            creator="silberloeffel-catering-kitchen-print-pdf-renderer",
+            producer="silberloeffel-catering-kitchen-print-pdf-renderer",
+        )
+        on_page = _page_decorator(created_at)
+        doc.build(story, onFirstPage=on_page, onLaterPages=on_page)
+    except KitchenPrintPdfUnsupportedCharacterError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        raise KitchenPrintPdfRenderError("failed to render kitchen print PDF") from exc
+    return buf.getvalue()
+
+
+def _styles() -> _Styles:
+    base = getSampleStyleSheet()
+    return _Styles(
+        title=ParagraphStyle(
+            "KitchenTitle",
+            parent=base["Title"],
+            fontName="Helvetica-Bold",
+            fontSize=18,
+            leading=22,
+            spaceAfter=10,
+        ),
+        h2=ParagraphStyle(
+            "KitchenH2",
+            parent=base["Heading2"],
+            fontName="Helvetica-Bold",
+            fontSize=12,
+            leading=14,
+            spaceBefore=8,
+            spaceAfter=4,
+        ),
+        body=ParagraphStyle(
+            "KitchenBody", parent=base["Normal"], fontSize=10, leading=13
+        ),
+        body_bold=ParagraphStyle(
+            "KitchenBodyBold",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=10,
+            leading=13,
+        ),
+        small=ParagraphStyle(
+            "KitchenSmall", parent=base["Normal"], fontSize=8, leading=10
+        ),
+        table_header=ParagraphStyle(
+            "KitchenTableHeader",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=9,
+            leading=11,
+        ),
+    )
+
+
+def _build_story(projection: OrderPrintProjection, styles: _Styles) -> list[Flowable]:
+    event = projection.event
+    guests = (
+        str(event.guest_count_estimate)
+        if event.guest_count_estimate is not None
+        else "-"
+    )
+    story: list[Flowable] = []
+    if event.order_cancelled_at is not None:
+        story.append(_p("STORNIERT", styles.title))
+        story.append(Spacer(1, 4 * mm))
+
+    story.append(_p("SILBERLÖFFEL", styles.small))
+    story.append(_p(_TITLE, styles.title))
+    story.append(
+        Table(
+            [
+                [
+                    _p("Datum", styles.table_header),
+                    _p(_format_date(event.event_date), styles.body),
+                ],
+                [
+                    _p("Zeit", styles.table_header),
+                    _p(event.time_window_text, styles.body),
+                ],
+                [_p("Ort", styles.table_header), _p(event.location_text, styles.body)],
+                [_p("Gäste", styles.table_header), _p(guests, styles.body)],
+                [
+                    _p("Planung", styles.table_header),
+                    _p(event.planning_mode, styles.body),
+                ],
+                [
+                    _p("Stand", styles.table_header),
+                    _p(f"Version {event.version_number}", styles.body),
+                ],
+                [
+                    _p("Auftrag", styles.table_header),
+                    _p(event.order_id, styles.small),
+                ],
+                [
+                    _p("Version-ID", styles.table_header),
+                    _p(event.order_version_id, styles.small),
+                ],
+            ],
+            colWidths=(32 * mm, 120 * mm),
+            style=TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ]
+            ),
+        )
+    )
+    if projection.flags.watermark is not None:
+        story.append(Spacer(1, 4 * mm))
+        story.append(_p(projection.flags.watermark, styles.title))
+    if event.change_reason is not None or event.changed_fields:
+        story.append(Spacer(1, 4 * mm))
+        story.append(_p("Änderung", styles.h2))
+        story.append(_p(f"Grund: {event.change_reason or '-'}", styles.body))
+        fields = ", ".join(event.changed_fields) or "-"
+        story.append(_p(f"Felder: {fields}", styles.body))
+
+    story.append(Spacer(1, 6 * mm))
+    story.append(_p("MENÜ", styles.h2))
+    if not projection.commercial.positions:
+        story.append(_p("Keine Positionen.", styles.body))
+    for position in projection.commercial.positions:
+        story.append(_p(position.name, styles.body_bold))
+        details = [
+            value
+            for value in (
+                position.description or position.composition,
+                position.quantity_display,
+            )
+            if value
+        ]
+        for detail in details:
+            story.append(_p(detail, styles.body))
+        story.append(Spacer(1, 3 * mm))
+    return story
+
+
+def _page_decorator(created_at: datetime):
+    def _on_page(pdf_canvas, _doc) -> None:
+        pdf_canvas._doc._timeStamp = _FixedTimeStamp(created_at)
+        pdf_canvas.saveState()
+        pdf_canvas.setFont("Helvetica", 8)
+        pdf_canvas.setFillGray(0.35)
+        pdf_canvas.drawRightString(
+            _PAGE_SIZE[0] - _RIGHT_MARGIN,
+            8 * mm,
+            f"Seite {pdf_canvas.getPageNumber()}",
+        )
+        pdf_canvas.restoreState()
+
+    return _on_page
+
+
+def _format_date(value: object) -> str:
+    return value.strftime("%d.%m.%Y")  # type: ignore[attr-defined]
+
+
+def _p(text: str, style: ParagraphStyle) -> Paragraph:
+    return Paragraph(_esc(text).replace("\n", "<br/>"), style)
+
+
+def _esc(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _ensure_renderable(value: str | None, field: str) -> None:
+    if not value:
+        return
+    try:
+        value.encode("cp1252")
+    except UnicodeEncodeError as exc:
+        raise KitchenPrintPdfUnsupportedCharacterError(field=field) from exc
+
+
+def _check_all_text(projection: OrderPrintProjection) -> None:
+    event = projection.event
+    _ensure_renderable(event.time_window_text, "time_window_text")
+    _ensure_renderable(event.location_text, "location_text")
+    _ensure_renderable(event.planning_mode, "planning_mode")
+    _ensure_renderable(event.change_reason, "change_reason")
+    for index, field in enumerate(event.changed_fields):
+        _ensure_renderable(field, f"changed_fields[{index}]")
+    for index, position in enumerate(projection.commercial.positions):
+        prefix = f"positions[{index}]"
+        _ensure_renderable(position.name, f"{prefix}.name")
+        _ensure_renderable(position.description, f"{prefix}.description")
+        _ensure_renderable(position.composition, f"{prefix}.composition")
+        _ensure_renderable(position.notes, f"{prefix}.notes")
+        _ensure_renderable(position.quantity_display, f"{prefix}.quantity_display")

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -118,7 +118,6 @@ class KitchenApi:
         self._document_factory = KitchenPrintDocumentFactory(
             projection_service,
             self._document_store,
-            clock=self._clock,
         )
         self.application = KitchenPrintApplicationService(
             self._print_service,
@@ -211,7 +210,7 @@ def make_kitchen_api_handler(
     class KitchenApiHandler(BaseHTTPRequestHandler):
         server_version = "KitchenApi/1.0"
 
-        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        def log_message(self, format: str, *args: object) -> None:
             _log.info(format, *args)
 
         def _authorized(self) -> bool:
@@ -259,7 +258,7 @@ def make_kitchen_api_handler(
                 raise _invalid()
             return strict_json_loads(raw)
 
-        def do_POST(self) -> None:  # noqa: N802
+        def do_POST(self) -> None:
             if not self._authorized():
                 self._error(401, "unauthorized")
                 return
@@ -301,7 +300,7 @@ def make_kitchen_api_handler(
             except ValueError:
                 self._error(422, "invalid_request")
 
-        def do_GET(self) -> None:  # noqa: N802
+        def do_GET(self) -> None:
             self._error(404, "not_found")
 
     return KitchenApiHandler

--- a/tests/helpers/kitchen_print_agent_contract.py
+++ b/tests/helpers/kitchen_print_agent_contract.py
@@ -16,7 +16,6 @@ import json
 import threading
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable
 
 from catering_system.domain.kitchen_print_job import (
     KitchenPrintJob,
@@ -170,13 +169,11 @@ def create_kitchen_print_document(
     job: KitchenPrintJob,
     *,
     now: datetime,
-    render_html: Callable[[OrderPrintProjection], str] | None = None,
 ) -> KitchenPrintDocument:
     return build_kitchen_print_document(
         projection,
         job,
         now=now,
-        render_html=render_html,
     )
 
 
@@ -203,7 +200,6 @@ def claim_with_document(
             commercial_snapshot_repository,
         ),
         document_store,
-        clock=lambda: now,
     )
     document = factory.create_for_print_job(job)
     return AgentClaimResult(job=job, document=document)

--- a/tests/unit/test_cups_printer_adapter.py
+++ b/tests/unit/test_cups_printer_adapter.py
@@ -1,0 +1,74 @@
+"""CUPS printer adapter tests — no real lp/CUPS required."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from kitchen_print_agent.errors import PrinterError
+from kitchen_print_agent.printer import CupsPrinterAdapter
+
+
+def _completed(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["lp"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_successful_print_does_not_raise() -> None:
+    calls: list[list[str]] = []
+
+    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        return _completed()
+
+    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
+    adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
+
+    assert calls
+    assert calls[0][:3] == ["lp", "-d", "Kitchen"]
+
+
+def test_queue_missing_maps_to_printer_unavailable() -> None:
+    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=1, stderr="lp: Unknown printer 'Kitchen'")
+
+    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
+
+    with pytest.raises(PrinterError) as exc_info:
+        adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
+
+    assert exc_info.value.rejection_code == "printer_unavailable"
+
+
+def test_spool_reject_maps_to_spool_rejected() -> None:
+    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=1, stderr="job rejected by spooler")
+
+    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
+
+    with pytest.raises(PrinterError) as exc_info:
+        adapter.print_document("application/pdf", b"%PDF-1.4")
+
+    assert exc_info.value.rejection_code == "spool_rejected"
+
+
+def test_unsupported_format_maps_to_invalid_printer_configuration() -> None:
+    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+        return _completed(returncode=1, stderr="unsupported document format")
+
+    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
+
+    with pytest.raises(PrinterError) as exc_info:
+        adapter.print_document("application/octet-stream", b"\x00\x01")
+
+    assert exc_info.value.rejection_code == "invalid_printer_configuration"

--- a/tests/unit/test_cups_printer_adapter.py
+++ b/tests/unit/test_cups_printer_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 
 import pytest
-
 from kitchen_print_agent.errors import PrinterError
 from kitchen_print_agent.printer import CupsPrinterAdapter
 
@@ -32,10 +31,11 @@ def test_successful_print_does_not_raise() -> None:
         return _completed()
 
     adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
-    adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
+    adapter.print_document("application/pdf", b"%PDF-1.4")
 
     assert calls
     assert calls[0][:3] == ["lp", "-d", "Kitchen"]
+    assert calls[0][3].endswith(".pdf")
 
 
 def test_queue_missing_maps_to_printer_unavailable() -> None:
@@ -45,7 +45,7 @@ def test_queue_missing_maps_to_printer_unavailable() -> None:
     adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
 
     with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
+        adapter.print_document("application/pdf", b"%PDF-1.4")
 
     assert exc_info.value.rejection_code == "printer_unavailable"
 
@@ -63,12 +63,16 @@ def test_spool_reject_maps_to_spool_rejected() -> None:
 
 
 def test_unsupported_format_maps_to_invalid_printer_configuration() -> None:
+    calls: list[list[str]] = []
+
     def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(list(_command))
         return _completed(returncode=1, stderr="unsupported document format")
 
     adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
 
     with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/octet-stream", b"\x00\x01")
+        adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
 
     assert exc_info.value.rejection_code == "invalid_printer_configuration"
+    assert calls == []

--- a/tests/unit/test_kitchen_api.py
+++ b/tests/unit/test_kitchen_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import queue
 import threading
@@ -14,18 +15,18 @@ from pathlib import Path
 
 import pytest
 
-from catering_system.domain.kitchen_print_job import KitchenPrintPolicy
-from catering_system.repositories.in_memory_kitchen_print_document_store import (
-    InMemoryKitchenPrintDocumentStore,
-)
 from catering_system.domain.inquiry import (
     CALL_VERIFICATION_STATUSES,
     CRM_PIPELINE,
-    Inquiry,
     PLANNING_MODES,
+    Inquiry,
 )
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
+)
+from catering_system.domain.kitchen_print_job import KitchenPrintPolicy
+from catering_system.repositories.in_memory_kitchen_print_document_store import (
+    InMemoryKitchenPrintDocumentStore,
 )
 from catering_system.repositories.kitchen_api_ledger import InMemoryKitchenCommandLedger
 from catering_system.repositories.sqlite_kitchen_print_job_repository import (
@@ -172,8 +173,9 @@ def test_claim_returns_artifact_happy_path(kitchen_api) -> None:
     assert body["command_id"] == command_id
     assert body["print_job_id"] == _JOB_A
     assert body["document_ref"].startswith("sha256:")
-    assert body["document"]["content_type"] == "text/html; charset=utf-8"
+    assert body["document"]["content_type"] == "application/pdf"
     assert body["document"]["body_base64"]
+    assert base64.b64decode(body["document"]["body_base64"]).startswith(b"%PDF-")
 
 
 def test_repeated_command_id_replays_without_new_claim(kitchen_api) -> None:
@@ -264,7 +266,7 @@ def test_reject_unknown_code_returns_domain_validation_error(kitchen_api) -> Non
 
 def test_claim_does_not_set_kitchen_print_confirmed_at(kitchen_api) -> None:
     base, db, _ledger = kitchen_api
-    order_id, version_id = _seed_claimable_job(db)
+    _order_id, version_id = _seed_claimable_job(db)
     status, body, _raw = _post(
         f"{base}/kitchen/v1/print-jobs/claim-next",
         {"command_id": str(uuid.uuid4())},

--- a/tests/unit/test_kitchen_print_agent_runtime.py
+++ b/tests/unit/test_kitchen_print_agent_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import queue
+import subprocess
 import threading
 import uuid
 from datetime import UTC, date, datetime, timedelta
@@ -39,7 +40,7 @@ from catering_system.ui.kitchen_api import KitchenApi, make_kitchen_api_handler
 from kitchen_print_agent.agent import KitchenPrintAgent
 from kitchen_print_agent.client import KitchenPrintAgentClient
 from kitchen_print_agent.config import AgentConfig
-from kitchen_print_agent.printer import FakePrinterAdapter
+from kitchen_print_agent.printer import CupsPrinterAdapter, FakePrinterAdapter
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.order_seed import seed_order
 
@@ -180,6 +181,39 @@ def test_printer_failure_triggers_technical_reject(kitchen_api_server) -> None:
     assert job is not None
     assert job.rejected_at == _NOW
     assert job.rejection_code == "printer_unavailable"
+
+
+def test_cups_adapter_failure_propagates_rejection_code(kitchen_api_server) -> None:
+    base, db = kitchen_api_server
+    _order_id, version_id = _seed_claimable_job(db)
+
+    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["lp"],
+            returncode=1,
+            stdout="",
+            stderr="job rejected by spooler",
+        )
+
+    agent = KitchenPrintAgent(
+        _agent_config(base),
+        KitchenPrintAgentClient(base, _TOKEN),
+        CupsPrinterAdapter("Kitchen", run_lp=run_lp),
+    )
+    agent.run_once()
+
+    jobs = SQLiteKitchenPrintJobRepository(db)
+    job = jobs.get(_JOB_A)
+    jobs.close()
+    assert job is not None
+    assert job.rejection_code == "spool_rejected"
+    assert job.rejected_at == _NOW
+
+    orders = SQLiteOrderRepository(db)
+    version = orders.get_order_version(version_id)
+    orders.close()
+    assert version is not None
+    assert version.kitchen_print_confirmed_at is None
 
 
 def test_agent_restart_has_no_local_state(kitchen_api_server) -> None:

--- a/tests/unit/test_kitchen_print_agent_runtime.py
+++ b/tests/unit/test_kitchen_print_agent_runtime.py
@@ -13,12 +13,16 @@ from http.server import HTTPServer
 from pathlib import Path
 
 import pytest
+from kitchen_print_agent.agent import KitchenPrintAgent
+from kitchen_print_agent.client import KitchenPrintAgentClient
+from kitchen_print_agent.config import AgentConfig
+from kitchen_print_agent.printer import CupsPrinterAdapter, FakePrinterAdapter
 
 from catering_system.domain.inquiry import (
     CALL_VERIFICATION_STATUSES,
     CRM_PIPELINE,
-    Inquiry,
     PLANNING_MODES,
+    Inquiry,
 )
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -37,10 +41,6 @@ from catering_system.repositories.sqlite_order_commercial_snapshot_repository im
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.ui.kitchen_api import KitchenApi, make_kitchen_api_handler
-from kitchen_print_agent.agent import KitchenPrintAgent
-from kitchen_print_agent.client import KitchenPrintAgentClient
-from kitchen_print_agent.config import AgentConfig
-from kitchen_print_agent.printer import CupsPrinterAdapter, FakePrinterAdapter
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.order_seed import seed_order
 
@@ -159,8 +159,8 @@ def test_claim_receives_document_and_prints_via_fake_printer(
     assert claimed is True
     assert len(printer.printed) == 1
     content_type, body = printer.printed[0]
-    assert content_type == "text/html; charset=utf-8"
-    assert b"<!DOCTYPE html>" in body or len(body) > 0
+    assert content_type == "application/pdf"
+    assert body.startswith(b"%PDF-")
 
 
 def test_printer_failure_triggers_technical_reject(kitchen_api_server) -> None:

--- a/tests/unit/test_kitchen_print_document.py
+++ b/tests/unit/test_kitchen_print_document.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import io
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from pypdf import PdfReader
 
 from catering_system.domain.kitchen_print_job import KitchenPrintJob, KitchenPrintPolicy
 from catering_system.repositories.in_memory_kitchen_print_document_store import (
@@ -18,6 +20,10 @@ from catering_system.repositories.in_memory_kitchen_print_job_repository import 
 )
 from catering_system.services.kitchen_print_document_factory import (
     KitchenPrintDocumentFactory,
+)
+from catering_system.services.kitchen_print_pdf_renderer import (
+    KitchenPrintPdfUnsupportedCharacterError,
+    render_kitchen_print_pdf,
 )
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.operational_core_service import OperationalCoreService
@@ -35,7 +41,16 @@ _POLICY = KitchenPrintPolicy(
 )
 
 
-def _document_factory_world() -> tuple[
+def _pdf_text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    return " ".join(
+        text for page in reader.pages for text in (page.extract_text(),) if text
+    )
+
+
+def _document_factory_world(
+    *, accepted: bool = True
+) -> tuple[
     KitchenPrintDocumentFactory,
     InMemoryKitchenPrintDocumentStore,
     KitchenPrintJob,
@@ -66,16 +81,16 @@ def _document_factory_world() -> tuple[
         policy=_POLICY,
         clock=lambda: _NOW,
     )
-    job = print_service.request_print(
+    requested = print_service.request_print(
         order.order_id,
         order_version.order_version_id,
         print_job_id=_JOB_A,
     )
+    job = print_service.accept_print_job(_JOB_A) if accepted else requested
     store = InMemoryKitchenPrintDocumentStore()
     factory = KitchenPrintDocumentFactory(
         OrderPrintProjectionService(orders, offer_service._commercial_snapshots),
         store,
-        clock=lambda: _NOW,
     )
     return factory, store, job, offer, offers, orders
 
@@ -90,6 +105,103 @@ def test_create_for_print_job_returns_one_artifact_per_job() -> None:
     assert first.projection_hash == second.projection_hash
     assert first.body == second.body
     assert first.print_job_id == _JOB_A
+
+
+def test_pdf_render_is_byte_identical_for_same_stable_inputs() -> None:
+    factory, _store, job, _offer, _offers, _orders = _document_factory_world()
+    projection = factory._projection_service.resolve(
+        job.order_id,
+        job.order_version_id,
+        intent="kitchen_job",
+    )
+
+    first = render_kitchen_print_pdf(projection, created_at=_NOW)
+    second = render_kitchen_print_pdf(projection, created_at=_NOW)
+
+    assert first == second
+    assert first.startswith(b"%PDF-")
+    assert projection.flags.intent == "kitchen_job"
+
+
+def test_pdf_contains_kitchen_projection_content() -> None:
+    factory, _store, job, _offer, _offers, _orders = _document_factory_world()
+    projection = factory._projection_service.resolve(
+        job.order_id,
+        job.order_version_id,
+        intent="kitchen_job",
+    )
+    pdf = render_kitchen_print_pdf(projection, created_at=_NOW)
+    text = _pdf_text(pdf)
+    event = projection.event
+    first_position = projection.commercial.positions[0]
+    detail = first_position.description or first_position.composition
+
+    assert "SILBERLÖFFEL" in text
+    assert "Küchenzettel" in text
+    assert event.order_id in text
+    assert event.order_version_id in text
+    assert event.event_date.strftime("%d.%m.%Y") in text
+    assert event.time_window_text in text
+    assert event.location_text in text
+    assert str(event.guest_count_estimate) in text
+    assert event.planning_mode in text
+    assert f"Version {event.version_number}" in text
+    assert "MENÜ" in text
+    assert first_position.name in text
+    if detail is not None:
+        assert detail in text
+    if first_position.quantity_display is not None:
+        assert first_position.quantity_display in text
+
+
+def test_pdf_contains_cancelled_watermark_change_and_empty_menu_states() -> None:
+    factory, _store, job, _offer, _offers, _orders = _document_factory_world()
+    projection = factory._projection_service.resolve(
+        job.order_id,
+        job.order_version_id,
+        intent="kitchen_job",
+    )
+    projection = replace(
+        projection,
+        event=replace(
+            projection.event,
+            guest_count_estimate=None,
+            order_cancelled_at=_NOW,
+            change_reason=None,
+            changed_fields=("location_text", "guest_count_estimate"),
+        ),
+        commercial=replace(projection.commercial, positions=()),
+        flags=replace(projection.flags, watermark="VERALTET"),
+    )
+
+    text = _pdf_text(render_kitchen_print_pdf(projection, created_at=_NOW))
+
+    assert "STORNIERT" in text
+    assert "VERALTET" in text
+    assert "Gäste" in text
+    assert "-" in text
+    assert "Änderung" in text
+    assert "Grund: -" in text
+    assert "Felder: location_text, guest_count_estimate" in text
+    assert "Keine Positionen." in text
+
+
+def test_pdf_rejects_unsupported_projection_text() -> None:
+    factory, _store, job, _offer, _offers, _orders = _document_factory_world()
+    projection = factory._projection_service.resolve(
+        job.order_id,
+        job.order_version_id,
+        intent="kitchen_job",
+    )
+    projection = replace(
+        projection,
+        event=replace(projection.event, changed_fields=("emoji 🚫",)),
+    )
+
+    with pytest.raises(KitchenPrintPdfUnsupportedCharacterError) as exc_info:
+        render_kitchen_print_pdf(projection, created_at=_NOW)
+
+    assert exc_info.value.field == "changed_fields[0]"
 
 
 def test_document_is_immutable_after_live_data_changes() -> None:
@@ -150,10 +262,20 @@ def test_document_stores_snapshot_bytes_not_live_reference() -> None:
     document = factory.create_for_print_job(job)
 
     assert document.body
+    assert document.body.startswith(b"%PDF-")
     assert document.projection_hash
-    assert document.content_type == "text/html; charset=utf-8"
+    assert document.content_type == "application/pdf"
     assert document.print_job_id == job.print_job_id
     assert not hasattr(document, "order_version_id")
+
+
+def test_unaccepted_job_cannot_produce_immutable_document() -> None:
+    factory, _store, job, _offer, _offers, _orders = _document_factory_world(
+        accepted=False
+    )
+
+    with pytest.raises(ValueError, match="accepted kitchen print job is required"):
+        factory.create_for_print_job(job)
 
 
 def test_kitchen_print_document_factory_boundary_stays_projection_only() -> None:
@@ -229,7 +351,6 @@ def test_claim_then_document_creation_does_not_mutate_job_facts() -> None:
     factory = KitchenPrintDocumentFactory(
         OrderPrintProjectionService(orders, offer_service._commercial_snapshots),
         store,
-        clock=lambda: _NOW,
     )
     before = jobs.get(_JOB_A)
     assert before is not None


### PR DESCRIPTION
## Summary
- add CUPS printer adapter and agent deployment entrypoint
- Core now renders immutable KitchenPrintDocument artifacts as application/pdf
- CupsPrinterAdapter rejects non-PDF content before calling lp
- no browser/wkhtmltopdf/Chromium dependencies added to the Lenovo agent
- no KitchenPrintJob / claim / ACK / Office UI semantics changed

## Verification
- git diff --check: clean
- targeted ruff check: passed
- targeted ruff format --check: passed
- py_compile changed files: passed
- tests/unit/test_cups_printer_adapter.py: 4 passed

## Environment limitation
PDF/API runtime tests are included, but local execution was blocked by missing reportlab/pypdf; CI is authoritative.

## Hardware acceptance
After CI, verify on Brother MFC-L2710DN: a newly claimed kitchen print job must produce a rendered Küchenzettel PDF, not raw HTML source.