### PR TITLE
feat: linkify www chat message urls

### DIFF
--- a/src/catering_system/ui/office_panel_chat.py
+++ b/src/catering_system/ui/office_panel_chat.py
@@ -20,7 +20,7 @@ _REFERENCE_LABELS = {
     "INQUIRY": "Anfrage",
     "CONTACT": "Kontakt",
 }
-_HTTP_URL_RE = re.compile(r"https?://[^\s<>'\"]+")
+_CHAT_URL_RE = re.compile(r"(?<![A-Za-z0-9@:/])(?:https?://|www\.)[^\s<>'\"]+")
 _TRAILING_URL_PUNCTUATION = ".,;:!?)"
 
 
@@ -82,7 +82,7 @@ def _message_preview(summary: dict[str, object]) -> str:
 def _linkify_message_body(body: str) -> str:
     parts: list[str] = []
     position = 0
-    for match in _HTTP_URL_RE.finditer(body):
+    for match in _CHAT_URL_RE.finditer(body):
         parts.append(_e(body[position : match.start()]))
         url = match.group(0)
         trailing = ""
@@ -90,9 +90,11 @@ def _linkify_message_body(body: str) -> str:
             trailing = url[-1] + trailing
             url = url[:-1]
         if url:
+            href = url if url.startswith(("http://", "https://")) else f"https://{url}"
+            escaped_href = _e(href)
             escaped_url = _e(url)
             parts.append(
-                f'<a href="{escaped_url}" target="_blank" rel="noopener noreferrer">'
+                f'<a href="{escaped_href}" target="_blank" rel="noopener noreferrer">'
                 f"{escaped_url}</a>"
             )
         parts.append(_e(trailing))

--- a/tests/unit/test_office_panel_chat.py
+++ b/tests/unit/test_office_panel_chat.py
@@ -277,6 +277,30 @@ def test_chat_message_body_linkifies_http_and_https_urls() -> None:
     ) in html
 
 
+def test_chat_message_body_linkifies_www_urls_with_https_href() -> None:
+    html = _render_message_body("Siehe (www.example.com), dann www.example.org/path.")
+
+    assert (
+        '(<a href="https://www.example.com" target="_blank" rel="noopener noreferrer">'
+        "www.example.com</a>),"
+    ) in html
+    assert (
+        '<a href="https://www.example.org/path" '
+        'target="_blank" rel="noopener noreferrer">'
+        "www.example.org/path</a>."
+    ) in html
+
+
+def test_chat_message_body_does_not_double_linkify_www_inside_http_urls() -> None:
+    https_html = _render_message_body("Visit https://www.example.com now")
+    http_html = _render_message_body("Visit http://www.example.com now")
+
+    assert https_html.count('target="_blank" rel="noopener noreferrer"') == 1
+    assert http_html.count('target="_blank" rel="noopener noreferrer"') == 1
+    assert 'href="https://www.example.com"' in https_html
+    assert 'href="http://www.example.com"' in http_html
+
+
 def test_chat_message_body_escapes_text_and_ignores_unsafe_schemes() -> None:
     html = _render_message_body(
         '5 < 7 & <script>alert("x")</script> javascript:alert(1) data:text/html,payload'


### PR DESCRIPTION
## Summary
- linkify plain www. URLs in internal chat messages
- preserve visible www. text while using https:// in href
- avoid double-linkifying http://www and https://www URLs
- preserve existing escaping and unsafe-scheme protections

## Validation
- focused chat/panel tests: 35 passed
- ruff check: pass
- ruff format --check: pass
- git diff --check: pass

No database, domain, API, or RemoteCoreClient changes.