### PR TITLE
feat: add internal employee chat panel

### DIFF
--- a/src/catering_system/ui/office_panel_chat.py
+++ b/src/catering_system/ui/office_panel_chat.py
@@ -1,0 +1,383 @@
+"""Office Panel presentation for internal employee chat."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import quote, urlencode
+from zoneinfo import ZoneInfo
+
+from catering_system.ui.office_panel_views import (
+    OfficePageContext,
+    _csrf_input,
+    _e,
+    _page,
+)
+
+_BERLIN = ZoneInfo("Europe/Berlin")
+_REFERENCE_LABELS = {
+    "ORDER": "Auftrag",
+    "INQUIRY": "Anfrage",
+    "CONTACT": "Kontakt",
+}
+
+
+def _as_list(value: object) -> list[dict[str, object]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _as_dict(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _short_id(value: object) -> str:
+    raw = str(value)
+    return raw[:8] if raw else ""
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _format_time(raw: object) -> str:
+    try:
+        value = datetime.fromisoformat(str(raw))
+    except ValueError:
+        return str(raw)
+    local = value.astimezone(_BERLIN)
+    return f"{local.day:02d}.{local.month:02d}. {local.hour:02d}:{local.minute:02d}"
+
+
+def _thread_title(
+    summary_or_detail: dict[str, object], current_employee_id: str
+) -> str:
+    thread = _as_dict(summary_or_detail.get("thread", summary_or_detail))
+    if thread.get("thread_type") == "GROUP":
+        title = str(thread.get("title") or "").strip()
+        return title or "Gruppenchat"
+    participants = _as_list(summary_or_detail.get("participants"))
+    for participant in participants:
+        if str(participant.get("employee_id")) != current_employee_id:
+            return str(participant.get("display_name") or "Direktchat")
+    return "Direktchat"
+
+
+def _participants_line(participants: list[dict[str, object]]) -> str:
+    names = [str(participant.get("display_name") or "") for participant in participants]
+    return " · ".join(name for name in names if name)
+
+
+def _message_preview(summary: dict[str, object]) -> str:
+    preview = summary.get("latest_message_preview")
+    if not isinstance(preview, dict):
+        return "Noch keine Nachrichten."
+    body = str(preview.get("body") or "").strip()
+    return body or "Verknüpfte Karte"
+
+
+def _reference_href(reference_type: str, reference_id: str) -> str | None:
+    if reference_type == "ORDER":
+        return f"/order/{quote(reference_id, safe='')}"
+    if reference_type == "INQUIRY":
+        return f"/inquiry/{quote(reference_id, safe='')}"
+    return None
+
+
+def _reference_card(reference: dict[str, object]) -> str:
+    reference_type = str(reference.get("reference_type") or "")
+    reference_id = str(reference.get("reference_id") or "")
+    label = _REFERENCE_LABELS.get(reference_type, reference_type or "Bezug")
+    title = f"{label} {_short_id(reference_id)}"
+    href = _reference_href(reference_type, reference_id)
+    title_html = (
+        f'<a href="{_e(href)}">{_e(title)}</a>' if href is not None else _e(title)
+    )
+    return (
+        '<div class="chat-reference-row">'
+        f"<span>{title_html}</span>"
+        f'<span class="chat-reference-meta">{_e(reference_id)}</span>'
+        "</div>"
+    )
+
+
+def _summary_row(summary: dict[str, object], current_employee_id: str) -> str:
+    thread = _as_dict(summary["thread"])
+    thread_id = str(thread["thread_id"])
+    unread = _int_value(summary.get("unread_count"))
+    row_class = "chat-thread-row unread" if unread else "chat-thread-row"
+    badge = f'<span class="badge">{unread}</span>' if unread else ""
+    return (
+        f'<a class="{row_class}" href="/chat/{_e(quote(thread_id, safe=""))}">'
+        '<span class="chat-thread-head">'
+        f'<span class="chat-thread-title">{_e(_thread_title(summary, current_employee_id))}</span>'
+        f'<span class="chat-meta">{_e(_format_time(summary["last_activity_at"]))}</span>'
+        "</span>"
+        f'<span class="chat-preview">{_e(_message_preview(summary))}</span>'
+        f'<span class="chat-meta">{_e(_participants_line(_as_list(summary.get("participants"))))}{badge}</span>'
+        "</a>"
+    )
+
+
+def render_chat_list(
+    threads: list[dict[str, object]],
+    *,
+    search_results: list[dict[str, object]] | None = None,
+    q: str = "",
+    context: OfficePageContext,
+) -> str:
+    current_employee_id = context.employee_account_id
+    sorted_threads = sorted(
+        threads,
+        key=lambda row: str(row.get("last_activity_at") or ""),
+        reverse=True,
+    )
+    rows = "".join(_summary_row(row, current_employee_id) for row in sorted_threads)
+    if not rows:
+        rows = '<p class="chat-empty">Keine Nachrichten vorhanden.</p>'
+    search_rows = ""
+    if search_results is not None:
+        search_rows = "".join(
+            _summary_row(row, current_employee_id) for row in search_results
+        )
+        if not search_rows:
+            search_rows = '<p class="chat-empty">Keine Treffer gefunden.</p>'
+        search_rows = f'<h2>Suche</h2><div class="chat-thread-list">{search_rows}</div>'
+    secondary_panel = search_rows or '<p class="chat-empty">Suchbegriff eingeben.</p>'
+    body = (
+        '<div class="chat-toolbar">'
+        '<form method="get" action="/chat" class="searchbox">'
+        '<label for="chat-q">Nachrichten durchsuchen</label> '
+        f'<input id="chat-q" type="text" name="q" value="{_e(q)}">'
+        '<button type="submit">Suchen</button>'
+        + (' <a href="/chat">Zurücksetzen</a>' if q else "")
+        + "</form>"
+        + (
+            '<a class="dashboard-button" href="/chat/new">Neuer Chat</a>'
+            if context.can("chat.create")
+            else ""
+        )
+        + "</div>"
+        '<div class="chat-layout">'
+        f'<section class="chat-thread-list">{rows}</section>'
+        f'<section class="chat-panel">{secondary_panel}</section>'
+        "</div>"
+    )
+    return _page("Nachrichten", body, active_section="chat", context=context)
+
+
+def render_chat_new(
+    employees: list[dict[str, object]],
+    *,
+    q: str,
+    context: OfficePageContext,
+    command_fields: str,
+) -> str:
+    employee_rows = []
+    for employee in employees:
+        employee_id = str(employee["employee_id"])
+        if employee_id == context.employee_account_id:
+            continue
+        employee_rows.append(
+            '<label class="chat-picker-row">'
+            f"<span>{_e(employee['display_name'])}</span>"
+            f'<input type="checkbox" name="participant_employee_id" value="{_e(employee_id)}">'
+            "</label>"
+        )
+    picker = (
+        "".join(employee_rows)
+        or '<p class="chat-empty">Keine Mitarbeitenden gefunden.</p>'
+    )
+    body = (
+        '<p class="subtitle"><a href="/chat">← Zurück zu Nachrichten</a></p>'
+        '<div class="chat-create-grid">'
+        '<section class="chat-panel">'
+        '<form method="get" action="/chat/new" class="searchbox">'
+        '<label for="chat-employee-q">Mitarbeitende suchen</label> '
+        f'<input id="chat-employee-q" name="q" value="{_e(q)}">'
+        '<button type="submit">Suchen</button>'
+        "</form>"
+        f'<div class="chat-picker-list">{picker}</div>'
+        "</section>"
+        '<section class="chat-panel">'
+        '<form method="post" action="/chat/threads">'
+        f"{_csrf_input(context)}{command_fields}"
+        '<p><label for="thread-type">Typ</label><br>'
+        '<select id="thread-type" name="thread_type">'
+        '<option value="DIRECT">Direktchat</option>'
+        '<option value="GROUP">Gruppe</option>'
+        "</select></p>"
+        '<p><label for="chat-title">Gruppentitel</label><br>'
+        '<input id="chat-title" name="title"></p>'
+        f'<div class="chat-picker-list">{picker}</div>'
+        '<p><button type="submit">Chat erstellen</button></p>'
+        "</form>"
+        "</section></div>"
+    )
+    return _page("Neuer Chat", body, active_section="chat", context=context)
+
+
+def _reply_quote(messages: list[dict[str, object]], reply_to_message_id: str) -> str:
+    if not reply_to_message_id:
+        return ""
+    for message in messages:
+        if str(message.get("message_id")) == reply_to_message_id:
+            body = str(message.get("body") or "").strip() or "Verknüpfte Karte"
+            return (
+                '<div class="chat-reply-quote">'
+                f"Antwort auf {_e(message.get('author_display_name') or '')}: {_e(body[:160])}"
+                "</div>"
+            )
+    return ""
+
+
+def _message_block(
+    message: dict[str, object], messages: list[dict[str, object]]
+) -> str:
+    reply = _reply_quote(messages, str(message.get("reply_to_message_id") or ""))
+    body = str(message.get("body") or "")
+    mentions = _as_list(message.get("mentions"))
+    mention_line = (
+        '<p class="chat-meta">'
+        + " ".join(f"@{_e(item.get('display_name') or '')}" for item in mentions)
+        + "</p>"
+        if mentions
+        else ""
+    )
+    references = "".join(
+        _reference_card(ref) for ref in _as_list(message.get("references"))
+    )
+    reference_list = (
+        f'<div class="chat-reference-list">{references}</div>' if references else ""
+    )
+    thread_id = str(message.get("thread_id") or "")
+    message_id = str(message.get("message_id") or "")
+    return (
+        '<article class="chat-message">'
+        '<div class="chat-message-head">'
+        f'<span class="chat-message-author">{_e(message.get("author_display_name") or "")}</span>'
+        f'<span class="chat-meta">{_e(_format_time(message.get("created_at")))}</span>'
+        "</div>"
+        f"{reply}"
+        + (f'<p class="chat-message-body">{_e(body)}</p>' if body else "")
+        + mention_line
+        + reference_list
+        + f'<p class="chat-meta"><a href="/chat/{_e(quote(thread_id, safe=""))}?reply_to={_e(quote(message_id, safe=""))}">Antworten</a></p>'
+        "</article>"
+    )
+
+
+def _participant_picker(participants: list[dict[str, object]]) -> str:
+    rows = []
+    for participant in participants:
+        rows.append(
+            '<label class="chat-picker-row">'
+            f"<span>@{_e(participant.get('display_name') or '')}</span>"
+            f'<input type="checkbox" name="mention_employee_id" value="{_e(participant.get("employee_id") or "")}">'
+            "</label>"
+        )
+    return "".join(rows) or '<p class="chat-empty">Keine Teilnehmer gefunden.</p>'
+
+
+def _entity_picker(results: list[dict[str, object]]) -> str:
+    rows = []
+    for result in results:
+        value = f"{result.get('reference_type')}:{result.get('reference_id')}"
+        rows.append(
+            '<label class="chat-picker-row">'
+            "<span>"
+            f"<strong>{_e(result.get('primary_label') or '')}</strong><br>"
+            f'<span class="chat-reference-meta">{_e(result.get("secondary_label") or "")}</span>'
+            "</span>"
+            f'<input type="checkbox" name="reference" value="{_e(value)}">'
+            "</label>"
+        )
+    return "".join(rows) or '<p class="chat-empty">Keine Verknüpfung gefunden.</p>'
+
+
+def render_chat_detail(
+    detail: dict[str, object],
+    *,
+    context: OfficePageContext,
+    read_command_fields: str,
+    send_command_fields: str,
+    participant_results: list[dict[str, object]],
+    mention_q: str,
+    entity_results: list[dict[str, object]],
+    reference_q: str,
+    reference_type: str,
+    reply_to_message_id: str,
+) -> str:
+    thread = _as_dict(detail["thread"])
+    thread_id = str(thread["thread_id"])
+    participants = _as_list(detail.get("participants"))
+    messages = _as_list(detail.get("messages"))
+    message_rows = "".join(_message_block(message, messages) for message in messages)
+    if not message_rows:
+        message_rows = '<p class="chat-empty">Keine Nachrichten vorhanden.</p>'
+    last_message_id = str(messages[-1]["message_id"]) if messages else ""
+    read_form = (
+        '<form method="post" action="/chat/'
+        f'{_e(quote(thread_id, safe=""))}/read" class="inline">'
+        f"{_csrf_input(context)}{read_command_fields}"
+        f'<input type="hidden" name="last_read_message_id" value="{_e(last_message_id)}">'
+        '<button type="submit">Gelesen markieren</button></form>'
+        if last_message_id
+        else ""
+    )
+    query_base = f"/chat/{quote(thread_id, safe='')}"
+    mention_query = urlencode({"mention_q": mention_q})
+    reference_query = urlencode(
+        {"reference_q": reference_q, "reference_type": reference_type}
+    )
+    reply_hidden = (
+        f'<input type="hidden" name="reply_to_message_id" value="{_e(reply_to_message_id)}">'
+        if reply_to_message_id
+        else ""
+    )
+    body = (
+        '<p class="subtitle"><a href="/chat">← Zurück zu Nachrichten</a></p>'
+        '<div class="chat-toolbar">'
+        f"<div><strong>{_e(_thread_title(detail, context.employee_account_id))}</strong>"
+        f'<div class="chat-participants">{_e(_participants_line(participants))}</div></div>'
+        f"{read_form}"
+        "</div>"
+        '<section class="chat-thread-view">'
+        f"{message_rows}</section>"
+        '<section class="chat-composer">'
+        f"{_reply_quote(messages, reply_to_message_id)}"
+        f'<form method="post" action="/chat/{_e(quote(thread_id, safe=""))}/messages">'
+        f"{_csrf_input(context)}{send_command_fields}{reply_hidden}"
+        '<p><label for="chat-body">Nachricht</label><br>'
+        '<textarea id="chat-body" name="body"></textarea></p>'
+        "<details><summary>@</summary>"
+        f'<p><a href="{_e(query_base + ("?" + mention_query if mention_q else ""))}">Teilnehmer aktualisieren</a></p>'
+        f"{_participant_picker(participant_results)}"
+        "</details>"
+        "<details><summary>+ Verknüpfen</summary>"
+        '<p><label for="reference-type">Typ</label><br>'
+        f'<select id="reference-type" name="reference_type"><option value="ORDER"{" selected" if reference_type == "ORDER" else ""}>Auftrag</option><option value="INQUIRY"{" selected" if reference_type == "INQUIRY" else ""}>Anfrage</option><option value="CONTACT"{" selected" if reference_type == "CONTACT" else ""}>Kontakt</option></select></p>'
+        f'<p><a href="{_e(query_base + ("?" + reference_query if reference_q else ""))}">Verknüpfungen suchen</a></p>'
+        f"{_entity_picker(entity_results)}"
+        "</details>"
+        '<div class="chat-composer-actions"><button type="submit">Senden</button></div>'
+        "</form>"
+        '<form method="get" action="'
+        f'{_e(query_base)}" class="searchbox">'
+        '<label for="mention-q">Teilnehmer suchen</label> '
+        f'<input id="mention-q" name="mention_q" value="{_e(mention_q)}">'
+        '<button type="submit">@</button></form>'
+        '<form method="get" action="'
+        f'{_e(query_base)}" class="searchbox">'
+        '<label for="reference-q">Verknüpfung suchen</label> '
+        f'<input id="reference-q" name="reference_q" value="{_e(reference_q)}">'
+        f'<select name="reference_type"><option value="ORDER"{" selected" if reference_type == "ORDER" else ""}>Auftrag</option><option value="INQUIRY"{" selected" if reference_type == "INQUIRY" else ""}>Anfrage</option><option value="CONTACT"{" selected" if reference_type == "CONTACT" else ""}>Kontakt</option></select>'
+        '<button type="submit">Suchen</button></form>'
+        "</section>"
+    )
+    return _page(
+        _thread_title(detail, context.employee_account_id),
+        body,
+        active_section="chat",
+        context=context,
+    )

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -1382,7 +1382,7 @@ def make_office_panel_handler(
                 reference_type = query.get("reference_type", ["ORDER"])[0]
                 if reference_type not in {"ORDER", "INQUIRY", "CONTACT"}:
                     reference_type = "ORDER"
-                detail = remote.get_chat_thread(
+                chat_detail = remote.get_chat_thread(
                     thread_id,
                     employee_session_token=session_token,
                 )
@@ -1402,7 +1402,7 @@ def make_office_panel_handler(
                 )
                 self._html(
                     render_chat_detail(
-                        detail,
+                        chat_detail,
                         context=self._page_context(auth, rueckruf_count=None),
                         read_command_fields=panel._command_fields(),
                         send_command_fields=panel._command_fields(),

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -116,6 +116,11 @@ from catering_system.ui.office_panel_authz import (
     require_business_permission,
     require_business_permission_post,
 )
+from catering_system.ui.office_panel_chat import (
+    render_chat_detail,
+    render_chat_list,
+    render_chat_new,
+)
 from catering_system.ui.office_panel_settings_users import (
     SettingsUsersAccessDenied,
     parse_selected_permissions,
@@ -147,6 +152,11 @@ _ROLE_LABELS = {
     "USER": "Benutzer",
     "VIEWER": "Leser",
 }
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) else 0
+
 
 _INQUIRY_COMMAND_ERROR_LABELS: dict[str, str] = {
     "conversion_blocked": (
@@ -547,6 +557,7 @@ def make_office_panel_handler(
             auth: OfficePanelRequestAuth | None = None,
             *,
             rueckruf_count: int | None | object = _RUECKRUF_COUNT_UNSET,
+            chat_unread_count: int | None | object = _RUECKRUF_COUNT_UNSET,
         ) -> OfficePageContext:
             if auth is None:
                 auth = getattr(self, "_request_auth", None)
@@ -599,7 +610,33 @@ def make_office_panel_handler(
                     and not auth.legacy_shared_access
                     else ""
                 ),
+                chat_unread_count=(
+                    self._chat_unread_count(auth)
+                    if chat_unread_count is _RUECKRUF_COUNT_UNSET
+                    else chat_unread_count
+                    if isinstance(chat_unread_count, int) or chat_unread_count is None
+                    else None
+                ),
             )
+
+        def _chat_unread_count(self, auth: OfficePanelRequestAuth | None) -> int | None:
+            if (
+                remote is None
+                or auth is None
+                or auth.kind != "employee"
+                or auth.employee is None
+                or auth.legacy_shared_access
+                or "chat.view" not in auth.employee.effective_permissions
+            ):
+                return None
+            session_token = session_token_from_headers(self.headers)
+            if session_token is None:
+                return None
+            try:
+                threads = remote.list_chat_threads(employee_session_token=session_token)
+            except RemoteCoreError:
+                return None
+            return sum(_int_value(thread.get("unread_count")) for thread in threads)
 
         def _require_settings_users_actor(
             self, auth: OfficePanelRequestAuth | None
@@ -696,6 +733,8 @@ def make_office_panel_handler(
                 return "orders"
             if parts == ["rueckruf"] or parts == ["rueckruf", "resolve"]:
                 return "callbacks"
+            if parts and parts[0] == "chat":
+                return "chat"
             if parts == ["gerichte", "new"] or (
                 len(parts) >= 2 and parts[0] == "gerichte"
             ):
@@ -762,6 +801,12 @@ def make_office_panel_handler(
                 return ("documents.send",)
             if parts == ["rueckruf", "resolve"]:
                 return ("queue.resolve",)
+            if parts == ["chat", "threads"]:
+                return ("chat.create",)
+            if len(parts) == 3 and parts[0] == "chat" and parts[2] == "messages":
+                return ("chat.send",)
+            if len(parts) == 3 and parts[0] == "chat" and parts[2] == "read":
+                return ("chat.view",)
             if parts == ["gerichte", "new"]:
                 return ("catalog.edit", "prices.edit")
             if len(parts) == 3 and parts[0] == "gerichte":
@@ -908,6 +953,24 @@ def make_office_panel_handler(
                 ),
                 status,
             )
+
+        def _chat_employee_session_or_forbidden(
+            self, auth: OfficePanelRequestAuth | None
+        ) -> str | None:
+            if (
+                remote is None
+                or auth is None
+                or auth.kind != "employee"
+                or auth.employee is None
+                or auth.legacy_shared_access
+            ):
+                self._business_forbidden(active_section="chat")
+                return None
+            session_token = session_token_from_headers(self.headers)
+            if session_token is None:
+                self._business_forbidden(active_section="chat")
+                return None
+            return session_token
 
         def _remote_error_page(self, exc: RemoteCoreError) -> None:
             """Pack §6.5 degradation: an unreachable/malformed Core Office API
@@ -1123,6 +1186,64 @@ def make_office_panel_handler(
                     return
                 context = self._page_context()
                 self._html(panel.render_email(context=context))
+            elif parts == ["chat"]:
+                if not self._require_business_permission_get(
+                    auth, "chat.view", active_section="chat"
+                ):
+                    return
+                session_token = self._chat_employee_session_or_forbidden(auth)
+                if session_token is None:
+                    return
+                assert remote is not None
+                query = parse_qs(parsed.query)
+                search_query = query.get("q", [""])[0].strip()
+                threads = remote.list_chat_threads(employee_session_token=session_token)
+                search_results = (
+                    remote.search_chat(
+                        employee_session_token=session_token,
+                        q=search_query,
+                    )
+                    if search_query
+                    else None
+                )
+                context = self._page_context(
+                    auth,
+                    rueckruf_count=None,
+                    chat_unread_count=sum(
+                        _int_value(thread.get("unread_count")) for thread in threads
+                    ),
+                )
+                self._html(
+                    render_chat_list(
+                        threads,
+                        search_results=search_results,
+                        q=search_query,
+                        context=context,
+                    )
+                )
+            elif parts == ["chat", "new"]:
+                if not self._require_business_permission_get(
+                    auth, "chat.create", active_section="chat"
+                ):
+                    return
+                session_token = self._chat_employee_session_or_forbidden(auth)
+                if session_token is None:
+                    return
+                assert remote is not None
+                query = parse_qs(parsed.query)
+                search_query = query.get("q", [""])[0].strip()
+                employees = remote.search_chat_employees(
+                    employee_session_token=session_token,
+                    q=search_query,
+                )
+                self._html(
+                    render_chat_new(
+                        employees,
+                        q=search_query,
+                        context=self._page_context(auth, rueckruf_count=None),
+                        command_fields=panel._command_fields(),
+                    )
+                )
             elif parts == ["aufgaben"]:
                 if not self._require_business_permission_get(
                     auth, "queue.view", active_section="tasks"
@@ -1245,6 +1366,54 @@ def make_office_panel_handler(
                 context = self._page_context()
                 page = panel.render_email_detail(parts[1], context=context)
                 self._html(page) if page else self.send_error(404)
+            elif len(parts) == 2 and parts[0] == "chat":
+                if not self._require_business_permission_get(
+                    auth, "chat.view", active_section="chat"
+                ):
+                    return
+                session_token = self._chat_employee_session_or_forbidden(auth)
+                if session_token is None:
+                    return
+                assert remote is not None
+                query = parse_qs(parsed.query)
+                thread_id = unquote(parts[1])
+                mention_q = query.get("mention_q", [""])[0].strip()
+                reference_q = query.get("reference_q", [""])[0].strip()
+                reference_type = query.get("reference_type", ["ORDER"])[0]
+                if reference_type not in {"ORDER", "INQUIRY", "CONTACT"}:
+                    reference_type = "ORDER"
+                detail = remote.get_chat_thread(
+                    thread_id,
+                    employee_session_token=session_token,
+                )
+                participant_results = remote.autocomplete_chat_participants(
+                    thread_id,
+                    employee_session_token=session_token,
+                    q=mention_q,
+                )
+                entity_results = (
+                    remote.search_chat_entities(
+                        employee_session_token=session_token,
+                        q=reference_q,
+                        reference_type=reference_type,
+                    )
+                    if reference_q
+                    else []
+                )
+                self._html(
+                    render_chat_detail(
+                        detail,
+                        context=self._page_context(auth, rueckruf_count=None),
+                        read_command_fields=panel._command_fields(),
+                        send_command_fields=panel._command_fields(),
+                        participant_results=participant_results,
+                        mention_q=mention_q,
+                        entity_results=entity_results,
+                        reference_q=reference_q,
+                        reference_type=reference_type,
+                        reply_to_message_id=query.get("reply_to", [""])[0],
+                    )
+                )
             elif len(parts) == 3 and parts[0] == "order" and parts[2] == "print":
                 if not self._require_business_permission_get(
                     auth, "orders.view", active_section="orders"
@@ -1688,6 +1857,12 @@ def make_office_panel_handler(
                     call_id,
                 )
                 self._redirect("/rueckruf")
+            elif parts == ["chat", "threads"]:
+                self._create_chat_thread(auth)
+            elif len(parts) == 3 and parts[0] == "chat" and parts[2] == "messages":
+                self._send_chat_message(auth, unquote(parts[1]))
+            elif len(parts) == 3 and parts[0] == "chat" and parts[2] == "read":
+                self._mark_chat_read(auth, unquote(parts[1]))
             elif parts == ["gerichte", "new"]:
                 self._create_catalog_dish()
             elif len(parts) == 3 and parts[0] == "gerichte" and parts[2] == "update":
@@ -1769,6 +1944,66 @@ def make_office_panel_handler(
                 self._settings_users_reset_password(auth, unquote(parts[2]))
             else:
                 self.send_error(404)
+
+        def _create_chat_thread(self, auth: OfficePanelRequestAuth | None) -> None:
+            session_token = self._chat_employee_session_or_forbidden(auth)
+            if session_token is None:
+                return
+            assert remote is not None
+            form = self._form()
+            thread = remote.create_chat_thread(
+                employee_session_token=session_token,
+                thread_type=form.get("thread_type", ""),
+                participant_employee_ids=self._form_list("participant_employee_id"),
+                title=form.get("title") or None,
+                command_id=form.get("_command_id") or None,
+            )
+            self._redirect(f"/chat/{quote(str(thread['thread_id']), safe='')}")
+
+        def _send_chat_message(
+            self, auth: OfficePanelRequestAuth | None, thread_id: str
+        ) -> None:
+            session_token = self._chat_employee_session_or_forbidden(auth)
+            if session_token is None:
+                return
+            assert remote is not None
+            form = self._form()
+            references = []
+            for raw in self._form_list("reference"):
+                reference_type, separator, reference_id = raw.partition(":")
+                if separator:
+                    references.append(
+                        {
+                            "reference_type": reference_type,
+                            "reference_id": reference_id,
+                        }
+                    )
+            remote.send_chat_message(
+                thread_id,
+                employee_session_token=session_token,
+                body=form.get("body", ""),
+                reply_to_message_id=form.get("reply_to_message_id") or None,
+                mention_employee_ids=self._form_list("mention_employee_id"),
+                references=references,
+                command_id=form.get("_command_id") or None,
+            )
+            self._redirect(f"/chat/{quote(thread_id, safe='')}")
+
+        def _mark_chat_read(
+            self, auth: OfficePanelRequestAuth | None, thread_id: str
+        ) -> None:
+            session_token = self._chat_employee_session_or_forbidden(auth)
+            if session_token is None:
+                return
+            assert remote is not None
+            form = self._form()
+            remote.mark_chat_thread_read(
+                thread_id,
+                employee_session_token=session_token,
+                last_read_message_id=form.get("last_read_message_id") or None,
+                command_id=form.get("_command_id") or None,
+            )
+            self._redirect(f"/chat/{quote(thread_id, safe='')}")
 
         def _settings_users_create(self, auth: OfficePanelRequestAuth | None) -> None:
             actor = self._settings_users_actor_or_forbidden(auth)

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -16,6 +16,7 @@ OfficeSection = Literal[
     "week",
     "callbacks",
     "catalog",
+    "chat",
     "settings",
 ]
 
@@ -54,6 +55,9 @@ stroke-linejoin="round"><path d="M7 8V3h10v5M7 17H4v-6a1 1 0 0 1 1-1h14a1 1 0
 stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
 stroke-linejoin="round"><path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5
 -9 2.5 2.5 5-5"/></symbol>
+<symbol id="office-i-chat" viewBox="0 0 24 24" fill="none"
+stroke="currentColor" stroke-width="1.8" stroke-linecap="round"
+stroke-linejoin="round"><path d="M4 5h16v11H8l-4 4V5Z"/><path d="M8 9h8M8 13h5"/></symbol>
 </svg>"""
 
 OFFICE_PANEL_STYLE = """
@@ -1468,6 +1472,113 @@ button.office-account-link:hover {
   color: #fff;
   background: var(--danger);
 }
+.chat-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, .8fr) minmax(0, 1.6fr);
+  gap: 18px;
+  align-items: start;
+}
+.chat-panel,
+.chat-thread-list,
+.chat-thread-view,
+.chat-composer {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.chat-panel { padding: 16px; }
+.chat-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.chat-thread-list { overflow: hidden; }
+.chat-thread-row {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+  color: inherit;
+  text-decoration: none;
+}
+.chat-thread-row:last-child { border-bottom: 0; }
+.chat-thread-row:hover { background: var(--canvas); }
+.chat-thread-row.unread {
+  background: var(--accent-soft);
+  font-weight: 720;
+}
+.chat-thread-head,
+.chat-message-head,
+.chat-reference-row,
+.chat-picker-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.chat-thread-title,
+.chat-message-author { font-weight: 760; }
+.chat-meta,
+.chat-preview,
+.chat-empty,
+.chat-reference-meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+.chat-thread-view { padding: 18px; }
+.chat-participants { margin-bottom: 16px; color: var(--muted); }
+.chat-message {
+  padding: 13px 0;
+  border-top: 1px solid var(--line);
+}
+.chat-message:first-of-type { border-top: 0; }
+.chat-message-body {
+  margin: 7px 0 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.chat-reply-quote {
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-left: 3px solid var(--accent);
+  color: var(--muted);
+  background: var(--canvas);
+  font-size: 12px;
+}
+.chat-reference-list,
+.chat-picker-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+.chat-reference-row,
+.chat-picker-row {
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--canvas);
+}
+.chat-composer {
+  margin-top: 18px;
+  padding: 16px;
+}
+.chat-composer textarea { width: 100%; min-height: 96px; }
+.chat-composer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+.chat-create-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
 @media (max-width: 820px) {
   .office-app { display: block; }
   .office-sidebar {
@@ -1520,6 +1631,7 @@ button.office-account-link:hover {
   .order-detail-layout { grid-template-columns: 1fr; }
   .order-detail-side { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .order-next-step { grid-column: 1 / -1; }
+  .chat-layout { grid-template-columns: 1fr; }
 }
 @media (max-width: 620px) {
   .office-content > h1 { font-size: 28px; }

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -127,6 +127,7 @@ class OfficePageContext:
     show_users_nav: bool = False
     employee_effective_permissions: frozenset[str] = frozenset()
     employee_account_id: str = ""
+    chat_unread_count: int | None = None
 
     def can(self, permission_code: str) -> bool:
         if permission_code not in PERMISSION_SET:
@@ -196,6 +197,17 @@ def _page(
         )
     if _nav_visible(context, "inquiries.view"):
         vertrieb.append(_nav_link("/emails", "E-Mail", "doc", "email", active_section))
+    if _nav_visible(context, "chat.view"):
+        vertrieb.append(
+            _nav_link(
+                "/chat",
+                "Nachrichten",
+                "chat",
+                "chat",
+                active_section,
+                badge=context.chat_unread_count,
+            )
+        )
     if _nav_visible(context, "queue.view"):
         vertrieb.append(
             _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section)

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -257,6 +257,7 @@ def test_v2_shell_is_local_no_js_and_has_complete_inline_icon_sprite() -> None:
         "office-i-users",
         "office-i-printer",
         "office-i-check",
+        "office-i-chat",
     }
     assert all(body.count(f'<symbol id="{symbol}"') == 1 for symbol in symbols)
 

--- a/tests/unit/test_office_panel_chat.py
+++ b/tests/unit/test_office_panel_chat.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import queue
+import re
+import sqlite3
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.repositories.sqlite_employee_auth_repository import (
+    SQLiteEmployeeAuthRepository,
+)
+from catering_system.services.employee_auth_service import EmployeeAuthService
+from catering_system.ui.employee_auth_http import CSRF_COOKIE_NAME, SESSION_COOKIE_NAME
+from catering_system.ui.office_api import create_office_api_server
+from catering_system.ui.office_panel import create_office_panel_server
+from catering_system.ui.remote_core_client import RemoteCoreClient
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+
+_API_TOKEN = "test-office-api-token"
+_NOW = datetime(2026, 8, 10, 8, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class PanelChatWorld:
+    panel_base: str
+    api_base: str
+    api_server: HTTPServer
+    api_thread: threading.Thread
+    panel_server: HTTPServer
+    panel_thread: threading.Thread
+    client: RemoteCoreClient
+    viktor_id: str
+    viktor_session: str
+    viktor_csrf: str
+    anna_id: str
+    anna_session: str
+
+
+def _run_server(factory) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        server = factory()
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host!s}:{int(port)}"
+
+
+def _seed_auth(db: Path) -> dict[str, str]:
+    repo = SQLiteEmployeeAuthRepository(db)
+    service = EmployeeAuthService(repo, now=lambda: _NOW)
+    service.bootstrap_superadmin(
+        username="chat.admin",
+        display_name="Chat Admin",
+        password="TempPassw0rd!",
+    )
+    first = service.authenticate(username="chat.admin", password="TempPassw0rd!")
+    service.change_password(
+        service.authenticate_session(first.session_token),
+        current_password="TempPassw0rd!",
+        new_password="ChangedPassw0rd!",
+    )
+    admin = service.authenticate(username="chat.admin", password="ChangedPassw0rd!")
+    actor = service.authenticate_session(admin.session_token)
+    viktor = service.create_account(
+        actor,
+        username="chat.viktor",
+        display_name="Viktor",
+        password="ViktorPassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    anna = service.create_account(
+        actor,
+        username="chat.anna",
+        display_name="Anna",
+        password="AnnaPassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    inactive = service.create_account(
+        actor,
+        username="chat.inactive",
+        display_name="Inactive Chat User",
+        password="InactivePassw0rd!",
+        role="USER",
+        must_change_password=False,
+    )
+    service.deactivate_account(actor, inactive.id)
+    viktor_login = service.authenticate(
+        username="chat.viktor", password="ViktorPassw0rd!"
+    )
+    anna_login = service.authenticate(username="chat.anna", password="AnnaPassw0rd!")
+    return {
+        "viktor_id": viktor.id,
+        "viktor_session": viktor_login.session_token,
+        "viktor_csrf": viktor_login.csrf_token,
+        "anna_id": anna.id,
+        "anna_session": anna_login.session_token,
+    }
+
+
+@pytest.fixture()
+def chat_panel_world(tmp_path: Path):
+    db = tmp_path / "chat-panel.db"
+    ids = _seed_auth(db)
+    api_server, api_thread, api_base = _run_server(
+        lambda: create_office_api_server(
+            str(db),
+            _API_TOKEN,
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+            employee_auth_now=lambda: _NOW,
+        )
+    )
+    remote = RemoteCoreClient(api_base, _API_TOKEN)
+    panel_connection = sqlite3.connect(str(db), check_same_thread=False)
+    panel_auth = EmployeeAuthService(
+        SQLiteEmployeeAuthRepository.from_connection(panel_connection),
+        now=lambda: _NOW,
+    )
+    panel_server, panel_thread, panel_base = _run_server(
+        lambda: create_office_panel_server(
+            InMemoryInquiryRepository(),
+            InMemoryOrderRepository(),
+            "shared-office-password",
+            host="127.0.0.1",
+            port=0,
+            remote=remote,
+            auth_mode="employee",
+            auth_service=panel_auth,
+            secure_cookie=False,
+            ui_version="v2",
+        )
+    )
+    yield PanelChatWorld(
+        panel_base=panel_base,
+        api_base=api_base,
+        api_server=api_server,
+        api_thread=api_thread,
+        panel_server=panel_server,
+        panel_thread=panel_thread,
+        client=remote,
+        **ids,
+    )
+    for server, thread in (
+        (panel_server, panel_thread),
+        (api_server, api_thread),
+    ):
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    panel_connection.close()
+
+
+def _cookie(world: PanelChatWorld) -> str:
+    return (
+        f"{SESSION_COOKIE_NAME}={world.viktor_session}; "
+        f"{CSRF_COOKIE_NAME}={world.viktor_csrf}"
+    )
+
+
+def _request(
+    world: PanelChatWorld,
+    path: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | list[tuple[str, str]] | None = None,
+) -> tuple[int, str, str]:
+    body = None
+    if data is not None:
+        body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(
+        f"{world.panel_base}{path}",
+        data=body,
+        method=method,
+        headers={"Cookie": _cookie(world)},
+    )
+    if data is not None:
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, resp.geturl(), resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.geturl(), exc.read().decode("utf-8")
+
+
+def _hidden(html: str, name: str) -> str:
+    match = re.search(rf'name="{re.escape(name)}" value="([^"]*)"', html)
+    assert match, f"missing hidden field {name}"
+    return match.group(1)
+
+
+def test_chat_nav_list_badge_and_search_use_remote_client(
+    chat_panel_world: PanelChatWorld,
+) -> None:
+    thread = chat_panel_world.client.create_chat_thread(
+        employee_session_token=chat_panel_world.viktor_session,
+        thread_type="DIRECT",
+        participant_employee_ids=[chat_panel_world.anna_id],
+    )
+    chat_panel_world.client.send_chat_message(
+        str(thread["thread_id"]),
+        employee_session_token=chat_panel_world.anna_session,
+        body="Bitte Angebot prüfen",
+    )
+
+    status, _url, html = _request(chat_panel_world, "/chat?q=Angebot")
+
+    assert status == 200
+    assert "Nachrichten" in html
+    assert "Anna" in html
+    assert "Bitte Angebot prüfen" in html
+    assert '<span class="badge">1</span>' in html
+    assert "Suchbegriff eingeben." not in html
+
+
+def test_chat_detail_get_does_not_mark_read_but_explicit_post_does(
+    chat_panel_world: PanelChatWorld,
+) -> None:
+    thread = chat_panel_world.client.create_chat_thread(
+        employee_session_token=chat_panel_world.viktor_session,
+        thread_type="DIRECT",
+        participant_employee_ids=[chat_panel_world.anna_id],
+    )
+    message = chat_panel_world.client.send_chat_message(
+        str(thread["thread_id"]),
+        employee_session_token=chat_panel_world.anna_session,
+        body="Neue Nachricht",
+    )
+
+    status, _url, html = _request(chat_panel_world, f"/chat/{thread['thread_id']}")
+    unread_after_get = chat_panel_world.client.list_chat_threads(
+        employee_session_token=chat_panel_world.viktor_session
+    )[0]["unread_count"]
+
+    assert status == 200
+    assert "Gelesen markieren" in html
+    assert unread_after_get == 1
+
+    status, url, _html = _request(
+        chat_panel_world,
+        f"/chat/{thread['thread_id']}/read",
+        method="POST",
+        data={
+            "_csrf_token": chat_panel_world.viktor_csrf,
+            "_command_id": _hidden(html, "_command_id"),
+            "last_read_message_id": str(message["message_id"]),
+        },
+    )
+    unread_after_post = chat_panel_world.client.list_chat_threads(
+        employee_session_token=chat_panel_world.viktor_session
+    )[0]["unread_count"]
+
+    assert status == 200
+    assert url.endswith(f"/chat/{thread['thread_id']}")
+    assert unread_after_post == 0
+
+
+def test_chat_create_uses_minimal_employee_picker_and_no_sensitive_fields(
+    chat_panel_world: PanelChatWorld,
+) -> None:
+    status, _url, html = _request(chat_panel_world, "/chat/new?q=Anna")
+
+    assert status == 200
+    assert "Anna" in html
+    assert "chat.anna" not in html
+    assert "role" not in html.lower()
+    assert "permission" not in html.lower()
+    assert "Inactive Chat User" not in html
+
+    status, url, _html = _request(
+        chat_panel_world,
+        "/chat/threads",
+        method="POST",
+        data=[
+            ("_csrf_token", chat_panel_world.viktor_csrf),
+            ("_command_id", _hidden(html, "_command_id")),
+            ("thread_type", "DIRECT"),
+            ("participant_employee_id", chat_panel_world.anna_id),
+            ("title", ""),
+        ],
+    )
+
+    assert status == 200
+    assert "/chat/" in url
+
+
+def test_chat_send_form_has_no_actor_field_and_uses_session_identity(
+    chat_panel_world: PanelChatWorld,
+) -> None:
+    thread = chat_panel_world.client.create_chat_thread(
+        employee_session_token=chat_panel_world.viktor_session,
+        thread_type="DIRECT",
+        participant_employee_ids=[chat_panel_world.anna_id],
+    )
+    status, _url, html = _request(
+        chat_panel_world,
+        f"/chat/{thread['thread_id']}?mention_q=Anna",
+    )
+
+    assert status == 200
+    assert 'name="author_employee_id"' not in html
+    assert 'name="actor_employee_id"' not in html
+    assert 'name="employee_id"' not in html
+
+    status, _url, _html = _request(
+        chat_panel_world,
+        f"/chat/{thread['thread_id']}/messages",
+        method="POST",
+        data=[
+            ("_csrf_token", chat_panel_world.viktor_csrf),
+            ("_command_id", _hidden(html, "_command_id")),
+            ("body", "@Anna erledigt"),
+            ("mention_employee_id", chat_panel_world.anna_id),
+        ],
+    )
+    detail = chat_panel_world.client.get_chat_thread(
+        str(thread["thread_id"]),
+        employee_session_token=chat_panel_world.viktor_session,
+    )
+    messages = detail["messages"]
+
+    assert status == 200
+    assert messages[-1]["author_employee_id"] == chat_panel_world.viktor_id
+    assert messages[-1]["mentions"][0]["employee_id"] == chat_panel_world.anna_id


### PR DESCRIPTION
## Summary
- add Office Panel UI for internal employee chat
- add unread navigation badge and last-activity conversation ordering
- support DIRECT/GROUP creation, replies and structured mentions
- support structured Auftrag/Anfrage/Kontakt references
- add chat search and explicit read marking
- add focused Office Panel chat regression tests

## Scope
Office Panel UI only. No customer chat, push notifications or realtime polling.

## Validation
- focused chat/panel suite: 104 passed
- ruff format: pass
- focused ruff check: pass
- git diff --check: pass