### PR TITLE
fix: use current order payment in customer documents

### DIFF
--- a/src/catering_system/services/customer_document_preview.py
+++ b/src/catering_system/services/customer_document_preview.py
@@ -6,8 +6,8 @@ No persistence. No Offer. No intake parsing. No PDF/HTML/email.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Callable
 
 from catering_system.domain.customer_document_preview import CustomerDocumentPreview
 from catering_system.domain.customer_document_projection import (
@@ -17,17 +17,22 @@ from catering_system.domain.customer_document_projection import (
 from catering_system.domain.inquiry import FulfillmentMode, Inquiry
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
+from catering_system.domain.order_payment_reminder import OrderPaymentReminder
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.payment_reminder_repository import (
+    PaymentReminderRepository,
+)
 from catering_system.services.customer_document_eligibility import (
     evaluate_customer_document_eligibility,
 )
 from catering_system.services.customer_document_projection import (
     build_customer_document_projection,
     build_customer_document_recipient,
+    resolve_document_payment,
 )
 
 _PREVIEW_DOCUMENT_ID = "preview"
@@ -45,6 +50,7 @@ def build_customer_document_preview(
     recipient_inquiry: Inquiry | None,
     invoice_address: CustomerAddress | None = None,
     delivery_address: CustomerAddress | None = None,
+    payment_reminder: OrderPaymentReminder | None = None,
     now: datetime | None = None,
 ) -> CustomerDocumentPreview:
     """Pure assemble of live preview facts + eligibility (no repos)."""
@@ -68,6 +74,9 @@ def build_customer_document_preview(
     )
     event = _event_from_version(order_version)
     if commercial_snapshot is not None and order_version is not None:
+        payment_method, payment_customer_visible_text = resolve_document_payment(
+            commercial_snapshot, payment_reminder
+        )
         projection = build_customer_document_projection(
             document_type="ORDER_CONFIRMATION",
             document_id=_PREVIEW_DOCUMENT_ID,
@@ -76,6 +85,8 @@ def build_customer_document_preview(
             commercial_snapshot=commercial_snapshot,
             recipient=recipient,
             fulfillment_mode=fulfillment_mode,
+            payment_method=payment_method,
+            payment_customer_visible_text=payment_customer_visible_text,
         )
         return CustomerDocumentPreview(
             document_type="ORDER_CONFIRMATION",
@@ -137,11 +148,13 @@ class CustomerDocumentPreviewService:
         inquiry_repository: InquiryRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository,
         *,
+        payment_reminder_repository: PaymentReminderRepository | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._orders = order_repository
         self._inquiries = inquiry_repository
         self._commercial_snapshots = commercial_snapshot_repository
+        self._payment_reminders = payment_reminder_repository
         self._now = now or (lambda: datetime.now(UTC))
 
     def preview_order_confirmation(
@@ -159,6 +172,11 @@ class CustomerDocumentPreviewService:
             version = self._orders.get_order_version(order.effective_order_version_id)
         commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
         inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+        payment_reminder = (
+            self._payment_reminders.get(order.order_id)
+            if self._payment_reminders is not None
+            else None
+        )
         return build_customer_document_preview(
             order=order,
             order_version=version,
@@ -166,5 +184,6 @@ class CustomerDocumentPreviewService:
             recipient_inquiry=inquiry,
             invoice_address=invoice_address,
             delivery_address=delivery_address,
+            payment_reminder=payment_reminder,
             now=self._now(),
         )

--- a/src/catering_system/services/customer_document_projection.py
+++ b/src/catering_system/services/customer_document_projection.py
@@ -26,6 +26,11 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
+from catering_system.domain.order_payment_reminder import (
+    PAYMENT_METHOD_LABELS,
+    OrderPaymentReminder,
+    PaymentMethod,
+)
 from catering_system.services.order_print_projection_service import (
     format_quantity_display,
 )
@@ -127,6 +132,8 @@ def build_customer_document_projection(
     commercial_snapshot: OrderCommercialSnapshot,
     recipient: CustomerDocumentRecipient,
     fulfillment_mode: FulfillmentMode = "UNKNOWN",
+    payment_method: PaymentMethod | None = None,
+    payment_customer_visible_text: str | None = None,
 ) -> CustomerDocumentProjection:
     """Assemble a frozen customer-document projection from value objects."""
     if commercial_snapshot.order_id != order_version.order_id:
@@ -137,6 +144,12 @@ def build_customer_document_projection(
     positions = tuple(
         _map_position(position, order_version.guest_count_estimate)
         for position in commercial_snapshot.positions
+    )
+    effective_payment_method = payment_method or commercial_snapshot.payment_method
+    effective_payment_text = (
+        payment_customer_visible_text
+        if payment_customer_visible_text is not None
+        else commercial_snapshot.payment_customer_visible_text
     )
     return CustomerDocumentProjection(
         document_type=document_type,
@@ -160,12 +173,33 @@ def build_customer_document_projection(
             planning_mode=order_version.planning_mode,
         ),
         positions=positions,
-        payment_method=commercial_snapshot.payment_method,
-        payment_customer_visible_text=commercial_snapshot.payment_customer_visible_text,
+        payment_method=effective_payment_method,
+        payment_customer_visible_text=effective_payment_text,
         net_total_cents=sum(p.net_total_cents for p in positions),
         vat_total_cents=sum(p.vat_amount_cents for p in positions),
         gross_total_cents=sum(p.gross_total_cents for p in positions),
         fulfillment_mode=fulfillment_mode,
+    )
+
+
+def resolve_document_payment(
+    commercial_snapshot: OrderCommercialSnapshot,
+    payment_reminder: OrderPaymentReminder | None,
+) -> tuple[PaymentMethod, str]:
+    """Resolve the customer-document payment fact for a not-yet-frozen document."""
+    if payment_reminder is None:
+        return (
+            commercial_snapshot.payment_method,
+            commercial_snapshot.payment_customer_visible_text,
+        )
+    if payment_reminder.payment_method == commercial_snapshot.payment_method:
+        return (
+            commercial_snapshot.payment_method,
+            commercial_snapshot.payment_customer_visible_text,
+        )
+    return (
+        payment_reminder.payment_method,
+        PAYMENT_METHOD_LABELS[payment_reminder.payment_method],
     )
 
 
@@ -225,6 +259,8 @@ class CustomerDocumentProjectionService:
         inquiry: Inquiry | None,
         invoice_address: CustomerAddress | None = None,
         delivery_address: CustomerAddress | None = None,
+        payment_method: PaymentMethod | None = None,
+        payment_customer_visible_text: str | None = None,
     ) -> CustomerDocumentProjection:
         fulfillment_mode = (
             inquiry.fulfillment_mode if inquiry is not None else "UNKNOWN"
@@ -243,4 +279,6 @@ class CustomerDocumentProjectionService:
             commercial_snapshot=commercial_snapshot,
             recipient=recipient,
             fulfillment_mode=fulfillment_mode,
+            payment_method=payment_method,
+            payment_customer_visible_text=payment_customer_visible_text,
         )

--- a/src/catering_system/services/order_confirmation_document_preview.py
+++ b/src/catering_system/services/order_confirmation_document_preview.py
@@ -176,6 +176,12 @@ def render_preview_html(preview: OrderConfirmationDocumentPreview) -> str:
         if preview.watermark is not None
         else ""
     )
+    payment_terms_html = (
+        ""
+        if preview.payment_customer_visible_text.casefold()
+        == preview.payment_method_label.casefold()
+        else f"<p>{_e(preview.payment_customer_visible_text)}</p>"
+    )
     recipient_lines = []
     if preview.recipient_company:
         recipient_lines.append(f"<p>{_e(preview.recipient_company)}</p>")
@@ -268,7 +274,7 @@ footer{{margin-top:2rem;padding-top:1rem;border-top:1px solid #ddd;font-size:0.9
 </section>
 <section class="section"><h2>Zahlung</h2>
 <p>{_e(preview.payment_method_label)}</p>
-<p>{_e(preview.payment_customer_visible_text)}</p>
+{payment_terms_html}
 </section>
 <footer><p>{_e(preview.footer_note)}</p></footer>
 </body></html>"""

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -7,12 +7,14 @@ Create policy lives in evaluate_customer_document_eligibility only.
 from __future__ import annotations
 
 import uuid
-from typing import Callable
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentCreationBlocked,
+)
+from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentEligibility as DocumentCreateEligibility,
 )
 from catering_system.domain.customer_document_projection import (
@@ -24,14 +26,15 @@ from catering_system.domain.inquiry import FulfillmentMode
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import OrderCommercialSnapshot
 from catering_system.domain.order_confirmation_document import (
+    SCHEMA_VERSION_V3,
     OrderConfirmationDocumentPosition,
     OrderConfirmationDocumentSnapshot,
     OrderConfirmationVatBucket,
     RecipientStatus,
-    SCHEMA_VERSION_V3,
 )
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHOD_LABELS,
+    OrderPaymentReminder,
     validate_payment_method,
 )
 from catering_system.repositories.inquiry_repository import InquiryRepository
@@ -42,12 +45,16 @@ from catering_system.repositories.order_confirmation_document_repository import 
     OrderConfirmationDocumentRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.payment_reminder_repository import (
+    PaymentReminderRepository,
+)
 from catering_system.services.customer_document_eligibility import (
     evaluate_customer_document_eligibility,
 )
 from catering_system.services.customer_document_projection import (
     CustomerDocumentProjectionService,
     build_customer_document_recipient,
+    resolve_document_payment,
 )
 from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
@@ -107,6 +114,7 @@ class OrderConfirmationDocumentService:
         document_repository: OrderConfirmationDocumentRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository,
         *,
+        payment_reminder_repository: PaymentReminderRepository | None = None,
         projection_service: CustomerDocumentProjectionService | None = None,
         now: Callable[[], datetime] | None = None,
     ) -> None:
@@ -114,6 +122,7 @@ class OrderConfirmationDocumentService:
         self._inquiries = inquiry_repository
         self._documents = document_repository
         self._commercial_snapshots = commercial_snapshot_repository
+        self._payment_reminders = payment_reminder_repository
         self._projection = projection_service or CustomerDocumentProjectionService()
         self._now = now or (lambda: datetime.now(UTC))
 
@@ -187,6 +196,9 @@ class OrderConfirmationDocumentService:
 
         document_id = str(uuid.uuid4())
         created_at = self._now()
+        payment_method, payment_customer_visible_text = resolve_document_payment(
+            commercial, self._payment_reminder(order.order_id)
+        )
         projection = self._projection.build(
             document_type="ORDER_CONFIRMATION",
             document_id=document_id,
@@ -196,6 +208,8 @@ class OrderConfirmationDocumentService:
             inquiry=self._inquiries.get_by_id(order.source_inquiry_id),
             invoice_address=invoice_address,
             delivery_address=delivery_address,
+            payment_method=payment_method,
+            payment_customer_visible_text=payment_customer_visible_text,
         )
         draft = _persist_snapshot_from_projection(
             projection,
@@ -305,6 +319,11 @@ class OrderConfirmationDocumentService:
             fulfillment_mode=fulfillment_mode,
         )
         return version, commercial, recipient, fulfillment_mode
+
+    def _payment_reminder(self, order_id: str) -> OrderPaymentReminder | None:
+        if self._payment_reminders is None:
+            return None
+        return self._payment_reminders.get(order_id)
 
 
 def _persist_snapshot_from_projection(

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -370,7 +370,9 @@ def _v_int(value: object) -> int:
     return value
 
 
-def _v_enum(value: object, validator: Callable[[str], _EnumValue]) -> _EnumValue:
+def _v_enum(  # noqa: UP047
+    value: object, validator: Callable[[str], _EnumValue]
+) -> _EnumValue:
     if not isinstance(value, str):
         raise _invalid()
     try:
@@ -550,11 +552,13 @@ class OfficeApi:
             self.inquiries,
             self.confirmation_documents,
             self.commercial_snapshots,
+            payment_reminder_repository=self.payment_reminders,
         )
         self.customer_document_preview_service = CustomerDocumentPreviewService(
             self.orders,
             self.inquiries,
             self.commercial_snapshots,
+            payment_reminder_repository=self.payment_reminders,
         )
         self.core = OperationalCoreService(
             self.orders,
@@ -3092,7 +3096,7 @@ def make_office_api_handler(
                     reasons=exc.reasons,
                     offer_id=exc.offer_id,
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _log.exception("internal error route=%s", template)
                 self._error(500, "internal")
 
@@ -3136,7 +3140,7 @@ def make_office_api_handler(
                     reasons=exc.reasons,
                     offer_id=exc.offer_id,
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _log.exception(
                     "internal error route=/office/v1/auth/configurator-handoff/exchange"
                 )

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -246,8 +246,8 @@ __all__ = [
     "PROGRESSION_BLOCKER_LABELS",
     "READY_TO_SEND_BLOCKER_LABELS",
     "SOURCE_LABELS",
-    "render_print_sheet",
     "render_buffet_cards",
+    "render_print_sheet",
 ]
 
 # -- Rückrufe: read-only pull from the separate auerswald-sync call-log
@@ -487,12 +487,13 @@ class OfficePanel:
         )
         if remote is None:
             pause_repo = pause_repository or InMemoryOrderOperationalPauseRepository()
+            payment_repo = payment_reminder_repo or InMemoryPaymentReminderRepository()
             self.inquiry_service = InquiryService(inquiry_repo)
             self.order_service = OrderService(order_repo)
             self.core = OperationalCoreService(order_repo, pause_repository=pause_repo)
             self._pause_repository = pause_repo
             self.payment_reminder_service = PaymentReminderService(
-                payment_reminder_repo or InMemoryPaymentReminderRepository(),
+                payment_repo,
                 order_repo,
                 today=api_views.berlin_today,
             )
@@ -509,11 +510,13 @@ class OfficePanel:
                 inquiry_repo,
                 document_repo,
                 self._commercial_snapshots,
+                payment_reminder_repository=payment_repo,
             )
             self.customer_document_preview_service = CustomerDocumentPreviewService(
                 order_repo,
                 inquiry_repo,
                 self._commercial_snapshots,
+                payment_reminder_repository=payment_repo,
             )
             self.confirmation_outbound_service = OrderConfirmationOutboundService(
                 order_repo,
@@ -1265,7 +1268,7 @@ class OfficePanel:
                     else "interessent"
                 )
             ),
-            inquiry_ids=tuple(),
+            inquiry_ids=(),
         )
         return self.contact_profile_service.ensure_for_projection(projection)
 

--- a/tests/unit/test_customer_document_preview.py
+++ b/tests/unit/test_customer_document_preview.py
@@ -19,6 +19,7 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
+from catering_system.domain.order_payment_reminder import OrderPaymentReminder
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
 )
@@ -30,6 +31,9 @@ from catering_system.repositories.in_memory_order_confirmation_document_reposito
 )
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
+)
+from catering_system.repositories.in_memory_payment_reminder_repository import (
+    InMemoryPaymentReminderRepository,
 )
 from catering_system.services.customer_document_preview import (
     CustomerDocumentPreviewNotFoundError,
@@ -144,7 +148,7 @@ def _commercial() -> OrderCommercialSnapshot:
                 vat_rate_percent=7,
                 vat_amount_cents=1624,
                 gross_total_cents=24824,
-                quantity=Decimal("80"),
+                quantity=Decimal(80),
                 quantity_mode="total",
                 unit_label="Stück",
             ),
@@ -174,6 +178,23 @@ def test_valid_preview_is_eligible() -> None:
     assert preview.gross_total_cents == 24824
     assert preview.event is not None
     assert preview.event.location_text == "Hamburg"
+
+
+def test_live_preview_uses_current_cash_payment_reminder() -> None:
+    preview = build_customer_document_preview(
+        order=_order(),
+        order_version=_version(),
+        commercial_snapshot=_commercial(),
+        recipient_inquiry=_inquiry(),
+        payment_reminder=OrderPaymentReminder(
+            order_id=_ORDER_ID,
+            payment_method="BAR_VOR_ORT",
+        ),
+        now=_NOW,
+    )
+
+    assert preview.payment_method == "BAR_VOR_ORT"
+    assert preview.payment_customer_visible_text == "Bar vor Ort"
 
 
 def test_missing_contact_preview_returns_blocker_not_exception() -> None:
@@ -268,12 +289,25 @@ def test_preview_service_does_not_persist_confirmation_document() -> None:
         )
     )
     commercials.create(_commercial())
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=_ORDER_ID,
+            payment_method="BAR_VOR_ORT",
+        )
+    )
 
     preview_service = CustomerDocumentPreviewService(
-        orders, inquiries, commercials, now=lambda: _NOW
+        orders,
+        inquiries,
+        commercials,
+        payment_reminder_repository=payment_reminders,
+        now=lambda: _NOW,
     )
     preview = preview_service.preview_order_confirmation(_ORDER_ID)
     assert preview.eligible is True
+    assert preview.payment_method == "BAR_VOR_ORT"
+    assert preview.payment_customer_visible_text == "Bar vor Ort"
     assert documents.get_latest_for_order(_ORDER_ID) is None
 
     confirmation = OrderConfirmationDocumentService(

--- a/tests/unit/test_order_confirmation_document.py
+++ b/tests/unit/test_order_confirmation_document.py
@@ -24,6 +24,11 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
+from catering_system.domain.order_payment_reminder import (
+    OrderPaymentReminder,
+    PaymentReminderView,
+)
+from catering_system.domain.ready_to_send import ReadyToSendEvaluation
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
 )
@@ -36,36 +41,41 @@ from catering_system.repositories.in_memory_order_confirmation_document_reposito
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
+from catering_system.repositories.in_memory_payment_reminder_repository import (
+    InMemoryPaymentReminderRepository,
+)
 from catering_system.repositories.sqlite_order_confirmation_document_repository import (
     SQLiteOrderConfirmationDocumentRepository,
+)
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewService,
 )
 from catering_system.services.customer_document_projection import (
     CustomerDocumentProjectionService,
 )
+from catering_system.services.offer_service import OfferService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_confirmation_document_hash import (
     compute_document_hash,
+)
+from catering_system.services.order_confirmation_document_preview import (
+    build_preview,
+    render_preview_html,
 )
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentService,
     OrderConfirmationDocumentStaleVersionError,
     _persist_snapshot_from_projection,
 )
-from catering_system.services.order_service import OrderService
-from catering_system.services.offer_service import OfferService
-from catering_system.domain.order_payment_reminder import PaymentReminderView
-from catering_system.domain.ready_to_send import ReadyToSendEvaluation
-from catering_system.ui import office_api_views as views
-from catering_system.services.customer_document_preview import (
-    CustomerDocumentPreviewService,
+from catering_system.services.order_confirmation_outbound_service import (
+    OutboundSendEligibility,
 )
+from catering_system.services.order_service import OrderService
+from catering_system.ui import office_api_views as views
 from catering_system.ui.office_panel_order_detail import (
     ConfirmationLivePreviewView,
     OrderDetailFormFields,
     render_order_detail,
-)
-from catering_system.services.order_confirmation_outbound_service import (
-    OutboundSendEligibility,
 )
 from tests.helpers.office_panel_context import legacy_office_context
 from tests.unit.test_offer_service import (
@@ -129,7 +139,7 @@ def _services() -> tuple[
 def _effective_order(
     services: tuple[object, ...],
 ) -> tuple[object, object]:
-    orders, _offers, _inquiries, _documents, service, _core, _offer_service = services
+    orders, _offers, _inquiries, _documents, _service, _core, _offer_service = services
     order = orders.list_orders()[0]
     version = orders.get_order_version(order.effective_order_version_id)
     assert version is not None
@@ -167,9 +177,8 @@ def test_no_effective_version_blocked() -> None:
 
 def test_pending_candidate_blocked() -> None:
     services = _services()
-    orders, _offers, _inquiries, _documents, service, _core, offer_service = services
+    orders, _offers, _inquiries, _documents, service, _core, _offer_service = services
     order, version = _effective_order(services)
-    offer_service  # silence lint
     OrderService(orders).propose_order_version_change(
         order.order_id,
         event_date=date(2026, 9, 1),
@@ -195,7 +204,7 @@ def test_kitchen_print_not_confirmed_blocked() -> None:
         version_id,
         variant_id,
         acceptance_id,
-        offers,
+        _offers,
         orders,
         inquiries,
         offer_service,
@@ -236,6 +245,112 @@ def test_snapshot_uses_effective_order_version_facts() -> None:
     assert snapshot.event_date == version.event_date
     assert snapshot.location_text == "Hamburg"
     assert snapshot.guest_count_estimate == 80
+
+
+def test_confirmation_snapshot_uses_current_cash_payment_reminder() -> None:
+    services = _services()
+    order, version = _effective_order(services)
+    orders, _offers, inquiries, documents, _service, _core, offer_service = services
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="BAR_VOR_ORT",
+        )
+    )
+    service = OrderConfirmationDocumentService(
+        orders,
+        inquiries,
+        documents,
+        offer_service._commercial_snapshots,
+        payment_reminder_repository=payment_reminders,
+        now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+
+    snapshot = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+    )
+    html = render_preview_html(build_preview(snapshot))
+
+    assert snapshot.payment_method == "BAR_VOR_ORT"
+    assert snapshot.payment_customer_visible_text == "Bar vor Ort"
+    assert "Bar vor Ort" in html
+    assert html.count("Bar vor Ort") == 1
+    assert "Zahlung per Rechnung" not in html
+
+
+def test_confirmation_snapshot_keeps_invoice_payment_reminder_text() -> None:
+    services = _services()
+    order, version = _effective_order(services)
+    orders, _offers, inquiries, documents, _service, _core, offer_service = services
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+        )
+    )
+    service = OrderConfirmationDocumentService(
+        orders,
+        inquiries,
+        documents,
+        offer_service._commercial_snapshots,
+        payment_reminder_repository=payment_reminders,
+        now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+
+    snapshot = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+    )
+
+    assert snapshot.payment_method == "RECHNUNG"
+    assert snapshot.payment_customer_visible_text == "Zahlung per Rechnung"
+
+
+def test_existing_confirmation_snapshot_ignores_later_payment_reminder_change() -> None:
+    services = _services()
+    order, version = _effective_order(services)
+    orders, _offers, inquiries, documents, _service, _core, offer_service = services
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+        )
+    )
+    service = OrderConfirmationDocumentService(
+        orders,
+        inquiries,
+        documents,
+        offer_service._commercial_snapshots,
+        payment_reminder_repository=payment_reminders,
+        now=lambda: datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
+    )
+    created = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+    )
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="BAR_VOR_ORT",
+        )
+    )
+
+    existing = service.prepare_snapshot(
+        order.order_id,
+        version.order_version_id,
+        "office-panel",
+    )
+
+    assert existing is created
+    assert existing.payment_method == "RECHNUNG"
+    assert existing.payment_customer_visible_text == "Zahlung per Rechnung"
 
 
 def test_snapshot_uses_accepted_offer_positions() -> None:
@@ -434,7 +549,7 @@ def test_fee_position_preserved() -> None:
                 vat_rate_percent=7,
                 vat_amount_cents=1624,
                 gross_total_cents=24824,
-                quantity=Decimal("80"),
+                quantity=Decimal(80),
                 quantity_mode="total",
                 unit_label="Stück",
             ),
@@ -486,7 +601,7 @@ def test_phone_without_email_still_allows_prepare() -> None:
         version_id,
         variant_id,
         acceptance_id,
-        offers,
+        _offers,
         orders,
         inquiries,
         offer_service,
@@ -540,7 +655,7 @@ def test_missing_customer_contact_blocks_prepare() -> None:
         version_id,
         variant_id,
         acceptance_id,
-        offers,
+        _offers,
         orders,
         inquiries,
         offer_service,
@@ -622,7 +737,7 @@ def test_address_warning_flows_into_confirmation_document() -> None:
 def test_confirmation_builds_via_customer_document_projection() -> None:
     services = _services()
     order, version = _effective_order(services)
-    orders, _offers, inquiries, _documents, service, _core, offer_service = services
+    _orders, _offers, inquiries, _documents, service, _core, offer_service = services
     commercial = offer_service._commercial_snapshots.get_by_order_id(order.order_id)
     assert commercial is not None
     inquiry = inquiries.get_by_id(order.source_inquiry_id)
@@ -679,7 +794,7 @@ def test_prepare_is_idempotent_per_order_version() -> None:
 
 def test_stale_expected_version_raises() -> None:
     services = _services()
-    order, version = _effective_order(services)
+    order, _version = _effective_order(services)
     service = services[4]
     with pytest.raises(OrderConfirmationDocumentStaleVersionError):
         service.prepare_snapshot(order.order_id, str(uuid.uuid4()), "office-panel")
@@ -906,7 +1021,7 @@ def test_office_panel_confirmation_block_renders() -> None:
 def test_confirmation_uses_snapshot_when_offer_repository_unavailable() -> None:
     services = _services()
     order, version = _effective_order(services)
-    orders, offers, _inquiries, _documents, service, _core, offer_service = services
+    _orders, offers, _inquiries, _documents, service, _core, offer_service = services
     offers._offers.clear()
 
     snapshot = service.prepare_snapshot(


### PR DESCRIPTION
## Summary

Fixes a source-of-truth mismatch where Office showed the current order payment method (for example `Bar vor Ort`) while a newly created Auftragsbestätigung still used the accepted-offer payment terms (`Rechnung`).

## Behavior

- live customer-document preview uses the current order payment fact when available
- newly created immutable Auftragsbestätigung snapshots freeze that current payment fact
- existing document snapshots remain immutable
- fallback to the commercial snapshot is preserved when no current payment reminder exists

## Verification

- targeted regression suite: 42 passed
- full pytest: 2735 passed
- targeted ruff check: passed
- ruff format --check: passed

## Scope

No KitchenPrint, OrderVersion/effective-version, document immutability, or payment-domain changes.