### PR TITLE
UI: show logged-in employee in office panel sidebar

### DIFF
--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -312,8 +312,8 @@ def _page(
         "</a>"
         '<div class="office-nav-label">Navigation</div>'
         f'<nav class="office-nav" aria-label="Office Panel">{nav}</nav>'
-        '<div class="office-user"><strong>Office Panel</strong>'
-        "<span>Tägliche Arbeitszentrale</span></div></aside>"
+        f'<div class="office-user"><strong>{_e(context.current_user_name or "Office Panel")}</strong>'
+        f"<span>{_e(context.current_user_role_label or 'Tägliche Arbeitszentrale')}</span></div></aside>"
         '<main class="office-workspace">'
         f'<header class="office-topbar"><span class="office-crumb">{_e(title)}</span>'
         f'<div class="office-account">{account_meta}{account_actions}</div></header>'


### PR DESCRIPTION
## Summary

- Replace hardcoded sidebar user block in `_page()` with `OfficePageContext.current_user_name` and `current_user_role_label`.
- Sidebar now matches the authenticated employee shown in the topbar.

No auth, session, API, or RBAC changes.

## Test plan

- [x] `pytest tests/unit/test_office_panel_employee_auth.py tests/unit/test_office_panel_auth_2d2.py -q`
- [ ] Manual: login as employee → sidebar shows display name + role label


Made with [Cursor](https://cursor.com)