### PR TITLE
feat: expose internal employee chat API

### DIFF
--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -37,9 +37,20 @@ from catering_system.domain.catalog import (
     validate_allergen_codes,
     validate_pricing_unit,
 )
+from catering_system.domain.chat import (
+    ChatMessage,
+    ChatMessageBundle,
+    ChatParticipant,
+    ChatReferenceType,
+    ChatThread,
+    ChatThreadSummary,
+    validate_chat_reference_type,
+    validate_chat_thread_type,
+)
 from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentCreationBlocked,
 )
+from catering_system.domain.employee_auth import AuthenticatedEmployee
 from catering_system.domain.inquiry import (
     ACTIVE_ORDER_CRM_STAGE,
     CRM_PIPELINE,
@@ -102,8 +113,12 @@ from catering_system.repositories.office_api_ledger import (
 from catering_system.repositories.sqlite_catalog_repository import (
     SQLiteCatalogRepository,
 )
+from catering_system.repositories.sqlite_chat_repository import SQLiteChatRepository
 from catering_system.repositories.sqlite_configurator_handoff_repository import (
     SQLiteConfiguratorHandoffRepository,
+)
+from catering_system.repositories.sqlite_contact_profile_repository import (
+    SQLiteContactProfileRepository,
 )
 from catering_system.repositories.sqlite_employee_auth_repository import (
     SQLiteEmployeeAuthRepository,
@@ -144,6 +159,12 @@ from catering_system.services.calendar_projection_service import (
 )
 from catering_system.services.catalog_dish_service import CatalogDishService
 from catering_system.services.catalog_dish_write_service import CatalogDishWriteService
+from catering_system.services.chat_service import (
+    ChatAccessDenied,
+    ChatNotFoundError,
+    ChatReferenceNotFoundError,
+    ChatService,
+)
 from catering_system.services.configurator_handoff_service import (
     HANDOFF_OPERATION_PREPARE_FIRST_OFFER,
     ConfiguratorHandoffService,
@@ -455,6 +476,119 @@ def _v_catalog_text(value: object, max_len: int) -> str | None:
     return text or None
 
 
+def _chat_thread_shape(thread: ChatThread) -> dict[str, object]:
+    return {
+        "thread_id": thread.thread_id,
+        "thread_type": thread.thread_type,
+        "title": thread.title,
+        "created_by_employee_id": thread.created_by_employee_id,
+        "created_at": thread.created_at.isoformat(),
+    }
+
+
+def _chat_participant_shape(
+    participant: ChatParticipant, display_name: str
+) -> dict[str, object]:
+    return {
+        "thread_id": participant.thread_id,
+        "employee_id": participant.employee_id,
+        "display_name": display_name,
+        "joined_at": participant.joined_at.isoformat(),
+        "last_read_message_id": participant.last_read_message_id,
+    }
+
+
+def _chat_employee_shape(employee_id: str, display_name: str) -> dict[str, object]:
+    return {"employee_id": employee_id, "display_name": display_name}
+
+
+def _chat_message_preview_shape(
+    message: ChatMessage | None,
+) -> dict[str, object] | None:
+    if message is None:
+        return None
+    return {
+        "message_id": message.message_id,
+        "author_employee_id": message.author_employee_id,
+        "body": message.body,
+        "created_at": message.created_at.isoformat(),
+    }
+
+
+def _chat_message_shape(
+    bundle: ChatMessageBundle,
+    *,
+    author_display_name: str,
+    mention_display_names: dict[str, str],
+) -> dict[str, object]:
+    message = bundle.message
+    return {
+        "message_id": message.message_id,
+        "thread_id": message.thread_id,
+        "author_employee_id": message.author_employee_id,
+        "author_display_name": author_display_name,
+        "body": message.body,
+        "reply_to_message_id": message.reply_to_message_id,
+        "created_at": message.created_at.isoformat(),
+        "mentions": [
+            {
+                "employee_id": mention.employee_id,
+                "display_name": mention_display_names[mention.employee_id],
+            }
+            for mention in bundle.mentions
+        ],
+        "references": [
+            {
+                "reference_type": reference.reference_type,
+                "reference_id": reference.reference_id,
+            }
+            for reference in bundle.references
+        ],
+    }
+
+
+def _chat_reference_args(value: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, list):
+        raise _invalid()
+    references: list[tuple[str, str]] = []
+    for raw in value:
+        if not isinstance(raw, dict):
+            raise _invalid()
+        _exact_keys(raw, {"reference_type", "reference_id"})
+        reference_type = _v_enum(raw["reference_type"], validate_chat_reference_type)
+        references.append((reference_type, _v_uuid(raw["reference_id"])))
+    return tuple(references)
+
+
+def _chat_employee_ids(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise _invalid()
+    return tuple(_v_uuid(employee_id) for employee_id in value)
+
+
+def _chat_error(exc: Exception) -> ApiError:
+    message = str(exc)
+    if isinstance(exc, ChatNotFoundError):
+        return ApiError(404, "not_found")
+    if isinstance(exc, ChatAccessDenied):
+        if "missing permission" in message or "application access" in message:
+            return ApiError(403, "forbidden")
+        return ApiError(404, "not_found")
+    if isinstance(exc, ChatReferenceNotFoundError):
+        return ApiError(422, "invalid_chat_reference")
+    if "reply target" in message:
+        return ApiError(422, "invalid_chat_reply")
+    if "mentioned employee" in message:
+        return ApiError(422, "invalid_chat_mention")
+    if "message requires" in message or "body" in message:
+        return ApiError(422, "invalid_chat_message")
+    if "reference" in message:
+        return ApiError(422, "invalid_chat_reference")
+    if "message" in message:
+        return ApiError(422, "invalid_chat_message")
+    return ApiError(422, "invalid_chat_thread")
+
+
 def _v_intake(
     args: dict[str, object], key: str, cap: int, keep: str | None
 ) -> str | None:
@@ -494,6 +628,9 @@ class OfficeApi:
         )
         self.offers = SQLiteOfferRepository.from_connection(connection)
         self.catalog = SQLiteCatalogRepository.from_connection(connection)
+        self.contact_profiles = SQLiteContactProfileRepository.from_connection(
+            connection
+        )
         self.employee_auth_repository = SQLiteEmployeeAuthRepository.from_connection(
             connection
         )
@@ -515,6 +652,7 @@ class OfficeApi:
         self.payment_reminders = SQLitePaymentReminderRepository.from_connection(
             connection
         )
+        self.chat = SQLiteChatRepository.from_connection(connection)
         self.confirmation_documents = (
             SQLiteOrderConfirmationDocumentRepository.from_connection(connection)
         )
@@ -534,6 +672,7 @@ class OfficeApi:
         self.events = DeferredEventSink()
         self.executor = CoreCommandExecutor(connection, self.events)
         self._active_command_id: str | None = None
+        self._active_employee: AuthenticatedEmployee | None = None
         self.inquiry_service = InquiryService(self.inquiries, event_sink=self.events)
         self.order_service = OrderService(self.orders, event_sink=self.events)
         self.offer_service = OfferService(
@@ -553,6 +692,13 @@ class OfficeApi:
             self.payment_reminders,
             self.orders,
             today=views.berlin_today,
+        )
+        self.chat_service = ChatService(
+            self.chat,
+            self.employee_auth_repository,
+            orders=self.orders,
+            inquiries=self.inquiries,
+            contacts=self.contact_profiles,
         )
         self.confirmation_document_service = OrderConfirmationDocumentService(
             self.orders,
@@ -1205,7 +1351,426 @@ class OfficeApi:
                 return order
         return None
 
+    def _require_active_employee(self) -> AuthenticatedEmployee:
+        if self._active_employee is None:
+            raise ApiError(401, "unauthorized")
+        return self._active_employee
+
+    def _employee_display_name(self, employee_id: str) -> str:
+        account = self.employee_auth_repository.get_account_by_id(employee_id)
+        if account is None:
+            raise ApiError(500, "internal")
+        return account.display_name
+
+    def _chat_participants_shape(
+        self, participants: tuple[ChatParticipant, ...]
+    ) -> list[dict[str, object]]:
+        return [
+            _chat_participant_shape(
+                participant, self._employee_display_name(participant.employee_id)
+            )
+            for participant in participants
+        ]
+
+    def _chat_thread_summary_shape(
+        self, summary: ChatThreadSummary
+    ) -> dict[str, object]:
+        latest = summary.latest_message
+        return {
+            "thread": _chat_thread_shape(summary.thread),
+            "participants": self._chat_participants_shape(summary.participants),
+            "latest_message_preview": _chat_message_preview_shape(latest),
+            "unread_count": summary.unread_count,
+            "last_activity_at": (
+                latest.created_at if latest is not None else summary.thread.created_at
+            ).isoformat(),
+        }
+
+    def _chat_thread_detail_shape(
+        self,
+        actor: AuthenticatedEmployee,
+        thread: ChatThread,
+        messages: tuple[ChatMessageBundle, ...],
+    ) -> dict[str, object]:
+        participants = self.chat.list_participants(thread.thread_id)
+        current = next(
+            participant
+            for participant in participants
+            if participant.employee_id == actor.account.id
+        )
+        participant_names = {
+            participant.employee_id: self._employee_display_name(
+                participant.employee_id
+            )
+            for participant in participants
+        }
+        author_ids = {bundle.message.author_employee_id for bundle in messages}
+        author_names = {
+            employee_id: self._employee_display_name(employee_id)
+            for employee_id in author_ids
+        }
+        return {
+            "thread": _chat_thread_shape(thread),
+            "participants": self._chat_participants_shape(participants),
+            "current_participant": _chat_participant_shape(
+                current, participant_names[current.employee_id]
+            ),
+            "messages": [
+                _chat_message_shape(
+                    bundle,
+                    author_display_name=author_names[bundle.message.author_employee_id],
+                    mention_display_names=participant_names,
+                )
+                for bundle in messages
+            ],
+        }
+
+    def list_chat_threads(
+        self, actor: AuthenticatedEmployee
+    ) -> dict[str, object]:
+        return {
+            "threads": [
+                self._chat_thread_summary_shape(summary)
+                for summary in self.chat_service.list_threads(actor)
+            ]
+        }
+
+    def chat_thread_detail(
+        self, actor: AuthenticatedEmployee, thread_id: str
+    ) -> dict[str, object]:
+        try:
+            messages = self.chat_service.list_messages(actor, thread_id, limit=200)
+            thread = self.chat.get_thread(thread_id)
+            if thread is None:
+                raise ChatNotFoundError(thread_id)
+        except (ChatAccessDenied, ChatNotFoundError) as exc:
+            raise _chat_error(exc) from exc
+        return self._chat_thread_detail_shape(actor, thread, messages)
+
+    def chat_thread_participants(
+        self, actor: AuthenticatedEmployee, thread_id: str, q: str
+    ) -> dict[str, object]:
+        try:
+            self.chat_service.list_messages(actor, thread_id, limit=1)
+            participants = self.chat.list_participants(thread_id)
+        except (ChatAccessDenied, ChatNotFoundError) as exc:
+            raise _chat_error(exc) from exc
+        needle = q.casefold()
+        shaped = self._chat_participants_shape(participants)
+        if needle:
+            shaped = [
+                row
+                for row in shaped
+                if needle in str(row["display_name"]).casefold()
+                or needle in str(row["employee_id"]).casefold()
+            ]
+        return {"participants": shaped[:20]}
+
+    def search_chat(self, actor: AuthenticatedEmployee, q: str) -> dict[str, object]:
+        summaries = self.chat_service.list_threads(actor)
+        if not q:
+            return {"results": []}
+        needle = q.casefold()
+        matching_thread_ids: set[str] = set()
+        like = f"%{needle}%"
+        rows = self._conn.execute(
+            """
+            SELECT DISTINCT thread.thread_id
+            FROM chat_threads thread
+            JOIN chat_participants participant
+              ON participant.thread_id = thread.thread_id
+             AND participant.employee_id = ?
+            LEFT JOIN chat_messages message
+              ON message.thread_id = thread.thread_id
+            WHERE lower(COALESCE(thread.title, '')) LIKE ?
+               OR lower(COALESCE(message.body, '')) LIKE ?
+            LIMIT 50
+            """,
+            (actor.account.id, like, like),
+        ).fetchall()
+        matching_thread_ids.update(str(row[0]) for row in rows)
+        for summary in summaries:
+            if summary.thread.thread_id in matching_thread_ids:
+                continue
+            participant_names = [
+                self._employee_display_name(participant.employee_id).casefold()
+                for participant in summary.participants
+            ]
+            if any(needle in name for name in participant_names):
+                matching_thread_ids.add(summary.thread.thread_id)
+        return {
+            "results": [
+                self._chat_thread_summary_shape(summary)
+                for summary in summaries
+                if summary.thread.thread_id in matching_thread_ids
+            ][:50]
+        }
+
+    def search_chat_entities(
+        self, actor: AuthenticatedEmployee, q: str, reference_type: ChatReferenceType
+    ) -> dict[str, object]:
+        if not actor.application_access_allowed:
+            raise ApiError(403, "forbidden")
+        if "chat.send" not in actor.effective_permissions:
+            raise ApiError(403, "forbidden")
+        entity_permission = {
+            "ORDER": "orders.view",
+            "INQUIRY": "inquiries.view",
+            "CONTACT": "customers.view",
+        }[reference_type]
+        if entity_permission not in actor.effective_permissions:
+            raise ApiError(403, "forbidden")
+        if len(q) < 2:
+            return {"results": []}
+        needle = q.casefold()
+        results: list[dict[str, object]] = []
+        if reference_type == "CONTACT":
+            for profile_id in self.contact_profiles.search_profile_ids(q)[:20]:
+                profile = self.contact_profiles.get_profile(profile_id)
+                if profile is None:
+                    continue
+                results.append(
+                    {
+                        "reference_type": "CONTACT",
+                        "reference_id": profile.contact_profile_id,
+                        "primary_label": profile.display_name,
+                        "secondary_label": profile.email or profile.phone or "",
+                        "meta": {"contact_profile_id": profile.contact_profile_id},
+                    }
+                )
+            return {"results": results}
+        if reference_type == "INQUIRY":
+            for inquiry in self.inquiries.list_all():
+                snapshot = inquiry.customer_snapshot
+                company_name = snapshot.company_name if snapshot is not None else None
+                contact_name = snapshot.contact_name if snapshot is not None else None
+                contact_email = snapshot.email if snapshot is not None else None
+                contact_phone = snapshot.phone if snapshot is not None else None
+                haystack = " ".join(
+                    str(value or "")
+                    for value in (
+                        inquiry.inquiry_id,
+                        company_name,
+                        contact_name,
+                        contact_email,
+                        contact_phone,
+                        inquiry.location_text,
+                        inquiry.intake_subject,
+                    )
+                ).casefold()
+                if needle not in haystack:
+                    continue
+                results.append(
+                    {
+                        "reference_type": "INQUIRY",
+                        "reference_id": inquiry.inquiry_id,
+                        "primary_label": company_name
+                        or contact_name
+                        or f"Anfrage {inquiry.inquiry_id[:8]}",
+                        "secondary_label": " · ".join(
+                            part
+                            for part in (
+                                inquiry.event_date.isoformat(),
+                                inquiry.location_text,
+                            )
+                            if part
+                        ),
+                        "meta": {"inquiry_id": inquiry.inquiry_id},
+                    }
+                )
+                if len(results) >= 20:
+                    break
+            return {"results": results}
+        for order in self.orders.list_orders():
+            order_inquiry = self.inquiries.get_by_id(order.source_inquiry_id)
+            snapshot = (
+                order_inquiry.customer_snapshot
+                if order_inquiry is not None
+                else None
+            )
+            company_name = snapshot.company_name if snapshot is not None else None
+            contact_name = snapshot.contact_name if snapshot is not None else None
+            location_text = (
+                order_inquiry.location_text if order_inquiry is not None else ""
+            )
+            haystack = " ".join(
+                str(value or "")
+                for value in (
+                    order.order_id,
+                    order.source_inquiry_id,
+                    company_name,
+                    contact_name,
+                    location_text,
+                )
+            ).casefold()
+            if needle not in haystack:
+                continue
+            results.append(
+                {
+                    "reference_type": "ORDER",
+                    "reference_id": order.order_id,
+                    "primary_label": f"Auftrag {order.order_id[:8]}",
+                    "secondary_label": (
+                        company_name or contact_name or location_text
+                    ),
+                    "meta": {
+                        "order_id": order.order_id,
+                        "source_inquiry_id": order.source_inquiry_id,
+                    },
+                }
+            )
+            if len(results) >= 20:
+                break
+        return {"results": results}
+
+    def search_chat_employees(
+        self, actor: AuthenticatedEmployee, q: str
+    ) -> dict[str, object]:
+        if not actor.application_access_allowed:
+            raise ApiError(403, "forbidden")
+        if "chat.create" not in actor.effective_permissions:
+            raise ApiError(403, "forbidden")
+        needle = q.casefold()
+        rows: list[tuple[str, str]] = []
+        for account in self.employee_auth_repository.list_accounts():
+            if not account.is_active:
+                continue
+            if needle and needle not in account.display_name.casefold():
+                continue
+            rows.append((account.display_name.casefold(), account.id))
+        rows.sort()
+        return {
+            "employees": [
+                _chat_employee_shape(
+                    employee_id,
+                    self._employee_display_name(employee_id),
+                )
+                for _display_name, employee_id in rows[:20]
+            ]
+        }
+
     # -- commands (run inside the executor transaction) --------------------
+
+    def cmd_create_chat_thread(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        employee = self._require_active_employee()
+        thread_type = _v_enum(args["thread_type"], validate_chat_thread_type)
+        participant_ids = _chat_employee_ids(args["participant_employee_ids"])
+        title = _v_optional_str(args.get("title"), 200)
+        try:
+            if thread_type == "DIRECT":
+                unique_ids = tuple(
+                    dict.fromkeys((employee.account.id, *participant_ids))
+                )
+                if len(unique_ids) != 2:
+                    raise ValueError("DIRECT chat requires exactly two participants")
+                other_id = next(
+                    participant_id
+                    for participant_id in unique_ids
+                    if participant_id != employee.account.id
+                )
+                existing = self.chat.find_direct_thread(employee.account.id, other_id)
+                thread = self.chat_service.create_direct_thread(employee, other_id)
+                status = 200 if existing is not None else 201
+            else:
+                if title is None:
+                    raise ValueError("GROUP chat title is required")
+                thread = self.chat_service.create_group_thread(
+                    employee,
+                    title=title,
+                    participant_employee_ids=participant_ids,
+                )
+                status = 201
+        except (
+            ChatAccessDenied,
+            ChatNotFoundError,
+            ChatReferenceNotFoundError,
+            TypeError,
+            ValueError,
+            sqlite3.IntegrityError,
+        ) as exc:
+            raise _chat_error(exc) from exc
+        participants = self.chat.list_participants(thread.thread_id)
+        return status, {
+            "thread": {
+                **_chat_thread_shape(thread),
+                "participants": self._chat_participants_shape(participants),
+            }
+        }
+
+    def cmd_send_chat_message(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        employee = self._require_active_employee()
+        thread_id = _v_uuid(path_ids["thread_id"])
+        references = _chat_reference_args(args.get("references", []))
+        mention_ids = _chat_employee_ids(args.get("mention_employee_ids", []))
+        try:
+            message = self.chat_service.send_message(
+                employee,
+                thread_id,
+                body=_v_str(args["body"], 20000),
+                reply_to_message_id=_v_optional_uuid4(args.get("reply_to_message_id")),
+                mention_employee_ids=mention_ids,
+                references=references,
+            )
+            bundles = self.chat.list_messages(thread_id, limit=200)
+            bundle = next(
+                bundle
+                for bundle in bundles
+                if bundle.message.message_id == message.message_id
+            )
+            participants = self.chat.list_participants(thread_id)
+        except (
+            ChatAccessDenied,
+            ChatNotFoundError,
+            ChatReferenceNotFoundError,
+            StopIteration,
+            TypeError,
+            ValueError,
+            sqlite3.IntegrityError,
+        ) as exc:
+            raise _chat_error(exc) from exc
+        participant_names = {
+            participant.employee_id: self._employee_display_name(
+                participant.employee_id
+            )
+            for participant in participants
+        }
+        return 201, {
+            "message": _chat_message_shape(
+                bundle,
+                author_display_name=self._employee_display_name(
+                    message.author_employee_id
+                ),
+                mention_display_names=participant_names,
+            )
+        }
+
+    def cmd_mark_chat_thread_read(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        employee = self._require_active_employee()
+        thread_id = _v_uuid(path_ids["thread_id"])
+        last_read_message_id = _v_optional_uuid4(args["last_read_message_id"])
+        try:
+            self.chat_service.mark_read(
+                employee, thread_id, last_read_message_id=last_read_message_id
+            )
+        except (
+            ChatAccessDenied,
+            ChatNotFoundError,
+            TypeError,
+            ValueError,
+            sqlite3.IntegrityError,
+        ) as exc:
+            raise _chat_error(exc) from exc
+        return 200, {
+            "thread_id": thread_id,
+            "employee_id": employee.account.id,
+            "last_read_message_id": last_read_message_id,
+        }
 
     def cmd_create_inquiry(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
@@ -2427,6 +2992,15 @@ _CATALOG_DISH_CREATE_ARGS = _ArgKeys(
     ),
     optional=frozenset({"description", "composition", "notes", "allergens"}),
 )
+_CHAT_THREAD_CREATE_ARGS = _ArgKeys(
+    required=frozenset({"thread_type", "participant_employee_ids"}),
+    optional=frozenset({"title"}),
+)
+_CHAT_MESSAGE_CREATE_ARGS = _ArgKeys(
+    required=frozenset({"body"}),
+    optional=frozenset({"reply_to_message_id", "mention_employee_ids", "references"}),
+)
+_CHAT_READ_ARGS = _ArgKeys(required=frozenset({"last_read_message_id"}))
 
 _COMMANDS: dict[str, _CommandSpec] = {
     "create_inquiry": _CommandSpec("cmd_create_inquiry", _CREATE_ARGS, set()),
@@ -2521,6 +3095,17 @@ _COMMANDS: dict[str, _CommandSpec] = {
     "deactivate_catalog_dish": _CommandSpec(
         "cmd_deactivate_catalog_dish", _NO_ARGS, {"updated_at"}
     ),
+    "create_chat_thread": _CommandSpec(
+        "cmd_create_chat_thread", _CHAT_THREAD_CREATE_ARGS, set()
+    ),
+    "send_chat_message": _CommandSpec(
+        "cmd_send_chat_message", _CHAT_MESSAGE_CREATE_ARGS, set()
+    ),
+    "mark_chat_thread_read": _CommandSpec(
+        "cmd_mark_chat_thread_read",
+        _CHAT_READ_ARGS,
+        set(),
+    ),
 }
 
 # route table: (regex, template, {method: kind})
@@ -2535,6 +3120,46 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/work-center$"),
         "/office/v1/work-center",
         {"GET": "work_center"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/threads$"),
+        "/office/v1/chat/threads",
+        {"GET": "list_chat_threads", "POST": "create_chat_thread"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/search$"),
+        "/office/v1/chat/search",
+        {"GET": "search_chat"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/entity-search$"),
+        "/office/v1/chat/entity-search",
+        {"GET": "search_chat_entities"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/employees$"),
+        "/office/v1/chat/employees",
+        {"GET": "search_chat_employees"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/threads/(?P<thread_id>[^/]+)$"),
+        "/office/v1/chat/threads/{thread_id}",
+        {"GET": "chat_thread_detail"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/threads/(?P<thread_id>[^/]+)/messages$"),
+        "/office/v1/chat/threads/{thread_id}/messages",
+        {"POST": "send_chat_message"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/threads/(?P<thread_id>[^/]+)/read$"),
+        "/office/v1/chat/threads/{thread_id}/read",
+        {"POST": "mark_chat_thread_read"},
+    ),
+    (
+        re.compile(r"^/office/v1/chat/threads/(?P<thread_id>[^/]+)/participants$"),
+        "/office/v1/chat/threads/{thread_id}/participants",
+        {"GET": "chat_thread_participants"},
     ),
     (
         re.compile(r"^/office/v1/inquiries$"),
@@ -3005,6 +3630,47 @@ def make_office_api_handler(
                 seen[key] = value
             return seen
 
+        def _employee_with_permission(
+            self, permission_code: str
+        ) -> AuthenticatedEmployee:
+            session_token = parse_employee_session_header_values(
+                self.headers.get_all("X-Employee-Session")
+            )
+            if session_token == "malformed":
+                raise _invalid()
+            if session_token is None:
+                raise ApiError(401, "unauthorized")
+            try:
+                employee = api.employee_auth_service.authenticate_session(
+                    session_token
+                )
+            except AuthenticationError as exc:
+                raise ApiError(401, "unauthorized") from exc
+            if not employee.application_access_allowed:
+                raise ApiError(403, "forbidden")
+            if permission_code not in employee.effective_permissions:
+                raise ApiError(403, "forbidden")
+            return employee
+
+        def _chat_employee(self, kind: str) -> AuthenticatedEmployee:
+            if kind == "create_chat_thread":
+                return self._employee_with_permission("chat.create")
+            if kind == "send_chat_message":
+                return self._employee_with_permission("chat.send")
+            if kind in {
+                "list_chat_threads",
+                "chat_thread_detail",
+                "chat_thread_participants",
+                "search_chat",
+                "mark_chat_thread_read",
+            }:
+                return self._employee_with_permission("chat.view")
+            if kind == "search_chat_entities":
+                return self._employee_with_permission("chat.send")
+            if kind == "search_chat_employees":
+                return self._employee_with_permission("chat.create")
+            raise ApiError(500, "internal")
+
         def _pagination(self, params: dict[str, str]) -> tuple[int, int]:
             try:
                 limit = int(params.get("limit", str(views.LIST_LIMIT_DEFAULT)))
@@ -3255,6 +3921,51 @@ def make_office_api_handler(
             elif kind == "list_tasks":
                 self._query(set())
                 self._respond(200, api.list_tasks())
+            elif kind == "list_chat_threads":
+                self._query(set())
+                employee = self._chat_employee(kind)
+                self._respond(200, api.list_chat_threads(employee))
+            elif kind == "chat_thread_detail":
+                self._query(set())
+                employee = self._chat_employee(kind)
+                self._respond(
+                    200,
+                    api.chat_thread_detail(
+                        employee, _v_uuid(path_ids["thread_id"])
+                    ),
+                )
+            elif kind == "chat_thread_participants":
+                params = self._query({"q"})
+                employee = self._chat_employee(kind)
+                q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip()
+                self._respond(
+                    200,
+                    api.chat_thread_participants(
+                        employee, _v_uuid(path_ids["thread_id"]), q
+                    ),
+                )
+            elif kind == "search_chat":
+                params = self._query({"q"})
+                employee = self._chat_employee(kind)
+                q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip()
+                self._respond(200, api.search_chat(employee, q))
+            elif kind == "search_chat_entities":
+                params = self._query({"q", "type"})
+                employee = self._chat_employee(kind)
+                q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip()
+                if "type" not in params:
+                    raise _invalid()
+                reference_type = _v_enum(
+                    params["type"], validate_chat_reference_type
+                )
+                self._respond(
+                    200, api.search_chat_entities(employee, q, reference_type)
+                )
+            elif kind == "search_chat_employees":
+                params = self._query({"q"})
+                employee = self._chat_employee(kind)
+                q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip()
+                self._respond(200, api.search_chat_employees(employee, q))
             elif kind == "list_calendar":
                 params = self._query({"from", "to"})
                 if "from" not in params or "to" not in params:
@@ -3386,6 +4097,12 @@ def make_office_api_handler(
                 raise _invalid()
             if provided - arg_spec.required - arg_spec.optional:
                 raise _invalid()
+            employee = (
+                self._chat_employee(kind)
+                if kind
+                in {"create_chat_thread", "send_chat_message", "mark_chat_thread_read"}
+                else None
+            )
 
             fingerprint = command_fingerprint(
                 template, path_ids, args, expect, CLIENT_ID
@@ -3399,10 +4116,12 @@ def make_office_api_handler(
                         raise ApiError(409, "command_id_conflict")
                     return recorded.result_status, recorded.result_body
                 api._active_command_id = command_id
+                api._active_employee = employee
                 try:
                     status, result = handler(path_ids, args, expect)
                 finally:
                     api._active_command_id = None
+                    api._active_employee = None
                 body = json.dumps(
                     {"command_id": command_id, **result}, ensure_ascii=False
                 )

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -1425,9 +1425,7 @@ class OfficeApi:
             ],
         }
 
-    def list_chat_threads(
-        self, actor: AuthenticatedEmployee
-    ) -> dict[str, object]:
+    def list_chat_threads(self, actor: AuthenticatedEmployee) -> dict[str, object]:
         return {
             "threads": [
                 self._chat_thread_summary_shape(summary)
@@ -1584,9 +1582,7 @@ class OfficeApi:
         for order in self.orders.list_orders():
             order_inquiry = self.inquiries.get_by_id(order.source_inquiry_id)
             snapshot = (
-                order_inquiry.customer_snapshot
-                if order_inquiry is not None
-                else None
+                order_inquiry.customer_snapshot if order_inquiry is not None else None
             )
             company_name = snapshot.company_name if snapshot is not None else None
             contact_name = snapshot.contact_name if snapshot is not None else None
@@ -1610,9 +1606,7 @@ class OfficeApi:
                     "reference_type": "ORDER",
                     "reference_id": order.order_id,
                     "primary_label": f"Auftrag {order.order_id[:8]}",
-                    "secondary_label": (
-                        company_name or contact_name or location_text
-                    ),
+                    "secondary_label": (company_name or contact_name or location_text),
                     "meta": {
                         "order_id": order.order_id,
                         "source_inquiry_id": order.source_inquiry_id,
@@ -3641,9 +3635,7 @@ def make_office_api_handler(
             if session_token is None:
                 raise ApiError(401, "unauthorized")
             try:
-                employee = api.employee_auth_service.authenticate_session(
-                    session_token
-                )
+                employee = api.employee_auth_service.authenticate_session(session_token)
             except AuthenticationError as exc:
                 raise ApiError(401, "unauthorized") from exc
             if not employee.application_access_allowed:
@@ -3930,9 +3922,7 @@ def make_office_api_handler(
                 employee = self._chat_employee(kind)
                 self._respond(
                     200,
-                    api.chat_thread_detail(
-                        employee, _v_uuid(path_ids["thread_id"])
-                    ),
+                    api.chat_thread_detail(employee, _v_uuid(path_ids["thread_id"])),
                 )
             elif kind == "chat_thread_participants":
                 params = self._query({"q"})
@@ -3955,9 +3945,7 @@ def make_office_api_handler(
                 q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip()
                 if "type" not in params:
                     raise _invalid()
-                reference_type = _v_enum(
-                    params["type"], validate_chat_reference_type
-                )
+                reference_type = _v_enum(params["type"], validate_chat_reference_type)
                 self._respond(
                     200, api.search_chat_entities(employee, q, reference_type)
                 )

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -909,7 +909,7 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
             is_preview=_bool(flags_data["is_preview"]),
             is_final_allowed=_bool(flags_data["is_final_allowed"]),
             is_stale=_bool(flags_data["is_stale"]),
-            watermark=watermark,
+            watermark=watermark,  # type: ignore[arg-type]
         ),
     )
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import re
-import socket
 import urllib.error
 import urllib.request
 import uuid
@@ -25,6 +24,10 @@ from catering_system.domain.catalog import (
     PricingUnit,
     validate_allergen_codes,
     validate_pricing_unit,
+)
+from catering_system.domain.chat import (
+    CHAT_REFERENCE_TYPE_SET,
+    CHAT_THREAD_TYPE_SET,
 )
 from catering_system.domain.customer_document_eligibility import (
     DOCUMENT_BLOCKER_CODES,
@@ -253,6 +256,7 @@ _VERSION_KEYS = frozenset(
 _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
     400: frozenset({"invalid_request"}),
     401: frozenset({"unauthorized"}),
+    403: frozenset({"forbidden"}),
     404: frozenset({"not_found"}),
     405: frozenset({"method_not_allowed"}),
     409: frozenset(
@@ -303,6 +307,11 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "offer_document_blocked",
             "confirmation_document_blocked",
             "order_not_ready_to_send",
+            "invalid_chat_thread",
+            "invalid_chat_message",
+            "invalid_chat_mention",
+            "invalid_chat_reference",
+            "invalid_chat_reply",
         }
     ),
     500: frozenset({"internal"}),
@@ -349,7 +358,7 @@ class InquiryDetailMeta:
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
 
 
@@ -900,7 +909,7 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
             is_preview=_bool(flags_data["is_preview"]),
             is_final_allowed=_bool(flags_data["is_final_allowed"]),
             is_stale=_bool(flags_data["is_stale"]),
-            watermark=watermark,  # type: ignore[arg-type]
+            watermark=watermark,
         ),
     )
 
@@ -1015,6 +1024,163 @@ def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
             None if data["updated_at"] is None else _datetime(data["updated_at"])
         ),
     )
+
+
+_CHAT_THREAD_KEYS = frozenset(
+    {"thread_id", "thread_type", "title", "created_by_employee_id", "created_at"}
+)
+_CHAT_THREAD_WITH_PARTICIPANTS_KEYS = _CHAT_THREAD_KEYS | {"participants"}
+_CHAT_PARTICIPANT_KEYS = frozenset(
+    {
+        "thread_id",
+        "employee_id",
+        "display_name",
+        "joined_at",
+        "last_read_message_id",
+    }
+)
+_CHAT_MESSAGE_PREVIEW_KEYS = frozenset(
+    {"message_id", "author_employee_id", "body", "created_at"}
+)
+_CHAT_REFERENCE_KEYS = frozenset({"reference_type", "reference_id"})
+_CHAT_MENTION_KEYS = frozenset({"employee_id", "display_name"})
+_CHAT_MESSAGE_KEYS = frozenset(
+    {
+        "message_id",
+        "thread_id",
+        "author_employee_id",
+        "author_display_name",
+        "body",
+        "reply_to_message_id",
+        "created_at",
+        "mentions",
+        "references",
+    }
+)
+_CHAT_SUMMARY_KEYS = frozenset(
+    {
+        "thread",
+        "participants",
+        "latest_message_preview",
+        "unread_count",
+        "last_activity_at",
+    }
+)
+_CHAT_DETAIL_KEYS = frozenset(
+    {"thread", "participants", "current_participant", "messages"}
+)
+_CHAT_ENTITY_RESULT_KEYS = frozenset(
+    {"reference_type", "reference_id", "primary_label", "secondary_label", "meta"}
+)
+_CHAT_EMPLOYEE_KEYS = frozenset({"employee_id", "display_name"})
+
+
+def _chat_reference_type(value: object) -> str:
+    raw = _str(value)
+    if raw not in CHAT_REFERENCE_TYPE_SET:
+        _bad_response()
+    return raw
+
+
+def _chat_thread(data: Mapping[str, object], *, participants: bool = False) -> None:
+    _exact(
+        data,
+        _CHAT_THREAD_WITH_PARTICIPANTS_KEYS if participants else _CHAT_THREAD_KEYS,
+    )
+    if _str(data["thread_type"]) not in CHAT_THREAD_TYPE_SET:
+        _bad_response()
+    _uuid4(data["thread_id"])
+    _optional_str(data["title"])
+    _uuid4(data["created_by_employee_id"])
+    _datetime(data["created_at"])
+    if participants:
+        for raw_participant in _list(data["participants"]):
+            _chat_participant(_dict(raw_participant))
+
+
+def _chat_participant(data: Mapping[str, object]) -> None:
+    _exact(data, _CHAT_PARTICIPANT_KEYS)
+    _uuid4(data["thread_id"])
+    _uuid4(data["employee_id"])
+    _str(data["display_name"])
+    _datetime(data["joined_at"])
+    _optional_uuid4(data["last_read_message_id"])
+
+
+def _chat_message_preview(value: object) -> None:
+    if value is None:
+        return
+    data = _dict(value)
+    _exact(data, _CHAT_MESSAGE_PREVIEW_KEYS)
+    _uuid4(data["message_id"])
+    _uuid4(data["author_employee_id"])
+    _str(data["body"])
+    _datetime(data["created_at"])
+
+
+def _chat_message(value: object) -> None:
+    data = _dict(value)
+    _exact(data, _CHAT_MESSAGE_KEYS)
+    _uuid4(data["message_id"])
+    _uuid4(data["thread_id"])
+    _uuid4(data["author_employee_id"])
+    _str(data["author_display_name"])
+    _str(data["body"])
+    _optional_uuid4(data["reply_to_message_id"])
+    _datetime(data["created_at"])
+    for raw_mention in _list(data["mentions"]):
+        mention = _dict(raw_mention)
+        _exact(mention, _CHAT_MENTION_KEYS)
+        _uuid4(mention["employee_id"])
+        _str(mention["display_name"])
+    for raw_reference in _list(data["references"]):
+        reference = _dict(raw_reference)
+        _exact(reference, _CHAT_REFERENCE_KEYS)
+        _chat_reference_type(reference["reference_type"])
+        _uuid4(reference["reference_id"])
+
+
+def _chat_summary(value: object) -> dict[str, object]:
+    data = _dict(value)
+    _exact(data, _CHAT_SUMMARY_KEYS)
+    _chat_thread(_dict(data["thread"]))
+    for raw_participant in _list(data["participants"]):
+        _chat_participant(_dict(raw_participant))
+    _chat_message_preview(data["latest_message_preview"])
+    _nonnegative_int(data["unread_count"])
+    _datetime(data["last_activity_at"])
+    return data
+
+
+def _chat_detail(value: object) -> dict[str, object]:
+    data = _dict(value)
+    _exact(data, _CHAT_DETAIL_KEYS)
+    _chat_thread(_dict(data["thread"]))
+    for raw_participant in _list(data["participants"]):
+        _chat_participant(_dict(raw_participant))
+    _chat_participant(_dict(data["current_participant"]))
+    for raw_message in _list(data["messages"]):
+        _chat_message(raw_message)
+    return data
+
+
+def _chat_entity_result(value: object) -> dict[str, object]:
+    data = _dict(value)
+    _exact(data, _CHAT_ENTITY_RESULT_KEYS)
+    _chat_reference_type(data["reference_type"])
+    _uuid4(data["reference_id"])
+    _str(data["primary_label"])
+    _str(data["secondary_label"])
+    _dict(data["meta"])
+    return data
+
+
+def _chat_employee(value: object) -> dict[str, object]:
+    data = _dict(value)
+    _exact(data, _CHAT_EMPLOYEE_KEYS)
+    _uuid4(data["employee_id"])
+    _str(data["display_name"])
+    return data
 
 
 def _validate_offer_prefill(value: object) -> None:
@@ -1140,9 +1306,12 @@ class RemoteCoreClient:
         query: Mapping[str, object] | None = None,
         body: Mapping[str, object] | None = None,
         expected: set[int],
+        employee_session_token: str | None = None,
     ) -> dict[str, object]:
         data = None
         headers = {"Authorization": f"Bearer {self._token}"}
+        if employee_session_token is not None:
+            headers["X-Employee-Session"] = employee_session_token
         if body is not None:
             data = json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode(
                 "utf-8"
@@ -1175,7 +1344,7 @@ class RemoteCoreClient:
             if code not in _ERROR_CODES_BY_STATUS.get(exc.code, frozenset()):
                 _bad_response()
             raise RemoteCoreError(exc.code, code) from exc
-        except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
             raise RemoteCoreError(503, "unreachable", unavailable=True) from exc
         with response:
             if response.status not in expected:
@@ -1193,9 +1362,19 @@ class RemoteCoreClient:
             _bad_response()
 
     def get(
-        self, path: str, query: Mapping[str, object] | None = None
+        self,
+        path: str,
+        query: Mapping[str, object] | None = None,
+        *,
+        employee_session_token: str | None = None,
     ) -> dict[str, object]:
-        return self._request("GET", path, query=query, expected={200})
+        return self._request(
+            "GET",
+            path,
+            query=query,
+            expected={200},
+            employee_session_token=employee_session_token,
+        )
 
     def get_text(self, path: str, query: Mapping[str, object] | None = None) -> str:
         url = self._url(path, query)
@@ -1206,7 +1385,7 @@ class RemoteCoreClient:
         )
         try:
             response = self._opener.open(request, timeout=_READ_TIMEOUT_SECONDS)
-        except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
             raise RemoteCoreError(503, "unreachable", unavailable=True) from exc
         with response:
             if response.status != 200:
@@ -1252,7 +1431,7 @@ class RemoteCoreClient:
                     # status survives, the code degrades to unexpected_status.
                     pass
             raise RemoteCoreError(exc.code, code) from exc
-        except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
             raise RemoteCoreError(503, "unreachable", unavailable=True) from exc
         with response:
             if response.status != 200:
@@ -1277,6 +1456,7 @@ class RemoteCoreClient:
         *,
         command_id: str | None = None,
         optional_result_keys: frozenset[str] | set[str] = frozenset(),
+        employee_session_token: str | None = None,
     ) -> dict[str, object]:
         """`result_keys` must all be present. `optional_result_keys` may be
         present — for commands whose response carries a field only in some
@@ -1294,6 +1474,7 @@ class RemoteCoreClient:
                 "args": dict(args),
             },
             expected=expected,
+            employee_session_token=employee_session_token,
         )
         required = result_keys | {"command_id"}
         if not required <= set(result) <= required | set(optional_result_keys):
@@ -1710,9 +1891,11 @@ class RemoteCoreClient:
                 }
                 if not keys <= set(item):
                     _bad_response()
-                if item.get("validity_hint") is not None:
-                    if _str(item["validity_hint"]) != "expires_today":
-                        _bad_response()
+                if (
+                    item.get("validity_hint") is not None
+                    and _str(item["validity_hint"]) != "expires_today"
+                ):
+                    _bad_response()
                 _uuid4(item["offer_id"])
                 _uuid4(item["inquiry_id"])
                 _uuid4(item["offer_version_id"])
@@ -2406,6 +2589,160 @@ class RemoteCoreClient:
                 _bad_response()
             _datetime(row["opened_at"])
         return body
+
+    def create_chat_thread(
+        self,
+        *,
+        employee_session_token: str,
+        thread_type: str,
+        participant_employee_ids: Sequence[str],
+        title: str | None = None,
+        command_id: str | None = None,
+    ) -> dict[str, object]:
+        args: dict[str, object] = {
+            "thread_type": thread_type,
+            "participant_employee_ids": list(participant_employee_ids),
+        }
+        if title is not None:
+            args["title"] = title
+        result = self.command(
+            "/office/v1/chat/threads",
+            args=args,
+            expect={},
+            expected={200, 201},
+            result_keys={"thread"},
+            command_id=command_id,
+            employee_session_token=employee_session_token,
+        )
+        thread = _dict(result["thread"])
+        _chat_thread(thread, participants=True)
+        return thread
+
+    def list_chat_threads(
+        self, *, employee_session_token: str
+    ) -> list[dict[str, object]]:
+        body = self.get(
+            "/office/v1/chat/threads",
+            employee_session_token=employee_session_token,
+        )
+        _exact(body, {"threads"})
+        return [_chat_summary(raw) for raw in _list(body["threads"])]
+
+    def get_chat_thread(
+        self, thread_id: str, *, employee_session_token: str
+    ) -> dict[str, object]:
+        body = self.get(
+            f"/office/v1/chat/threads/{quote(thread_id, safe='')}",
+            employee_session_token=employee_session_token,
+        )
+        return _chat_detail(body)
+
+    def send_chat_message(
+        self,
+        thread_id: str,
+        *,
+        employee_session_token: str,
+        body: str,
+        reply_to_message_id: str | None = None,
+        mention_employee_ids: Sequence[str] = (),
+        references: Sequence[Mapping[str, object]] = (),
+        command_id: str | None = None,
+    ) -> dict[str, object]:
+        result = self.command(
+            f"/office/v1/chat/threads/{quote(thread_id, safe='')}/messages",
+            args={
+                "body": body,
+                "reply_to_message_id": reply_to_message_id,
+                "mention_employee_ids": list(mention_employee_ids),
+                "references": [dict(reference) for reference in references],
+            },
+            expect={},
+            expected={201},
+            result_keys={"message"},
+            command_id=command_id,
+            employee_session_token=employee_session_token,
+        )
+        _chat_message(result["message"])
+        return _dict(result["message"])
+
+    def mark_chat_thread_read(
+        self,
+        thread_id: str,
+        *,
+        employee_session_token: str,
+        last_read_message_id: str | None,
+        command_id: str | None = None,
+    ) -> dict[str, object]:
+        result = self.command(
+            f"/office/v1/chat/threads/{quote(thread_id, safe='')}/read",
+            args={"last_read_message_id": last_read_message_id},
+            expect={},
+            expected={200},
+            result_keys={"thread_id", "employee_id", "last_read_message_id"},
+            command_id=command_id,
+            employee_session_token=employee_session_token,
+        )
+        _uuid4(result["thread_id"])
+        _uuid4(result["employee_id"])
+        _optional_uuid4(result["last_read_message_id"])
+        return result
+
+    def autocomplete_chat_participants(
+        self,
+        thread_id: str,
+        *,
+        employee_session_token: str,
+        q: str = "",
+    ) -> list[dict[str, object]]:
+        body = self.get(
+            f"/office/v1/chat/threads/{quote(thread_id, safe='')}/participants",
+            query={"q": q} if q else None,
+            employee_session_token=employee_session_token,
+        )
+        _exact(body, {"participants"})
+        participants = []
+        for raw_participant in _list(body["participants"]):
+            participant = _dict(raw_participant)
+            _chat_participant(participant)
+            participants.append(participant)
+        return participants
+
+    def search_chat_entities(
+        self,
+        *,
+        employee_session_token: str,
+        q: str,
+        reference_type: str,
+    ) -> list[dict[str, object]]:
+        body = self.get(
+            "/office/v1/chat/entity-search",
+            query={"q": q, "type": reference_type},
+            employee_session_token=employee_session_token,
+        )
+        _exact(body, {"results"})
+        return [_chat_entity_result(raw) for raw in _list(body["results"])]
+
+    def search_chat_employees(
+        self, *, employee_session_token: str, q: str = ""
+    ) -> list[dict[str, object]]:
+        body = self.get(
+            "/office/v1/chat/employees",
+            query={"q": q} if q else None,
+            employee_session_token=employee_session_token,
+        )
+        _exact(body, {"employees"})
+        return [_chat_employee(raw) for raw in _list(body["employees"])]
+
+    def search_chat(
+        self, *, employee_session_token: str, q: str
+    ) -> list[dict[str, object]]:
+        body = self.get(
+            "/office/v1/chat/search",
+            query={"q": q},
+            employee_session_token=employee_session_token,
+        )
+        _exact(body, {"results"})
+        return [_chat_summary(raw) for raw in _list(body["results"])]
 
     def list_calendar(self, from_date: date, to_date: date) -> dict[str, object]:
         params = {
@@ -3817,9 +4154,12 @@ class _RemoteConfirmationOutboundService:
     ) -> OutboundSendEligibility:
         confirmation = self._client.confirmation_document_service.eligibility(order_id)
         snapshot = confirmation.snapshot
-        if document_snapshot_id is not None and snapshot is not None:
-            if snapshot.document_snapshot_id != document_snapshot_id:
-                snapshot = None
+        if (
+            document_snapshot_id is not None
+            and snapshot is not None
+            and snapshot.document_snapshot_id != document_snapshot_id
+        ):
+            snapshot = None
         if snapshot is None:
             return OutboundSendEligibility(
                 state="dokument_fehlt",

--- a/tests/unit/test_chat_office_api.py
+++ b/tests/unit/test_chat_office_api.py
@@ -570,6 +570,113 @@ def test_chat_employee_picker_is_minimal_active_and_requires_create(chat_api) ->
     assert body == {"error": "forbidden"}
 
 
+def test_chat_api_validation_and_empty_result_paths(chat_api) -> None:
+    base, ids = chat_api
+    headers = _headers(ids["viktor_session"])
+
+    status, body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=headers,
+        args={
+            "thread_type": "GROUP",
+            "participant_employee_ids": [ids["anna_id"]],
+            "title": "   ",
+        },
+    )
+    assert status == 422
+    assert body == {"error": "invalid_chat_thread"}
+
+    status, body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=headers,
+        args={"thread_type": "DIRECT", "participant_employee_ids": []},
+    )
+    assert status == 422
+    assert body == {"error": "invalid_chat_thread"}
+
+    status, body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=headers,
+        args={"thread_type": "BOGUS", "participant_employee_ids": [ids["anna_id"]]},
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+    status, body = _get(
+        f"{base}/office/v1/chat/entity-search?q=Mueller&type=BOGUS",
+        headers=headers,
+    )
+    assert status == 400
+    assert body == {"error": "invalid_request"}
+
+    for reference_type in ("ORDER", "INQUIRY", "CONTACT"):
+        status, body = _get(
+            f"{base}/office/v1/chat/entity-search?q=M&type={reference_type}",
+            headers=headers,
+        )
+        assert status == 200
+        assert body == {"results": []}
+
+    thread_id = _direct(base, ids)
+    status, body = _get(
+        f"{base}/office/v1/chat/threads/{thread_id}/participants",
+        headers=headers,
+    )
+    assert status == 200
+    assert {row["employee_id"] for row in body["participants"]} == {
+        ids["viktor_id"],
+        ids["anna_id"],
+    }
+
+    status, body = _get(
+        f"{base}/office/v1/chat/employees?q=does-not-exist",
+        headers=headers,
+    )
+    assert status == 200
+    assert body == {"employees": []}
+
+    status, body = _get(
+        f"{base}/office/v1/chat/search",
+        headers=headers,
+    )
+    assert status == 200
+    assert body == {"results": []}
+
+
+def test_entity_picker_success_for_order_inquiry_and_empty_matches(chat_api) -> None:
+    base, ids = chat_api
+    headers = _headers(ids["viktor_session"])
+
+    status, orders = _get(
+        f"{base}/office/v1/chat/entity-search?q=Mueller&type=ORDER",
+        headers=headers,
+    )
+    assert status == 200
+    assert orders["results"][0]["reference_type"] == "ORDER"
+    assert orders["results"][0]["reference_id"] == ids["order_id"]
+    assert orders["results"][0]["meta"] == {
+        "order_id": ids["order_id"],
+        "source_inquiry_id": ids["inquiry_id"],
+    }
+
+    status, inquiries = _get(
+        f"{base}/office/v1/chat/entity-search?q=Berlin&type=INQUIRY",
+        headers=headers,
+    )
+    assert status == 200
+    assert inquiries["results"][0]["reference_type"] == "INQUIRY"
+    assert inquiries["results"][0]["reference_id"] == ids["inquiry_id"]
+    assert inquiries["results"][0]["meta"] == {"inquiry_id": ids["inquiry_id"]}
+
+    for reference_type in ("ORDER", "INQUIRY", "CONTACT"):
+        status, body = _get(
+            f"{base}/office/v1/chat/entity-search?q=zz-no-match&type={reference_type}",
+            headers=headers,
+        )
+        assert status == 200
+        assert body == {"results": []}
+
+
 def test_chat_search_does_not_reveal_inaccessible_title_participants_or_reference(
     chat_api,
 ) -> None:
@@ -639,13 +746,41 @@ def test_remote_core_client_chat_methods_preserve_shapes(chat_api) -> None:
         body="ok",
         reply_to_message_id=str(message["message_id"]),
     )
+    read_marker = client.mark_chat_thread_read(
+        str(thread["thread_id"]),
+        employee_session_token=ids["viktor_session"],
+        last_read_message_id=str(message["message_id"]),
+    )
+    threads = client.list_chat_threads(employee_session_token=ids["viktor_session"])
     detail = client.get_chat_thread(
         str(thread["thread_id"]), employee_session_token=ids["viktor_session"]
+    )
+    participants = client.autocomplete_chat_participants(
+        str(thread["thread_id"]),
+        employee_session_token=ids["viktor_session"],
+    )
+    entity_results = client.search_chat_entities(
+        employee_session_token=ids["viktor_session"],
+        q="Mueller",
+        reference_type="CONTACT",
+    )
+    search_results = client.search_chat(
+        employee_session_token=ids["viktor_session"], q="@Anna"
     )
     employees = client.search_chat_employees(
         employee_session_token=ids["viktor_session"], q="Anna"
     )
     messages = cast(list[dict[str, Any]], detail["messages"])
+    assert read_marker["thread_id"] == thread["thread_id"]
+    assert read_marker["employee_id"] == ids["viktor_id"]
+    assert read_marker["last_read_message_id"] == message["message_id"]
+    assert threads[0]["thread"]["thread_id"] == thread["thread_id"]
+    assert {row["employee_id"] for row in participants} == {
+        ids["viktor_id"],
+        ids["anna_id"],
+    }
+    assert entity_results[0]["reference_id"] == ids["contact_profile_id"]
+    assert search_results[0]["thread"]["thread_id"] == thread["thread_id"]
     assert employees == [{"employee_id": ids["anna_id"], "display_name": "Anna"}]
     assert messages[0]["mentions"][0]["employee_id"] == ids["anna_id"]
     assert messages[0]["references"][0]["reference_id"] == ids["inquiry_id"]
@@ -682,6 +817,125 @@ def test_remote_core_client_rejects_malformed_chat_response() -> None:
         with pytest.raises(RemoteCoreError) as exc:
             client.list_chat_threads(employee_session_token="session")
         assert exc.value.code == "invalid_response"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_remote_core_client_rejects_malformed_chat_method_responses() -> None:
+    valid_uuid = str(uuid.uuid4())
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            payload_by_path: dict[str, object] = {
+                "/office/v1/chat/threads": {"threads": [{"thread": {}}]},
+                f"/office/v1/chat/threads/{valid_uuid}": {
+                    "thread": {},
+                    "participants": [],
+                    "current_participant": {},
+                    "messages": [],
+                },
+                f"/office/v1/chat/threads/{valid_uuid}/participants": {
+                    "participants": [{"employee_id": "not-a-uuid"}]
+                },
+                "/office/v1/chat/entity-search": {
+                    "results": [{"reference_type": "BOGUS"}]
+                },
+                "/office/v1/chat/employees": {
+                    "employees": [
+                        {
+                            "employee_id": valid_uuid,
+                            "display_name": "Anna",
+                            "username": "leak",
+                        }
+                    ]
+                },
+                "/office/v1/chat/search": {
+                    "results": [{"thread": {"thread_type": "BOGUS"}}]
+                },
+            }
+            path = self.path.split("?", 1)[0]
+            payload = json.dumps(payload_by_path[path]).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self) -> None:
+            length = int(self.headers["Content-Length"])
+            request = json.loads(self.rfile.read(length).decode())
+            payload_by_path: dict[str, object] = {
+                "/office/v1/chat/threads": {
+                    "command_id": request["command_id"],
+                    "thread": {"thread_type": "BOGUS"},
+                },
+                f"/office/v1/chat/threads/{valid_uuid}/messages": {
+                    "command_id": request["command_id"],
+                    "message": {"references": [{"reference_type": "BOGUS"}]},
+                },
+                f"/office/v1/chat/threads/{valid_uuid}/read": {
+                    "command_id": request["command_id"],
+                    "thread_id": valid_uuid,
+                    "employee_id": "not-a-uuid",
+                    "last_read_message_id": None,
+                },
+            }
+            payload = json.dumps(payload_by_path[self.path]).encode()
+            status = 201 if self.path.endswith("/messages") else 200
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    client = RemoteCoreClient(f"http://{host!s}:{int(port)}", _TOKEN)
+    try:
+        calls = [
+            lambda: client.create_chat_thread(
+                employee_session_token="session",
+                thread_type="DIRECT",
+                participant_employee_ids=[valid_uuid],
+            ),
+            lambda: client.get_chat_thread(
+                valid_uuid, employee_session_token="session"
+            ),
+            lambda: client.send_chat_message(
+                valid_uuid,
+                employee_session_token="session",
+                body="bad",
+            ),
+            lambda: client.mark_chat_thread_read(
+                valid_uuid,
+                employee_session_token="session",
+                last_read_message_id=None,
+            ),
+            lambda: client.autocomplete_chat_participants(
+                valid_uuid,
+                employee_session_token="session",
+            ),
+            lambda: client.search_chat_entities(
+                employee_session_token="session",
+                q="Mueller",
+                reference_type="CONTACT",
+            ),
+            lambda: client.search_chat_employees(
+                employee_session_token="session", q="Anna"
+            ),
+            lambda: client.search_chat(employee_session_token="session", q="Anna"),
+        ]
+        for call in calls:
+            with pytest.raises(RemoteCoreError) as exc:
+                call()
+            assert exc.value.code == "invalid_response"
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/unit/test_chat_office_api.py
+++ b/tests/unit/test_chat_office_api.py
@@ -1,0 +1,688 @@
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, date, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import quote
+
+import pytest
+
+from catering_system.domain.contact_profile import ContactProfile
+from catering_system.repositories.sqlite_contact_profile_repository import (
+    SQLiteContactProfileRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+from tests.helpers.order_seed import seed_order
+
+_TOKEN = "test-office-api-token"
+_AUTH = {"Authorization": f"Bearer {_TOKEN}"}
+_NOW = datetime(2026, 8, 10, 8, 0, tzinfo=UTC)
+
+
+def _start_api_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.office_api import create_office_api_server
+
+        server = create_office_api_server(
+            str(db),
+            _TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+            employee_auth_now=lambda: _NOW,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host!s}:{int(port)}"
+
+
+def _seed_auth(db: Path) -> dict[str, str]:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(repo, now=lambda: _NOW)
+    service.bootstrap_superadmin(
+        username="chat.admin",
+        display_name="Chat Admin",
+        password="TempPassw0rd!",
+    )
+    initial = service.authenticate(username="chat.admin", password="TempPassw0rd!")
+    service.change_password(
+        service.authenticate_session(initial.session_token),
+        current_password="TempPassw0rd!",
+        new_password="ChangedPassw0rd!",
+    )
+    admin_session = service.authenticate(
+        username="chat.admin", password="ChangedPassw0rd!"
+    ).session_token
+    admin_actor = service.authenticate_session(admin_session)
+    viktor = service.create_account(
+        admin_actor,
+        username="chat.viktor",
+        display_name="Viktor",
+        password="ViktorPassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    anna = service.create_account(
+        admin_actor,
+        username="chat.anna",
+        display_name="Anna",
+        password="AnnaPassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    lena = service.create_account(
+        admin_actor,
+        username="chat.lena",
+        display_name="Lena",
+        password="LenaPassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    viewer = service.create_account(
+        admin_actor,
+        username="chat.viewer",
+        display_name="Viewer",
+        password="ViewerPassw0rd!",
+        role="VIEWER",
+        must_change_password=False,
+    )
+    service.create_account(
+        admin_actor,
+        username="chat.send.only",
+        display_name="Chat Send Only",
+        password="ChatSendPassw0rd!",
+        role="USER",
+        explicit_permissions={"chat.send"},
+        must_change_password=False,
+    )
+    service.create_account(
+        admin_actor,
+        username="chat.no.orders",
+        display_name="Chat No Orders",
+        password="NoOrdersPassw0rd!",
+        role="USER",
+        explicit_permissions={"chat.send", "inquiries.view", "customers.view"},
+        must_change_password=False,
+    )
+    service.create_account(
+        admin_actor,
+        username="chat.no.inquiries",
+        display_name="Chat No Inquiries",
+        password="NoInquiriesPassw0rd!",
+        role="USER",
+        explicit_permissions={"chat.send", "orders.view", "customers.view"},
+        must_change_password=False,
+    )
+    service.create_account(
+        admin_actor,
+        username="chat.no.customers",
+        display_name="Chat No Customers",
+        password="NoCustomersPassw0rd!",
+        role="USER",
+        explicit_permissions={"chat.send", "orders.view", "inquiries.view"},
+        must_change_password=False,
+    )
+    service.create_account(
+        admin_actor,
+        username="chat.create.only",
+        display_name="Chat Create Only",
+        password="ChatCreatePassw0rd!",
+        role="USER",
+        explicit_permissions={"chat.create"},
+        must_change_password=False,
+    )
+    inactive = service.create_account(
+        admin_actor,
+        username="chat.inactive",
+        display_name="Inactive Chat User",
+        password="InactivePassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    service.deactivate_account(admin_actor, inactive.id)
+    sessions = {
+        "viktor_session": service.authenticate(
+            username="chat.viktor", password="ViktorPassw0rd!"
+        ).session_token,
+        "anna_session": service.authenticate(
+            username="chat.anna", password="AnnaPassw0rd!"
+        ).session_token,
+        "lena_session": service.authenticate(
+            username="chat.lena", password="LenaPassw0rd!"
+        ).session_token,
+        "viewer_session": service.authenticate(
+            username="chat.viewer", password="ViewerPassw0rd!"
+        ).session_token,
+        "chat_send_only_session": service.authenticate(
+            username="chat.send.only", password="ChatSendPassw0rd!"
+        ).session_token,
+        "chat_send_no_orders_session": service.authenticate(
+            username="chat.no.orders", password="NoOrdersPassw0rd!"
+        ).session_token,
+        "chat_send_no_inquiries_session": service.authenticate(
+            username="chat.no.inquiries", password="NoInquiriesPassw0rd!"
+        ).session_token,
+        "chat_send_no_customers_session": service.authenticate(
+            username="chat.no.customers", password="NoCustomersPassw0rd!"
+        ).session_token,
+        "chat_create_only_session": service.authenticate(
+            username="chat.create.only", password="ChatCreatePassw0rd!"
+        ).session_token,
+    }
+    repo.close()
+    return {
+        "viktor_id": viktor.id,
+        "anna_id": anna.id,
+        "lena_id": lena.id,
+        "viewer_id": viewer.id,
+        "inactive_id": inactive.id,
+        **sessions,
+    }
+
+
+def _seed_entities(db: Path) -> dict[str, str]:
+    inquiries = SQLiteInquiryRepository(db)
+    orders = SQLiteOrderRepository(db)
+    inquiry = InquiryService(inquiries).create_inquiry(
+        event_date=date(2026, 8, 15),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="abends",
+        location_text="Berlin",
+        guest_count_estimate=26,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="mueller@example.com",
+        contact_phone="+49301234567",
+        company_name="Mueller GmbH",
+        contact_name="Marta Mueller",
+    )
+    order, _version = seed_order(orders, inquiry)
+    profiles = SQLiteContactProfileRepository(db)
+    contact_id = str(uuid.uuid4())
+    profiles.create_profile(
+        ContactProfile(
+            contact_profile_id=contact_id,
+            display_name="Marta Mueller",
+            email="mueller@example.com",
+            phone="+49301234567",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    inquiries.close()
+    orders.close()
+    profiles.close()
+    return {
+        "inquiry_id": inquiry.inquiry_id,
+        "order_id": order.order_id,
+        "contact_profile_id": contact_id,
+    }
+
+
+@pytest.fixture()
+def chat_api(tmp_path: Path):
+    db = tmp_path / "core.db"
+    ids = {**_seed_auth(db), **_seed_entities(db)}
+    server, thread, base = _start_api_server(db)
+    try:
+        yield base, ids
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert thread.is_alive() is False
+
+
+def _headers(session_token: str) -> dict[str, str]:
+    return {**_AUTH, "X-Employee-Session": session_token}
+
+
+def _post(
+    url: str,
+    *,
+    headers: dict[str, str],
+    args: dict[str, object] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    body = json.dumps(
+        {"command_id": str(uuid.uuid4()), "expect": {}, "args": args or {}}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={**headers, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _get(url: str, *, headers: dict[str, str]) -> tuple[int, dict[str, Any]]:
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _direct(base: str, ids: dict[str, str]) -> str:
+    status, body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=_headers(ids["viktor_session"]),
+        args={"thread_type": "DIRECT", "participant_employee_ids": [ids["anna_id"]]},
+    )
+    assert status == 201
+    return str(body["thread"]["thread_id"])
+
+
+def test_direct_duplicate_is_order_independent_and_actor_is_session_bound(
+    chat_api,
+) -> None:
+    base, ids = chat_api
+    first = _direct(base, ids)
+    status, duplicate = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=_headers(ids["anna_session"]),
+        args={"thread_type": "DIRECT", "participant_employee_ids": [ids["viktor_id"]]},
+    )
+    assert status == 200
+    assert duplicate["thread"]["thread_id"] == first
+
+    status, spoof = _post(
+        f"{base}/office/v1/chat/threads/{first}/messages",
+        headers=_headers(ids["viktor_session"]),
+        args={
+            "body": "spoof",
+            "author_employee_id": ids["lena_id"],
+        },
+    )
+    assert status == 400
+    assert spoof["error"] == "invalid_request"
+
+
+def test_send_message_atomicity_and_message_validity(chat_api) -> None:
+    base, ids = chat_api
+    thread_id = _direct(base, ids)
+    headers = _headers(ids["viktor_session"])
+    url = f"{base}/office/v1/chat/threads/{thread_id}/messages"
+
+    status, body = _post(
+        url,
+        headers=headers,
+        args={
+            "body": "   ",
+            "mention_employee_ids": [ids["anna_id"]],
+            "references": [],
+        },
+    )
+    assert status == 422
+    assert body["error"] == "invalid_chat_message"
+
+    status, body = _post(
+        url,
+        headers=headers,
+        args={"body": "hi", "mention_employee_ids": [ids["lena_id"]]},
+    )
+    assert status == 422
+    assert body["error"] == "invalid_chat_mention"
+
+    status, body = _post(
+        url,
+        headers=headers,
+        args={
+            "body": "hi",
+            "references": [
+                {"reference_type": "ORDER", "reference_id": str(uuid.uuid4())}
+            ],
+        },
+    )
+    assert status == 422
+    assert body["error"] == "invalid_chat_reference"
+
+    status, detail = _get(
+        f"{base}/office/v1/chat/threads/{thread_id}",
+        headers=headers,
+    )
+    assert status == 200
+    assert detail["messages"] == []
+
+    status, sent = _post(
+        url,
+        headers=headers,
+        args={
+            "body": "",
+            "references": [
+                {
+                    "reference_type": "CONTACT",
+                    "reference_id": ids["contact_profile_id"],
+                }
+            ],
+        },
+    )
+    assert status == 201
+    assert sent["message"]["body"] == ""
+    assert sent["message"]["references"] == [
+        {"reference_type": "CONTACT", "reference_id": ids["contact_profile_id"]}
+    ]
+
+
+def test_membership_and_read_marker_are_enforced(chat_api) -> None:
+    base, ids = chat_api
+    first_thread = _direct(base, ids)
+    second_status, second_body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=_headers(ids["viktor_session"]),
+        args={"thread_type": "DIRECT", "participant_employee_ids": [ids["lena_id"]]},
+    )
+    assert second_status == 201
+    second_thread = str(second_body["thread"]["thread_id"])
+
+    status, _body = _get(
+        f"{base}/office/v1/chat/threads/{first_thread}",
+        headers=_headers(ids["lena_session"]),
+    )
+    assert status == 404
+    status, _body = _post(
+        f"{base}/office/v1/chat/threads/{first_thread}/messages",
+        headers=_headers(ids["lena_session"]),
+        args={"body": "no"},
+    )
+    assert status == 404
+
+    status, first_message = _post(
+        f"{base}/office/v1/chat/threads/{first_thread}/messages",
+        headers=_headers(ids["viktor_session"]),
+        args={"body": "first"},
+    )
+    assert status == 201
+    status, second_message = _post(
+        f"{base}/office/v1/chat/threads/{second_thread}/messages",
+        headers=_headers(ids["viktor_session"]),
+        args={"body": "second"},
+    )
+    assert status == 201
+
+    status, body = _post(
+        f"{base}/office/v1/chat/threads/{first_thread}/read",
+        headers=_headers(ids["anna_session"]),
+        args={"last_read_message_id": second_message["message"]["message_id"]},
+    )
+    assert status == 422
+    assert body["error"] == "invalid_chat_message"
+
+    status, _body = _post(
+        f"{base}/office/v1/chat/threads/{first_thread}/read",
+        headers=_headers(ids["anna_session"]),
+        args={"last_read_message_id": first_message["message"]["message_id"]},
+    )
+    assert status == 200
+
+    status, anna_detail = _get(
+        f"{base}/office/v1/chat/threads/{first_thread}",
+        headers=_headers(ids["anna_session"]),
+    )
+    assert status == 200
+    assert (
+        anna_detail["current_participant"]["last_read_message_id"]
+        == first_message["message"]["message_id"]
+    )
+    status, viktor_detail = _get(
+        f"{base}/office/v1/chat/threads/{first_thread}",
+        headers=_headers(ids["viktor_session"]),
+    )
+    assert status == 200
+    assert viktor_detail["current_participant"]["last_read_message_id"] is None
+
+
+def test_search_picker_participants_and_rbac(chat_api) -> None:
+    base, ids = chat_api
+    thread_id = _direct(base, ids)
+    _post(
+        f"{base}/office/v1/chat/threads/{thread_id}/messages",
+        headers=_headers(ids["viktor_session"]),
+        args={"body": "secret-mueller"},
+    )
+
+    status, results = _get(
+        f"{base}/office/v1/chat/search?q=secret-mueller",
+        headers=_headers(ids["anna_session"]),
+    )
+    assert status == 200
+    assert [row["thread"]["thread_id"] for row in results["results"]] == [thread_id]
+
+    status, results = _get(
+        f"{base}/office/v1/chat/search?q=secret-mueller",
+        headers=_headers(ids["lena_session"]),
+    )
+    assert status == 200
+    assert results["results"] == []
+
+    status, participants = _get(
+        f"{base}/office/v1/chat/threads/{thread_id}/participants?q=Len",
+        headers=_headers(ids["viktor_session"]),
+    )
+    assert status == 200
+    assert participants["participants"] == []
+
+    status, contacts = _get(
+        f"{base}/office/v1/chat/entity-search?q=Mueller&type=CONTACT",
+        headers=_headers(ids["viktor_session"]),
+    )
+    assert status == 200
+    assert contacts["results"][0]["reference_id"] == ids["contact_profile_id"]
+    assert contacts["results"][0]["meta"] == {
+        "contact_profile_id": ids["contact_profile_id"]
+    }
+
+    status, body = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=_headers(ids["viewer_session"]),
+        args={"thread_type": "DIRECT", "participant_employee_ids": [ids["anna_id"]]},
+    )
+    assert status == 403
+    assert body["error"] == "forbidden"
+
+
+def test_entity_picker_requires_target_entity_view_permission(chat_api) -> None:
+    base, ids = chat_api
+    cases = [
+        ("ORDER", "chat_send_no_orders_session"),
+        ("INQUIRY", "chat_send_no_inquiries_session"),
+        ("CONTACT", "chat_send_no_customers_session"),
+    ]
+    for reference_type, session_key in cases:
+        status, body = _get(
+            f"{base}/office/v1/chat/entity-search?q=Mueller&type={reference_type}",
+            headers=_headers(ids[session_key]),
+        )
+        assert status == 403
+        assert body == {"error": "forbidden"}
+
+    status, body = _get(
+        f"{base}/office/v1/chat/entity-search?q=Mueller&type=CONTACT",
+        headers=_headers(ids["chat_send_only_session"]),
+    )
+    assert status == 403
+    assert body == {"error": "forbidden"}
+
+
+def test_chat_employee_picker_is_minimal_active_and_requires_create(chat_api) -> None:
+    base, ids = chat_api
+    status, body = _get(
+        f"{base}/office/v1/chat/employees?q=chat",
+        headers=_headers(ids["chat_create_only_session"]),
+    )
+    assert status == 200
+    employees = body["employees"]
+    assert employees
+    assert all(set(row) == {"employee_id", "display_name"} for row in employees)
+    assert ids["inactive_id"] not in {row["employee_id"] for row in employees}
+    assert "Inactive Chat User" not in {row["display_name"] for row in employees}
+    assert [row["display_name"] for row in employees] == sorted(
+        row["display_name"] for row in employees
+    )
+    serialized = json.dumps(body)
+    for forbidden in (
+        "username",
+        "role",
+        "permissions",
+        "password",
+        "session",
+        "must_change_password",
+    ):
+        assert forbidden not in serialized
+
+    status, body = _get(
+        f"{base}/office/v1/chat/employees?q=chat",
+        headers=_headers(ids["viewer_session"]),
+    )
+    assert status == 403
+    assert body == {"error": "forbidden"}
+
+
+def test_chat_search_does_not_reveal_inaccessible_title_participants_or_reference(
+    chat_api,
+) -> None:
+    base, ids = chat_api
+    status, created = _post(
+        f"{base}/office/v1/chat/threads",
+        headers=_headers(ids["viktor_session"]),
+        args={
+            "thread_type": "GROUP",
+            "title": "secret-title-leak-check",
+            "participant_employee_ids": [ids["lena_id"]],
+        },
+    )
+    assert status == 201
+    thread_id = str(created["thread"]["thread_id"])
+    status, sent = _post(
+        f"{base}/office/v1/chat/threads/{thread_id}/messages",
+        headers=_headers(ids["viktor_session"]),
+        args={
+            "body": "secret-body-leak-check",
+            "references": [
+                {
+                    "reference_type": "CONTACT",
+                    "reference_id": ids["contact_profile_id"],
+                }
+            ],
+        },
+    )
+    assert status == 201
+    assert sent["message"]["references"][0]["reference_id"] == ids["contact_profile_id"]
+
+    for query in (
+        "secret-title-leak-check",
+        "secret-body-leak-check",
+        "Lena",
+        "Marta Mueller",
+        ids["contact_profile_id"],
+    ):
+        status, results = _get(
+            f"{base}/office/v1/chat/search?q={quote(query)}",
+            headers=_headers(ids["anna_session"]),
+        )
+        assert status == 200
+        assert results["results"] == []
+
+
+def test_remote_core_client_chat_methods_preserve_shapes(chat_api) -> None:
+    base, ids = chat_api
+    client = RemoteCoreClient(base, _TOKEN)
+    thread = client.create_chat_thread(
+        employee_session_token=ids["viktor_session"],
+        thread_type="DIRECT",
+        participant_employee_ids=[ids["anna_id"]],
+    )
+    message = client.send_chat_message(
+        str(thread["thread_id"]),
+        employee_session_token=ids["viktor_session"],
+        body="@Anna",
+        mention_employee_ids=[ids["anna_id"]],
+        references=[
+            {"reference_type": "INQUIRY", "reference_id": ids["inquiry_id"]},
+        ],
+    )
+    reply = client.send_chat_message(
+        str(thread["thread_id"]),
+        employee_session_token=ids["anna_session"],
+        body="ok",
+        reply_to_message_id=str(message["message_id"]),
+    )
+    detail = client.get_chat_thread(
+        str(thread["thread_id"]), employee_session_token=ids["viktor_session"]
+    )
+    employees = client.search_chat_employees(
+        employee_session_token=ids["viktor_session"], q="Anna"
+    )
+    messages = cast(list[dict[str, Any]], detail["messages"])
+    assert employees == [{"employee_id": ids["anna_id"], "display_name": "Anna"}]
+    assert messages[0]["mentions"][0]["employee_id"] == ids["anna_id"]
+    assert messages[0]["references"][0]["reference_id"] == ids["inquiry_id"]
+    assert messages[1]["reply_to_message_id"] == reply["reply_to_message_id"]
+
+    with pytest.raises(RemoteCoreError) as exc:
+        client.search_chat_entities(
+            employee_session_token=ids["viewer_session"],
+            q="Mueller",
+            reference_type="CONTACT",
+        )
+    assert exc.value.status == 403
+
+
+def test_remote_core_client_rejects_malformed_chat_response() -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            payload = json.dumps({"threads": [{"thread": {}}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        client = RemoteCoreClient(f"http://{host!s}:{int(port)}", _TOKEN)
+        with pytest.raises(RemoteCoreError) as exc:
+            client.list_chat_threads(employee_session_token="session")
+        assert exc.value.code == "invalid_response"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)


### PR DESCRIPTION
## Summary
- expose internal employee chat through Office API
- add strict RemoteCoreClient chat methods and response validation
- enforce participant isolation and actor identity from employee auth context
- add entity picker authorization by target resource permission
- add minimal active-employee picker for new chat creation
- add API/client regression coverage

## Scope
Office API + RemoteCoreClient only. No Office Panel chat UI.

## Validation
- chat core/API: 23 passed
- employee auth/settings: 59 passed
- focused ruff: pass
- git diff --check: pass
- focused mypy with missing imports ignored: pass
- Manual Tasks leak check: clean