### PR TITLE
Preserve seconds in offer sent timestamps

### DIFF
--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -209,6 +209,10 @@ _OFFER_COMMAND_ERROR_LABELS: dict[str, str] = {
     "sent_recording_blocked": (
         "Der Versand kann in diesem Angebotsstatus nicht vermerkt werden."
     ),
+    "invalid_sent_evidence": (
+        "Der Versandnachweis ist ungültig. Bitte prüfen Sie Zeitpunkt, Kanal, "
+        "Empfänger und Referenz; der Versandzeitpunkt darf nicht in der Zukunft liegen."
+    ),
     "conversion_already_exists": "Dieses Angebot wurde bereits in einen Auftrag umgewandelt.",
     "conversion_blocked": (
         "Das angenommene Angebot kann derzeit nicht in einen Auftrag umgewandelt werden."
@@ -277,6 +281,11 @@ def office_command_error_message(code_or_text: str) -> str:
         return _OFFER_COMMAND_ERROR_LABELS["acceptance_blocked"]
     if "sent recording blocked" in lowered:
         return _OFFER_COMMAND_ERROR_LABELS["sent_recording_blocked"]
+    if (
+        "recorded_at cannot precede sent_at" in lowered
+        or "sentevidence cannot predate its offerversion" in lowered
+    ):
+        return _OFFER_COMMAND_ERROR_LABELS["invalid_sent_evidence"]
     if "rejection blocked" in lowered or "rejection evidence already exists" in lowered:
         if "already exists" in lowered:
             return _OFFER_COMMAND_ERROR_LABELS["rejection_evidence_exists"]

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -247,7 +247,7 @@ def _mark_sent_form(
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
         f'<label>Versandzeitpunkt <input type="datetime-local" name="sent_at" '
-        f'value="{_e(default_at)}" required></label>'
+        f'step="1" value="{_e(default_at)}" required></label>'
         f'<label>Kanal <select name="channel" required>'
         f"{_select_options(SENT_CHANNELS, _SENT_CHANNEL_LABELS)}"
         "</select></label>"
@@ -288,7 +288,7 @@ def _record_acceptance_form(
         f"{variant_options}"
         "</select></label>"
         f'<label>Annahmezeitpunkt <input type="datetime-local" name="accepted_at" '
-        f'value="{_e(default_at)}" required></label>'
+        f'step="1" value="{_e(default_at)}" required></label>'
         f'<label>Kanal <select name="channel" required>'
         f"{_select_options(ACCEPTANCE_CHANNELS, _ACCEPTANCE_CHANNEL_LABELS)}"
         "</select></label>"
@@ -315,7 +315,7 @@ def _record_rejection_form(
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
         f'<label>Ablehnungszeitpunkt <input type="datetime-local" name="rejected_at" '
-        f'value="{_e(default_at)}" required></label>'
+        f'step="1" value="{_e(default_at)}" required></label>'
         '<label>Kommentar / Nachweis (optional) <input name="evidence_reference" '
         'maxlength="1000" placeholder="Telefonische Absage"></label>'
         "</fieldset>"

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -30,16 +30,21 @@ def parse_datetime_local_berlin(value: str) -> datetime:
     raw = value.strip()
     if not raw:
         raise ValueError("datetime is required")
-    if len(raw) < 16 or raw[10] != "T":
+    if raw[10:11] != "T":
         raise ValueError("invalid datetime-local value")
-    parsed = datetime.strptime(raw[:16], "%Y-%m-%dT%H:%M")
+    if len(raw) == 16:
+        parsed = datetime.strptime(raw, "%Y-%m-%dT%H:%M")
+    elif len(raw) == 19:
+        parsed = datetime.strptime(raw, "%Y-%m-%dT%H:%M:%S")
+    else:
+        raise ValueError("invalid datetime-local value")
     return parsed.replace(tzinfo=BERLIN)
 
 
 def default_datetime_local_berlin() -> str:
     from catering_system.ui.office_api_views import BERLIN
 
-    return datetime.now(BERLIN).strftime("%Y-%m-%dT%H:%M")
+    return datetime.now(BERLIN).strftime("%Y-%m-%dT%H:%M:%S")
 
 
 def format_datetime_utc_iso(value: datetime) -> str:

--- a/tests/unit/test_office_panel_datetime.py
+++ b/tests/unit/test_office_panel_datetime.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from catering_system.ui import office_panel_views
+from catering_system.ui.office_panel_views import (
+    default_datetime_local_berlin,
+    format_datetime_utc_iso,
+    parse_datetime_local_berlin,
+)
+
+
+def test_default_datetime_local_berlin_preserves_seconds(monkeypatch) -> None:
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            assert tz is not None
+            return datetime(2026, 8, 17, 17, 15, 54, tzinfo=tz)
+
+    monkeypatch.setattr(office_panel_views, "datetime", FixedDateTime)
+
+    assert default_datetime_local_berlin() == "2026-08-17T17:15:54"
+
+
+def test_datetime_local_seconds_roundtrip_to_utc() -> None:
+    parsed = parse_datetime_local_berlin("2026-08-17T17:15:54")
+
+    assert parsed.isoformat() == "2026-08-17T17:15:54+02:00"
+    assert format_datetime_utc_iso(parsed) == "2026-08-17T15:15:54+00:00"
+
+
+def test_datetime_local_legacy_minute_input_still_parses() -> None:
+    parsed = parse_datetime_local_berlin("2026-08-17T17:15")
+
+    assert parsed.isoformat() == "2026-08-17T17:15:00+02:00"
+    assert parsed.astimezone(UTC).isoformat() == "2026-08-17T15:15:00+00:00"

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -473,6 +473,25 @@ def _offer_form_fields(html: str, action_suffix: str) -> dict[str, str]:
     return fields
 
 
+def _form_block(html: str, action_suffix: str) -> str:
+    match = re.search(
+        rf"(<form[^>]*{re.escape(action_suffix)}[^>]*>.*?</form>)",
+        html,
+        re.DOTALL,
+    )
+    assert match, f"missing form for {action_suffix!r}"
+    return match.group(1)
+
+
+def _input_value(html: str, name: str) -> str:
+    match = re.search(
+        rf'<input[^>]*name="{re.escape(name)}"[^>]*value="([^"]*)"',
+        html,
+    )
+    assert match, f"missing input value {name!r}"
+    return match.group(1)
+
+
 @pytest.fixture()
 def direct_world(tmp_path: Path):
     db = tmp_path / "offer-actions.db"
@@ -503,6 +522,35 @@ def test_prepared_shows_mark_sent_form_only(direct_world) -> None:
     assert 'action="/offer/' in html and "/mark-sent" in html
     assert "Annahme erfassen" not in html
     assert "In Auftrag umwandeln" not in html
+
+
+def test_mark_sent_unchanged_default_with_seconds_is_accepted(direct_world) -> None:
+    panel_url, api_url, ids, db = direct_world
+    offer_id, _version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    form = _form_block(html, "/mark-sent")
+    sent_at = _input_value(form, "sent_at")
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", sent_at)
+    assert 'name="sent_at"' in form and 'step="1"' in form
+    fields = _offer_form_fields(html, "/mark-sent")
+    fields.update(
+        {
+            "sent_at": sent_at,
+            "channel": "email",
+            "recipient_reference": "kunde@example.invalid",
+            "evidence_reference": "E-Mail Versand",
+        }
+    )
+
+    status, final_url, _body = _post(f"{panel_url}/offer/{offer_id}/mark-sent", fields)
+
+    assert status == 200
+    assert final_url.endswith(f"/offer/{offer_id}")
+    offers = SQLiteOfferRepository(db)
+    offer = offers.get(offer_id)
+    offers.close()
+    assert offer is not None
+    assert offer.sent_evidence[0].sent_at == parse_datetime_local_berlin(sent_at)
 
 
 def test_offer_detail_shows_position_description_and_composition(
@@ -671,6 +719,50 @@ def test_mark_sent_requires_evidence_reference(direct_world) -> None:
     status, _url, body = _post(f"{panel_url}/offer/{offer_id}/mark-sent", fields)
     assert status == 400
     assert "evidence_reference is required" in body or "Fehler" in body
+
+
+def test_mark_sent_future_timestamp_shows_german_error(direct_world) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    fields = _offer_form_fields(html, "/mark-sent")
+    fields.update(
+        {
+            "sent_at": "2999-01-01T10:00",
+            "channel": "email",
+            "recipient_reference": "kunde@example.invalid",
+            "evidence_reference": "E-Mail vom 01.01.2999",
+        }
+    )
+
+    status, _url, body = _post(f"{panel_url}/offer/{offer_id}/mark-sent", fields)
+
+    assert status == 400
+    assert "Der Versandnachweis ist ungültig" in body
+    assert "invalid_sent_evidence" not in body
+
+
+def test_mark_sent_before_offer_version_created_at_shows_german_error(
+    direct_world,
+) -> None:
+    panel_url, api_url, ids, _db = direct_world
+    offer_id, _version_id = _prepare_offer(api_url, ids["inquiry_convertible"])
+    _status, html = _get(f"{panel_url}/offer/{offer_id}")
+    fields = _offer_form_fields(html, "/mark-sent")
+    fields.update(
+        {
+            "sent_at": "2000-01-01T10:00:00",
+            "channel": "email",
+            "recipient_reference": "kunde@example.invalid",
+            "evidence_reference": "E-Mail vom 01.01.2000",
+        }
+    )
+
+    status, _url, body = _post(f"{panel_url}/offer/{offer_id}/mark-sent", fields)
+
+    assert status == 400
+    assert "Der Versandnachweis ist ungültig" in body
+    assert "invalid_sent_evidence" not in body
 
 
 def test_datetime_local_converts_to_berlin_iso(direct_world) -> None:


### PR DESCRIPTION
## Summary

- Preserve seconds in Office Panel datetime-local defaults and parsing for offer lifecycle timestamps.
- Add step=1 to datetime-local inputs that render second-precision defaults.
- Keep Europe/Berlin as the business wall-time timezone and preserve existing UTC Office API serialization.
- Add German UX mapping for invalid_sent_evidence so domain validation does not render as a raw code.

## Root Cause

Immediate mark-sent after preparing an offer could submit a minute-truncated timestamp. If the OfferVersion was created at e.g. 15:15:54 UTC, the form value 17:15 Europe/Berlin serialized to 15:15:00 UTC and correctly violated SentEvidence >= OfferVersion.created_at.

## Validation

- .venv/bin/pytest tests/unit/test_office_panel_datetime.py tests/unit/test_office_panel_offer_actions.py::test_mark_sent_unchanged_default_with_seconds_is_accepted tests/unit/test_office_panel_offer_actions.py::test_datetime_local_converts_to_berlin_iso tests/unit/test_office_panel_offer_actions.py::test_mark_sent_future_timestamp_shows_german_error tests/unit/test_office_panel_offer_actions.py::test_mark_sent_before_offer_version_created_at_shows_german_error tests/unit/test_office_panel_offer_actions.py::test_remote_offer_mark_sent_parity -q -> 8 passed
- .venv/bin/pytest tests/unit/test_office_panel_offer_actions.py -q -> 40 passed
- .venv/bin/pytest -q -> 2892 passed
- .venv/bin/ruff format --check -> passed
- .venv/bin/ruff check -> passed
- git diff --check -> passed