### PR TITLE
fix: show cash payment warning on kitchen sheet

### DIFF
--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -14,10 +14,14 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
+from catering_system.domain.order_payment_reminder import PaymentMethod
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.payment_reminder_repository import (
+    PaymentReminderRepository,
+)
 
 PrintIntent = Literal["preview", "change_preview", "final", "kitchen_job"]
 PrintWatermark = Literal["ENTWURF", "VERALTET", "ÄNDERUNG – NOCH NICHT WIRKSAM"]
@@ -81,10 +85,16 @@ class PrintFlagsBlock:
 
 
 @dataclass(frozen=True)
+class PrintPaymentBlock:
+    payment_method: PaymentMethod | None
+
+
+@dataclass(frozen=True)
 class OrderPrintProjection:
     event: PrintEventBlock
     commercial: PrintCommercialBlock
     flags: PrintFlagsBlock
+    payment: PrintPaymentBlock = PrintPaymentBlock(payment_method=None)
 
 
 class _QuantityDisplaySource(Protocol):
@@ -132,9 +142,11 @@ class OrderPrintProjectionService:
         self,
         order_repository: OrderRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+        payment_reminder_repository: PaymentReminderRepository | None = None,
     ) -> None:
         self._orders = order_repository
         self._commercial_snapshots = commercial_snapshot_repository
+        self._payment_reminders = payment_reminder_repository
 
     def resolve(
         self,
@@ -159,6 +171,15 @@ class OrderPrintProjectionService:
             event=_event_block(order, version),
             commercial=commercial,
             flags=flags,
+            payment=self._resolve_payment(order),
+        )
+
+    def _resolve_payment(self, order: Order) -> PrintPaymentBlock:
+        if self._payment_reminders is None:
+            return PrintPaymentBlock(payment_method=None)
+        reminder = self._payment_reminders.get(order.order_id)
+        return PrintPaymentBlock(
+            payment_method=None if reminder is None else reminder.payment_method
         )
 
     def _resolve_commercial(

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -370,9 +370,7 @@ def _v_int(value: object) -> int:
     return value
 
 
-def _v_enum(  # noqa: UP047
-    value: object, validator: Callable[[str], _EnumValue]
-) -> _EnumValue:
+def _v_enum(value: object, validator: Callable[[str], _EnumValue]) -> _EnumValue:
     if not isinstance(value, str):
         raise _invalid()
     try:
@@ -612,6 +610,7 @@ class OfficeApi:
         self.print_projection_service = OrderPrintProjectionService(
             self.orders,
             self.commercial_snapshots,
+            self.payment_reminders,
         )
         self.buffet_cards_service = BuffetCardsService(
             self.orders,
@@ -3096,7 +3095,7 @@ def make_office_api_handler(
                     reasons=exc.reasons,
                     offer_id=exc.offer_id,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _log.exception("internal error route=%s", template)
                 self._error(500, "internal")
 
@@ -3140,7 +3139,7 @@ def make_office_api_handler(
                     reasons=exc.reasons,
                     offer_id=exc.offer_id,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _log.exception(
                     "internal error route=/office/v1/auth/configurator-handoff/exchange"
                 )

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -13,14 +13,16 @@ from __future__ import annotations
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
+from catering_system.domain.calendar_entry_projection import (
+    CALENDAR_ENTRY_KIND_LABELS,
+    CalendarEntryProjection,
+)
+from catering_system.domain.catalog import (
+    CatalogDish,
+    CatalogPriceHistoryEntry,
+    allergen_labels,
+)
 from catering_system.domain.contact_projection import ContactProjection
-from catering_system.domain.inquiry_contact_completeness import (
-    derive_inquiry_contact_completeness,
-    missing_contact_fields,
-)
-from catering_system.domain.inquiry_customer_snapshot import (
-    customer_snapshot_to_mapping,
-)
 from catering_system.domain.email_intake_projection import EmailIntakeProjection
 from catering_system.domain.inquiry import (
     Inquiry,
@@ -29,16 +31,13 @@ from catering_system.domain.inquiry import (
     derive_inquiry_offer_projection,
     derive_inquiry_office_state,
 )
-from catering_system.domain.calendar_entry_projection import (
-    CALENDAR_ENTRY_KIND_LABELS,
-    CalendarEntryProjection,
+from catering_system.domain.inquiry_contact_completeness import (
+    derive_inquiry_contact_completeness,
+    missing_contact_fields,
 )
-from catering_system.domain.offer_queue import (
-    OfferQueueItem,
-    OfferQueueSection,
-    OfferQueueSnapshot,
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_snapshot_to_mapping,
 )
-from catering_system.domain.task_projection import TaskProjection
 from catering_system.domain.offer import (
     Offer,
     OfferPosition,
@@ -46,20 +45,11 @@ from catering_system.domain.offer import (
     OfferVersion,
     derive_offer_state,
 )
-from catering_system.services.offer_budget_presentation import (
-    compute_offer_budget_presentation,
+from catering_system.domain.offer_queue import (
+    OfferQueueItem,
+    OfferQueueSection,
+    OfferQueueSnapshot,
 )
-from catering_system.services.order_print_projection_service import (
-    OrderPrintProjection,
-    PrintPositionLine,
-)
-from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
-from catering_system.domain.catalog import allergen_labels
-from catering_system.services.catalog_dish_service import (
-    AllergenCodeDefinition,
-    CatalogDishListResult,
-)
-from catering_system.domain.catalog import CatalogDish, CatalogPriceHistoryEntry
 from catering_system.domain.order import (
     Order,
     OrderVersion,
@@ -71,8 +61,17 @@ from catering_system.domain.order_operational_pause import (
 )
 from catering_system.domain.order_payment_reminder import PaymentReminderView
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
+from catering_system.domain.task_projection import TaskProjection
 from catering_system.domain.wochenuebersicht import Wochenuebersicht
 from catering_system.domain.work_center import WorkCenterSnapshot
+from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
+from catering_system.services.catalog_dish_service import (
+    AllergenCodeDefinition,
+    CatalogDishListResult,
+)
+from catering_system.services.offer_budget_presentation import (
+    compute_offer_budget_presentation,
+)
 from catering_system.services.order_confirmation_document_preview import (
     OrderConfirmationDocumentPreview,
     preview_to_json,
@@ -81,8 +80,11 @@ from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentEligibility,
     OrderConfirmationDocumentSummary,
 )
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    PrintPositionLine,
+)
 from catering_system.ui.office_panel_offer_prefill import offer_prefill_payload
-
 
 BERLIN = ZoneInfo("Europe/Berlin")
 
@@ -1111,6 +1113,7 @@ def order_print_projection_shape(projection: OrderPrintProjection) -> dict[str, 
     event = projection.event
     commercial = projection.commercial
     flags = projection.flags
+    payment = projection.payment
     return {
         "event": {
             "order_id": event.order_id,
@@ -1152,6 +1155,9 @@ def order_print_projection_shape(projection: OrderPrintProjection) -> dict[str, 
             "is_final_allowed": flags.is_final_allowed,
             "is_stale": flags.is_stale,
             "watermark": flags.watermark,
+        },
+        "payment": {
+            "payment_method": payment.payment_method,
         },
     }
 

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -102,8 +102,8 @@ from catering_system.ui.office_panel import (
     render_rueckruf,
 )
 from catering_system.ui.office_panel_authz import (
-    BusinessAccessDenied,
     DYNAMIC_CATALOG_UPDATE_AUTH,
+    BusinessAccessDenied,
     DynamicCatalogUpdateAuth,
     authorize_catalog_update,
     require_all_business_permissions,
@@ -953,10 +953,10 @@ def make_office_panel_handler(
             lists = getattr(self, "_form_lists_cache", {})
             return lists.get(key, [])
 
-        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        def log_message(self, format: str, *args: object) -> None:
             pass
 
-        def do_GET(self) -> None:  # noqa: N802
+        def do_GET(self) -> None:
             parsed = urlparse(self.path)
             parts = [part for part in parsed.path.split("/") if part]
             auth = self._resolve_request_auth()
@@ -1356,6 +1356,7 @@ def make_office_panel_handler(
             return OrderPrintProjectionService(
                 order_repo,
                 panel._commercial_snapshots,
+                payment_reminder_repo,
             ).resolve(order_id, version_id, intent="preview")
 
         def _resolve_buffet_cards_view(self, order_id: str, version_id: str):
@@ -1366,6 +1367,7 @@ def make_office_panel_handler(
                 OrderPrintProjectionService(
                     order_repo,
                     panel._commercial_snapshots,
+                    payment_reminder_repo,
                 ),
             ).resolve(order_id, version_id)
 
@@ -1465,7 +1467,7 @@ def make_office_panel_handler(
             )
             self._html(body)
 
-        def do_POST(self) -> None:  # noqa: N802
+        def do_POST(self) -> None:
             parts = [part for part in urlparse(self.path).path.split("/") if part]
             auth = self._resolve_request_auth()
             self._request_auth = auth

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -389,6 +389,14 @@ def render_print_sheet(projection: OrderPrintProjection) -> str:
             f'<p class="label">Geänderte Felder:</p><p class="value">'
             f"{_e(fields)}</p></div>"
         )
+    payment_warning_html = (
+        '<div class="payment-warning">'
+        "<p><strong>ACHTUNG: Barzahlung vor Ort.</strong></p>"
+        "<p>Rechnung dem Fahrer mitgeben.</p>"
+        "</div>"
+        if projection.payment.payment_method == "BAR_VOR_ORT"
+        else ""
+    )
     menu_html = _render_menu_section(projection)
     return f"""<!DOCTYPE html>
 <html lang="de"><head><meta charset="utf-8"><title>Küchenzettel</title>
@@ -406,11 +414,14 @@ hr{{border:none;border-top:2px solid #000;margin:1.25rem 0}}
 .stand{{margin-top:1rem}}
 .cancelled{{color:#a00;font-size:2rem;border:4px solid #a00;padding:0.5rem;text-align:center}}
 .watermark{{color:#666;font-size:2rem;border:3px dashed #666;padding:0.5rem;text-align:center;margin-bottom:1rem}}
+.payment-warning{{border:4px solid #000;padding:0.75rem;margin:1rem 0;font-size:1.35rem}}
+.payment-warning p{{margin:0.2rem 0}}
 button{{font-size:1rem;margin-top:1.5rem;padding:0.5rem 1rem}}
 </style></head><body>
 {cancelled_banner}
 {watermark_html}
 {change_html}
+{payment_warning_html}
 <p class="brand">SILBERLÖFFEL</p>
 <hr>
 <p class="label">Datum:</p>

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -19,6 +19,13 @@ from datetime import date, datetime
 from typing import Any, NoReturn, cast
 from urllib.parse import quote, urlencode, urlparse
 
+from catering_system.domain.catalog import (
+    CatalogDish,
+    CatalogDishCreatePayload,
+    PricingUnit,
+    validate_allergen_codes,
+    validate_pricing_unit,
+)
 from catering_system.domain.customer_document_eligibility import (
     DOCUMENT_BLOCKER_CODES,
     DocumentBlocker,
@@ -36,10 +43,10 @@ from catering_system.domain.customer_document_projection import (
     DocumentType,
 )
 from catering_system.domain.inquiry import (
+    PLANNING_MODE_SET,
     FulfillmentMode,
     Inquiry,
     InquiryOfficeNextAction,
-    PLANNING_MODE_SET,
     PlanningMode,
     set_inquiry_fulfillment_mode,
     validate_call_verification_status,
@@ -48,10 +55,6 @@ from catering_system.domain.inquiry import (
     validate_fulfillment_mode,
     validate_planning_mode,
 )
-from catering_system.domain.inquiry_offer_preparation import (
-    InquiryOfferPreparationBlocker,
-)
-from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.inquiry_contact_completeness import (
     complete_inquiry_contact_information,
 )
@@ -63,6 +66,11 @@ from catering_system.domain.inquiry_customer_snapshot import (
     set_inquiry_customer_addresses,
     snapshot_from_structured_contact,
 )
+from catering_system.domain.inquiry_offer_preparation import (
+    InquiryOfferPreparationBlocker,
+)
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_confirmation_outbound import FakeOutboxMessage
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHODS,
     OrderPaymentReminder,
@@ -71,6 +79,8 @@ from catering_system.domain.order_payment_reminder import (
     validate_payment_method,
 )
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
+from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
+from catering_system.services.inquiry_service import validate_inquiry_source
 from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentEligibility,
     OrderConfirmationDocumentSummary,
@@ -79,23 +89,14 @@ from catering_system.services.order_confirmation_outbound_service import (
     OutboundSendEligibility,
     OutboundSendSummary,
 )
-from catering_system.domain.order_confirmation_outbound import FakeOutboxMessage
-from catering_system.domain.catalog import (
-    CatalogDish,
-    CatalogDishCreatePayload,
-    PricingUnit,
-    validate_allergen_codes,
-    validate_pricing_unit,
-)
-from catering_system.services.inquiry_service import validate_inquiry_source
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
     PrintCommercialBlock,
     PrintEventBlock,
     PrintFlagsBlock,
+    PrintPaymentBlock,
     PrintPositionLine,
 )
-from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
 
 _MAX_RESPONSE_BYTES = 512 * 1024
 _READ_TIMEOUT_SECONDS = 3
@@ -349,7 +350,7 @@ class InquiryDetailMeta:
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
 
 
@@ -819,7 +820,8 @@ _PRINT_FLAGS_KEYS = frozenset(
         "watermark",
     }
 )
-_PRINT_PROJECTION_KEYS = frozenset({"event", "commercial", "flags"})
+_PRINT_PAYMENT_KEYS = frozenset({"payment_method"})
+_PRINT_PROJECTION_KEYS = frozenset({"event", "commercial", "flags", "payment"})
 
 
 def _print_position_line(data: Mapping[str, object]) -> PrintPositionLine:
@@ -844,6 +846,8 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
     _exact(commercial_data, _PRINT_COMMERCIAL_KEYS)
     flags_data = _dict(data["flags"])
     _exact(flags_data, _PRINT_FLAGS_KEYS)
+    payment_data = _dict(data["payment"])
+    _exact(payment_data, _PRINT_PAYMENT_KEYS)
     source = _str(commercial_data["source"])
     if source not in {"offer_conversion", "none"}:
         _bad_response()
@@ -861,6 +865,14 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
         planning_mode = validate_planning_mode(_str(event_data["planning_mode"]))
     except ValueError:
         _bad_response()
+    payment_method_raw = payment_data["payment_method"]
+    if payment_method_raw is None:
+        payment_method = None
+    else:
+        try:
+            payment_method = validate_payment_method(_str(payment_method_raw))
+        except ValueError:
+            _bad_response()
     return OrderPrintProjection(
         event=PrintEventBlock(
             order_id=_uuid4(event_data["order_id"]),
@@ -902,6 +914,7 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
             is_stale=_bool(flags_data["is_stale"]),
             watermark=watermark,  # type: ignore[arg-type]
         ),
+        payment=PrintPaymentBlock(payment_method=payment_method),
     )
 
 

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -8,9 +8,6 @@ never opening core.db in remote mode, and half-config startup rejection.
 
 from __future__ import annotations
 
-from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
-from tests.helpers.order_seed import seed_order
-
 import base64
 import json
 import os
@@ -23,42 +20,47 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from datetime import date
+from datetime import UTC, date, datetime
 from http.server import HTTPServer
 from pathlib import Path
 
 import pytest
 
+from catering_system.domain.catalog import CatalogDish
+from catering_system.domain.offer_snapshot import compute_snapshot_hash
+from catering_system.repositories.sqlite_catalog_repository import (
+    SQLiteCatalogRepository,
+)
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
 from catering_system.repositories.sqlite_offer_repository import (
     SQLiteOfferRepository,
 )
-from catering_system.repositories.sqlite_catalog_repository import (
-    SQLiteCatalogRepository,
-)
-from catering_system.domain.catalog import CatalogDish
-from datetime import UTC, datetime
 from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
     SQLiteOrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.sqlite_order_repository import (
     SQLiteOrderRepository,
 )
-from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
 from catering_system.ui.office_api import create_office_api_server
-from tests.helpers.offer_pdf_static_content import (
-    fake_offer_pdf_static_content,
-)
 from catering_system.ui.office_panel_http import (
     create_office_panel_server,
     csrf_token_for_password,
 )
-from catering_system.ui.remote_core_client import RemoteCoreClient
+from catering_system.ui.remote_core_client import (
+    RemoteCoreClient,
+    RemoteCoreError,
+    _print_projection,
+)
+from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+from tests.helpers.offer_pdf_static_content import (
+    fake_offer_pdf_static_content,
+)
+from tests.helpers.order_seed import seed_order
 
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
@@ -70,6 +72,76 @@ _SNAPSHOT_ID = "77777777-7777-4777-8777-777777777771"
 _HIDDEN_REMOTE_FIELD = re.compile(
     r'<input type="hidden" name="_(?:command_id|expect_[a-zA-Z_]+)" value="[^"]*">'
 )
+
+
+def _remote_print_projection_payload() -> dict[str, object]:
+    return {
+        "event": {
+            "order_id": "11111111-1111-4111-8111-111111111111",
+            "order_version_id": "22222222-2222-4222-8222-222222222222",
+            "version_number": 1,
+            "event_date": "2026-10-01",
+            "time_window_text": "mittags",
+            "location_text": "Hamburg",
+            "guest_count_estimate": 25,
+            "planning_mode": "caterer_suggestion",
+            "kitchen_print_confirmed_at": None,
+            "order_cancelled_at": None,
+            "is_candidate": False,
+            "is_effective": True,
+            "change_reason": None,
+            "changed_fields": [],
+        },
+        "commercial": {
+            "source": "offer_conversion",
+            "offer_id": "33333333-3333-4333-8333-333333333333",
+            "offer_version_id": "44444444-4444-4444-8444-444444444444",
+            "accepted_variant_id": "55555555-5555-4555-8555-555555555555",
+            "variant_label": "Standard",
+            "positions": [],
+        },
+        "flags": {
+            "intent": "preview",
+            "is_preview": False,
+            "is_final_allowed": True,
+            "is_stale": False,
+            "watermark": None,
+        },
+        "payment": {
+            "payment_method": None,
+        },
+    }
+
+
+def test_remote_print_projection_accepts_missing_payment_method() -> None:
+    projection = _print_projection(_remote_print_projection_payload())
+
+    assert projection.payment.payment_method is None
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    (
+        (("commercial", "source"), "invalid"),
+        (("flags", "intent"), "invalid"),
+        (("flags", "watermark"), "invalid"),
+        (("event", "planning_mode"), "invalid"),
+        (("payment", "payment_method"), "invalid"),
+    ),
+)
+def test_remote_print_projection_rejects_invalid_payment_shape(
+    path: tuple[str, str], value: object
+) -> None:
+    payload = _remote_print_projection_payload()
+    section = payload[path[0]]
+    assert isinstance(section, dict)
+    section[path[1]] = value
+
+    with pytest.raises(RemoteCoreError) as exc_info:
+        _print_projection(payload)
+
+    assert exc_info.value.status == 502
+    assert exc_info.value.code == "invalid_response"
 
 
 @pytest.fixture(autouse=True)
@@ -95,7 +167,7 @@ def _seed(db_path: Path) -> dict[str, str]:
     OrderService(orders)
     core = OperationalCoreService(orders)
 
-    def make_inquiry(**overrides):  # noqa: ANN202
+    def make_inquiry(**overrides):
         base = dict(
             event_date=date(2026, 10, 1),
             inquiry_source="manual",
@@ -970,8 +1042,9 @@ def test_v2_remote_inquiry_detail_preserves_linked_order_truncation_warning(
     core = OperationalCoreService(orders)
     first, version = seed_order(orders, inquiry)
     core.cancel_order(first.order_id)
-    from datetime import UTC, datetime
     import uuid
+    from datetime import UTC, datetime
+
     from catering_system.domain.order import Order, OrderVersion
 
     now = datetime.now(UTC)

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from tests.helpers.order_seed import seed_order
-
 from datetime import date
 
 import pytest
@@ -11,20 +9,25 @@ import pytest
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
 )
-from catering_system.services.order_print_projection_service import (
-    OrderPrintProjectionService,
-    PrintFinalRequiresEffectiveError,
-    PrintProjectionNotFoundError,
-)
-from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.domain.order_payment_reminder import OrderPaymentReminder
 from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
     InMemoryOrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
+from catering_system.repositories.in_memory_payment_reminder_repository import (
+    InMemoryPaymentReminderRepository,
+)
+from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjectionService,
+    PrintFinalRequiresEffectiveError,
+    PrintProjectionNotFoundError,
+)
 from catering_system.services.order_service import OrderService
 from catering_system.ui.office_panel_views import render_print_sheet
+from tests.helpers.order_seed import seed_order
 from tests.unit.test_offer_service import (
     _INQUIRY_ID,
     _accepted_offer_state,
@@ -36,8 +39,9 @@ from tests.unit.test_offer_service import (
 def _projection_service(
     orders,
     snapshots: InMemoryOrderCommercialSnapshotRepository,
+    payment_reminders: InMemoryPaymentReminderRepository | None = None,
 ) -> OrderPrintProjectionService:
-    return OrderPrintProjectionService(orders, snapshots)
+    return OrderPrintProjectionService(orders, snapshots, payment_reminders)
 
 
 def test_order_with_offer_conversion_has_menu_positions() -> None:
@@ -68,6 +72,68 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
     assert "Fingerfood Paket" in sheet
     assert "Frozen description" in sheet
     assert "Menge: 80 Stück" in sheet
+
+
+def test_cash_payment_warning_rendered_on_print_sheet() -> None:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="BAR_VOR_ORT",
+        )
+    )
+
+    projection = _projection_service(
+        orders, service._commercial_snapshots, payment_reminders
+    ).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    sheet = render_print_sheet(projection)
+
+    assert projection.payment.payment_method == "BAR_VOR_ORT"
+    assert "ACHTUNG: Barzahlung vor Ort." in sheet
+    assert "Rechnung dem Fahrer mitgeben." in sheet
+
+
+def test_invoice_payment_warning_not_rendered_on_print_sheet() -> None:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    payment_reminders = InMemoryPaymentReminderRepository()
+    payment_reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+        )
+    )
+
+    projection = _projection_service(
+        orders, service._commercial_snapshots, payment_reminders
+    ).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    sheet = render_print_sheet(projection)
+
+    assert projection.payment.payment_method == "RECHNUNG"
+    assert "ACHTUNG: Barzahlung vor Ort." not in sheet
+    assert "Rechnung dem Fahrer mitgeben." not in sheet
 
 
 def test_print_fails_when_commercial_snapshot_missing_for_seeded_order() -> None:


### PR DESCRIPTION
## Summary

Adds an operational cash-payment warning to the kitchen/courier print sheet when an order uses `BAR_VOR_ORT`.

## Behavior

- OrderPrintProjection carries the current order payment method from the payment reminder model
- Office API and remote panel JSON include that print payment fact
- Küchenzettel renders:
  - `ACHTUNG: Barzahlung vor Ort.`
  - `Rechnung dem Fahrer mitgeben.`
- Invoice orders do not render the cash warning

## Verification

- `tests/unit/test_order_print_projection.py`: 25 passed
- API/remote focused tests: 3 passed
- targeted ruff check: passed
- targeted ruff format --check: passed
- acceptance render check confirmed the warning text for `BAR_VOR_ORT`