### PR TITLE
Version delivery address changes with order context

### DIFF
--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -35,6 +35,10 @@ from catering_system.repositories.order_repository import OrderRepository
 _log = logging.getLogger(__name__)
 
 
+class OperationalContextMissingError(ValueError):
+    """Exact parent OrderVersion has no frozen operational context to inherit."""
+
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -289,6 +293,112 @@ class OrderService:
             "propose_order_version_change order_id=%s version=%s candidate=%s",
             order_id,
             version.version_number,
+            version.order_version_id,
+        )
+        return version
+
+    def propose_delivery_address_change(
+        self,
+        order_id: str,
+        *,
+        parent_order_version_id: str,
+        delivery_address: CustomerAddress | None,
+        actor_reference: str,
+        change_reason: str,
+    ) -> OrderVersion:
+        """Append a candidate version with delivery address changed from exact parent.
+
+        This narrow workflow deliberately does not consult Inquiry/customer live
+        state. Recipient facts are inherited only from the supplied parent
+        version's frozen operational context.
+        """
+        current = self._order_repository.get_order(order_id)
+        if current is None:
+            raise ValueError(f"no order with id {order_id!r}")
+        if current.cancelled_at is not None:
+            raise ValueError(
+                f"order {order_id!r} is cancelled (Storno); no further versions"
+            )
+        parent = self._order_repository.get_order_version(parent_order_version_id)
+        if parent is None or parent.order_id != order_id:
+            raise ValueError(
+                f"order_version_id {parent_order_version_id!r} is not a version "
+                f"of order {order_id!r}"
+            )
+        parent_context = self._order_repository.get_operational_context(
+            parent_order_version_id
+        )
+        if parent_context is None:
+            raise OperationalContextMissingError(
+                f"operational context missing for order_version_id "
+                f"{parent_order_version_id!r}"
+            )
+        versions = self._order_repository.list_order_versions(order_id)
+        if not versions:
+            raise ValueError(f"order {order_id!r} has no source version")
+
+        now = _utc_now()
+        version = OrderVersion(
+            order_version_id=str(uuid.uuid4()),
+            order_id=order_id,
+            version_number=max(item.version_number for item in versions) + 1,
+            created_at=now,
+            event_date=parent.event_date,
+            time_window_text=parent.time_window_text,
+            location_text=parent.location_text,
+            guest_count_estimate=parent.guest_count_estimate,
+            planning_mode=parent.planning_mode,
+            parent_order_version_id=parent.order_version_id,
+            created_by=actor_reference,
+            change_reason=change_reason,
+            changed_fields=("delivery_address",),
+        )
+        operational_context = OrderOperationalContextData(
+            recipient_company=parent_context.recipient_company,
+            recipient_name=parent_context.recipient_name,
+            recipient_phone=parent_context.recipient_phone,
+            delivery_address=delivery_address,
+        )
+        context = _explicit_operational_context(
+            order=current,
+            version=version,
+            data=operational_context,
+            created_at=now,
+        )
+        previous_candidate_id = current.candidate_order_version_id
+        updated = replace(
+            current,
+            candidate_order_version_id=version.order_version_id,
+            updated_at=now,
+        )
+        self._order_repository.append_order_version(updated, version, context)
+        if (
+            previous_candidate_id is not None
+            and previous_candidate_id != current.effective_order_version_id
+        ):
+            self._emit(
+                OrderVersionCandidateSuperseded(
+                    order_id=order_id,
+                    superseded_order_version_id=previous_candidate_id,
+                    new_candidate_order_version_id=version.order_version_id,
+                    occurred_at=now,
+                )
+            )
+        self._emit(
+            OrderVersionChangeProposed(
+                order_id=order_id,
+                old_effective_order_version_id=current.effective_order_version_id,
+                new_candidate_order_version_id=version.order_version_id,
+                actor_reference=actor_reference,
+                change_reason=change_reason,
+                changed_fields=version.changed_fields,
+                occurred_at=now,
+            )
+        )
+        _log.info(
+            "propose_delivery_address_change order_id=%s parent=%s version=%s",
+            order_id,
+            parent_order_version_id,
             version.order_version_id,
         )
         return version

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -235,7 +235,10 @@ from catering_system.services.order_print_projection_service import (
     PrintFinalRequiresEffectiveError,
     PrintProjectionNotFoundError,
 )
-from catering_system.services.order_service import OrderService
+from catering_system.services.order_service import (
+    OperationalContextMissingError,
+    OrderService,
+)
 from catering_system.services.payment_reminder_service import PaymentReminderService
 from catering_system.services.task_projection_service import TaskProjectionService
 from catering_system.services.wochenuebersicht_service import WochenuebersichtService
@@ -2512,27 +2515,68 @@ class OfficeApi:
             != order.candidate_order_version_id
         ):
             raise ApiError(409, "stale_state")
+        has_delivery_change = (
+            "parent_order_version_id" in args or "delivery_address" in args
+        )
         try:
-            version = self.order_service.propose_order_version_change(
-                order.order_id,
-                event_date=_v_date(args["event_date"]),
-                time_window_text=_v_str(args["time_window_text"], 500),
-                location_text=_v_str(args["location_text"], 500),
-                guest_count_estimate=_v_guest_count(args["guest_count_estimate"]),
-                planning_mode=_v_enum(args["planning_mode"], validate_planning_mode),
-                actor_reference=(
-                    _v_str(args["actor_reference"], 200)
-                    if "actor_reference" in args
-                    else CLIENT_ID
-                ),
-                change_reason=(
-                    _v_str(args["change_reason"], 1000)
-                    if "change_reason" in args
-                    else "Operational order change"
-                ),
+            actor_reference = (
+                _v_str(args["actor_reference"], 200)
+                if "actor_reference" in args
+                else CLIENT_ID
             )
+            change_reason = (
+                _v_str(args["change_reason"], 1000)
+                if "change_reason" in args
+                else "Operational order change"
+            )
+            if has_delivery_change:
+                if (
+                    "parent_order_version_id" not in args
+                    or "delivery_address" not in args
+                ):
+                    raise _invalid()
+                version = self.order_service.propose_delivery_address_change(
+                    order.order_id,
+                    parent_order_version_id=_v_uuid(args["parent_order_version_id"]),
+                    delivery_address=customer_address_from_mapping(
+                        args["delivery_address"]
+                    ),
+                    actor_reference=actor_reference,
+                    change_reason=change_reason,
+                )
+            else:
+                required = {
+                    "event_date",
+                    "time_window_text",
+                    "location_text",
+                    "guest_count_estimate",
+                    "planning_mode",
+                }
+                if not required <= set(args):
+                    raise _invalid()
+                version = self.order_service.propose_order_version_change(
+                    order.order_id,
+                    event_date=_v_date(args["event_date"]),
+                    time_window_text=_v_str(args["time_window_text"], 500),
+                    location_text=_v_str(args["location_text"], 500),
+                    guest_count_estimate=_v_guest_count(args["guest_count_estimate"]),
+                    planning_mode=_v_enum(
+                        args["planning_mode"], validate_planning_mode
+                    ),
+                    actor_reference=actor_reference,
+                    change_reason=change_reason,
+                )
+        except OperationalContextMissingError as exc:
+            raise ApiError(422, "operational_context_missing") from exc
+        except TypeError as exc:
+            raise ApiError(422, "validation_error") from exc
         except ValueError as exc:
-            raise ApiError(422, "order_cancelled") from exc
+            message = str(exc)
+            if "cancelled" in message:
+                raise ApiError(422, "order_cancelled") from exc
+            if "not a version of order" in message:
+                raise ApiError(422, "version_not_owned") from exc
+            raise ApiError(422, "validation_error") from exc
         return 201, {
             "order_version_id": version.order_version_id,
             "version_number": version.version_number,
@@ -2996,16 +3040,20 @@ _UPDATE_ARGS = _ArgKeys(
     optional=_INTAKE_OPTIONAL,
 )
 _VERSION_ARGS = _ArgKeys(
-    required=frozenset(
+    required=frozenset(),
+    optional=frozenset(
         {
             "event_date",
             "time_window_text",
             "location_text",
             "guest_count_estimate",
             "planning_mode",
+            "actor_reference",
+            "change_reason",
+            "parent_order_version_id",
+            "delivery_address",
         }
     ),
-    optional=frozenset({"actor_reference", "change_reason"}),
 )
 _NO_ARGS = _ArgKeys(required=frozenset())
 _SNAPSHOT_ARGS = _ArgKeys(required=frozenset({"snapshot"}))

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3354,6 +3354,21 @@ class OfficePanel:
                         if not cancelled and context.can("orders.version.create")
                         else ""
                     ),
+                    delivery_address_command_fields=(
+                        self._command_fields(
+                            {
+                                "latest_version_number": str(latest_version_number),
+                                "current_effective_order_version_id": (
+                                    order.effective_order_version_id or ""
+                                ),
+                                "current_candidate_order_version_id": (
+                                    order.candidate_order_version_id or ""
+                                ),
+                            }
+                        )
+                        if not cancelled and context.can("orders.version.create")
+                        else ""
+                    ),
                     payment_command_fields=(
                         self._command_fields(
                             {
@@ -3675,6 +3690,21 @@ class OfficePanel:
                 if not cancelled and source_inquiry is not None
                 else ""
             ),
+            delivery_address_command_fields=(
+                self._command_fields(
+                    {
+                        "latest_version_number": str(latest_version_number),
+                        "current_effective_order_version_id": (
+                            order.effective_order_version_id or ""
+                        ),
+                        "current_candidate_order_version_id": (
+                            order.candidate_order_version_id or ""
+                        ),
+                    }
+                )
+                if not cancelled and context.can("orders.version.create")
+                else ""
+            ),
             fulfillment_mode_command_fields=(
                 self._command_fields(
                     {
@@ -3695,6 +3725,7 @@ class OfficePanel:
             source_inquiry,
             order,
             detail_forms,
+            target_version=action_target,
             context=context,
         )
         confirmation_card = render_confirmation_card(
@@ -3904,6 +3935,60 @@ class OfficePanel:
                 actor_reference="office-panel",
                 change_reason=form.get("change_reason", "").strip()
                 or "Operational order change",
+            )
+
+        if self._remote is not None:
+            work()
+        elif self._command_executor is not None:
+            self._command_executor.run(work)
+        else:
+            work()
+
+    def change_delivery_address(self, order_id: str, form: dict[str, str]) -> None:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise ValueError(f"no order with id {order_id!r}")
+        parent_order_version_id = form.get("parent_order_version_id", "").strip()
+        if not parent_order_version_id:
+            raise ValueError("parent_order_version_id is required")
+        if self._remote is None:
+            versions = self._orders.list_order_versions(order_id)
+            latest = max((version.version_number for version in versions), default=0)
+            expected_raw = form.get("_expect_latest_version_number", "").strip()
+            if expected_raw and int(expected_raw) != latest:
+                raise ValueError(
+                    "Der Auftrag wurde zwischenzeitlich geändert. "
+                    "Bitte laden Sie die Seite neu."
+                )
+            expected_effective = form.get("_expect_current_effective_order_version_id")
+            expected_candidate = form.get("_expect_current_candidate_order_version_id")
+            if (
+                expected_effective is not None
+                and (expected_effective or None) != order.effective_order_version_id
+            ) or (
+                expected_candidate is not None
+                and (expected_candidate or None) != order.candidate_order_version_id
+            ):
+                raise ValueError(
+                    "Der Auftrag wurde zwischenzeitlich geändert. "
+                    "Bitte laden Sie die Seite neu."
+                )
+        delivery = canonicalize_customer_address(
+            CustomerAddress(
+                street=_opt_contact(form, "delivery_street"),
+                postal_code=_opt_contact(form, "delivery_postal_code"),
+                city=_opt_contact(form, "delivery_city"),
+                country=_opt_contact(form, "delivery_country"),
+            )
+        )
+
+        def work() -> None:
+            self.order_service.propose_delivery_address_change(
+                order_id,
+                parent_order_version_id=parent_order_version_id,
+                delivery_address=delivery,
+                actor_reference="office-panel",
+                change_reason="Lieferadresse geändert",
             )
 
         if self._remote is not None:

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -189,6 +189,10 @@ _INQUIRY_COMMAND_ERROR_LABELS: dict[str, str] = {
         "Die eingegebenen Kontaktdaten sind ungültig — bitte E-Mail-Adresse "
         "oder Telefonnummer prüfen."
     ),
+    "operational_context_missing": (
+        "Der gewählte Auftragsstand hat keinen eingefrorenen Empfängerkontext. "
+        "Bitte Support kontaktieren; es wurde nichts gespeichert."
+    ),
 }
 
 
@@ -788,6 +792,7 @@ def make_office_panel_handler(
                 action = parts[2]
                 order_post_permissions: dict[str, tuple[str, ...]] = {
                     "version": ("orders.version.create",),
+                    "delivery-address": ("orders.version.create",),
                     "print-confirm": ("orders.print.confirm",),
                     "effective": ("orders.effective.set",),
                     "ready": ("orders.ready.release",),
@@ -2422,6 +2427,8 @@ def make_office_panel_handler(
         def _order_action(self, order_id: str, action: str) -> None:
             if action == "version":
                 panel.create_version(order_id, self._form())
+            elif action == "delivery-address":
+                panel.change_delivery_address(order_id, self._form())
             elif action == "print-confirm":
                 form = self._form()
                 _ = form["order_version_id"]

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -10,7 +10,6 @@ from typing import Literal
 from catering_system.domain.customer_document_preview import CustomerDocumentPreview
 from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import FULFILLMENT_MODES, PLANNING_MODES, Inquiry
-from catering_system.domain.inquiry_customer_snapshot import DELIVERY_ADDRESS_MODES
 from catering_system.domain.order import (
     Order,
     OrderVersion,
@@ -175,6 +174,7 @@ class OrderDetailFormFields:
     pause_command_fields: str = ""
     resume_command_fields: str = ""
     customer_addresses_command_fields: str = ""
+    delivery_address_command_fields: str = ""
     fulfillment_mode_command_fields: str = ""
     version_change_prefill: OrderVersionChangePrefill | None = None
 
@@ -839,46 +839,24 @@ def _address_input_block(prefix: str, address: CustomerAddress | None) -> str:
 
 
 def _customer_addresses_form(
-    inquiry: Inquiry,
     order: Order,
+    target_version: OrderVersion,
     forms: OrderDetailFormFields,
 ) -> str:
-    snapshot = inquiry.customer_snapshot
-    mode = snapshot.delivery_address_mode if snapshot is not None else "UNKNOWN"
-    invoice = snapshot.invoice_address if snapshot is not None else None
-    delivery = snapshot.delivery_address if snapshot is not None else None
-    options = "".join(
-        f'<option value="{_e(value)}"{" selected" if value == mode else ""}>'
-        f"{_e(_DELIVERY_MODE_LABELS[value])}</option>"
-        for value in DELIVERY_ADDRESS_MODES
-    )
-    delivery_display = "block" if mode == "SEPARATE" else "none"
-    delivery_fields_id = f"delivery-address-fields-{order.order_id}"
+    delivery: CustomerAddress | None = None
     return (
-        '<details class="order-edit"><summary>Adressen bearbeiten</summary>'
+        '<details class="order-edit"><summary>Lieferadresse ändern</summary>'
         '<div class="order-edit-body">'
-        f'<form method="post" action="/inquiry/{_e(inquiry.inquiry_id)}/customer-addresses" '
+        f'<form method="post" action="/order/{_e(order.order_id)}/delivery-address" '
         'onsubmit="return confirm('
-        "'Kundenadressen für die Auftragsbestätigung werden gespeichert.'"
+        "'Die geänderte Lieferadresse legt einen neuen Auftragsstand an.'"
         ');">'
-        f"{forms.csrf_input}{forms.customer_addresses_command_fields}"
-        f'<input type="hidden" name="return_order_id" value="{_e(order.order_id)}">'
+        f"{forms.csrf_input}{forms.delivery_address_command_fields}"
+        '<input type="hidden" name="parent_order_version_id" '
+        f'value="{_e(target_version.order_version_id)}">'
         "<fieldset>"
-        "<p><strong>Rechnungsadresse</strong></p>"
-        + _address_input_block("invoice", invoice)
-        + "<p><label>Liefermodus</label>"
-        + (
-            f'<select name="delivery_address_mode" '
-            f"onchange=\"var box=document.getElementById('{_e(delivery_fields_id)}');"
-            "if(box){box.style.display=this.value==='SEPARATE'?'block':'none';}\">"
-        )
-        + f"{options}</select></p>"
-        f'<div id="{_e(delivery_fields_id)}" '
-        f'style="display:{delivery_display}">'
-        "<p><strong>Abweichende Lieferadresse</strong></p>"
         + _address_input_block("delivery", delivery)
-        + "</div>"
-        '<p><button type="submit">Adressen speichern</button></p>'
+        + '<p><button type="submit">Neuen Stand mit Lieferadresse anlegen</button></p>'
         "</fieldset></form></div></details>"
     )
 
@@ -888,6 +866,7 @@ def render_customer_addresses_card(
     order: Order,
     forms: OrderDetailFormFields,
     *,
+    target_version: OrderVersion | None = None,
     editable: bool = True,
     context: OfficePageContext | None = None,
 ) -> str:
@@ -924,12 +903,13 @@ def render_customer_addresses_card(
         f'<dd style="white-space:pre-line">{_e(effective_label)}</dd></div>'
     )
     form = (
-        _customer_addresses_form(inquiry, order, forms)
+        _customer_addresses_form(order, target_version, forms)
         if (
             editable
             and order.cancelled_at is None
+            and target_version is not None
             and page_context.can("inquiries.view")
-            and page_context.can("customers.edit")
+            and page_context.can("orders.version.create")
         )
         else ""
     )
@@ -1369,7 +1349,11 @@ def render_order_detail(
             source_inquiry, order, forms, context=page_context
         )
         + render_customer_addresses_card(
-            source_inquiry, order, forms, context=page_context
+            source_inquiry,
+            order,
+            forms,
+            target_version=target,
+            context=page_context,
         )
         + _confirmation_card(
             order, confirmation, forms, live_preview, context=page_context

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -309,6 +309,7 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "invalid_rejection_evidence",
             "invalid_withdrawal_evidence",
             "order_version_not_current_candidate",
+            "operational_context_missing",
             "validation_error",
             # Issue #39: the three document blockers. All are real Office API
             # business errors that were missing here, so the status whitelist
@@ -3656,6 +3657,90 @@ class _RemoteOrderService:
         if order is None:
             raise RemoteCoreError(404, "not_found")
         return self.create_relevant_order_change_version(order, **values)
+
+    def propose_delivery_address_change(
+        self,
+        order_id: str,
+        *,
+        parent_order_version_id: str,
+        delivery_address: CustomerAddress | None,
+        actor_reference: str,
+        change_reason: str,
+    ) -> OrderVersion:
+        order = self._client.get_order(order_id)
+        if order is None:
+            raise RemoteCoreError(404, "not_found")
+        versions = self._client.list_order_versions(order.order_id)
+        parent = next(
+            (
+                version
+                for version in versions
+                if version.order_version_id == parent_order_version_id
+            ),
+            None,
+        )
+        if parent is None:
+            raise RemoteCoreError(422, "version_not_owned")
+        total_count, _truncated = self._client.order_versions_meta(order.order_id)
+        latest = total_count or max(
+            (version.version_number for version in versions), default=0
+        )
+        expected_latest = self._client.form_value("_expect_latest_version_number")
+        expected_effective = self._client.form_value(
+            "_expect_current_effective_order_version_id"
+        )
+        expected_candidate = self._client.form_value(
+            "_expect_current_candidate_order_version_id"
+        )
+        result = self._client.command(
+            f"/office/v1/orders/{quote(order.order_id, safe='')}/versions",
+            {
+                "parent_order_version_id": parent_order_version_id,
+                "delivery_address": customer_address_to_mapping(delivery_address),
+                "actor_reference": actor_reference,
+                "change_reason": change_reason,
+            },
+            {
+                "latest_version_number": (
+                    int(expected_latest) if expected_latest is not None else latest
+                ),
+                "current_effective_order_version_id": (
+                    order.effective_order_version_id
+                    if expected_effective is None
+                    else (expected_effective or None)
+                ),
+                "current_candidate_order_version_id": (
+                    order.candidate_order_version_id
+                    if expected_candidate is None
+                    else (expected_candidate or None)
+                ),
+            },
+            expected={201},
+            result_keys={
+                "order_version_id",
+                "version_number",
+                "candidate_order_version_id",
+                "parent_order_version_id",
+                "changed_fields",
+            },
+        )
+        return OrderVersion(
+            order_version_id=_uuid4(result["order_version_id"]),
+            order_id=order.order_id,
+            version_number=_int(result["version_number"]),
+            created_at=order.updated_at,
+            event_date=parent.event_date,
+            time_window_text=parent.time_window_text,
+            location_text=parent.location_text,
+            guest_count_estimate=parent.guest_count_estimate,
+            planning_mode=parent.planning_mode,
+            parent_order_version_id=_optional_uuid4(result["parent_order_version_id"]),
+            created_by=actor_reference,
+            change_reason=change_reason,
+            changed_fields=tuple(
+                _str(value) for value in _list(result["changed_fields"])
+            ),
+        )
 
 
 class _RemoteCatalogDishWriteService:

--- a/tests/unit/test_customer_address_source_v1_b_panel.py
+++ b/tests/unit/test_customer_address_source_v1_b_panel.py
@@ -13,6 +13,8 @@ from datetime import UTC, date, datetime
 from http.server import HTTPServer
 from pathlib import Path
 
+import pytest
+
 from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.order import OrderVersion
@@ -265,6 +267,95 @@ def _panel(db: Path, *, ui_version: str = "v2") -> OfficePanel:
         command_executor=CoreCommandExecutor(connection),
         ui_version=ui_version,
     )
+
+
+def test_panel_change_delivery_address_creates_order_version_with_parent_context(
+    tmp_path: Path,
+) -> None:
+    db, order_id, inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+    order = panel._orders.get_order(order_id)
+    assert order is not None
+    v1 = panel._orders.list_order_versions(order_id)[0]
+    v1_context = panel._orders.get_operational_context(v1.order_version_id)
+    assert v1_context is not None
+    before_inquiry = panel._inquiries.get_by_id(inquiry_id)
+    assert before_inquiry is not None
+
+    panel.change_delivery_address(
+        order_id,
+        {
+            "parent_order_version_id": v1.order_version_id,
+            "delivery_street": "Neue Lieferstraße 7",
+            "delivery_postal_code": "20097",
+            "delivery_city": "Hamburg",
+            "delivery_country": "DE",
+            "_expect_latest_version_number": "1",
+            "_expect_current_effective_order_version_id": (
+                order.effective_order_version_id or ""
+            ),
+            "_expect_current_candidate_order_version_id": (
+                order.candidate_order_version_id or ""
+            ),
+        },
+    )
+
+    versions = panel._orders.list_order_versions(order_id)
+    assert [version.version_number for version in versions] == [1, 2]
+    v2 = versions[1]
+    assert v2.parent_order_version_id == v1.order_version_id
+    assert v2.changed_fields == ("delivery_address",)
+    v2_context = panel._orders.get_operational_context(v2.order_version_id)
+    assert v2_context is not None
+    assert v2_context.source == "explicit_change"
+    assert v2_context.recipient_company == v1_context.recipient_company
+    assert v2_context.recipient_name == v1_context.recipient_name
+    assert v2_context.recipient_phone == v1_context.recipient_phone
+    assert v2_context.delivery_address is not None
+    assert v2_context.delivery_address.street == "Neue Lieferstraße 7"
+    assert panel._orders.get_operational_context(v1.order_version_id) == v1_context
+    after_inquiry = panel._inquiries.get_by_id(inquiry_id)
+    assert after_inquiry is not None
+    assert after_inquiry.customer_snapshot == before_inquiry.customer_snapshot
+
+
+def test_panel_change_delivery_address_rejects_missing_parent_id(
+    tmp_path: Path,
+) -> None:
+    db, order_id, _inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+
+    with pytest.raises(ValueError, match="parent_order_version_id is required"):
+        panel.change_delivery_address(
+            order_id,
+            {
+                "delivery_street": "Neue Lieferstraße 7",
+                "delivery_postal_code": "20097",
+                "delivery_city": "Hamburg",
+                "delivery_country": "DE",
+            },
+        )
+
+
+def test_panel_change_delivery_address_preserves_stale_state_gate(
+    tmp_path: Path,
+) -> None:
+    db, order_id, _inquiry_id = _seed_order_world(tmp_path)
+    panel = _panel(db)
+    v1 = panel._orders.list_order_versions(order_id)[0]
+
+    with pytest.raises(ValueError, match="zwischenzeitlich geändert"):
+        panel.change_delivery_address(
+            order_id,
+            {
+                "parent_order_version_id": v1.order_version_id,
+                "delivery_street": "Neue Lieferstraße 7",
+                "delivery_postal_code": "20097",
+                "delivery_city": "Hamburg",
+                "delivery_country": "DE",
+                "_expect_latest_version_number": "99",
+            },
+        )
 
 
 def test_order_detail_shows_separate_addresses_after_service_write(

--- a/tests/unit/test_customer_address_source_v1_b_panel.py
+++ b/tests/unit/test_customer_address_source_v1_b_panel.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
+from catering_system.domain.order import OrderVersion
 from catering_system.repositories.core_transaction import (
     CoreCommandExecutor,
     open_core_connection,
@@ -81,6 +82,7 @@ def _empty_forms(**overrides: object) -> OrderDetailFormFields:
         version_command_fields="",
         payment_command_fields="",
         customer_addresses_command_fields="",
+        delivery_address_command_fields="",
     )
     base.update(overrides)
     return OrderDetailFormFields(**base)  # type: ignore[arg-type]
@@ -106,8 +108,23 @@ def test_address_card_separate_shows_stored_and_effective() -> None:
         created_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
         updated_at=datetime(2026, 7, 18, 10, 0, tzinfo=UTC),
     )
+    version = OrderVersion(
+        order_version_id="33333333-3333-4333-8333-333333333333",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=order.created_at,
+        event_date=inquiry.event_date,
+        time_window_text=inquiry.time_window_text,
+        location_text=inquiry.location_text,
+        guest_count_estimate=inquiry.guest_count_estimate,
+        planning_mode=inquiry.planning_mode,
+    )
     card = render_customer_addresses_card(
-        inquiry, order, _empty_forms(), context=legacy_office_context()
+        inquiry,
+        order,
+        _empty_forms(delivery_address_command_fields='<input name="_expect_x">'),
+        target_version=version,
+        context=legacy_office_context(),
     )
     assert "Rechnungsadresse" in card
     assert "Bürostraße 1" in card
@@ -115,10 +132,12 @@ def test_address_card_separate_shows_stored_and_effective() -> None:
     assert "Gespeicherte Lieferadresse" in card
     assert "Eventplatz 9" in card
     assert "Effektive Lieferadresse" in card
-    assert "Adressen bearbeiten" in card
-    assert 'action="/inquiry/' in card
-    assert "customer-addresses" in card
-    assert 'name="return_order_id"' in card
+    assert "Lieferadresse ändern" in card
+    assert f'action="/order/{order.order_id}/delivery-address"' in card
+    assert 'action="/inquiry/' not in card
+    assert "customer-addresses" not in card
+    assert 'name="return_order_id"' not in card
+    assert f'value="{version.order_version_id}"' in card
 
 
 def test_address_card_same_as_invoice_distinguishes_stored_vs_effective() -> None:
@@ -265,8 +284,9 @@ def test_order_detail_shows_separate_addresses_after_service_write(
     assert "Bürostraße 1" in page
     assert "Eventplatz 9" in page
     assert "Abweichende Lieferadresse" in page
-    assert 'action="/inquiry/' in page
-    assert "customer-addresses" in page
+    assert f'action="/order/{order_id}/delivery-address"' in page
+    assert f'action="/inquiry/{inquiry_id}/customer-addresses"' not in page
+    assert 'name="parent_order_version_id"' in page
 
 
 def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None:
@@ -401,36 +421,19 @@ def _post(url: str, fields: dict[str, str]) -> tuple[int, str]:
         return exc.code, exc.read().decode("utf-8")
 
 
-def test_panel_http_customer_addresses_form_round_trip(tmp_path: Path) -> None:
+def test_panel_http_order_delivery_address_form_uses_order_action(
+    tmp_path: Path,
+) -> None:
     db, order_id, inquiry_id = _seed_order_world(tmp_path)
     base, server = _start_panel_server(db)
     try:
         status, page = _get(f"{base}/order/{order_id}")
         assert status == 200
         assert "Kundenadressen" in page
-        assert "Adressen bearbeiten" in page
-        status, _body = _post(
-            f"{base}/inquiry/{inquiry_id}/customer-addresses",
-            {
-                "_csrf_token": _CSRF,
-                "return_order_id": order_id,
-                "delivery_address_mode": "SEPARATE",
-                "invoice_street": _INVOICE.street or "",
-                "invoice_postal_code": _INVOICE.postal_code or "",
-                "invoice_city": _INVOICE.city or "",
-                "invoice_country": _INVOICE.country or "",
-                "delivery_street": _DELIVERY.street or "",
-                "delivery_postal_code": _DELIVERY.postal_code or "",
-                "delivery_city": _DELIVERY.city or "",
-                "delivery_country": _DELIVERY.country or "",
-            },
-        )
-        assert status in {200, 302}
-        status, page = _get(f"{base}/order/{order_id}")
-        assert status == 200
-        assert "Eventplatz 9" in page
-        assert "Abweichende Lieferadresse" in page
-        assert "Bürostraße 1" in page
+        assert "Lieferadresse ändern" in page
+        assert f'action="/order/{order_id}/delivery-address"' in page
+        assert f'action="/inquiry/{inquiry_id}/customer-addresses"' not in page
+        assert 'name="parent_order_version_id"' in page
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -22,6 +22,7 @@ from catering_system.domain.catalog import CatalogDish
 from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.kitchen_print_job import KitchenPrintJob
+from catering_system.domain.offer import OfferPosition, OfferVariant, OfferVersion
 from catering_system.domain.offer_snapshot import compute_snapshot_hash
 from catering_system.repositories.sqlite_catalog_repository import (
     SQLiteCatalogRepository,
@@ -72,6 +73,45 @@ _SERVICE_TOKENS = {
 }
 _CONFIGURATOR_AUTH = {"Authorization": "Bearer svc-configurator-token"}
 _WRONG_SERVICE_AUTH = {"Authorization": "Bearer svc-office-token"}
+
+
+def _offer_version_for_order_creation() -> OfferVersion:
+    offer_version_id = str(uuid.uuid4())
+    return OfferVersion(
+        offer_version_id=offer_version_id,
+        offer_id=str(uuid.uuid4()),
+        version_number=1,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        valid_until=date(2026, 9, 1),
+        snapshot_id=str(uuid.uuid4()),
+        snapshot_hash="sha256:" + ("0" * 64),
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count=25,
+        planning_mode="caterer_suggestion",
+        payment_method="RECHNUNG",
+        payment_customer_visible_text="Zahlung per Rechnung",
+        variants=(
+            OfferVariant(
+                variant_id=str(uuid.uuid4()),
+                offer_version_id=offer_version_id,
+                label="Standard",
+                positions=(
+                    OfferPosition(
+                        position_id=str(uuid.uuid4()),
+                        kind="catalog",
+                        name="Menü",
+                        unit_net_cents=100,
+                        net_total_cents=100,
+                        vat_rate_percent=7,
+                        vat_amount_cents=7,
+                        gross_total_cents=107,
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
 def _seed(db_path: Path) -> dict[str, str]:
@@ -201,6 +241,35 @@ def _employee_auth(db_path: Path) -> dict[str, str]:
     login = service.authenticate(username="auth.handoff", password="ChangedPassw0rd!")
     repo.close()
     return {"account_id": account.id, "session_token": login.session_token}
+
+
+def _create_order_with_operational_context(db_path: Path) -> tuple[str, str]:
+    inquiries = SQLiteInquiryRepository(db_path)
+    orders = SQLiteOrderRepository(db_path)
+    inquiry = InquiryService(inquiries).create_inquiry(
+        event_date=date(2026, 10, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="kunde@example.com",
+        contact_phone="+4940235649",
+        company_name="A GmbH",
+        contact_name="B Person",
+    )
+    order, version = OrderService(orders).create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_for_order_creation(),
+        inquiry,
+    )
+    inquiries.close()
+    orders.close()
+    return order.order_id, version.order_version_id
 
 
 def _mint_first_offer_handoff(
@@ -1615,6 +1684,172 @@ def test_versions_expect_and_cancelled_gate(api) -> None:
         },
     )
     assert (status, body["error"]) == (422, "order_cancelled")
+
+
+def test_delivery_address_version_command_creates_explicit_context(api) -> None:
+    base, _ids, db = api
+    order_id, parent_id = _create_order_with_operational_context(db)
+    url = f"{base}/office/v1/orders/{order_id}/versions"
+    new_address = {
+        "street": "Neuer Weg 5",
+        "postal_code": "20095",
+        "city": "Hamburg",
+        "country": "Deutschland",
+    }
+
+    status, body, _h = _post(
+        url,
+        args={
+            "parent_order_version_id": parent_id,
+            "delivery_address": new_address,
+            "actor_reference": "office-panel",
+            "change_reason": "Lieferadresse geändert",
+        },
+        expect={
+            "latest_version_number": 1,
+            "current_effective_order_version_id": None,
+            "current_candidate_order_version_id": None,
+        },
+    )
+
+    assert status == 201
+    assert body["version_number"] == 2
+    assert body["parent_order_version_id"] == parent_id
+    assert body["changed_fields"] == ["delivery_address"]
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        """
+        SELECT order_version_id, source, recipient_company, recipient_name,
+               recipient_phone, delivery_address_json
+        FROM order_version_operational_context_snapshots
+        WHERE order_id = ?
+        ORDER BY created_at
+        """,
+        (order_id,),
+    ).fetchall()
+    inquiry_rows = conn.execute(
+        """
+        SELECT snapshot_company_name, snapshot_contact_name, snapshot_phone,
+               snapshot_delivery_address_json
+        FROM inquiries
+        WHERE inquiry_id = (SELECT source_inquiry_id FROM orders WHERE order_id = ?)
+        """,
+        (order_id,),
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 2
+    v1_row, v2_row = rows
+    assert v1_row[1] == "initial_inquiry_snapshot"
+    assert v2_row[0] == body["order_version_id"]
+    assert v2_row[1] == "explicit_change"
+    assert v2_row[2:5] == ("A GmbH", "B Person", "+4940235649")
+    assert json.loads(v2_row[5]) == new_address
+    assert v1_row[5] != v2_row[5]
+    assert inquiry_rows == [("A GmbH", "B Person", "+4940235649", None)]
+
+
+def test_delivery_address_version_command_rejects_missing_parent_context(api) -> None:
+    base, ids, db = api
+    order_id = ids["order_unprinted"]
+    parent_id = ids["version_unprinted"]
+    conn = sqlite3.connect(db)
+    before_count = conn.execute(
+        "SELECT COUNT(*) FROM order_versions WHERE order_id = ?",
+        (order_id,),
+    ).fetchone()[0]
+    conn.close()
+
+    status, body, _h = _post(
+        f"{base}/office/v1/orders/{order_id}/versions",
+        args={
+            "parent_order_version_id": parent_id,
+            "delivery_address": {
+                "street": "Neuer Weg 5",
+                "postal_code": "20095",
+                "city": "Hamburg",
+                "country": "Deutschland",
+            },
+        },
+        expect={
+            "latest_version_number": 1,
+            "current_effective_order_version_id": None,
+            "current_candidate_order_version_id": None,
+        },
+    )
+
+    conn = sqlite3.connect(db)
+    after_count = conn.execute(
+        "SELECT COUNT(*) FROM order_versions WHERE order_id = ?",
+        (order_id,),
+    ).fetchone()[0]
+    candidate = conn.execute(
+        "SELECT candidate_order_version_id FROM orders WHERE order_id = ?",
+        (order_id,),
+    ).fetchone()[0]
+    conn.close()
+    assert (status, body["error"]) == (422, "operational_context_missing")
+    assert after_count == before_count
+    assert candidate is None
+
+
+def test_delivery_address_version_command_rejects_parent_not_owned(api) -> None:
+    base, ids, db = api
+    order_id, _parent_id = _create_order_with_operational_context(db)
+    conn = sqlite3.connect(db)
+    before_count = conn.execute(
+        "SELECT COUNT(*) FROM order_versions WHERE order_id = ?",
+        (order_id,),
+    ).fetchone()[0]
+    conn.close()
+
+    status, body, _h = _post(
+        f"{base}/office/v1/orders/{order_id}/versions",
+        args={
+            "parent_order_version_id": ids["version_ready"],
+            "delivery_address": {
+                "street": "Neuer Weg 5",
+                "postal_code": None,
+                "city": None,
+                "country": None,
+            },
+        },
+        expect={
+            "latest_version_number": 1,
+            "current_effective_order_version_id": None,
+            "current_candidate_order_version_id": None,
+        },
+    )
+    conn = sqlite3.connect(db)
+    after_count = conn.execute(
+        "SELECT COUNT(*) FROM order_versions WHERE order_id = ?",
+        (order_id,),
+    ).fetchone()[0]
+    conn.close()
+    assert (status, body["error"]) == (422, "version_not_owned")
+    assert after_count == before_count
+
+
+def test_delivery_address_version_command_preserves_stale_state_gate(api) -> None:
+    base, _ids, db = api
+    order_id, parent_id = _create_order_with_operational_context(db)
+    status, body, _h = _post(
+        f"{base}/office/v1/orders/{order_id}/versions",
+        args={
+            "parent_order_version_id": parent_id,
+            "delivery_address": {
+                "street": "Neuer Weg 5",
+                "postal_code": None,
+                "city": None,
+                "country": None,
+            },
+        },
+        expect={
+            "latest_version_number": 9,
+            "current_effective_order_version_id": None,
+            "current_candidate_order_version_id": None,
+        },
+    )
+    assert (status, body["error"]) == (409, "stale_state")
 
 
 def test_print_confirm_effective_and_gates(api) -> None:

--- a/tests/unit/test_order_print_projection.py
+++ b/tests/unit/test_order_print_projection.py
@@ -258,6 +258,78 @@ def test_kitchen_sheet_shows_existing_customer_contact_and_delivery_address() ->
     assert "Sonstiges" not in sheet
 
 
+def test_kitchen_sheet_for_delivery_address_change_uses_new_version_context() -> None:
+    (
+        offer,
+        version_id,
+        variant_id,
+        acceptance_id,
+        _offers,
+        orders,
+        inquiries,
+        service,
+    ) = _accepted_offer_state()
+    inquiry = inquiries.get_by_id(_INQUIRY_ID)
+    assert inquiry is not None
+    inquiries.update(
+        replace(
+            inquiry,
+            customer_snapshot=InquiryCustomerSnapshot(
+                company_name="Grant Hotel",
+                contact_name="Fr.Garent",
+                email="grant@example.invalid",
+                phone="+4940235649",
+                invoice_address=CustomerAddress(
+                    street="Alter Wall 22",
+                    postal_code="20457",
+                    city="Hamburg",
+                    country="Deutschland",
+                ),
+                delivery_address_mode="SAME_AS_INVOICE",
+            ),
+        )
+    )
+    _converted, order, v1 = service.convert_accepted_offer(
+        offer.offer_id,
+        version_id,
+        variant_id,
+        acceptance_id,
+    )
+    new_address = CustomerAddress(
+        street="Neuer Lieferweg 9",
+        postal_code="20095",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    v2 = OrderService(orders).propose_delivery_address_change(
+        order.order_id,
+        parent_order_version_id=v1.order_version_id,
+        delivery_address=new_address,
+        actor_reference="office-panel",
+        change_reason="Lieferadresse geändert",
+    )
+
+    projection = _projection_service(
+        orders,
+        service._commercial_snapshots,
+    ).resolve(order.order_id, v2.order_version_id)
+    sheet = render_print_sheet(projection)
+
+    assert projection.customer.company_name == "Grant Hotel"
+    assert projection.customer.contact_name == "Fr.Garent"
+    assert projection.customer.phone == "+4940235649"
+    assert projection.customer.delivery_address_lines == (
+        "Neuer Lieferweg 9",
+        "20095 Hamburg",
+        "Deutschland",
+    )
+    assert "Grant Hotel" in sheet
+    assert "Fr.Garent" in sheet
+    assert "+4940235649" in sheet
+    assert "Neuer Lieferweg 9" in sheet
+    assert "Alter Wall 22" not in sheet
+
+
 def test_kitchen_sheet_missing_operational_context_shows_blank_facts() -> None:
     offer, version_id, variant_id, acceptance_id, _offers, orders, _inq, service = (
         _accepted_offer_state()

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -32,6 +32,7 @@ from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
 from catering_system.services.order_service import (
+    OperationalContextMissingError,
     OrderService,
     _operational_context_for_new_version,
 )
@@ -342,6 +343,159 @@ def test_operational_context_inherits_from_exact_parent_not_latest_branch() -> N
     assert repo.get_operational_context(v2.order_version_id).recipient_company == (
         "Branch B GmbH"
     )
+
+
+def test_delivery_address_change_creates_explicit_context_without_inquiry_mutation() -> (
+    None
+):
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    before_context = repo.get_operational_context(v1.order_version_id)
+    assert before_context is not None
+    new_address = CustomerAddress(
+        street="Neuer Weg 5",
+        postal_code="20095",
+        city="Hamburg",
+        country="Deutschland",
+    )
+
+    v2 = svc.propose_delivery_address_change(
+        order.order_id,
+        parent_order_version_id=v1.order_version_id,
+        delivery_address=new_address,
+        actor_reference="office-panel",
+        change_reason="Lieferadresse geändert",
+    )
+
+    after_context = repo.get_operational_context(v1.order_version_id)
+    v2_context = repo.get_operational_context(v2.order_version_id)
+    assert v2.version_number == 2
+    assert v2.parent_order_version_id == v1.order_version_id
+    assert v2.changed_fields == ("delivery_address",)
+    assert after_context == before_context
+    assert inquiry.customer_snapshot == _CONTACT_COMPLETE_SNAPSHOT
+    assert v2_context is not None
+    assert v2_context.source == "explicit_change"
+    assert v2_context.recipient_company == before_context.recipient_company
+    assert v2_context.recipient_name == before_context.recipient_name
+    assert v2_context.recipient_phone == before_context.recipient_phone
+    assert v2_context.delivery_address == new_address
+
+
+def test_delivery_address_change_uses_explicit_parent_not_latest_branch() -> None:
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    branch_b = OrderOperationalContextData(
+        recipient_company="Branch B GmbH",
+        recipient_name="Berta Branch",
+        recipient_phone="+4940555",
+        delivery_address=CustomerAddress(
+            street="Branch Weg 2",
+            postal_code="20095",
+            city="Hamburg",
+            country="Deutschland",
+        ),
+    )
+    v2 = svc.propose_order_version_change(
+        order.order_id,
+        event_date=v1.event_date,
+        time_window_text=v1.time_window_text,
+        location_text=v1.location_text,
+        guest_count_estimate=40,
+        planning_mode=v1.planning_mode,
+        actor_reference="office",
+        change_reason="branch",
+        operational_context=branch_b,
+    )
+    new_address = CustomerAddress(
+        street="Zurück zu V1 9",
+        postal_code="20457",
+        city="Hamburg",
+        country="Deutschland",
+    )
+
+    v3 = svc.propose_delivery_address_change(
+        order.order_id,
+        parent_order_version_id=v1.order_version_id,
+        delivery_address=new_address,
+        actor_reference="office-panel",
+        change_reason="Lieferadresse geändert",
+    )
+
+    v3_context = repo.get_operational_context(v3.order_version_id)
+    assert v2.version_number == 2
+    assert v3.version_number == 3
+    assert v3.parent_order_version_id == v1.order_version_id
+    assert v3_context is not None
+    assert v3_context.recipient_company == "Müller GmbH"
+    assert v3_context.recipient_company != "Branch B GmbH"
+    assert v3_context.delivery_address == new_address
+
+
+def test_delivery_address_change_rejects_missing_parent_context_without_partial_version() -> (
+    None
+):
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order, v1 = seed_order(repo, _sample_inquiry())
+    before_versions = repo.list_order_versions(order.order_id)
+
+    with pytest.raises(OperationalContextMissingError):
+        svc.propose_delivery_address_change(
+            order.order_id,
+            parent_order_version_id=v1.order_version_id,
+            delivery_address=CustomerAddress(street="Neuer Weg 5"),
+            actor_reference="office-panel",
+            change_reason="Lieferadresse geändert",
+        )
+
+    assert repo.list_order_versions(order.order_id) == before_versions
+    assert repo.get_order(order.order_id).candidate_order_version_id is None
+
+
+def test_delivery_address_change_rejects_parent_not_owned_without_partial_version() -> (
+    None
+):
+    inquiry = _sample_inquiry()
+    repo = InMemoryOrderRepository()
+    svc = OrderService(repo)
+    order_a, v1a = svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        _offer_version_from_inquiry(inquiry),
+        inquiry,
+    )
+    other_inquiry = replace(inquiry, inquiry_id="22222222-2222-2222-2222-222222222222")
+    order_b, v1b = svc.create_order_from_offer_version(
+        other_inquiry.inquiry_id,
+        _offer_version_from_inquiry(other_inquiry),
+        other_inquiry,
+    )
+    before_versions = repo.list_order_versions(order_a.order_id)
+
+    with pytest.raises(ValueError, match="not a version of order"):
+        svc.propose_delivery_address_change(
+            order_a.order_id,
+            parent_order_version_id=v1b.order_version_id,
+            delivery_address=CustomerAddress(street="Neuer Weg 5"),
+            actor_reference="office-panel",
+            change_reason="Lieferadresse geändert",
+        )
+
+    assert v1a.order_id == order_a.order_id
+    assert v1b.order_id == order_b.order_id
+    assert repo.list_order_versions(order_a.order_id) == before_versions
 
 
 def test_legacy_parent_without_operational_context_does_not_invent_child_context() -> (

--- a/tests/unit/test_remote_core_client.py
+++ b/tests/unit/test_remote_core_client.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import queue
+import sqlite3
 import socket
 import threading
 import time
@@ -20,6 +21,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.sqlite_inquiry_repository import (
     SQLiteInquiryRepository,
@@ -374,6 +376,12 @@ def test_same_contracts_without_reasons_are_unaffected(status: int, code: str) -
     behaving exactly as before the fix."""
     error = _expect_error(status, _error_body(error=code))
     assert (error.status, error.code) == (status, code)
+
+
+def test_operational_context_missing_is_business_422_not_unavailable() -> None:
+    error = _expect_error(422, _error_body(error="operational_context_missing"))
+    assert (error.status, error.code) == (422, "operational_context_missing")
+    assert error.unavailable is False
 
 
 def test_unknown_422_code_is_still_rejected() -> None:
@@ -837,6 +845,97 @@ def test_create_relevant_order_change_version_returns_the_version_not_bad_respon
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_remote_delivery_address_change_sends_narrow_payload_and_returns_version(
+    tmp_path,
+) -> None:
+    db = tmp_path / "core.db"
+    inquiries = SQLiteInquiryRepository(db)
+    orders = SQLiteOrderRepository(db)
+    inquiry = InquiryService(inquiries).create_inquiry(
+        event_date=date(2026, 10, 1),
+        inquiry_source="manual",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
+        call_verification_required=False,
+        call_verification_status="not_required",
+        contact_email="kunde@example.com",
+        contact_phone="+4940235649",
+    )
+    order, v1 = seed_order(orders, inquiry)
+    inquiries.close()
+    orders.close()
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        INSERT INTO order_version_operational_context_snapshots (
+            order_version_id, order_id, recipient_company, recipient_name,
+            recipient_phone, delivery_address_json, created_at, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            v1.order_version_id,
+            order.order_id,
+            "A GmbH",
+            "B Person",
+            "+4940235649",
+            json.dumps(
+                {
+                    "street": "Alter Wall 22",
+                    "postal_code": "20457",
+                    "city": "Hamburg",
+                    "country": "Deutschland",
+                },
+                separators=(",", ":"),
+            ),
+            v1.created_at.isoformat(),
+            "initial_inquiry_snapshot",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    url, server = _run_office_api_in_thread(db)
+    try:
+        client = RemoteCoreClient(url, _TOKEN)
+        client.begin_request({})
+        result = client.order_service.propose_delivery_address_change(
+            order.order_id,
+            parent_order_version_id=v1.order_version_id,
+            delivery_address=CustomerAddress(
+                street="Neuer Weg 5",
+                postal_code="20095",
+                city="Hamburg",
+                country="Deutschland",
+            ),
+            actor_reference="office-panel",
+            change_reason="Lieferadresse geändert",
+        )
+        assert result.version_number == 2
+        assert result.parent_order_version_id == v1.order_version_id
+        assert result.changed_fields == ("delivery_address",)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    conn = sqlite3.connect(db)
+    context = conn.execute(
+        """
+        SELECT source, recipient_company, recipient_name, recipient_phone,
+               delivery_address_json
+        FROM order_version_operational_context_snapshots
+        WHERE order_version_id = ?
+        """,
+        (result.order_version_id,),
+    ).fetchone()
+    conn.close()
+    assert context[:4] == ("explicit_change", "A GmbH", "B Person", "+4940235649")
+    assert json.loads(context[4])["street"] == "Neuer Weg 5"
 
 
 def test_prepare_next_offer_version_parses_success_payload() -> None:


### PR DESCRIPTION
## Summary

- Route Auftrag Lieferadresse changes through the Order version command instead of mutating Inquiry customer addresses.
- Create a new OrderVersion with an explicit frozen operational context sourced from the exact parent snapshot.
- Preserve existing PR #120 storage architecture and Kitchen Print exact-version operational context projection.
- Add narrow RemoteCoreClient error handling for known operational_context_missing domain errors without broad 4xx reclassification.

## Validation

- .venv/bin/pytest tests/unit/test_order_service.py tests/unit/test_sqlite_repositories.py tests/unit/test_office_api.py tests/unit/test_remote_core_client.py tests/unit/test_customer_address_source_v1_b_panel.py tests/unit/test_order_print_projection.py -q -> 385 passed
- .venv/bin/pytest tests/unit/test_office_panel.py tests/unit/test_office_panel_remote.py tests/unit/test_customer_address_source_v1_b_panel.py tests/unit/test_kitchen_print_service.py tests/unit/test_kitchen_print_document.py tests/unit/test_order_print_projection.py -q -> 221 passed
- .venv/bin/pytest -q -> 2883 passed
- .venv/bin/ruff format --check -> passed
- .venv/bin/ruff check -> passed
- git diff --check -> passed