### PR TITLE
Improve kitchen print readability and delivery context

### DIFF
--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -7,6 +7,8 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal, Protocol
 
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry import FulfillmentMode
 from catering_system.domain.offer import PositionQuantityMode
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_commercial_snapshot import (
@@ -14,8 +16,14 @@ from catering_system.domain.order_commercial_snapshot import (
     OrderCommercialPosition,
     OrderCommercialSnapshot,
 )
+from catering_system.domain.order_confirmation_document import (
+    OrderConfirmationDocumentSnapshot,
+)
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.order_confirmation_document_repository import (
+    OrderConfirmationDocumentRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
 
@@ -29,6 +37,13 @@ class PrintProjectionNotFoundError(LookupError):
 
 class PrintFinalRequiresEffectiveError(ValueError):
     """Final print intent requires the effective OrderVersion."""
+
+
+@dataclass(frozen=True)
+class PrintChangeLine:
+    label: str
+    before: str
+    after: str
 
 
 @dataclass(frozen=True)
@@ -47,6 +62,7 @@ class PrintEventBlock:
     is_effective: bool
     change_reason: str | None = None
     changed_fields: tuple[str, ...] = ()
+    change_lines: tuple[PrintChangeLine, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -68,7 +84,18 @@ class PrintCommercialBlock:
     offer_version_id: str | None = None
     accepted_variant_id: str | None = None
     variant_label: str | None = None
+    payment_method: str | None = None
+    gross_total_cents: int | None = None
     positions: tuple[PrintPositionLine, ...] = ()
+
+
+@dataclass(frozen=True)
+class PrintCustomerBlock:
+    company_name: str | None = None
+    contact_name: str | None = None
+    phone: str | None = None
+    delivery_address_lines: tuple[str, ...] = ()
+    fulfillment_mode: FulfillmentMode = "UNKNOWN"
 
 
 @dataclass(frozen=True)
@@ -85,6 +112,7 @@ class OrderPrintProjection:
     event: PrintEventBlock
     commercial: PrintCommercialBlock
     flags: PrintFlagsBlock
+    customer: PrintCustomerBlock = PrintCustomerBlock()
 
 
 class _QuantityDisplaySource(Protocol):
@@ -132,9 +160,12 @@ class OrderPrintProjectionService:
         self,
         order_repository: OrderRepository,
         commercial_snapshot_repository: OrderCommercialSnapshotRepository,
+        confirmation_document_repository: OrderConfirmationDocumentRepository
+        | None = None,
     ) -> None:
         self._orders = order_repository
         self._commercial_snapshots = commercial_snapshot_repository
+        self._confirmation_documents = confirmation_document_repository
 
     def resolve(
         self,
@@ -149,25 +180,61 @@ class OrderPrintProjectionService:
         version = self._orders.get_order_version(order_version_id)
         if version is None or version.order_id != order_id:
             raise PrintProjectionNotFoundError(order_version_id)
-        commercial = self._resolve_commercial(order, version)
+        confirmation_snapshot = self._resolve_confirmation_snapshot(order, version)
+        commercial = self._resolve_commercial(
+            order, version, confirmation_snapshot=confirmation_snapshot
+        )
         flags = self._resolve_flags(order, version, intent=intent)
         if intent == "final" and not flags.is_final_allowed:
             raise PrintFinalRequiresEffectiveError(
                 "final print requires the effective order version"
             )
         return OrderPrintProjection(
-            event=_event_block(order, version),
+            event=_event_block(
+                order,
+                version,
+                self._resolve_parent_version(version),
+            ),
             commercial=commercial,
             flags=flags,
+            customer=_customer_block(confirmation_snapshot),
         )
 
-    def _resolve_commercial(
+    def _resolve_confirmation_snapshot(
         self, order: Order, version: OrderVersion
+    ) -> OrderConfirmationDocumentSnapshot | None:
+        if self._confirmation_documents is None:
+            return None
+        snapshot = self._confirmation_documents.get_by_order_version_id(
+            version.order_version_id
+        )
+        if snapshot is None or snapshot.order_id != order.order_id:
+            return None
+        return snapshot
+
+    def _resolve_parent_version(self, version: OrderVersion) -> OrderVersion | None:
+        if version.parent_order_version_id is None:
+            return None
+        parent = self._orders.get_order_version(version.parent_order_version_id)
+        if parent is None or parent.order_id != version.order_id:
+            return None
+        return parent
+
+    def _resolve_commercial(
+        self,
+        order: Order,
+        version: OrderVersion,
+        *,
+        confirmation_snapshot: OrderConfirmationDocumentSnapshot | None = None,
     ) -> PrintCommercialBlock:
         snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
         if snapshot is None:
             raise MissingCommercialSnapshotError(order.order_id)
-        return _commercial_from_snapshot(snapshot, version.guest_count_estimate)
+        return _commercial_from_snapshot(
+            snapshot,
+            version.guest_count_estimate,
+            confirmation_snapshot=confirmation_snapshot,
+        )
 
     def _resolve_flags(
         self,
@@ -236,7 +303,9 @@ class OrderPrintProjectionService:
         return "ENTWURF"
 
 
-def _event_block(order: Order, version: OrderVersion) -> PrintEventBlock:
+def _event_block(
+    order: Order, version: OrderVersion, previous: OrderVersion | None = None
+) -> PrintEventBlock:
     return PrintEventBlock(
         order_id=order.order_id,
         order_version_id=version.order_version_id,
@@ -252,11 +321,15 @@ def _event_block(order: Order, version: OrderVersion) -> PrintEventBlock:
         is_effective=version.order_version_id == order.effective_order_version_id,
         change_reason=version.change_reason,
         changed_fields=version.changed_fields,
+        change_lines=_change_lines(previous, version),
     )
 
 
 def _commercial_from_snapshot(
-    snapshot: OrderCommercialSnapshot, guest_count_estimate: int | None
+    snapshot: OrderCommercialSnapshot,
+    guest_count_estimate: int | None,
+    *,
+    confirmation_snapshot: OrderConfirmationDocumentSnapshot | None = None,
 ) -> PrintCommercialBlock:
     return PrintCommercialBlock(
         source="offer_conversion",
@@ -264,6 +337,16 @@ def _commercial_from_snapshot(
         offer_version_id=snapshot.source_offer_version_id,
         accepted_variant_id=snapshot.source_variant_id,
         variant_label=snapshot.variant_label,
+        payment_method=(
+            confirmation_snapshot.payment_method
+            if confirmation_snapshot is not None
+            else snapshot.payment_method
+        ),
+        gross_total_cents=(
+            confirmation_snapshot.gross_total_cents
+            if confirmation_snapshot is not None
+            else None
+        ),
         positions=tuple(
             _position_line_from_snapshot(position, guest_count_estimate)
             for position in snapshot.positions
@@ -284,3 +367,78 @@ def _position_line_from_snapshot(
         quantity_display=format_quantity_display(position, guest_count_estimate),
         unit_label=position.unit_label,
     )
+
+
+def _customer_block(
+    snapshot: OrderConfirmationDocumentSnapshot | None,
+) -> PrintCustomerBlock:
+    if snapshot is None:
+        return PrintCustomerBlock()
+    return PrintCustomerBlock(
+        company_name=(snapshot.recipient_company or "").strip() or None,
+        contact_name=(snapshot.recipient_name or "").strip() or None,
+        phone=(snapshot.recipient_phone or "").strip() or None,
+        delivery_address_lines=_address_lines(snapshot.delivery_address),
+        fulfillment_mode=snapshot.fulfillment_mode or "UNKNOWN",
+    )
+
+
+def _address_lines(address: CustomerAddress | None) -> tuple[str, ...]:
+    if address is None:
+        return ()
+    city_line = " ".join(
+        part
+        for part in (
+            (address.postal_code or "").strip(),
+            (address.city or "").strip(),
+        )
+        if part
+    )
+    return tuple(
+        line
+        for line in (
+            (address.street or "").strip(),
+            city_line,
+            (address.country or "").strip(),
+        )
+        if line
+    )
+
+
+def _change_lines(
+    previous: OrderVersion | None, current: OrderVersion
+) -> tuple[PrintChangeLine, ...]:
+    if previous is None:
+        return ()
+    lines: list[PrintChangeLine] = []
+    _append_change(
+        lines,
+        "Datum",
+        previous.event_date.strftime("%d.%m.%Y"),
+        current.event_date.strftime("%d.%m.%Y"),
+    )
+    _append_change(
+        lines,
+        "Zeitfenster / Anlieferung",
+        previous.time_window_text,
+        current.time_window_text,
+    )
+    _append_change(lines, "Ort", previous.location_text, current.location_text)
+    _append_change(
+        lines,
+        "Gästezahl geändert",
+        _optional_int_text(previous.guest_count_estimate),
+        _optional_int_text(current.guest_count_estimate),
+    )
+    return tuple(lines)
+
+
+def _append_change(
+    lines: list[PrintChangeLine], label: str, before: str, after: str
+) -> None:
+    if before != after:
+        lines.append(PrintChangeLine(label=label, before=before, after=after))
+
+
+def _optional_int_text(value: int | None) -> str:
+    return str(value) if value is not None else "–"

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -770,6 +770,7 @@ class OfficeApi:
         self.print_projection_service = OrderPrintProjectionService(
             self.orders,
             self.commercial_snapshots,
+            self.confirmation_documents,
         )
         self.buffet_cards_service = BuffetCardsService(
             self.orders,

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -13,14 +13,16 @@ from __future__ import annotations
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
+from catering_system.domain.calendar_entry_projection import (
+    CALENDAR_ENTRY_KIND_LABELS,
+    CalendarEntryProjection,
+)
+from catering_system.domain.catalog import (
+    CatalogDish,
+    CatalogPriceHistoryEntry,
+    allergen_labels,
+)
 from catering_system.domain.contact_projection import ContactProjection
-from catering_system.domain.inquiry_contact_completeness import (
-    derive_inquiry_contact_completeness,
-    missing_contact_fields,
-)
-from catering_system.domain.inquiry_customer_snapshot import (
-    customer_snapshot_to_mapping,
-)
 from catering_system.domain.email_intake_projection import EmailIntakeProjection
 from catering_system.domain.inquiry import (
     Inquiry,
@@ -29,16 +31,13 @@ from catering_system.domain.inquiry import (
     derive_inquiry_offer_projection,
     derive_inquiry_office_state,
 )
-from catering_system.domain.calendar_entry_projection import (
-    CALENDAR_ENTRY_KIND_LABELS,
-    CalendarEntryProjection,
+from catering_system.domain.inquiry_contact_completeness import (
+    derive_inquiry_contact_completeness,
+    missing_contact_fields,
 )
-from catering_system.domain.offer_queue import (
-    OfferQueueItem,
-    OfferQueueSection,
-    OfferQueueSnapshot,
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_snapshot_to_mapping,
 )
-from catering_system.domain.task_projection import TaskProjection
 from catering_system.domain.offer import (
     Offer,
     OfferPosition,
@@ -46,20 +45,11 @@ from catering_system.domain.offer import (
     OfferVersion,
     derive_offer_state,
 )
-from catering_system.services.offer_budget_presentation import (
-    compute_offer_budget_presentation,
+from catering_system.domain.offer_queue import (
+    OfferQueueItem,
+    OfferQueueSection,
+    OfferQueueSnapshot,
 )
-from catering_system.services.order_print_projection_service import (
-    OrderPrintProjection,
-    PrintPositionLine,
-)
-from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
-from catering_system.domain.catalog import allergen_labels
-from catering_system.services.catalog_dish_service import (
-    AllergenCodeDefinition,
-    CatalogDishListResult,
-)
-from catering_system.domain.catalog import CatalogDish, CatalogPriceHistoryEntry
 from catering_system.domain.order import (
     Order,
     OrderVersion,
@@ -71,8 +61,17 @@ from catering_system.domain.order_operational_pause import (
 )
 from catering_system.domain.order_payment_reminder import PaymentReminderView
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
+from catering_system.domain.task_projection import TaskProjection
 from catering_system.domain.wochenuebersicht import Wochenuebersicht
 from catering_system.domain.work_center import WorkCenterSnapshot
+from catering_system.services.buffet_cards_service import BuffetCard, BuffetCardsView
+from catering_system.services.catalog_dish_service import (
+    AllergenCodeDefinition,
+    CatalogDishListResult,
+)
+from catering_system.services.offer_budget_presentation import (
+    compute_offer_budget_presentation,
+)
 from catering_system.services.order_confirmation_document_preview import (
     OrderConfirmationDocumentPreview,
     preview_to_json,
@@ -81,8 +80,11 @@ from catering_system.services.order_confirmation_document_service import (
     OrderConfirmationDocumentEligibility,
     OrderConfirmationDocumentSummary,
 )
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    PrintPositionLine,
+)
 from catering_system.ui.office_panel_offer_prefill import offer_prefill_payload
-
 
 BERLIN = ZoneInfo("Europe/Berlin")
 
@@ -1107,10 +1109,19 @@ def _print_position_line_shape(line: PrintPositionLine) -> dict[str, object]:
     }
 
 
+def _print_change_line_shape(line) -> dict[str, object]:
+    return {
+        "label": line.label,
+        "before": line.before,
+        "after": line.after,
+    }
+
+
 def order_print_projection_shape(projection: OrderPrintProjection) -> dict[str, object]:
     event = projection.event
     commercial = projection.commercial
     flags = projection.flags
+    customer = projection.customer
     return {
         "event": {
             "order_id": event.order_id,
@@ -1135,6 +1146,9 @@ def order_print_projection_shape(projection: OrderPrintProjection) -> dict[str, 
             "is_effective": event.is_effective,
             "change_reason": event.change_reason,
             "changed_fields": list(event.changed_fields),
+            "change_lines": [
+                _print_change_line_shape(line) for line in event.change_lines
+            ],
         },
         "commercial": {
             "source": commercial.source,
@@ -1142,9 +1156,18 @@ def order_print_projection_shape(projection: OrderPrintProjection) -> dict[str, 
             "offer_version_id": commercial.offer_version_id,
             "accepted_variant_id": commercial.accepted_variant_id,
             "variant_label": commercial.variant_label,
+            "payment_method": commercial.payment_method,
+            "gross_total_cents": commercial.gross_total_cents,
             "positions": [
                 _print_position_line_shape(line) for line in commercial.positions
             ],
+        },
+        "customer": {
+            "company_name": customer.company_name,
+            "contact_name": customer.contact_name,
+            "phone": customer.phone,
+            "delivery_address_lines": list(customer.delivery_address_lines),
+            "fulfillment_mode": customer.fulfillment_mode,
         },
         "flags": {
             "intent": flags.intent,

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -32,6 +32,9 @@ from catering_system.repositories.contact_profile_repository import (
     ContactProfileRepository,
 )
 from catering_system.repositories.inquiry_repository import InquiryRepository
+from catering_system.repositories.in_memory_order_confirmation_document_repository import (
+    InMemoryOrderConfirmationDocumentRepository,
+)
 from catering_system.repositories.kitchen_print_job_repository import (
     KitchenPrintJobRepository,
 )
@@ -399,6 +402,9 @@ def make_office_panel_handler(
             configurator_handoff_service = ConfiguratorHandoffService(
                 SQLiteConfiguratorHandoffRepository.from_connection(repository)
             )
+    local_confirmation_document_repo = (
+        confirmation_document_repo or InMemoryOrderConfirmationDocumentRepository()
+    )
     panel = OfficePanel(
         inquiry_repo,
         order_repo,
@@ -408,7 +414,7 @@ def make_office_panel_handler(
         remote=remote,
         command_executor=command_executor,
         payment_reminder_repo=payment_reminder_repo,
-        confirmation_document_repo=confirmation_document_repo,
+        confirmation_document_repo=local_confirmation_document_repo,
         confirmation_outbound_repo=confirmation_outbound_repo,
         pause_repository=pause_repository,
         contact_note_repo=contact_note_repo,
@@ -1530,6 +1536,7 @@ def make_office_panel_handler(
             return OrderPrintProjectionService(
                 order_repo,
                 panel._commercial_snapshots,
+                local_confirmation_document_repo,
             ).resolve(order_id, version_id, intent="preview")
 
         def _resolve_buffet_cards_view(self, order_id: str, version_id: str):
@@ -1540,6 +1547,7 @@ def make_office_panel_handler(
                 OrderPrintProjectionService(
                     order_repo,
                     panel._commercial_snapshots,
+                    local_confirmation_document_repo,
                 ),
             ).resolve(order_id, version_id)
 

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -354,24 +354,86 @@ def _format_print_date(value: date) -> str:
     return value.strftime("%d.%m.%Y")
 
 
+def _format_eur_cents(cents: int) -> str:
+    return f"{cents / 100:.2f}".replace(".", ",")
+
+
 def _render_menu_section(projection: OrderPrintProjection) -> str:
     positions = projection.commercial.positions
     if not positions:
         return '<p class="menu-empty">Kein Menü hinterlegt</p>'
     blocks: list[str] = []
     for line in positions:
-        detail = line.description or line.composition
-        detail_html = f'<p class="menu-detail">{_e(detail)}</p>' if detail else ""
+        details = "".join(
+            f'<p class="menu-detail">{_e(value)}</p>'
+            for value in (line.description, line.composition)
+            if value
+        )
+        notes_html = f'<p class="menu-notes">{_e(line.notes)}</p>' if line.notes else ""
         quantity_html = (
-            f'<p class="menu-qty">Menge: {_e(line.quantity_display)}</p>'
+            f'<span class="menu-qty">{_e(line.quantity_display)}</span>'
             if line.quantity_display
             else ""
         )
         blocks.append(
-            f'<div class="menu-item"><p class="menu-name">• {_e(line.name)}</p>'
-            f"{detail_html}{quantity_html}</div>"
+            '<div class="menu-item">'
+            f'<div class="menu-item-head">{quantity_html}'
+            f'<p class="menu-name">{_e(line.name)}</p></div>'
+            f"{details}{notes_html}</div>"
         )
     return "".join(blocks)
+
+
+def _render_customer_section(projection: OrderPrintProjection) -> str:
+    customer = projection.customer
+    address_html = (
+        "<br>".join(_e(line) for line in customer.delivery_address_lines)
+        if customer.delivery_address_lines
+        else "–"
+    )
+    return (
+        '<section class="print-section">'
+        "<h2>Kunde / Lieferung</h2>"
+        '<dl class="facts">'
+        f"<div><dt>Kunde / Firma</dt><dd>{_e(customer.company_name or '–')}</dd></div>"
+        f"<div><dt>Ansprechpartner</dt><dd>{_e(customer.contact_name or '–')}</dd></div>"
+        f"<div><dt>Telefonnummer</dt><dd>{_e(customer.phone or '–')}</dd></div>"
+        f"<div><dt>Lieferadresse</dt><dd>{address_html}</dd></div>"
+        "</dl></section>"
+    )
+
+
+def _render_cash_block(projection: OrderPrintProjection) -> str:
+    commercial = projection.commercial
+    if commercial.payment_method != "BAR_VOR_ORT":
+        return ""
+    amount = (
+        f" – {_e(_format_eur_cents(commercial.gross_total_cents))} € KASSIEREN"
+        if commercial.gross_total_cents is not None
+        else " – BEIM KUNDEN KASSIEREN"
+    )
+    return (
+        '<section class="cash-block">'
+        f"<p>BARZAHLUNG{amount}</p>"
+        "<p>RECHNUNG MITNEHMEN UND DEM KUNDEN ÜBERGEBEN</p>"
+        "</section>"
+    )
+
+
+def _render_change_summary(projection: OrderPrintProjection) -> str:
+    event = projection.event
+    if event.change_reason is None and not event.change_lines:
+        return ""
+    rows = "".join(
+        f"<p>{_e(line.label)}: {_e(line.before)} → {_e(line.after)}</p>"
+        for line in event.change_lines
+    )
+    reason = (
+        f'<p class="change-reason">{_e(event.change_reason)}</p>'
+        if event.change_reason
+        else ""
+    )
+    return f'<section class="change-summary"><h2>ÄNDERUNG</h2>{rows}{reason}</section>'
 
 
 def render_print_sheet(projection: OrderPrintProjection) -> str:
@@ -391,51 +453,65 @@ def render_print_sheet(projection: OrderPrintProjection) -> str:
     watermark_html = (
         f'<p class="watermark">{_e(watermark)}</p>' if watermark is not None else ""
     )
-    change_html = ""
-    if event.change_reason is not None or event.changed_fields:
-        fields = ", ".join(event.changed_fields) or "–"
-        change_html = (
-            '<div class="change-summary">'
-            f'<p class="label">Änderungsgrund:</p><p class="value">'
-            f"{_e(event.change_reason or '–')}</p>"
-            f'<p class="label">Geänderte Felder:</p><p class="value">'
-            f"{_e(fields)}</p></div>"
-        )
+    change_html = _render_change_summary(projection)
+    customer_html = _render_customer_section(projection)
+    cash_html = _render_cash_block(projection)
     menu_html = _render_menu_section(projection)
     return f"""<!DOCTYPE html>
 <html lang="de"><head><meta charset="utf-8"><title>Küchenzettel</title>
 <style>
-body{{font-family:monospace;font-size:1.25rem;margin:2rem;max-width:40rem;line-height:1.5}}
-hr{{border:none;border-top:2px solid #000;margin:1.25rem 0}}
-.brand{{font-size:1.5rem;font-weight:bold;letter-spacing:0.08em}}
-.label{{margin:0.75rem 0 0.15rem;font-weight:bold}}
-.value{{margin:0 0 0.5rem}}
+@page{{size:A4;margin:14mm}}
+body{{font-family:Arial,sans-serif;font-size:13pt;margin:0;color:#111;line-height:1.35}}
+hr{{border:none;border-top:2px solid #000;margin:0.75rem 0}}
+h1{{font-size:2rem;margin:0}}
+h2{{font-size:1.1rem;margin:0 0 0.4rem;text-transform:uppercase;letter-spacing:0.04em}}
+.brand{{font-size:1rem;font-weight:bold;letter-spacing:0.08em;text-align:right}}
+.top{{display:grid;grid-template-columns:1fr auto;gap:1rem;align-items:start;margin-bottom:0.75rem}}
+.hero{{display:grid;grid-template-columns:repeat(4,1fr);gap:0.45rem;margin:0.75rem 0}}
+.hero-box{{border:2px solid #111;padding:0.45rem;min-height:3.8rem}}
+.hero-label{{font-size:0.75rem;text-transform:uppercase;font-weight:bold;margin:0 0 0.25rem;color:#555}}
+.hero-value{{font-size:1.25rem;font-weight:bold;margin:0}}
+.print-section{{border-top:2px solid #111;padding-top:0.65rem;margin-top:0.75rem}}
+.facts{{display:grid;grid-template-columns:repeat(2,1fr);gap:0.5rem 1rem;margin:0}}
+.facts div{{break-inside:avoid}}
+.facts dt{{font-weight:bold;font-size:0.8rem;text-transform:uppercase;color:#555}}
+.facts dd{{margin:0.1rem 0 0;white-space:normal}}
 .menu-title{{font-weight:bold;margin:0.5rem 0}}
-.menu-item{{margin:0.75rem 0 1rem}}
-.menu-name{{margin:0}}
-.menu-detail,.menu-qty{{margin:0.15rem 0 0 1.25rem}}
+.menu-item{{border-top:1px solid #aaa;padding-top:0.5rem;margin:0.6rem 0 0.8rem;break-inside:avoid}}
+.menu-item-head{{display:flex;gap:0.6rem;align-items:baseline}}
+.menu-name{{margin:0;font-weight:bold;font-size:1.1rem}}
+.menu-detail,.menu-notes{{margin:0.2rem 0 0 0}}
+.menu-notes{{font-weight:bold}}
+.menu-qty{{font-size:1.05rem;font-weight:bold;border:2px solid #111;padding:0.1rem 0.35rem;min-width:5rem;text-align:center}}
 .menu-empty{{margin:0.5rem 0;font-style:italic}}
-.stand{{margin-top:1rem}}
+.stand{{margin-top:1rem;color:#555;font-size:0.9rem}}
 .cancelled{{color:#a00;font-size:2rem;border:4px solid #a00;padding:0.5rem;text-align:center}}
 .watermark{{color:#666;font-size:2rem;border:3px dashed #666;padding:0.5rem;text-align:center;margin-bottom:1rem}}
+.change-summary{{border:3px solid #111;padding:0.6rem;margin:0.75rem 0}}
+.change-summary p{{margin:0.2rem 0;font-weight:bold}}
+.change-reason{{font-weight:normal!important}}
+.cash-block{{border:5px solid #111;padding:0.75rem;margin:0.75rem 0;text-align:center;break-inside:avoid}}
+.cash-block p{{font-size:1.35rem;font-weight:bold;margin:0.25rem 0}}
 button{{font-size:1rem;margin-top:1.5rem;padding:0.5rem 1rem}}
+@media print{{button{{display:none}}}}
 </style></head><body>
 {cancelled_banner}
 {watermark_html}
+<div class="top"><h1>Küchenzettel</h1><p class="brand">SILBERLÖFFEL</p></div>
+<section class="hero">
+<div class="hero-box"><p class="hero-label">Datum</p><p class="hero-value">{_e(_format_print_date(event.event_date))}</p></div>
+<div class="hero-box"><p class="hero-label">Zeitfenster / Anlieferung</p><p class="hero-value">{_e(event.time_window_text)}</p></div>
+<div class="hero-box"><p class="hero-label">Ort</p><p class="hero-value">{_e(event.location_text)}</p></div>
+<div class="hero-box"><p class="hero-label">Gäste</p><p class="hero-value">{_e(guests)}</p></div>
+</section>
 {change_html}
-<p class="brand">SILBERLÖFFEL</p>
-<hr>
-<p class="label">Datum:</p>
-<p class="value">{_e(_format_print_date(event.event_date))}</p>
-<p class="label">Ort:</p>
-<p class="value">{_e(event.location_text)}</p>
-<p class="label">Gäste:</p>
-<p class="value">{_e(guests)}</p>
-<hr>
-<p class="menu-title">MENÜ</p>
+{cash_html}
+{customer_html}
+<section class="print-section">
+<h2>Bestellung / Menü</h2>
 {menu_html}
-<hr>
-<p class="stand">Stand:<br>Version {event.version_number}</p>
+</section>
+<p class="stand">Stand Version {event.version_number}</p>
 <p><button onclick="window.print()">Drucken</button></p>
 </body></html>"""
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -94,7 +94,9 @@ from catering_system.services.order_confirmation_outbound_service import (
 )
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjection,
+    PrintChangeLine,
     PrintCommercialBlock,
+    PrintCustomerBlock,
     PrintEventBlock,
     PrintFlagsBlock,
     PrintPositionLine,
@@ -807,8 +809,10 @@ _PRINT_EVENT_KEYS = frozenset(
         "is_effective",
         "change_reason",
         "changed_fields",
+        "change_lines",
     }
 )
+_PRINT_CHANGE_LINE_KEYS = frozenset({"label", "before", "after"})
 _PRINT_COMMERCIAL_KEYS = frozenset(
     {
         "source",
@@ -816,7 +820,18 @@ _PRINT_COMMERCIAL_KEYS = frozenset(
         "offer_version_id",
         "accepted_variant_id",
         "variant_label",
+        "payment_method",
+        "gross_total_cents",
         "positions",
+    }
+)
+_PRINT_CUSTOMER_KEYS = frozenset(
+    {
+        "company_name",
+        "contact_name",
+        "phone",
+        "delivery_address_lines",
+        "fulfillment_mode",
     }
 )
 _PRINT_FLAGS_KEYS = frozenset(
@@ -828,7 +843,7 @@ _PRINT_FLAGS_KEYS = frozenset(
         "watermark",
     }
 )
-_PRINT_PROJECTION_KEYS = frozenset({"event", "commercial", "flags"})
+_PRINT_PROJECTION_KEYS = frozenset({"event", "commercial", "customer", "flags"})
 
 
 def _print_position_line(data: Mapping[str, object]) -> PrintPositionLine:
@@ -845,12 +860,23 @@ def _print_position_line(data: Mapping[str, object]) -> PrintPositionLine:
     )
 
 
+def _print_change_line(data: Mapping[str, object]) -> PrintChangeLine:
+    _exact(data, _PRINT_CHANGE_LINE_KEYS)
+    return PrintChangeLine(
+        label=_str(data["label"]),
+        before=_str(data["before"]),
+        after=_str(data["after"]),
+    )
+
+
 def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
     _exact(data, _PRINT_PROJECTION_KEYS)
     event_data = _dict(data["event"])
     _exact(event_data, _PRINT_EVENT_KEYS)
     commercial_data = _dict(data["commercial"])
     _exact(commercial_data, _PRINT_COMMERCIAL_KEYS)
+    customer_data = _dict(data["customer"])
+    _exact(customer_data, _PRINT_CUSTOMER_KEYS)
     flags_data = _dict(data["flags"])
     _exact(flags_data, _PRINT_FLAGS_KEYS)
     source = _str(commercial_data["source"])
@@ -868,6 +894,18 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
         _bad_response()
     try:
         planning_mode = validate_planning_mode(_str(event_data["planning_mode"]))
+        fulfillment_mode = validate_fulfillment_mode(
+            _str(customer_data["fulfillment_mode"])
+        )
+    except ValueError:
+        _bad_response()
+    payment_method_raw = commercial_data.get("payment_method")
+    try:
+        payment_method = (
+            None
+            if payment_method_raw is None
+            else validate_payment_method(_str(payment_method_raw))
+        )
     except ValueError:
         _bad_response()
     return OrderPrintProjection(
@@ -890,6 +928,10 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
             changed_fields=tuple(
                 _str(value) for value in _list(event_data.get("changed_fields"))
             ),
+            change_lines=tuple(
+                _print_change_line(_dict(value))
+                for value in _list(event_data["change_lines"])
+            ),
         ),
         commercial=PrintCommercialBlock(
             source=source,  # type: ignore[arg-type]
@@ -899,10 +941,21 @@ def _print_projection(data: Mapping[str, object]) -> OrderPrintProjection:
                 commercial_data.get("accepted_variant_id")
             ),
             variant_label=_optional_str(commercial_data.get("variant_label")),
+            payment_method=payment_method,
+            gross_total_cents=_optional_int(commercial_data.get("gross_total_cents")),
             positions=tuple(
                 _print_position_line(_dict(item))
                 for item in _list(commercial_data["positions"])
             ),
+        ),
+        customer=PrintCustomerBlock(
+            company_name=_optional_str(customer_data.get("company_name")),
+            contact_name=_optional_str(customer_data.get("contact_name")),
+            phone=_optional_str(customer_data.get("phone")),
+            delivery_address_lines=tuple(
+                _str(line) for line in _list(customer_data["delivery_address_lines"])
+            ),
+            fulfillment_mode=fulfillment_mode,
         ),
         flags=PrintFlagsBlock(
             intent=intent,  # type: ignore[arg-type]

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -1108,7 +1108,9 @@ def test_print_sheet_renders(panel: str) -> None:
     vid = body.split("print?version=")[1].split('"')[0]
     status, sheet = _get(f"{panel}/order/{oid}/print?version={vid}")
     assert status == 200
-    assert "Küchenzettel" in sheet and "Hamburg" in sheet and "MENÜ" in sheet
+    assert (
+        "Küchenzettel" in sheet and "Hamburg" in sheet and "Bestellung / Menü" in sheet
+    )
 
 
 def test_cancel_shows_storniert_and_hides_actions(panel: str) -> None:

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -2,29 +2,38 @@
 
 from __future__ import annotations
 
-from tests.helpers.order_seed import seed_order
-
-from datetime import date
+from dataclasses import replace
+from datetime import UTC, date, datetime
 
 import pytest
 
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.order_commercial_snapshot import (
     MissingCommercialSnapshotError,
 )
+from catering_system.domain.order_confirmation_document import (
+    SCHEMA_VERSION_V3,
+    OrderConfirmationDocumentSnapshot,
+)
+from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
+    InMemoryOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.in_memory_order_confirmation_document_repository import (
+    InMemoryOrderConfirmationDocumentRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_print_projection_service import (
     OrderPrintProjectionService,
     PrintFinalRequiresEffectiveError,
     PrintProjectionNotFoundError,
 )
-from catering_system.services.operational_core_service import OperationalCoreService
-from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
-    InMemoryOrderCommercialSnapshotRepository,
-)
-from catering_system.repositories.in_memory_order_repository import (
-    InMemoryOrderRepository,
-)
 from catering_system.services.order_service import OrderService
 from catering_system.ui.office_panel_views import render_print_sheet
+from tests.helpers.order_seed import seed_order
 from tests.unit.test_offer_service import (
     _INQUIRY_ID,
     _accepted_offer_state,
@@ -36,8 +45,64 @@ from tests.unit.test_offer_service import (
 def _projection_service(
     orders,
     snapshots: InMemoryOrderCommercialSnapshotRepository,
+    confirmations: InMemoryOrderConfirmationDocumentRepository | None = None,
 ) -> OrderPrintProjectionService:
-    return OrderPrintProjectionService(orders, snapshots)
+    return OrderPrintProjectionService(orders, snapshots, confirmations)
+
+
+def _insert_confirmation_snapshot(
+    confirmations: InMemoryOrderConfirmationDocumentRepository,
+    *,
+    order_id: str,
+    order_version_id: str,
+    event_date: date,
+    gross_total_cents: int = 32109,
+    payment_method: str = "RECHNUNG",
+    company_name: str = "Müller GmbH",
+    contact_name: str = "Anna Müller",
+    phone: str = "+49 40 123456",
+) -> None:
+    address = CustomerAddress(
+        street="Alter Wall 22",
+        postal_code="20457",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    confirmations.insert(
+        OrderConfirmationDocumentSnapshot(
+            document_snapshot_id=f"doc-{order_version_id}",
+            order_id=order_id,
+            order_version_id=order_version_id,
+            offer_id="offer-1",
+            offer_version_id="offer-version-1",
+            document_reference="AB-TEST-V1",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            created_by="office",
+            recipient_name=contact_name,
+            recipient_email="anna.mueller@example.invalid",
+            recipient_company=company_name,
+            recipient_phone=phone,
+            recipient_status="ready",
+            event_date=event_date,
+            time_window_text="12:00–13:00",
+            location_text="Hamburg",
+            guest_count_estimate=35,
+            planning_mode="caterer_suggestion",
+            positions=(),
+            vat_buckets=(),
+            net_total_cents=30000,
+            vat_total_cents=gross_total_cents - 30000,
+            gross_total_cents=gross_total_cents,
+            payment_method=payment_method,
+            payment_customer_visible_text="Zahlung laut Vereinbarung.",
+            document_hash="sha256:" + ("0" * 64),
+            schema_version=SCHEMA_VERSION_V3,
+            invoice_address=address,
+            delivery_address=address,
+            delivery_address_differs=False,
+            fulfillment_mode="DELIVERY",
+        )
+    )
 
 
 def test_order_with_offer_conversion_has_menu_positions() -> None:
@@ -64,10 +129,154 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
     assert projection.commercial.positions[0].quantity_display == "80 Stück"
 
     sheet = render_print_sheet(projection)
-    assert "MENÜ" in sheet
+    assert "Bestellung / Menü" in sheet
     assert "Fingerfood Paket" in sheet
     assert "Frozen description" in sheet
-    assert "Menge: 80 Stück" in sheet
+    assert "80 Stück" in sheet
+    assert "Frozen customization" in sheet
+    assert "guest_count_estimate" not in sheet
+    assert "caterer_suggestion" not in sheet
+    assert order.order_id not in sheet
+    assert order_version.order_version_id not in sheet
+
+
+def test_kitchen_sheet_shows_existing_customer_contact_and_delivery_address() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        inquiries,
+        service,
+    ) = _accepted_offer_state()
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="Müller GmbH",
+                contact_name="Anna Müller",
+                email="anna.mueller@example.invalid",
+                phone="+49 40 123456",
+                invoice_address=CustomerAddress(
+                    street="Alter Wall 22",
+                    postal_code="20457",
+                    city="Hamburg",
+                    country="Deutschland",
+                ),
+                delivery_address_mode="SAME_AS_INVOICE",
+            ),
+        )
+    )
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    confirmations = InMemoryOrderConfirmationDocumentRepository()
+    _insert_confirmation_snapshot(
+        confirmations,
+        order_id=order.order_id,
+        order_version_id=order_version.order_version_id,
+        event_date=order_version.event_date,
+    )
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="Live Mutation GmbH",
+                contact_name="Live Mutation",
+                email="live@example.invalid",
+                phone="+49 40 999999",
+                invoice_address=CustomerAddress(
+                    street="Mutable Weg 1",
+                    postal_code="99999",
+                    city="Geändert",
+                    country="Deutschland",
+                ),
+                delivery_address_mode="SAME_AS_INVOICE",
+            ),
+        )
+    )
+
+    projection = _projection_service(
+        orders,
+        service._commercial_snapshots,
+        confirmations,
+    ).resolve(order.order_id, order_version.order_version_id)
+    sheet = render_print_sheet(projection)
+
+    assert "Müller GmbH" in sheet
+    assert "Anna Müller" in sheet
+    assert "+49 40 123456" in sheet
+    assert "Alter Wall 22" in sheet
+    assert "20457 Hamburg" in sheet
+    assert "Deutschland" in sheet
+    assert "Live Mutation" not in sheet
+    assert "Mutable Weg" not in sheet
+    assert "Sonstiges" not in sheet
+
+
+def test_kitchen_sheet_cash_block_only_for_barzahlung() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        _inquiries,
+        service,
+    ) = _accepted_offer_state()
+    _converted, order, order_version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    snapshots = service._commercial_snapshots
+    invoice_projection = _projection_service(orders, snapshots).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    assert "BARZAHLUNG" not in render_print_sheet(invoice_projection)
+
+    snapshot = snapshots.get_by_order_id(order.order_id)
+    assert snapshot is not None
+    cash_snapshot = replace(snapshot, payment_method="BAR_VOR_ORT")
+    snapshots._by_id[snapshot.snapshot_id] = cash_snapshot
+    cash_projection = _projection_service(orders, snapshots).resolve(
+        order.order_id,
+        order_version.order_version_id,
+    )
+    sheet = render_print_sheet(cash_projection)
+
+    assert "BARZAHLUNG – BEIM KUNDEN KASSIEREN" in sheet
+    assert "RECHNUNG MITNEHMEN UND DEM KUNDEN ÜBERGEBEN" in sheet
+
+    confirmations = InMemoryOrderConfirmationDocumentRepository()
+    _insert_confirmation_snapshot(
+        confirmations,
+        order_id=order.order_id,
+        order_version_id=order_version.order_version_id,
+        event_date=order_version.event_date,
+        gross_total_cents=43210,
+        payment_method="BAR_VOR_ORT",
+    )
+    cash_projection_with_amount = _projection_service(
+        orders,
+        snapshots,
+        confirmations,
+    ).resolve(order.order_id, order_version.order_version_id)
+    sheet = render_print_sheet(cash_projection_with_amount)
+
+    assert "BARZAHLUNG – 432,10 € KASSIEREN" in sheet
+    assert "BARZAHLUNG – BEIM KUNDEN KASSIEREN" not in sheet
+    assert "RECHNUNG MITNEHMEN UND DEM KUNDEN ÜBERGEBEN" in sheet
 
 
 def test_print_fails_when_commercial_snapshot_missing_for_seeded_order() -> None:
@@ -209,12 +418,12 @@ def test_candidate_change_preview_contains_reason_diff_and_frozen_offer_menu() -
     v2 = OrderService(orders).propose_order_version_change(
         order.order_id,
         event_date=v1.event_date,
-        time_window_text="18:00",
+        time_window_text=v1.time_window_text,
         location_text=v1.location_text,
-        guest_count_estimate=v1.guest_count_estimate,
+        guest_count_estimate=35,
         planning_mode=v1.planning_mode,
         actor_reference="office-panel",
-        change_reason="Beginn verschoben",
+        change_reason="Anzahl geändert",
     )
     service = _projection_service(orders, offer_service._commercial_snapshots)
     effective = service.resolve(order.order_id, v1.order_version_id)
@@ -222,13 +431,14 @@ def test_candidate_change_preview_contains_reason_diff_and_frozen_offer_menu() -
 
     assert candidate.flags.intent == "change_preview"
     assert candidate.flags.watermark == "ÄNDERUNG – NOCH NICHT WIRKSAM"
-    assert candidate.event.change_reason == "Beginn verschoben"
-    assert candidate.event.changed_fields == ("time_window_text",)
+    assert candidate.event.change_reason == "Anzahl geändert"
+    assert candidate.event.changed_fields == ("guest_count_estimate",)
     assert candidate.commercial.positions == effective.commercial.positions
     sheet = render_print_sheet(candidate)
     assert "ÄNDERUNG – NOCH NICHT WIRKSAM" in sheet
-    assert "Beginn verschoben" in sheet
-    assert "time_window_text" in sheet
+    assert "Anzahl geändert" in sheet
+    assert "Gästezahl geändert: 80 → 35" in sheet
+    assert "guest_count_estimate" not in sheet
 
 
 def test_stale_stand_shows_veraltet_watermark() -> None:
@@ -329,7 +539,7 @@ def test_cancelled_order_shows_storniert_banner_but_remains_readable() -> None:
     sheet = render_print_sheet(projection)
     assert "STORNIERT" in sheet
     assert "SILBERLÖFFEL" in sheet
-    assert "MENÜ" in sheet
+    assert "Bestellung / Menü" in sheet
     assert "Fingerfood Paket" in sheet
 
 
@@ -544,7 +754,7 @@ def test_print_uses_snapshot_when_offer_repository_unavailable() -> None:
     assert projection.commercial.positions[0].quantity_display == "80 Stück"
     sheet = render_print_sheet(projection)
     assert "Fingerfood Paket" in sheet
-    assert "Menge: 80 Stück" in sheet
+    assert "80 Stück" in sheet
 
 
 def test_print_snapshot_immune_to_later_offer_mutation() -> None:


### PR DESCRIPTION
## Summary

- improve A4 Küchenzettel readability
- show Datum, Zeitfenster/Anlieferung, Gäste, Kunde/Firma, Ansprechpartner, Telefonnummer and frozen Lieferadresse
- improve menu quantity/notes presentation
- add BAR_VOR_ORT warning and Rechnung reminder
- use authoritative frozen confirmation snapshot amount when available
- render human-readable changes without internal field names
- remove UUID/version/source/internal metadata from kitchen print

## Safety

- no live Inquiry/Customer fallback
- customer/contact/address data come from OrderConfirmationDocumentSnapshot for the exact order_version_id
- cash amount comes only from OrderConfirmationDocumentSnapshot.gross_total_cents
- no approximate amount is calculated

## Validation

- targeted kitchen tests: 33 passed
- kitchen agent contract: 9 passed
- API/remote parity: 11 passed
- full pytest: 2821 passed
- ruff format --check: pass
- git diff --check: pass
- new Ruff diagnostics on changed lines: 0

## Out of scope

- separate Anlieferung / Essensbeginn fields
- structured Liefer-/Zugangshinweise
- structured Sonstiges
- Rückholung scheduling
- equipment return / Courier-App workflow
