### PR TITLE
fix: keep new chat picker inside create form

### DIFF
--- a/src/catering_system/ui/office_panel_chat.py
+++ b/src/catering_system/ui/office_panel_chat.py
@@ -197,7 +197,6 @@ def render_chat_new(
         f'<input id="chat-employee-q" name="q" value="{_e(q)}">'
         '<button type="submit">Suchen</button>'
         "</form>"
-        f'<div class="chat-picker-list">{picker}</div>'
         "</section>"
         '<section class="chat-panel">'
         '<form method="post" action="/chat/threads">'

--- a/tests/unit/test_office_panel_chat.py
+++ b/tests/unit/test_office_panel_chat.py
@@ -211,6 +211,16 @@ def _hidden(html: str, name: str) -> str:
     return match.group(1)
 
 
+def _form(html: str, *, method: str, action: str) -> str:
+    match = re.search(
+        rf'<form[^>]*method="{re.escape(method)}"[^>]*action="{re.escape(action)}"[^>]*>.*?</form>',
+        html,
+        flags=re.DOTALL,
+    )
+    assert match, f"missing {method} form {action}"
+    return match.group(0)
+
+
 def test_chat_nav_list_badge_and_search_use_remote_client(
     chat_panel_world: PanelChatWorld,
 ) -> None:
@@ -288,6 +298,13 @@ def test_chat_create_uses_minimal_employee_picker_and_no_sensitive_fields(
     assert "role" not in html.lower()
     assert "permission" not in html.lower()
     assert "Inactive Chat User" not in html
+    assert html.count('name="participant_employee_id"') == 1
+
+    search_form = _form(html, method="get", action="/chat/new")
+    create_form = _form(html, method="post", action="/chat/threads")
+    assert 'name="q"' in search_form
+    assert 'name="participant_employee_id"' not in search_form
+    assert 'name="participant_employee_id"' in create_form
 
     status, url, _html = _request(
         chat_panel_world,


### PR DESCRIPTION
## Summary
- remove the duplicate employee picker from the chat search section
- keep the only participant picker inside POST /chat/threads
- add regression coverage for picker/form ownership and employee search

## Validation
- focused chat/panel tests: 31 passed
- ruff check: pass
- ruff format --check: pass
- git diff --check: pass

Production deployment is not included.