### PR TITLE
Freeze operational context per order version

### DIFF
--- a/src/catering_system/domain/order_operational_context.py
+++ b/src/catering_system/domain/order_operational_context.py
@@ -1,0 +1,64 @@
+"""Frozen operational customer/delivery context bound to one OrderVersion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Literal
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+
+OrderOperationalContextSource = Literal[
+    "initial_inquiry_snapshot",
+    "inherited_parent",
+    "explicit_change",
+    "confirmation_snapshot_backfill",
+]
+
+ORDER_OPERATIONAL_CONTEXT_SOURCES: tuple[OrderOperationalContextSource, ...] = (
+    "initial_inquiry_snapshot",
+    "inherited_parent",
+    "explicit_change",
+    "confirmation_snapshot_backfill",
+)
+
+
+@dataclass(frozen=True)
+class OrderOperationalContextData:
+    recipient_company: str | None
+    recipient_name: str | None
+    recipient_phone: str | None
+    delivery_address: CustomerAddress | None
+
+
+@dataclass(frozen=True)
+class OrderVersionOperationalContextSnapshot:
+    order_version_id: str
+    order_id: str
+    recipient_company: str | None
+    recipient_name: str | None
+    recipient_phone: str | None
+    delivery_address: CustomerAddress | None
+    created_at: datetime
+    source: OrderOperationalContextSource
+
+    def __post_init__(self) -> None:
+        if self.source not in ORDER_OPERATIONAL_CONTEXT_SOURCES:
+            raise ValueError("invalid operational context source")
+
+
+def copy_operational_context_for_version(
+    snapshot: OrderVersionOperationalContextSnapshot,
+    *,
+    order_version_id: str,
+    order_id: str,
+    created_at: datetime,
+    source: OrderOperationalContextSource = "inherited_parent",
+) -> OrderVersionOperationalContextSnapshot:
+    return replace(
+        snapshot,
+        order_version_id=order_version_id,
+        order_id=order_id,
+        created_at=created_at,
+        source=source,
+    )

--- a/src/catering_system/repositories/in_memory_order_repository.py
+++ b/src/catering_system/repositories/in_memory_order_repository.py
@@ -5,15 +5,24 @@ from __future__ import annotations
 from dataclasses import replace
 
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
 
 
 class InMemoryOrderRepository:
     def __init__(self) -> None:
         self._orders: dict[str, Order] = {}
         self._versions: dict[str, OrderVersion] = {}
+        self._operational_contexts: dict[
+            str, OrderVersionOperationalContextSnapshot
+        ] = {}
 
     def save_order_with_initial_version(
-        self, order: Order, version: OrderVersion
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
     ) -> None:
         """Persist both initial records as one in-memory state change."""
         if version.order_id != order.order_id or version.version_number != 1:
@@ -32,11 +41,18 @@ class InMemoryOrderRepository:
             )
         next_orders = dict(self._orders)
         next_versions = dict(self._versions)
+        next_contexts = dict(self._operational_contexts)
         next_versions[version.order_version_id] = version
         self._validate_order_references(order, next_versions)
+        if operational_context is not None:
+            self._validate_operational_context(version, operational_context)
+            if operational_context.order_version_id in next_contexts:
+                raise KeyError(operational_context.order_version_id)
+            next_contexts[operational_context.order_version_id] = operational_context
         next_orders[order.order_id] = order
         self._orders = next_orders
         self._versions = next_versions
+        self._operational_contexts = next_contexts
 
     def get_order(self, order_id: str) -> Order | None:
         return self._orders.get(order_id)
@@ -50,7 +66,12 @@ class InMemoryOrderRepository:
         self._validate_order_references(order, self._versions)
         self._orders[order.order_id] = order
 
-    def append_order_version(self, order: Order, version: OrderVersion) -> None:
+    def append_order_version(
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
+    ) -> None:
         """Append a version and update its aggregate root as one state change."""
         if version.order_id != order.order_id or version.version_number < 1:
             raise ValueError("version must belong to the supplied order")
@@ -69,11 +90,18 @@ class InMemoryOrderRepository:
             )
         next_orders = dict(self._orders)
         next_versions = dict(self._versions)
+        next_contexts = dict(self._operational_contexts)
         next_versions[version.order_version_id] = version
         self._validate_order_references(order, next_versions)
+        if operational_context is not None:
+            self._validate_operational_context(version, operational_context)
+            if operational_context.order_version_id in next_contexts:
+                raise KeyError(operational_context.order_version_id)
+            next_contexts[operational_context.order_version_id] = operational_context
         next_orders[order.order_id] = order
         self._orders = next_orders
         self._versions = next_versions
+        self._operational_contexts = next_contexts
 
     def update_order_version(self, version: OrderVersion) -> None:
         existing = self._versions.get(version.order_version_id)
@@ -115,3 +143,19 @@ class InMemoryOrderRepository:
     def list_order_versions(self, order_id: str) -> list[OrderVersion]:
         rows = [v for v in self._versions.values() if v.order_id == order_id]
         return sorted(rows, key=lambda v: v.version_number)
+
+    def get_operational_context(
+        self, order_version_id: str
+    ) -> OrderVersionOperationalContextSnapshot | None:
+        return self._operational_contexts.get(order_version_id)
+
+    @staticmethod
+    def _validate_operational_context(
+        version: OrderVersion,
+        context: OrderVersionOperationalContextSnapshot,
+    ) -> None:
+        if (
+            context.order_version_id != version.order_version_id
+            or context.order_id != version.order_id
+        ):
+            raise ValueError("operational context owner is invalid")

--- a/src/catering_system/repositories/order_repository.py
+++ b/src/catering_system/repositories/order_repository.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from typing import Protocol
 
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
 
 
 class OrderRepository(Protocol):
     def save_order_with_initial_version(
-        self, order: Order, version: OrderVersion
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
     ) -> None: ...
 
     def get_order(self, order_id: str) -> Order | None: ...
@@ -18,10 +24,19 @@ class OrderRepository(Protocol):
 
     def update_order(self, order: Order) -> None: ...
 
-    def append_order_version(self, order: Order, version: OrderVersion) -> None: ...
+    def append_order_version(
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
+    ) -> None: ...
 
     def update_order_version(self, version: OrderVersion) -> None: ...
 
     def get_order_version(self, order_version_id: str) -> OrderVersion | None: ...
 
     def list_order_versions(self, order_id: str) -> list[OrderVersion]: ...
+
+    def get_operational_context(
+        self, order_version_id: str
+    ) -> OrderVersionOperationalContextSnapshot | None: ...

--- a/src/catering_system/repositories/sqlite_order_repository.py
+++ b/src/catering_system/repositories/sqlite_order_repository.py
@@ -13,8 +13,17 @@ from dataclasses import replace
 from datetime import date, datetime
 from pathlib import Path
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import validate_planning_mode
+from catering_system.domain.inquiry_customer_snapshot import (
+    customer_address_from_mapping,
+    customer_address_to_mapping,
+)
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    ORDER_OPERATIONAL_CONTEXT_SOURCES,
+    OrderVersionOperationalContextSnapshot,
+)
 from catering_system.repositories.sqlite_migrations import apply_migrations
 
 _CREATE_ORDERS = """
@@ -113,6 +122,105 @@ _INVARIANT_MUTATION_TRIGGERS = (
             OR NEW.order_id <> orders.order_id))
     BEGIN SELECT RAISE(ABORT, 'order version is referenced'); END""",
 )
+
+
+def _create_operational_context_table(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS order_version_operational_context_snapshots (
+            order_version_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            recipient_company TEXT,
+            recipient_name TEXT,
+            recipient_phone TEXT,
+            delivery_address_json TEXT,
+            created_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            CHECK (
+                source IN (
+                    'initial_inquiry_snapshot',
+                    'inherited_parent',
+                    'explicit_change',
+                    'confirmation_snapshot_backfill'
+                )
+            ),
+            FOREIGN KEY (order_version_id) REFERENCES order_versions(order_version_id),
+            FOREIGN KEY (order_id) REFERENCES orders(order_id)
+        );
+        CREATE TRIGGER IF NOT EXISTS trg_order_version_operational_context_owner_insert
+        BEFORE INSERT ON order_version_operational_context_snapshots
+        WHEN NOT EXISTS (
+            SELECT 1 FROM order_versions v
+            WHERE v.order_version_id = NEW.order_version_id
+              AND v.order_id = NEW.order_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'order version operational context owner is invalid');
+        END;
+        CREATE TRIGGER IF NOT EXISTS trg_order_version_operational_context_immutable_update
+        BEFORE UPDATE ON order_version_operational_context_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order version operational context is immutable');
+        END;
+        CREATE TRIGGER IF NOT EXISTS trg_order_version_operational_context_immutable_delete
+        BEFORE DELETE ON order_version_operational_context_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'order version operational context is immutable');
+        END;
+        """
+    )
+
+
+def _backfill_operational_context_from_confirmations(
+    connection: sqlite3.Connection,
+) -> None:
+    exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+        "AND name = 'order_confirmation_document_snapshots'"
+    ).fetchone()
+    if exists is None:
+        return
+    rows = connection.execute(
+        """
+        SELECT d.canonical_snapshot_json
+        FROM order_confirmation_document_snapshots d
+        JOIN order_versions v ON v.order_version_id = d.order_version_id
+        LEFT JOIN order_version_operational_context_snapshots c
+          ON c.order_version_id = d.order_version_id
+        WHERE c.order_version_id IS NULL
+        """
+    ).fetchall()
+    for (raw,) in rows:
+        payload = json.loads(raw)
+        delivery_address = payload.get("delivery_address")
+        connection.execute(
+            """
+            INSERT OR IGNORE INTO order_version_operational_context_snapshots (
+                order_version_id,
+                order_id,
+                recipient_company,
+                recipient_name,
+                recipient_phone,
+                delivery_address_json,
+                created_at,
+                source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(payload["order_version_id"]),
+                str(payload["order_id"]),
+                _optional_text(payload.get("recipient_company")),
+                _optional_text(payload.get("recipient_name")),
+                _optional_text(payload.get("recipient_phone")),
+                (
+                    json.dumps(delivery_address, ensure_ascii=False, sort_keys=True)
+                    if delivery_address is not None
+                    else None
+                ),
+                str(payload["created_at"]),
+                "confirmation_snapshot_backfill",
+            ),
+        )
 
 
 def _migration_1_create_tables(connection: sqlite3.Connection) -> None:
@@ -251,6 +359,11 @@ def _migration_7_immutable_version_change_metadata(
     )
 
 
+def _migration_8_operational_context_snapshots(connection: sqlite3.Connection) -> None:
+    _create_operational_context_table(connection)
+    _backfill_operational_context_from_confirmations(connection)
+
+
 _MIGRATIONS = (
     (1, "create_order_tables", _migration_1_create_tables),
     (2, "add_cancelled_at", _migration_2_add_cancelled_at),
@@ -263,11 +376,39 @@ _MIGRATIONS = (
         "immutable_version_change_metadata",
         _migration_7_immutable_version_change_metadata,
     ),
+    (
+        8,
+        "operational_context_snapshots",
+        _migration_8_operational_context_snapshots,
+    ),
 )
 
 
 def _dt(value: str) -> datetime:
     return datetime.fromisoformat(value)
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _address_json(address: CustomerAddress | None) -> str | None:
+    if address is None:
+        return None
+    return json.dumps(
+        customer_address_to_mapping(address),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def _address_from_json(raw: str | None) -> CustomerAddress | None:
+    if raw is None:
+        return None
+    return customer_address_from_mapping(json.loads(raw))
 
 
 class SQLiteOrderRepository:
@@ -276,7 +417,12 @@ class SQLiteOrderRepository:
         self._manage_transactions = True
         try:
             apply_migrations(self._conn, "orders", _MIGRATIONS)
+            _backfill_operational_context_from_confirmations(self._conn)
+            if self._conn.in_transaction:
+                self._conn.commit()
         except Exception:
+            if self._conn.in_transaction:
+                self._conn.rollback()
             self._conn.close()
             raise
 
@@ -289,9 +435,10 @@ class SQLiteOrderRepository:
         repo._conn = connection
         repo._manage_transactions = False
         apply_migrations(connection, "orders", _MIGRATIONS)
+        _backfill_operational_context_from_confirmations(connection)
         return repo
 
-    def _write_scope(self):  # noqa: ANN202
+    def _write_scope(self):
         # `with self._write_scope():` commits on exit — correct standalone, fatal
         # inside an externally-owned transaction (it would commit half a
         # command). nullcontext leaves control with the coordinator.
@@ -301,7 +448,10 @@ class SQLiteOrderRepository:
         self._conn.close()
 
     def save_order_with_initial_version(
-        self, order: Order, version: OrderVersion
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
     ) -> None:
         """Create the aggregate root and v1 in one SQLite transaction."""
         if version.order_id != order.order_id or version.version_number != 1:
@@ -316,6 +466,8 @@ class SQLiteOrderRepository:
                 "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 self._version_values(version),
             )
+            if operational_context is not None:
+                self._insert_operational_context(version, operational_context)
 
     def get_order(self, order_id: str) -> Order | None:
         row = self._conn.execute(
@@ -354,7 +506,12 @@ class SQLiteOrderRepository:
             for r in rows
         ]
 
-    def append_order_version(self, order: Order, version: OrderVersion) -> None:
+    def append_order_version(
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
+    ) -> None:
         """Append a version and update its aggregate root in one transaction."""
         if version.order_id != order.order_id or version.version_number < 1:
             raise ValueError("version must belong to the supplied order")
@@ -364,6 +521,8 @@ class SQLiteOrderRepository:
                 "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 self._version_values(version),
             )
+            if operational_context is not None:
+                self._insert_operational_context(version, operational_context)
             updated = self._update_order_row(order)
             if updated != 1:
                 raise KeyError(order.order_id)
@@ -411,6 +570,43 @@ class SQLiteOrderRepository:
             """,
             self._order_values(order)[1:] + (order.order_id,),
         ).rowcount
+
+    def _insert_operational_context(
+        self,
+        version: OrderVersion,
+        context: OrderVersionOperationalContextSnapshot,
+    ) -> None:
+        if (
+            context.order_version_id != version.order_version_id
+            or context.order_id != version.order_id
+        ):
+            raise ValueError("operational context owner is invalid")
+        if context.source not in ORDER_OPERATIONAL_CONTEXT_SOURCES:
+            raise ValueError("invalid operational context source")
+        self._conn.execute(
+            """
+            INSERT INTO order_version_operational_context_snapshots (
+                order_version_id,
+                order_id,
+                recipient_company,
+                recipient_name,
+                recipient_phone,
+                delivery_address_json,
+                created_at,
+                source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                context.order_version_id,
+                context.order_id,
+                context.recipient_company,
+                context.recipient_name,
+                context.recipient_phone,
+                _address_json(context.delivery_address),
+                context.created_at.isoformat(),
+                context.source,
+            ),
+        )
 
     @staticmethod
     def _order_values(order: Order) -> tuple:
@@ -460,6 +656,34 @@ class SQLiteOrderRepository:
             (order_id,),
         ).fetchall()
         return [self._row_to_version(r) for r in rows]
+
+    def get_operational_context(
+        self, order_version_id: str
+    ) -> OrderVersionOperationalContextSnapshot | None:
+        row = self._conn.execute(
+            """
+            SELECT order_version_id, order_id, recipient_company, recipient_name,
+                   recipient_phone, delivery_address_json, created_at, source
+            FROM order_version_operational_context_snapshots
+            WHERE order_version_id = ?
+            """,
+            (order_version_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        source = row[7]
+        if source not in ORDER_OPERATIONAL_CONTEXT_SOURCES:
+            raise ValueError("invalid operational context source")
+        return OrderVersionOperationalContextSnapshot(
+            order_version_id=row[0],
+            order_id=row[1],
+            recipient_company=row[2],
+            recipient_name=row[3],
+            recipient_phone=row[4],
+            delivery_address=_address_from_json(row[5]),
+            created_at=_dt(row[6]),
+            source=source,
+        )
 
     @staticmethod
     def _row_to_version(row: tuple) -> OrderVersion:

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -14,9 +14,9 @@ from catering_system.domain.inquiry_contact_completeness import (
     inquiry_contact_complete,
 )
 from catering_system.domain.inquiry_offer_preparation import (
-    InquiryOfferPreparationBlocker,
     REASON_ACTIVE_ORDER_EXISTS,
     REASON_OFFER_ALREADY_EXISTS,
+    InquiryOfferPreparationBlocker,
     evaluate_inquiry_offer_preparation,
 )
 from catering_system.domain.offer import (
@@ -40,27 +40,27 @@ from catering_system.domain.offer import (
     offer_allows_withdrawal,
     offer_has_newer_open_version,
 )
-from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.offer_snapshot import (
     OfferSnapshotPosition,
     OfferSnapshotV1,
     OfferSnapshotV2,
     OfferSnapshotVariant,
 )
-from catering_system.repositories.inquiry_repository import InquiryRepository
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    build_order_commercial_snapshot,
+)
 from catering_system.repositories.in_memory_order_commercial_snapshot_repository import (
     InMemoryOrderCommercialSnapshotRepository,
 )
+from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
 from catering_system.repositories.order_repository import OrderRepository
-from catering_system.services.order_service import OrderService
 from catering_system.services.offer_snapshot_validation import validate_offer_snapshot
-from catering_system.domain.order_commercial_snapshot import (
-    build_order_commercial_snapshot,
-)
+from catering_system.services.order_service import OrderService
 
 _log = logging.getLogger(__name__)
 
@@ -580,6 +580,7 @@ class OfferService:
         order, order_version = self._order_service.create_order_from_offer_version(
             offer.source_inquiry_id,
             version,
+            inquiry,
         )
         acceptance = offer.acceptance_evidence
         if acceptance is None or acceptance.acceptance_id != acceptance_id:

--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -19,6 +19,9 @@ from catering_system.domain.order_commercial_snapshot import (
 from catering_system.domain.order_confirmation_document import (
     OrderConfirmationDocumentSnapshot,
 )
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
 from catering_system.repositories.order_commercial_snapshot_repository import (
     OrderCommercialSnapshotRepository,
 )
@@ -197,7 +200,9 @@ class OrderPrintProjectionService:
             ),
             commercial=commercial,
             flags=flags,
-            customer=_customer_block(confirmation_snapshot),
+            customer=_customer_block(
+                self._orders.get_operational_context(order_version_id)
+            ),
         )
 
     def _resolve_confirmation_snapshot(
@@ -370,7 +375,7 @@ def _position_line_from_snapshot(
 
 
 def _customer_block(
-    snapshot: OrderConfirmationDocumentSnapshot | None,
+    snapshot: OrderVersionOperationalContextSnapshot | None,
 ) -> PrintCustomerBlock:
     if snapshot is None:
         return PrintCustomerBlock()
@@ -379,7 +384,6 @@ def _customer_block(
         contact_name=(snapshot.recipient_name or "").strip() or None,
         phone=(snapshot.recipient_phone or "").strip() or None,
         delivery_address_lines=_address_lines(snapshot.delivery_address),
-        fulfillment_mode=snapshot.fulfillment_mode or "UNKNOWN",
     )
 
 

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -12,8 +12,9 @@ import logging
 import uuid
 from collections.abc import Callable
 from dataclasses import replace
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import (
     Inquiry,
     validate_planning_mode,
@@ -24,13 +25,18 @@ from catering_system.domain.operational_core_events import (
     OrderVersionChangeProposed,
 )
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    OrderOperationalContextData,
+    OrderVersionOperationalContextSnapshot,
+    copy_operational_context_for_version,
+)
 from catering_system.repositories.order_repository import OrderRepository
 
 _log = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class OrderService:
@@ -89,6 +95,7 @@ class OrderService:
         self,
         source_inquiry_id: str,
         offer_version: CommercialOfferVersion,
+        inquiry: Inquiry | None = None,
     ) -> tuple[Order, OrderVersion]:
         """Create Order + v1 from commercial OfferVersion facts (not Inquiry)."""
         now = _utc_now()
@@ -110,7 +117,12 @@ class OrderService:
             guest_count_estimate=offer_version.guest_count,
             planning_mode=offer_version.planning_mode,
         )
-        self._order_repository.save_order_with_initial_version(order, version)
+        context = (
+            _initial_operational_context(order, version, inquiry, created_at=now)
+            if inquiry is not None
+            else None
+        )
+        self._order_repository.save_order_with_initial_version(order, version, context)
         _log.info(
             "create_order_from_offer_version inquiry_id=%s order_id=%s version=%s",
             source_inquiry_id,
@@ -128,6 +140,7 @@ class OrderService:
         location_text: str,
         guest_count_estimate: int | None,
         planning_mode: str,
+        operational_context: OrderOperationalContextData | None = None,
     ) -> OrderVersion:
         """Append a new OrderVersion; increments version_number; does not select any version as active."""
         current = self._order_repository.get_order(order.order_id)
@@ -152,8 +165,15 @@ class OrderService:
             guest_count_estimate=guest_count_estimate,
             planning_mode=pm,
         )
+        context = _operational_context_for_new_version(
+            order_repository=self._order_repository,
+            order=current,
+            version=version,
+            data=operational_context,
+            created_at=now,
+        )
         self._order_repository.append_order_version(
-            replace(current, updated_at=now), version
+            replace(current, updated_at=now), version, context
         )
         _log.info(
             "create_relevant_order_change_version order_id=%s version=%s",
@@ -173,6 +193,7 @@ class OrderService:
         planning_mode: str,
         actor_reference: str,
         change_reason: str,
+        operational_context: OrderOperationalContextData | None = None,
     ) -> OrderVersion:
         """Append an immutable snapshot and atomically make it current candidate.
 
@@ -233,7 +254,14 @@ class OrderService:
             candidate_order_version_id=version.order_version_id,
             updated_at=now,
         )
-        self._order_repository.append_order_version(updated, version)
+        context = _operational_context_for_new_version(
+            order_repository=self._order_repository,
+            order=current,
+            version=version,
+            data=operational_context,
+            created_at=now,
+        )
+        self._order_repository.append_order_version(updated, version, context)
         if (
             previous_candidate_id is not None
             and previous_candidate_id != current.effective_order_version_id
@@ -316,3 +344,103 @@ class OrderService:
         if not cid:
             return None
         return self._order_repository.get_order_version(cid)
+
+
+def _initial_operational_context(
+    order: Order,
+    version: OrderVersion,
+    inquiry: Inquiry,
+    *,
+    created_at: datetime,
+) -> OrderVersionOperationalContextSnapshot:
+    snapshot = inquiry.customer_snapshot
+    delivery_address: CustomerAddress | None = None
+    if snapshot is not None and inquiry.fulfillment_mode != "PICKUP":
+        if snapshot.delivery_address_mode == "SAME_AS_INVOICE":
+            delivery_address = snapshot.invoice_address
+        elif snapshot.delivery_address_mode == "SEPARATE":
+            delivery_address = snapshot.delivery_address
+    return OrderVersionOperationalContextSnapshot(
+        order_version_id=version.order_version_id,
+        order_id=order.order_id,
+        recipient_company=(
+            (snapshot.company_name or "").strip() or None
+            if snapshot is not None
+            else None
+        ),
+        recipient_name=(
+            (snapshot.contact_name or "").strip() or None
+            if snapshot is not None
+            else None
+        ),
+        recipient_phone=(
+            (snapshot.phone or "").strip() or None if snapshot is not None else None
+        ),
+        delivery_address=delivery_address,
+        created_at=created_at,
+        source="initial_inquiry_snapshot",
+    )
+
+
+def _inherited_operational_context(
+    order_repository: OrderRepository,
+    parent_id: str,
+    version: OrderVersion,
+    *,
+    created_at: datetime,
+) -> OrderVersionOperationalContextSnapshot | None:
+    parent = order_repository.get_operational_context(parent_id)
+    if parent is None:
+        return None
+    return copy_operational_context_for_version(
+        parent,
+        order_version_id=version.order_version_id,
+        order_id=version.order_id,
+        created_at=created_at,
+        source="inherited_parent",
+    )
+
+
+def _operational_context_for_new_version(
+    *,
+    order_repository: OrderRepository,
+    order: Order,
+    version: OrderVersion,
+    data: OrderOperationalContextData | None,
+    created_at: datetime,
+) -> OrderVersionOperationalContextSnapshot | None:
+    if data is not None:
+        return _explicit_operational_context(
+            order=order,
+            version=version,
+            data=data,
+            created_at=created_at,
+        )
+    parent_id = version.parent_order_version_id
+    if parent_id is None:
+        return None
+    return _inherited_operational_context(
+        order_repository,
+        parent_id,
+        version,
+        created_at=created_at,
+    )
+
+
+def _explicit_operational_context(
+    *,
+    order: Order,
+    version: OrderVersion,
+    data: OrderOperationalContextData,
+    created_at: datetime,
+) -> OrderVersionOperationalContextSnapshot:
+    return OrderVersionOperationalContextSnapshot(
+        order_version_id=version.order_version_id,
+        order_id=order.order_id,
+        recipient_company=data.recipient_company,
+        recipient_name=data.recipient_name,
+        recipient_phone=data.recipient_phone,
+        delivery_address=data.delivery_address,
+        created_at=created_at,
+        source="explicit_change",
+    )

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -422,18 +422,13 @@ def _render_cash_block(projection: OrderPrintProjection) -> str:
 
 def _render_change_summary(projection: OrderPrintProjection) -> str:
     event = projection.event
-    if event.change_reason is None and not event.change_lines:
+    if not event.change_lines:
         return ""
     rows = "".join(
         f"<p>{_e(line.label)}: {_e(line.before)} → {_e(line.after)}</p>"
         for line in event.change_lines
     )
-    reason = (
-        f'<p class="change-reason">{_e(event.change_reason)}</p>'
-        if event.change_reason
-        else ""
-    )
-    return f'<section class="change-summary"><h2>ÄNDERUNG</h2>{rows}{reason}</section>'
+    return f'<section class="change-summary"><h2>ÄNDERUNG</h2>{rows}</section>'
 
 
 def render_print_sheet(projection: OrderPrintProjection) -> str:
@@ -460,44 +455,44 @@ def render_print_sheet(projection: OrderPrintProjection) -> str:
     return f"""<!DOCTYPE html>
 <html lang="de"><head><meta charset="utf-8"><title>Küchenzettel</title>
 <style>
-@page{{size:A4;margin:14mm}}
-body{{font-family:Arial,sans-serif;font-size:13pt;margin:0;color:#111;line-height:1.35}}
-hr{{border:none;border-top:2px solid #000;margin:0.75rem 0}}
-h1{{font-size:2rem;margin:0}}
-h2{{font-size:1.1rem;margin:0 0 0.4rem;text-transform:uppercase;letter-spacing:0.04em}}
-.brand{{font-size:1rem;font-weight:bold;letter-spacing:0.08em;text-align:right}}
-.top{{display:grid;grid-template-columns:1fr auto;gap:1rem;align-items:start;margin-bottom:0.75rem}}
-.hero{{display:grid;grid-template-columns:repeat(4,1fr);gap:0.45rem;margin:0.75rem 0}}
-.hero-box{{border:2px solid #111;padding:0.45rem;min-height:3.8rem}}
-.hero-label{{font-size:0.75rem;text-transform:uppercase;font-weight:bold;margin:0 0 0.25rem;color:#555}}
-.hero-value{{font-size:1.25rem;font-weight:bold;margin:0}}
-.print-section{{border-top:2px solid #111;padding-top:0.65rem;margin-top:0.75rem}}
-.facts{{display:grid;grid-template-columns:repeat(2,1fr);gap:0.5rem 1rem;margin:0}}
+@page{{size:A4 portrait;margin:12mm}}
+body{{font-family:Arial,sans-serif;font-size:12.5pt;margin:0;color:#111;line-height:1.3}}
+hr{{border:none;border-top:2px solid #000;margin:0.6rem 0}}
+h1{{font-size:1.65rem;margin:0}}
+h2{{font-size:1rem;margin:0 0 0.35rem;text-transform:uppercase;letter-spacing:0.04em}}
+.brand{{font-size:1rem;font-weight:bold;letter-spacing:0.08em;text-align:right;margin:0}}
+.version-label{{font-size:0.95rem;font-weight:bold;margin:0.15rem 0 0;text-align:right}}
+.top{{display:grid;grid-template-columns:1fr auto;gap:0.75rem;align-items:start;margin-bottom:0.45rem}}
+.hero{{display:grid;grid-template-columns:repeat(4,1fr);gap:0.35rem;margin:0.45rem 0 0.55rem}}
+.hero-box{{border:2px solid #111;padding:0.35rem;min-height:3.1rem}}
+.hero-label{{font-size:0.68rem;text-transform:uppercase;font-weight:bold;margin:0 0 0.18rem;color:#555}}
+.hero-value{{font-size:1.08rem;font-weight:bold;margin:0}}
+.print-section{{border-top:2px solid #111;padding-top:0.5rem;margin-top:0.55rem}}
+.facts{{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:0.35rem 0.8rem;margin:0}}
 .facts div{{break-inside:avoid}}
-.facts dt{{font-weight:bold;font-size:0.8rem;text-transform:uppercase;color:#555}}
-.facts dd{{margin:0.1rem 0 0;white-space:normal}}
+.facts dt{{font-weight:bold;font-size:0.72rem;text-transform:uppercase;color:#555}}
+.facts dd{{margin:0.08rem 0 0;white-space:normal;overflow-wrap:anywhere}}
 .menu-title{{font-weight:bold;margin:0.5rem 0}}
-.menu-item{{border-top:1px solid #aaa;padding-top:0.5rem;margin:0.6rem 0 0.8rem;break-inside:avoid}}
+.menu-item{{border-top:1px solid #aaa;padding-top:0.4rem;margin:0.45rem 0 0.6rem;break-inside:avoid}}
 .menu-item-head{{display:flex;gap:0.6rem;align-items:baseline}}
-.menu-name{{margin:0;font-weight:bold;font-size:1.1rem}}
-.menu-detail,.menu-notes{{margin:0.2rem 0 0 0}}
+.menu-name{{margin:0;font-weight:bold;font-size:1.05rem;overflow-wrap:anywhere}}
+.menu-detail,.menu-notes{{margin:0.15rem 0 0 0;overflow-wrap:anywhere}}
 .menu-notes{{font-weight:bold}}
-.menu-qty{{font-size:1.05rem;font-weight:bold;border:2px solid #111;padding:0.1rem 0.35rem;min-width:5rem;text-align:center}}
+.menu-qty{{font-size:1rem;font-weight:bold;border:2px solid #111;padding:0.08rem 0.3rem;min-width:4.5rem;text-align:center;flex:0 0 auto}}
 .menu-empty{{margin:0.5rem 0;font-style:italic}}
 .stand{{margin-top:1rem;color:#555;font-size:0.9rem}}
 .cancelled{{color:#a00;font-size:2rem;border:4px solid #a00;padding:0.5rem;text-align:center}}
 .watermark{{color:#666;font-size:2rem;border:3px dashed #666;padding:0.5rem;text-align:center;margin-bottom:1rem}}
-.change-summary{{border:3px solid #111;padding:0.6rem;margin:0.75rem 0}}
+.change-summary{{border:3px solid #111;padding:0.5rem;margin:0.55rem 0}}
 .change-summary p{{margin:0.2rem 0;font-weight:bold}}
-.change-reason{{font-weight:normal!important}}
-.cash-block{{border:5px solid #111;padding:0.75rem;margin:0.75rem 0;text-align:center;break-inside:avoid}}
+.cash-block{{border:5px solid #111;padding:0.65rem;margin:0.55rem 0;text-align:center;break-inside:avoid}}
 .cash-block p{{font-size:1.35rem;font-weight:bold;margin:0.25rem 0}}
 button{{font-size:1rem;margin-top:1.5rem;padding:0.5rem 1rem}}
 @media print{{button{{display:none}}}}
 </style></head><body>
 {cancelled_banner}
 {watermark_html}
-<div class="top"><h1>Küchenzettel</h1><p class="brand">SILBERLÖFFEL</p></div>
+<div class="top"><h1>Küchenzettel</h1><div><p class="brand">SILBERLÖFFEL</p><p class="version-label">Version {_e(str(event.version_number))}</p></div></div>
 <section class="hero">
 <div class="hero-box"><p class="hero-label">Datum</p><p class="hero-value">{_e(_format_print_date(event.event_date))}</p></div>
 <div class="hero-box"><p class="hero-label">Zeitfenster / Anlieferung</p><p class="hero-value">{_e(event.time_window_text)}</p></div>
@@ -511,7 +506,6 @@ button{{font-size:1rem;margin-top:1.5rem;padding:0.5rem 1rem}}
 <h2>Bestellung / Menü</h2>
 {menu_html}
 </section>
-<p class="stand">Stand Version {event.version_number}</p>
 <p><button onclick="window.print()">Drucken</button></p>
 </body></html>"""
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -74,6 +74,9 @@ from catering_system.domain.inquiry_offer_preparation import (
 )
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_confirmation_outbound import FakeOutboxMessage
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHODS,
     OrderPaymentReminder,
@@ -3137,18 +3140,33 @@ class RemoteCoreClient:
         self._write_forbidden()
 
     def save_order_with_initial_version(
-        self, order: Order, version: OrderVersion
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
     ) -> None:
         self._write_forbidden()
 
     def update_order(self, order: Order) -> None:
         self._write_forbidden()
 
-    def append_order_version(self, order: Order, version: OrderVersion) -> None:
+    def append_order_version(
+        self,
+        order: Order,
+        version: OrderVersion,
+        operational_context: OrderVersionOperationalContextSnapshot | None = None,
+    ) -> None:
         self._write_forbidden()
 
     def update_order_version(self, version: OrderVersion) -> None:
         self._write_forbidden()
+
+    def get_operational_context(
+        self, order_version_id: str
+    ) -> OrderVersionOperationalContextSnapshot | None:
+        raise RuntimeError(
+            "remote panel reads operational context through print-data projections"
+        )
 
     def _write_forbidden(self) -> NoReturn:
         raise RuntimeError("remote panel writes only through Core Office API commands")

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -130,10 +130,13 @@ def test_order_with_offer_conversion_has_menu_positions() -> None:
 
     sheet = render_print_sheet(projection)
     assert "Bestellung / Menü" in sheet
+    assert "@page{size:A4 portrait" in sheet
+    assert "Version 1" in sheet
     assert "Fingerfood Paket" in sheet
     assert "Frozen description" in sheet
     assert "80 Stück" in sheet
     assert "Frozen customization" in sheet
+    assert "Stand Version" not in sheet
     assert "guest_count_estimate" not in sheet
     assert "caterer_suggestion" not in sheet
     assert order.order_id not in sheet
@@ -177,13 +180,6 @@ def test_kitchen_sheet_shows_existing_customer_contact_and_delivery_address() ->
         variant_id,
         acceptance_id,
     )
-    confirmations = InMemoryOrderConfirmationDocumentRepository()
-    _insert_confirmation_snapshot(
-        confirmations,
-        order_id=order.order_id,
-        order_version_id=order_version.order_version_id,
-        event_date=order_version.event_date,
-    )
     inquiries.update(
         replace(
             inquiry,
@@ -206,7 +202,6 @@ def test_kitchen_sheet_shows_existing_customer_contact_and_delivery_address() ->
     projection = _projection_service(
         orders,
         service._commercial_snapshots,
-        confirmations,
     ).resolve(order.order_id, order_version.order_version_id)
     sheet = render_print_sheet(projection)
 
@@ -219,6 +214,30 @@ def test_kitchen_sheet_shows_existing_customer_contact_and_delivery_address() ->
     assert "Live Mutation" not in sheet
     assert "Mutable Weg" not in sheet
     assert "Sonstiges" not in sheet
+
+
+def test_kitchen_sheet_missing_operational_context_shows_blank_facts() -> None:
+    offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
+        _accepted_offer_state()
+    )
+    _converted, order, version = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    orders._operational_contexts.pop(version.order_version_id, None)
+    projection = _projection_service(orders, service._commercial_snapshots).resolve(
+        order.order_id,
+        version.order_version_id,
+    )
+
+    sheet = render_print_sheet(projection)
+
+    assert "<dt>Kunde / Firma</dt><dd>–</dd>" in sheet
+    assert "<dt>Ansprechpartner</dt><dd>–</dd>" in sheet
+    assert "<dt>Telefonnummer</dt><dd>–</dd>" in sheet
+    assert "<dt>Lieferadresse</dt><dd>–</dd>" in sheet
 
 
 def test_kitchen_sheet_cash_block_only_for_barzahlung() -> None:
@@ -337,6 +356,7 @@ def test_new_order_version_uses_version_facts_and_accepted_offer_menu() -> None:
     sheet = render_print_sheet(projection)
     assert "Lübeck" in sheet
     assert "Version 2" in sheet
+    assert "Stand Version" not in sheet
     assert "Fingerfood Paket" in sheet
 
 
@@ -415,7 +435,7 @@ def test_candidate_change_preview_contains_reason_diff_and_frozen_offer_menu() -
     core = OperationalCoreService(orders)
     core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     core.make_order_version_effective(order.order_id, v1.order_version_id)
-    v2 = OrderService(orders).propose_order_version_change(
+    intermediate = OrderService(orders).propose_order_version_change(
         order.order_id,
         event_date=v1.event_date,
         time_window_text=v1.time_window_text,
@@ -425,19 +445,33 @@ def test_candidate_change_preview_contains_reason_diff_and_frozen_offer_menu() -
         actor_reference="office-panel",
         change_reason="Anzahl geändert",
     )
+    core.confirm_kitchen_print(order.order_id, intermediate.order_version_id)
+    core.make_order_version_effective(order.order_id, intermediate.order_version_id)
+    v2 = OrderService(orders).propose_order_version_change(
+        order.order_id,
+        event_date=intermediate.event_date,
+        time_window_text=intermediate.time_window_text,
+        location_text=intermediate.location_text,
+        guest_count_estimate=40,
+        planning_mode=intermediate.planning_mode,
+        actor_reference="office-panel",
+        change_reason="anzahl",
+    )
     service = _projection_service(orders, offer_service._commercial_snapshots)
-    effective = service.resolve(order.order_id, v1.order_version_id)
+    effective = service.resolve(order.order_id, intermediate.order_version_id)
     candidate = service.resolve(order.order_id, v2.order_version_id)
 
     assert candidate.flags.intent == "change_preview"
     assert candidate.flags.watermark == "ÄNDERUNG – NOCH NICHT WIRKSAM"
-    assert candidate.event.change_reason == "Anzahl geändert"
+    assert candidate.event.change_reason == "anzahl"
     assert candidate.event.changed_fields == ("guest_count_estimate",)
     assert candidate.commercial.positions == effective.commercial.positions
     sheet = render_print_sheet(candidate)
     assert "ÄNDERUNG – NOCH NICHT WIRKSAM" in sheet
-    assert "Anzahl geändert" in sheet
-    assert "Gästezahl geändert: 80 → 35" in sheet
+    assert "Version 3" in sheet
+    assert "Gästezahl geändert: 35 → 40" in sheet
+    assert "Anzahl geändert" not in sheet
+    assert "anzahl" not in sheet
     assert "guest_count_estimate" not in sheet
 
 

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import fields, replace
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -13,26 +13,42 @@ _SRC = Path(__file__).resolve().parents[2] / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from tests.helpers.order_seed import seed_order
-
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import (
     CALL_VERIFICATION_STATUSES,
     CRM_PIPELINE,
-    Inquiry,
     PLANNING_MODES,
+    Inquiry,
 )
-from catering_system.domain.order import Order, OrderVersion
-from catering_system.repositories.in_memory_order_repository import (
-    InMemoryOrderRepository,
-)
-from catering_system.services.order_service import OrderService
-
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
 )
+from catering_system.domain.offer import OfferPosition, OfferVariant, OfferVersion
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    OrderOperationalContextData,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.order_service import (
+    OrderService,
+    _operational_context_for_new_version,
+)
+from tests.helpers.order_seed import seed_order
 
 _CONTACT_COMPLETE_SNAPSHOT = _CCSnapshot(
-    email="kunde@example.com", phone="+49301234567"
+    company_name="Müller GmbH",
+    contact_name="Anna Müller",
+    email="kunde@example.com",
+    phone="+49301234567",
+    invoice_address=CustomerAddress(
+        street="Alter Wall 22",
+        postal_code="20457",
+        city="Hamburg",
+        country="Deutschland",
+    ),
+    delivery_address_mode="SAME_AS_INVOICE",
 )
 
 _B3_FORBIDDEN_FIELD_NAMES = frozenset(
@@ -53,7 +69,7 @@ def _module_source_lower(module: object) -> str:
 
 
 def _sample_inquiry() -> Inquiry:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return Inquiry(
         inquiry_id="11111111-1111-1111-1111-111111111111",
         event_date=date(2026, 10, 1),
@@ -69,6 +85,44 @@ def _sample_inquiry() -> Inquiry:
         call_verification_required=False,
         call_verification_status=CALL_VERIFICATION_STATUSES[0],
         customer_snapshot=_CONTACT_COMPLETE_SNAPSHOT,
+    )
+
+
+def _offer_version_from_inquiry(inquiry: Inquiry) -> OfferVersion:
+    return OfferVersion(
+        offer_version_id="offer-version-1",
+        offer_id="offer-1",
+        version_number=1,
+        created_at=inquiry.created_at,
+        valid_until=inquiry.event_date,
+        snapshot_id="snapshot-1",
+        snapshot_hash="sha256:" + ("0" * 64),
+        event_date=inquiry.event_date,
+        time_window_text=inquiry.time_window_text,
+        location_text=inquiry.location_text,
+        guest_count=inquiry.guest_count_estimate,
+        planning_mode=inquiry.planning_mode,
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        variants=(
+            OfferVariant(
+                variant_id="variant-1",
+                offer_version_id="offer-version-1",
+                label="Standard",
+                positions=(
+                    OfferPosition(
+                        position_id="position-1",
+                        kind="catalog",
+                        name="Menü",
+                        unit_net_cents=100,
+                        net_total_cents=100,
+                        vat_rate_percent=7,
+                        vat_amount_cents=7,
+                        gross_total_cents=107,
+                    ),
+                ),
+            ),
+        ),
     )
 
 
@@ -113,6 +167,203 @@ def test_create_relevant_order_change_version_second_preserves_first() -> None:
     updated_order = repo.get_order(order.order_id)
     assert updated_order is not None
     assert updated_order.updated_at >= order.updated_at
+
+
+def test_initial_version_stores_frozen_operational_context() -> None:
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, version = svc.create_order_from_offer_version(
+        _sample_inquiry().inquiry_id,
+        _offer_version_from_inquiry(_sample_inquiry()),
+        _sample_inquiry(),
+    )
+
+    context = repo.get_operational_context(version.order_version_id)
+    assert context is not None
+    assert context.order_id == order.order_id
+    assert context.recipient_company == "Müller GmbH"
+    assert context.recipient_name == "Anna Müller"
+    assert context.recipient_phone == "+49301234567"
+    assert context.delivery_address is not None
+    assert context.delivery_address.street == "Alter Wall 22"
+    assert context.source == "initial_inquiry_snapshot"
+
+
+def test_child_version_inherits_parent_operational_context_not_live_inquiry() -> None:
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    mutated = replace(
+        inquiry,
+        customer_snapshot=replace(
+            inquiry.customer_snapshot,
+            company_name="Live Mutation GmbH",
+            contact_name="Live Mutation",
+        ),
+    )
+    v2 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=40,
+        planning_mode=v1.planning_mode,
+        actor_reference="office",
+        change_reason="anzahl",
+    )
+
+    v1_context = repo.get_operational_context(v1.order_version_id)
+    v2_context = repo.get_operational_context(v2.order_version_id)
+    assert mutated.customer_snapshot is not None
+    assert mutated.customer_snapshot.company_name == "Live Mutation GmbH"
+    assert v1_context is not None
+    assert v2_context is not None
+    assert v2_context.order_version_id == v2.order_version_id
+    assert v2_context.recipient_company == v1_context.recipient_company
+    assert v2_context.recipient_company == "Müller GmbH"
+    assert v2_context.source == "inherited_parent"
+    assert v1_context is not v2_context
+
+
+def test_explicit_operational_context_change_and_grandchild_inheritance() -> None:
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    new_address = CustomerAddress(
+        street="Neuer Weg 5",
+        postal_code="20095",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    explicit = OrderOperationalContextData(
+        recipient_company="Neue Firma GmbH",
+        recipient_name="Nina Neu",
+        recipient_phone="+494012345",
+        delivery_address=new_address,
+    )
+    v2 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=40,
+        planning_mode=v1.planning_mode,
+        actor_reference="office",
+        change_reason="adresse",
+        operational_context=explicit,
+    )
+    v1_context = repo.get_operational_context(v1.order_version_id)
+    v2_context = repo.get_operational_context(v2.order_version_id)
+    assert v1_context is not None
+    assert v2_context is not None
+    assert v1_context.recipient_company == "Müller GmbH"
+    assert v2_context.recipient_company == "Neue Firma GmbH"
+    assert v2_context.delivery_address == new_address
+    assert v2_context.source == "explicit_change"
+
+    v3 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v2.event_date,
+        time_window_text=v2.time_window_text,
+        location_text=v2.location_text,
+        guest_count_estimate=45,
+        planning_mode=v2.planning_mode,
+        actor_reference="office",
+        change_reason="anzahl",
+    )
+    v3_context = repo.get_operational_context(v3.order_version_id)
+    assert v3_context is not None
+    assert v3_context.recipient_company == "Neue Firma GmbH"
+    assert v3_context.delivery_address == new_address
+    assert v3_context.source == "inherited_parent"
+
+
+def test_operational_context_inherits_from_exact_parent_not_latest_branch() -> None:
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    explicit_b = OrderOperationalContextData(
+        recipient_company="Branch B GmbH",
+        recipient_name="Berta Branch",
+        recipient_phone="+4940555",
+        delivery_address=CustomerAddress(
+            street="Branch Weg 2",
+            postal_code="20095",
+            city="Hamburg",
+            country="Deutschland",
+        ),
+    )
+    v2 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=40,
+        planning_mode=v1.planning_mode,
+        actor_reference="office",
+        change_reason="adresse",
+        operational_context=explicit_b,
+    )
+    v3 = replace(
+        v2,
+        order_version_id="branch-v3",
+        version_number=3,
+        parent_order_version_id=v1.order_version_id,
+    )
+
+    inherited = _operational_context_for_new_version(
+        order_repository=repo,
+        order=order,
+        version=v3,
+        data=None,
+        created_at=v3.created_at,
+    )
+
+    assert inherited is not None
+    assert inherited.order_version_id == v3.order_version_id
+    assert inherited.source == "inherited_parent"
+    assert inherited.recipient_company == "Müller GmbH"
+    assert inherited.recipient_company != "Branch B GmbH"
+    assert repo.get_operational_context(v2.order_version_id).recipient_company == (
+        "Branch B GmbH"
+    )
+
+
+def test_legacy_parent_without_operational_context_does_not_invent_child_context() -> (
+    None
+):
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
+
+    v2 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=40,
+        planning_mode=v1.planning_mode,
+        actor_reference="office",
+        change_reason="anzahl",
+    )
+
+    assert repo.get_operational_context(v1.order_version_id) is None
+    assert repo.get_operational_context(v2.order_version_id) is None
 
 
 def test_in_memory_repository_rejects_operational_version_update() -> None:

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -20,12 +20,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
+from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
-from catering_system.repositories.sqlite_order_repository import (
-    SQLiteOrderRepository,
-)
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.ui import remote_core_client as rcc
 from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
@@ -670,6 +669,32 @@ def test_write_methods_raise_runtime_error_not_type_error(
     client = RemoteCoreClient("http://127.0.0.1:8084", _TOKEN)
     with pytest.raises(RuntimeError, match="Core Office API commands"):
         getattr(client, method_name)(*args)
+
+
+def test_remote_core_client_satisfies_order_repository_protocol_shape() -> None:
+    client = RemoteCoreClient("http://127.0.0.1:8084", _TOKEN)
+    repo: OrderRepository = client
+
+    assert repo is client
+    with pytest.raises(RuntimeError, match="print-data projections"):
+        client.get_operational_context("version-1")
+
+
+def test_remote_order_write_stubs_accept_optional_operational_context() -> None:
+    client = RemoteCoreClient("http://127.0.0.1:8084", _TOKEN)
+
+    with pytest.raises(RuntimeError, match="Core Office API commands"):
+        client.save_order_with_initial_version(
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            operational_context=None,
+        )
+    with pytest.raises(RuntimeError, match="Core Office API commands"):
+        client.append_order_version(
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            operational_context=None,
+        )
 
 
 def test_find_by_source_and_external_ref_no_match_returns_none() -> None:

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -2,20 +2,29 @@
 
 from __future__ import annotations
 
-from tests.helpers.order_seed import seed_order
-
 import sqlite3
 from dataclasses import replace
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import (
     CALL_VERIFICATION_STATUSES,
     CRM_PIPELINE,
-    Inquiry,
     PLANNING_MODES,
+    Inquiry,
+)
+from catering_system.domain.inquiry_customer_snapshot import (
+    InquiryCustomerSnapshot as _CCSnapshot,
+)
+from catering_system.domain.order_confirmation_document import (
+    SCHEMA_VERSION_V3,
+    OrderConfirmationDocumentSnapshot,
+)
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
 )
 from catering_system.repositories.inquiry_repository import (
     DuplicateExternalReferenceError,
@@ -24,22 +33,32 @@ from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
 )
 from catering_system.repositories.sqlite_migrations import apply_migrations
+from catering_system.repositories.sqlite_order_confirmation_document_repository import (
+    SQLiteOrderConfirmationDocumentRepository,
+)
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.operational_core_service import OperationalCoreService
 from catering_system.services.order_service import OrderService
 from catering_system.services.progression_service import ProgressionService
-
-from catering_system.domain.inquiry_customer_snapshot import (
-    InquiryCustomerSnapshot as _CCSnapshot,
-)
+from tests.helpers.order_seed import seed_order
 
 _CONTACT_COMPLETE_SNAPSHOT = _CCSnapshot(
-    email="kunde@example.com", phone="+49301234567"
+    company_name="Müller GmbH",
+    contact_name="Anna Müller",
+    email="kunde@example.com",
+    phone="+49301234567",
+    invoice_address=CustomerAddress(
+        street="Alter Wall 22",
+        postal_code="20457",
+        city="Hamburg",
+        country="Deutschland",
+    ),
+    delivery_address_mode="SAME_AS_INVOICE",
 )
 
 
 def _sample_inquiry() -> Inquiry:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return Inquiry(
         inquiry_id="11111111-1111-1111-1111-111111111111",
         event_date=date(2026, 10, 1),
@@ -59,6 +78,53 @@ def _sample_inquiry() -> Inquiry:
         intake_summary="Zusammenfassung",
         intake_external_ref="ref-1",
         customer_snapshot=_CONTACT_COMPLETE_SNAPSHOT,
+    )
+
+
+def _confirmation_snapshot(
+    order_id: str,
+    order_version_id: str,
+    *,
+    created_at: datetime,
+) -> OrderConfirmationDocumentSnapshot:
+    address = CustomerAddress(
+        street="Backfill Straße 1",
+        postal_code="20457",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    return OrderConfirmationDocumentSnapshot(
+        document_snapshot_id=f"doc-{order_version_id}",
+        order_id=order_id,
+        order_version_id=order_version_id,
+        offer_id="offer-1",
+        offer_version_id="offer-version-1",
+        document_reference="AB-TEST-V1",
+        created_at=created_at,
+        created_by="office",
+        recipient_name="Backfill Anna",
+        recipient_email="backfill@example.invalid",
+        recipient_company="Backfill GmbH",
+        recipient_phone="+4940999",
+        recipient_status="ready",
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode=PLANNING_MODES[0],
+        positions=(),
+        vat_buckets=(),
+        net_total_cents=1000,
+        vat_total_cents=190,
+        gross_total_cents=1190,
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        document_hash="sha256:" + ("0" * 64),
+        schema_version=SCHEMA_VERSION_V3,
+        invoice_address=address,
+        delivery_address=address,
+        delivery_address_differs=False,
+        fulfillment_mode="DELIVERY",
     )
 
 
@@ -96,7 +162,7 @@ def test_sqlite_inquiry_migration_from_pre_intake_context_schema(
         );
         """
     )
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     conn.execute(
         "INSERT INTO inquiries VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
@@ -259,6 +325,98 @@ def test_order_roundtrip_and_version_ordering(tmp_path: Path) -> None:
     assert rows[1] == v2
 
 
+def test_order_operational_context_backfill_from_exact_confirmation_snapshot(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "test.db"
+    orders = SQLiteOrderRepository(db)
+    order, version = seed_order(orders, _sample_inquiry())
+    confirmations = SQLiteOrderConfirmationDocumentRepository(db)
+    confirmations.insert(
+        _confirmation_snapshot(
+            order.order_id,
+            version.order_version_id,
+            created_at=datetime.now(UTC),
+        )
+    )
+
+    reopened = SQLiteOrderRepository(db)
+    context = reopened.get_operational_context(version.order_version_id)
+    assert context is not None
+    assert context.recipient_company == "Backfill GmbH"
+    assert context.recipient_name == "Backfill Anna"
+    assert context.recipient_phone == "+4940999"
+    assert context.delivery_address is not None
+    assert context.delivery_address.street == "Backfill Straße 1"
+    assert context.source == "confirmation_snapshot_backfill"
+
+    reopened_again = SQLiteOrderRepository(db)
+    assert reopened_again.get_operational_context(version.order_version_id) == context
+
+
+def test_order_operational_context_backfill_requires_exact_version(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "test.db"
+    orders = SQLiteOrderRepository(db)
+    order, v1 = seed_order(orders, _sample_inquiry())
+    v2 = OrderService(orders).create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Hamburg",
+        guest_count_estimate=30,
+        planning_mode=PLANNING_MODES[0],
+    )
+    confirmations = SQLiteOrderConfirmationDocumentRepository(db)
+    confirmations.insert(
+        _confirmation_snapshot(
+            order.order_id,
+            v1.order_version_id,
+            created_at=datetime.now(UTC),
+        )
+    )
+
+    reopened = SQLiteOrderRepository(db)
+    assert reopened.get_operational_context(v1.order_version_id) is not None
+    assert reopened.get_operational_context(v2.order_version_id) is None
+
+
+def test_order_operational_context_snapshot_is_immutable(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    orders = SQLiteOrderRepository(db)
+    order, version = seed_order(orders, _sample_inquiry())
+    confirmations = SQLiteOrderConfirmationDocumentRepository(db)
+    confirmations.insert(
+        _confirmation_snapshot(
+            order.order_id,
+            version.order_version_id,
+            created_at=datetime.now(UTC),
+        )
+    )
+    orders.close()
+
+    reopened = SQLiteOrderRepository(db)
+    assert reopened.get_operational_context(version.order_version_id) is not None
+    with pytest.raises(sqlite3.DatabaseError, match="operational context is immutable"):
+        reopened._conn.execute(
+            """
+            UPDATE order_version_operational_context_snapshots
+            SET recipient_name = ?
+            WHERE order_version_id = ?
+            """,
+            ("Mutation", version.order_version_id),
+        )
+    with pytest.raises(sqlite3.DatabaseError, match="operational context is immutable"):
+        reopened._conn.execute(
+            """
+            DELETE FROM order_version_operational_context_snapshots
+            WHERE order_version_id = ?
+            """,
+            (version.order_version_id,),
+        )
+
+
 def test_initial_order_and_version_creation_rolls_back_together(tmp_path: Path) -> None:
     """A failed v1 insert must not leave an order without its initial version."""
     repo = SQLiteOrderRepository(tmp_path / "test.db")
@@ -266,6 +424,7 @@ def test_initial_order_and_version_creation_rolls_back_together(tmp_path: Path) 
     new_order = replace(
         existing_order,
         order_id="new-order",
+        source_inquiry_id="22222222-2222-2222-2222-222222222222",
         candidate_order_version_id=None,
         effective_order_version_id=None,
     )
@@ -276,6 +435,77 @@ def test_initial_order_and_version_creation_rolls_back_together(tmp_path: Path) 
 
     assert repo.get_order(new_order.order_id) is None
     assert repo.get_order_version(existing_v1.order_version_id) == existing_v1
+
+
+def test_initial_operational_context_failure_rolls_back_order_version(
+    tmp_path: Path,
+) -> None:
+    repo = SQLiteOrderRepository(tmp_path / "test.db")
+    existing_order, existing_v1 = seed_order(repo, _sample_inquiry())
+    new_order = replace(
+        existing_order,
+        order_id="new-order",
+        source_inquiry_id="33333333-3333-3333-3333-333333333333",
+        candidate_order_version_id=None,
+        effective_order_version_id=None,
+    )
+    new_v1 = replace(
+        existing_v1,
+        order_id=new_order.order_id,
+        order_version_id="new-version",
+    )
+    bad_context = OrderVersionOperationalContextSnapshot(
+        order_version_id=existing_v1.order_version_id,
+        order_id=existing_order.order_id,
+        recipient_company="Bad GmbH",
+        recipient_name="Bad",
+        recipient_phone="+490",
+        delivery_address=None,
+        created_at=datetime.now(UTC),
+        source="explicit_change",
+    )
+
+    with pytest.raises(ValueError, match="operational context owner is invalid"):
+        repo.save_order_with_initial_version(new_order, new_v1, bad_context)
+
+    assert repo.get_order(new_order.order_id) is None
+    assert repo.get_order_version(new_v1.order_version_id) is None
+    assert repo.get_operational_context(new_v1.order_version_id) is None
+
+
+def test_append_operational_context_failure_rolls_back_version_order_and_context(
+    tmp_path: Path,
+) -> None:
+    repo = SQLiteOrderRepository(tmp_path / "test.db")
+    order, v1 = seed_order(repo, _sample_inquiry())
+    updated_order = replace(
+        order,
+        updated_at=order.updated_at + timedelta(minutes=1),
+        candidate_order_version_id="new-version",
+    )
+    new_v2 = replace(
+        v1,
+        order_version_id="new-version",
+        version_number=2,
+        parent_order_version_id=v1.order_version_id,
+    )
+    bad_context = OrderVersionOperationalContextSnapshot(
+        order_version_id=v1.order_version_id,
+        order_id=order.order_id,
+        recipient_company="Bad GmbH",
+        recipient_name="Bad",
+        recipient_phone="+490",
+        delivery_address=None,
+        created_at=datetime.now(UTC),
+        source="explicit_change",
+    )
+
+    with pytest.raises(ValueError, match="operational context owner is invalid"):
+        repo.append_order_version(updated_order, new_v2, bad_context)
+
+    assert repo.get_order(order.order_id) == order
+    assert repo.get_order_version(new_v2.order_version_id) is None
+    assert repo.get_operational_context(new_v2.order_version_id) is None
 
 
 def test_initial_version_must_belong_to_order_and_be_v1(tmp_path: Path) -> None:
@@ -406,6 +636,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         ("orders", 5),
         ("orders", 6),  # PROXMOX pack §6.2: unique active source inquiry
         ("orders", 7),  # immutable change provenance + snapshot guard
+        ("orders", 8),  # frozen operational context per order version
     ]
 
 


### PR DESCRIPTION
## Summary
- add frozen operational customer/delivery context snapshots per OrderVersion
- create V1 context from frozen Inquiry customer snapshot during accepted-offer conversion
- inherit V2+ context only from exact parent_order_version_id
- support explicit operational context changes without mutating older versions
- backfill only exact matching confirmation document snapshots
- make Kitchen Print read customer/contact/address only from exact operational context

## Safety
- OrderVersion and operational context snapshot are inserted in the same transaction
- failed snapshot insert rolls back the new OrderVersion and Order update
- no live Inquiry/Customer fallback
- no latest/effective/max-version fallback for operational context inheritance
- source is constrained by typed domain values and SQLite CHECK

## Validation
- targeted operational/kitchen suite: 76 passed
- exact-parent branching regression: pass
- snapshot rollback regressions: pass
- ruff format --check: pass
- git diff --check: pass
- full local pytest not reproducible on system Python because reportlab/pypdf are missing; CI should run via locked uv environment

## Expected legacy behavior
Existing historical versions without exact operational context remain blank. Production Version 5 is expected to keep showing — unless an explicit repair/update is handled separately.