### PR TITLE
Activate kitchen version after confirmed print

### DIFF
--- a/src/catering_system/repositories/in_memory_kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/in_memory_kitchen_print_job_repository.py
@@ -11,7 +11,7 @@ from catering_system.domain.kitchen_print_job import (
     KitchenPrintPolicy,
     validate_kitchen_print_job_transition,
 )
-from catering_system.domain.order import OrderVersion
+from catering_system.domain.order import Order, OrderVersion
 from catering_system.repositories.order_repository import OrderRepository
 
 
@@ -79,8 +79,13 @@ class InMemoryKitchenPrintJobRepository:
         self._jobs = next_jobs
 
     def acknowledge_and_confirm(
-        self, job: KitchenPrintJob, confirmed_version: OrderVersion
-    ) -> None:
+        self,
+        job: KitchenPrintJob,
+        confirmed_version: OrderVersion,
+        *,
+        expected_order: Order,
+        activated_order: Order | None = None,
+    ) -> bool:
         previous_job = self._jobs.get(job.print_job_id)
         if previous_job is None:
             raise KeyError(job.print_job_id)
@@ -104,14 +109,32 @@ class InMemoryKitchenPrintJobRepository:
                 raise ValueError("confirmation facts must share one timestamp")
         elif confirmed_version != previous_version:
             raise ValueError("existing kitchen confirmation is not revocable")
+        current_order = self._orders.get_order(job.order_id)
+        if current_order is None:
+            raise KeyError(job.order_id)
+        if activated_order is not None:
+            if activated_order.order_id != job.order_id:
+                raise ValueError("activated order does not belong to print job")
+            if activated_order.effective_order_version_id != job.order_version_id:
+                raise ValueError("activated order must select the printed version")
 
-        # Both writes have been fully validated. The OrderRepository update is
-        # the only operation that can fail; the dict swap after it cannot leave
-        # a partial in-memory state.
+        # All writes have been fully validated. Repository updates happen before
+        # the local job dict swap, so a failure cannot leave a partial job state.
+        activation_applied = (
+            activated_order is not None
+            and current_order.candidate_order_version_id
+            == expected_order.candidate_order_version_id
+            and current_order.effective_order_version_id
+            == expected_order.effective_order_version_id
+        )
+        if activation_applied:
+            assert activated_order is not None
+            self._orders.update_order(activated_order)
         self._orders.update_order_version(confirmed_version)
         next_jobs = dict(self._jobs)
         next_jobs[job.print_job_id] = job
         self._jobs = next_jobs
+        return activation_applied
 
     def claim_next_eligible(
         self, now: datetime, policy: KitchenPrintPolicy

--- a/src/catering_system/repositories/kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/kitchen_print_job_repository.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Protocol
 
 from catering_system.domain.kitchen_print_job import KitchenPrintJob, KitchenPrintPolicy
-from catering_system.domain.order import OrderVersion
+from catering_system.domain.order import Order, OrderVersion
 
 
 class KitchenPrintJobRepository(Protocol):
@@ -28,8 +28,13 @@ class KitchenPrintJobRepository(Protocol):
     ) -> None: ...
 
     def acknowledge_and_confirm(
-        self, job: KitchenPrintJob, confirmed_version: OrderVersion
-    ) -> None: ...
+        self,
+        job: KitchenPrintJob,
+        confirmed_version: OrderVersion,
+        *,
+        expected_order: Order,
+        activated_order: Order | None = None,
+    ) -> bool: ...
 
     def claim_next_eligible(
         self, now: datetime, policy: KitchenPrintPolicy

--- a/src/catering_system/repositories/sqlite_kitchen_print_job_repository.py
+++ b/src/catering_system/repositories/sqlite_kitchen_print_job_repository.py
@@ -20,7 +20,7 @@ from catering_system.domain.kitchen_print_job import (
     KitchenPrintPolicy,
     validate_kitchen_print_job_transition,
 )
-from catering_system.domain.order import OrderVersion
+from catering_system.domain.order import Order, OrderVersion
 from catering_system.repositories.sqlite_migrations import apply_migrations
 
 _REJECTION_CODES_SQL = ", ".join(
@@ -317,8 +317,13 @@ class SQLiteKitchenPrintJobRepository:
             self._insert(new_job)
 
     def acknowledge_and_confirm(
-        self, job: KitchenPrintJob, confirmed_version: OrderVersion
-    ) -> None:
+        self,
+        job: KitchenPrintJob,
+        confirmed_version: OrderVersion,
+        *,
+        expected_order: Order,
+        activated_order: Order | None = None,
+    ) -> bool:
         previous_job = self.get(job.print_job_id)
         if previous_job is None:
             raise KeyError(job.print_job_id)
@@ -330,6 +335,13 @@ class SQLiteKitchenPrintJobRepository:
             or confirmed_version.order_version_id != job.order_version_id
         ):
             raise ValueError("confirmed version does not belong to print job")
+        if expected_order.order_id != job.order_id:
+            raise ValueError("expected order does not belong to print job")
+        if activated_order is not None:
+            if activated_order.order_id != job.order_id:
+                raise ValueError("activated order does not belong to print job")
+            if activated_order.effective_order_version_id != job.order_version_id:
+                raise ValueError("activated order must select the printed version")
 
         current = self._conn.execute(
             "SELECT kitchen_print_confirmed_at FROM order_versions "
@@ -345,6 +357,7 @@ class SQLiteKitchenPrintJobRepository:
         elif confirmed_version.kitchen_print_confirmed_at != current_confirmation:
             raise ValueError("existing kitchen confirmation is not revocable")
 
+        activation_applied = False
         with self._write_scope():
             if current_confirmation is None:
                 updated = self._conn.execute(
@@ -359,7 +372,42 @@ class SQLiteKitchenPrintJobRepository:
                 ).rowcount
                 if updated != 1:
                     raise ValueError("stale kitchen print confirmation")
+            if activated_order is not None:
+                updated_order = self._conn.execute(
+                    """
+                    UPDATE orders SET
+                        source_inquiry_id = ?, created_at = ?, updated_at = ?,
+                        candidate_order_version_id = ?, effective_order_version_id = ?,
+                        cancelled_at = ?
+                    WHERE order_id = ?
+                      AND (
+                        candidate_order_version_id = ?
+                        OR (candidate_order_version_id IS NULL AND ? IS NULL)
+                      )
+                      AND (
+                        effective_order_version_id = ?
+                        OR (effective_order_version_id IS NULL AND ? IS NULL)
+                      )
+                    """,
+                    (
+                        activated_order.source_inquiry_id,
+                        activated_order.created_at.isoformat(),
+                        activated_order.updated_at.isoformat(),
+                        activated_order.candidate_order_version_id,
+                        activated_order.effective_order_version_id,
+                        activated_order.cancelled_at.isoformat()
+                        if activated_order.cancelled_at is not None
+                        else None,
+                        activated_order.order_id,
+                        expected_order.candidate_order_version_id,
+                        expected_order.candidate_order_version_id,
+                        expected_order.effective_order_version_id,
+                        expected_order.effective_order_version_id,
+                    ),
+                ).rowcount
+                activation_applied = updated_order == 1
             self._update_facts(job)
+        return activation_applied
 
     def claim_next_eligible(
         self, now: datetime, policy: KitchenPrintPolicy

--- a/src/catering_system/services/kitchen_print_service.py
+++ b/src/catering_system/services/kitchen_print_service.py
@@ -17,7 +17,10 @@ from catering_system.domain.kitchen_print_job import (
     KitchenPrintJob,
     KitchenPrintPolicy,
 )
-from catering_system.domain.operational_core_events import KitchenPrintConfirmed
+from catering_system.domain.operational_core_events import (
+    KitchenPrintConfirmed,
+    OrderVersionMadeEffective,
+)
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.repositories.kitchen_print_job_repository import (
     KitchenPrintJobRepository,
@@ -185,7 +188,7 @@ class KitchenPrintService:
         a duplicate KitchenPrintConfirmed event.
         """
 
-        job, _order, version = self._active_job_context(print_job_id)
+        job, order, version = self._active_job_context(print_job_id)
         if job.acknowledged_at is not None:
             stored_version = self._orders.get_order_version(job.order_version_id)
             assert stored_version is not None
@@ -208,7 +211,13 @@ class KitchenPrintService:
             if confirmation_was_new
             else version
         )
-        self._jobs.acknowledge_and_confirm(acknowledged, confirmed_version)
+        activated_order = self._activation_after_successful_print(order, version, now)
+        activation_applied = self._jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed_version,
+            expected_order=order,
+            activated_order=activated_order,
+        )
         if confirmation_was_new and self._event_sink is not None:
             self._event_sink(
                 KitchenPrintConfirmed(
@@ -216,7 +225,40 @@ class KitchenPrintService:
                     order_version_id=job.order_version_id,
                 )
             )
+        if activation_applied and self._event_sink is not None:
+            self._event_sink(
+                OrderVersionMadeEffective(
+                    order_id=job.order_id,
+                    order_version_id=job.order_version_id,
+                )
+            )
         return acknowledged, confirmed_version
+
+    @staticmethod
+    def _activation_after_successful_print(
+        order: Order, version: OrderVersion, now: datetime
+    ) -> Order | None:
+        if order.cancelled_at is not None:
+            return None
+        if order.candidate_order_version_id == version.order_version_id:
+            return replace(
+                order,
+                effective_order_version_id=version.order_version_id,
+                candidate_order_version_id=None,
+                updated_at=now,
+            )
+        if (
+            order.effective_order_version_id is None
+            and order.candidate_order_version_id is None
+            and version.version_number == 1
+            and version.parent_order_version_id is None
+        ):
+            return replace(
+                order,
+                effective_order_version_id=version.order_version_id,
+                updated_at=now,
+            )
+        return None
 
     def reprint(
         self,

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -163,25 +163,6 @@ class TaskProjectionService:
                             event_date,
                         )
                     )
-                elif next_action["action"] == "effective":
-                    tasks.append(
-                        (
-                            TaskProjection(
-                                task_id=f"order:{order.order_id}:effective:{version_id}",
-                                category="order_effective",
-                                title="Version wirksam setzen",
-                                subtitle=subtitle,
-                                entity_type="order",
-                                entity_id=order.order_id,
-                                action_label="Auftrag öffnen",
-                                action_href=f"/order/{order.order_id}",
-                                due_at=None,
-                                urgency="normal",
-                                opened_at=order.created_at,
-                            ),
-                            event_date,
-                        )
-                    )
             try:
                 payment = self._payment_reminders.view(order.order_id)
             except (KeyError, ValueError):

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -559,8 +559,9 @@ def resolve_next_action(
 ) -> dict[str, str] | None:
     """Exactly the panel's `_next_step_action` rule (§1.2): target version =
     candidate if it names a real owned version, else the highest
-    version_number; print-confirm before effective; null when cancelled,
-    versionless, or nothing to do."""
+    version_number; print-confirm is the only manual next action because
+    kitchen-agent ACK activates a safe/current printed version automatically;
+    null when cancelled, versionless, or nothing to do."""
     if order.cancelled_at is not None or not versions:
         return None
     target = next(
@@ -571,8 +572,6 @@ def resolve_next_action(
         target = max(versions, key=lambda v: v.version_number)
     if target.kitchen_print_confirmed_at is None:
         return {"action": "print-confirm", "order_version_id": target.order_version_id}
-    if target.order_version_id != order.effective_order_version_id:
-        return {"action": "effective", "order_version_id": target.order_version_id}
     return None
 
 

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -248,6 +248,19 @@ if TYPE_CHECKING:
     from catering_system.repositories.core_transaction import CoreCommandExecutor
     from catering_system.ui.remote_core_client import RemoteCoreClient
 
+_KITCHEN_PRINT_REJECTION_MESSAGES = {
+    "render_failed": "Druckauftrag fehlgeschlagen.",
+    "spool_rejected": "Druckauftrag fehlgeschlagen.",
+    "printer_unavailable": "Drucker nicht erreichbar.",
+    "printer_stopped": "Drucker ist angehalten.",
+    "job_aborted": "Druckauftrag fehlgeschlagen.",
+    "job_canceled": "Druckauftrag fehlgeschlagen.",
+    "paper_missing": "Papier fehlt.",
+    "media_empty": "Papier fehlt.",
+    "invalid_printer_configuration": "Drucker ist nicht korrekt eingerichtet.",
+    "order_cancelled": "Der Auftrag wurde storniert.",
+}
+
 __all__ = [
     "CALL_VERIFICATION_STATUS_LABELS",
     "PROGRESSION_BLOCKER_LABELS",
@@ -727,6 +740,28 @@ class OfficePanel:
         ):
             return "Erneut drucken"
         return "Küchendruck starten"
+
+    def _kitchen_print_status_message(self, order_version_id: str) -> str:
+        if self.kitchen_print_service is None:
+            return "Druckauftrag wird verarbeitet …"
+        attempts = self.kitchen_print_service.list_print_jobs_for_version(
+            order_version_id
+        )
+        if not attempts:
+            return "Druckauftrag wird verarbeitet …"
+        latest = attempts[-1]
+        if latest.acknowledged_at is not None:
+            return "Küchenzettel erfolgreich gedruckt"
+        if latest.rejected_at is not None:
+            return _KITCHEN_PRINT_REJECTION_MESSAGES.get(
+                latest.rejection_code or "",
+                "Druckauftrag fehlgeschlagen.",
+            )
+        if self.kitchen_print_service.is_ack_overdue(latest):
+            return "Druckauftrag fehlgeschlagen."
+        if latest.accepted_at is not None:
+            return "Druckauftrag wird verarbeitet …"
+        return "Druckauftrag wird verarbeitet …"
 
     @staticmethod
     def _missed_calls_open(
@@ -1870,13 +1905,11 @@ class OfficePanel:
                 "print-confirm",
             )
         elif version.order_version_id != order.effective_order_version_id:
-            if not context.can("orders.effective.set"):
-                return ""
-            label, action = "Wirksam machen", "effective"
-            expect = {
-                "effective_version_id": order.effective_order_version_id or "",
-                "candidate_version_id": order.candidate_order_version_id or "",
-            }
+            return (
+                '<p class="muted">Der Küchenzettel wurde gedruckt. '
+                "Der aktuelle Küchenstand wird automatisch übernommen, "
+                "sobald die Druckmeldung verarbeitet ist.</p>"
+            )
         else:
             return ""
         return (
@@ -3263,6 +3296,7 @@ class OfficePanel:
         if self._ui_version == "v2":
             print_confirm_fields: dict[str, str] = {}
             print_confirm_labels: dict[str, str] = {}
+            print_status_messages: dict[str, str] = {}
             effective_fields: dict[str, str] = {}
             target = next(
                 (
@@ -3290,25 +3324,12 @@ class OfficePanel:
                         print_confirm_labels[version.order_version_id] = (
                             self._kitchen_print_action_label(version.order_version_id)
                         )
-                    if (
-                        target is not None
-                        and version.order_version_id == target.order_version_id
-                        and version.kitchen_print_confirmed_at is not None
-                        and version.order_version_id != order.effective_order_version_id
-                        and context.can("orders.effective.set")
-                    ):
-                        effective_fields[version.order_version_id] = (
-                            self._command_fields(
-                                {
-                                    "effective_version_id": (
-                                        order.effective_order_version_id or ""
-                                    ),
-                                    "candidate_version_id": (
-                                        order.candidate_order_version_id or ""
-                                    ),
-                                }
-                            )
+                        print_status_messages[version.order_version_id] = (
+                            self._kitchen_print_status_message(version.order_version_id)
                         )
+                    # Successful kitchen-agent ACK now activates the safe/current
+                    # printed stand automatically; the old manual effective action
+                    # is kept out of the normal Office workflow.
             latest_version_number = versions_total_count or max(
                 (version.version_number for version in versions), default=0
             )
@@ -3442,6 +3463,7 @@ class OfficePanel:
                     ),
                     version_change_prefill=change_prefill if not cancelled else None,
                     print_confirm_button_labels=print_confirm_labels,
+                    print_status_messages=print_status_messages,
                 ),
                 confirmation=confirmation,
                 live_preview=live_preview,

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -170,6 +170,7 @@ class OrderDetailFormFields:
     payment_command_fields: str
     confirmation_command_fields: str = ""
     print_confirm_button_labels: Mapping[str, str] = field(default_factory=dict)
+    print_status_messages: Mapping[str, str] = field(default_factory=dict)
     send_command_fields: str = ""
     pause_command_fields: str = ""
     resume_command_fields: str = ""
@@ -285,10 +286,9 @@ def _state_copy(
             "Den Küchenzettel prüfen und den Küchendruck starten.",
         )
     if next_action is not None and next_action.get("action") == "effective":
-        stand = target.version_number if target is not None else ""
         return (
-            f"Stand {stand} als Küchenstand festlegen",
-            "Der Ausdruck ist bestätigt. Jetzt den geprüften Stand übernehmen.",
+            "Küchenstand wird übernommen",
+            "Der Ausdruck ist bestätigt. Der geprüfte Stand wird automatisch übernommen.",
         )
     if ready.ready:
         return (
@@ -338,8 +338,12 @@ def _primary_action(
         button_label = forms.print_confirm_button_labels.get(
             target.order_version_id, "Küchendruck starten"
         )
+        status_message = forms.print_status_messages.get(
+            target.order_version_id,
+            "Druckauftrag wird verarbeitet …",
+        )
         heading = (
-            f"Küchendruck für Stand {target.version_number} erneut starten"
+            "Druck fehlgeschlagen"
             if button_label == "Erneut drucken"
             else f"Küchendruck für Stand {target.version_number} starten"
         )
@@ -347,7 +351,7 @@ def _primary_action(
             '<section class="order-next-step">'
             '<div class="order-eyebrow">Nächster Schritt</div>'
             f"<h2>{heading}</h2>"
-            "<p>Der Auftrag wird erst nach erfolgreicher Druckmeldung der Küche bestätigt.</p>"
+            f"<p>{_e(status_message)}</p>"
             '<div class="order-next-actions">'
             f'<a class="order-button secondary" target="_blank" rel="noopener" '
             f'href="/order/{_e(order.order_id)}/print?version='
@@ -363,24 +367,12 @@ def _primary_action(
             "</form></div></section>"
         )
     if action == "effective":
-        if (
-            not context.can("orders.effective.set")
-            or target.order_version_id not in forms.effective_command_fields
-        ):
-            return ""
-        command_fields = forms.effective_command_fields.get(target.order_version_id, "")
         return (
             '<section class="order-next-step">'
             '<div class="order-eyebrow">Nächster Schritt</div>'
-            f"<h2>Stand {target.version_number} als Küchenstand festlegen</h2>"
-            "<p>Der Ausdruck ist bestätigt. Dieser Stand wird zur aktuellen "
-            "Arbeitsgrundlage für die Küche.</p>"
-            f'<form method="post" action="/order/{_e(order.order_id)}/effective">'
-            f"{forms.csrf_input}{command_fields}"
-            f'<input type="hidden" name="order_version_id" '
-            f'value="{_e(target.order_version_id)}">'
-            '<button class="order-button" type="submit">Stand übernehmen</button>'
-            "</form></section>"
+            "<h2>Küchenstand wird automatisch übernommen</h2>"
+            "<p>Der Ausdruck ist bestätigt. Dieser Stand wird ohne weiteren "
+            "manuellen Schritt zur Arbeitsgrundlage für die Küche.</p></section>"
         )
     return ""
 
@@ -425,11 +417,11 @@ def _operational_progress(
         steps += _progress_item(
             "done" if effective else ("current" if printed else "waiting"),
             "✓" if effective else "2",
-            f"Stand {target.version_number} als Küchenstand festlegen",
+            "Küchenstand automatisch übernehmen",
             (
                 "Die Küche arbeitet mit diesem Stand."
                 if effective
-                else "Dieser Schritt ist erst nach der Druckbestätigung möglich."
+                else "Nach erfolgreichem Druck wird dieser Stand automatisch übernommen."
             ),
         )
         steps += _progress_item(
@@ -470,6 +462,28 @@ def _operational_progress(
         '<section class="order-card order-content-card">'
         "<h2>Operative Vorbereitung</h2>"
         f"{steps}{blocker_html}{ready_form}</section>"
+    )
+
+
+def _stale_print_notice(order: Order, versions: Sequence[OrderVersion]) -> str:
+    if order.candidate_order_version_id is None:
+        return ""
+    stale_prints = [
+        version
+        for version in versions
+        if version.kitchen_print_confirmed_at is not None
+        and version.order_version_id != order.effective_order_version_id
+        and version.order_version_id != order.candidate_order_version_id
+    ]
+    if not stale_prints:
+        return ""
+    latest = max(stale_prints, key=lambda version: version.version_number)
+    return (
+        '<div class="order-notice blocked">'
+        "<strong>Küchendruck nicht übernommen:</strong> "
+        f"Stand {_e(latest.version_number)} wurde gedruckt, aber inzwischen gibt es "
+        "einen neueren Stand. Der ältere Stand wurde nicht als aktueller "
+        "Küchenstand übernommen.</div>"
     )
 
 
@@ -1329,6 +1343,7 @@ def render_order_detail(
         + cancelled_banner
         + paused_banner
         + truncation_warning
+        + _stale_print_notice(order, versions)
         + '<section class="order-hero"><div>'
         f'<div class="order-eyebrow">{_e(stand_label)}</div>'
         f"<h1>{_e(title)}</h1>"

--- a/tests/unit/test_kitchen_api.py
+++ b/tests/unit/test_kitchen_api.py
@@ -309,9 +309,12 @@ def test_ack_confirms_order_version_and_replays(kitchen_api) -> None:
 
     orders = SQLiteOrderRepository(db)
     version = orders.get_order_version(version_id)
+    order = orders.get_order(_order_id)
     orders.close()
     assert version is not None
     assert version.kitchen_print_confirmed_at == _NOW
+    assert order is not None
+    assert order.effective_order_version_id == version_id
 
 
 def test_ack_requires_agent_auth(kitchen_api) -> None:

--- a/tests/unit/test_kitchen_print_repository_errors.py
+++ b/tests/unit/test_kitchen_print_repository_errors.py
@@ -129,10 +129,12 @@ def test_in_memory_acknowledge_rejects_version_mismatch() -> None:
     jobs.update(accepted)
     acknowledged = replace(accepted, acknowledged_at=_NOW + timedelta(seconds=2))
     wrong_version = orders.get_order_version(version_id)
+    order = orders.get_order(order_id)
     assert wrong_version is not None
+    assert order is not None
     mismatched = replace(wrong_version, order_id="00000000-0000-4000-8000-000000000000")
     with pytest.raises(ValueError, match="does not belong to print job"):
-        jobs.acknowledge_and_confirm(acknowledged, mismatched)
+        jobs.acknowledge_and_confirm(acknowledged, mismatched, expected_order=order)
 
 
 def test_in_memory_validate_new_job_rejects_duplicate_attempt_number() -> None:
@@ -170,11 +172,13 @@ def test_sqlite_acknowledge_rejects_missing_acknowledged_at(tmp_path: Path) -> N
     )
     jobs.update(accepted)
     version = orders.get_order_version(version_id)
+    order = orders.get_order(order_id)
     assert version is not None
+    assert order is not None
     with pytest.raises(
         ValueError, match="atomic confirmation requires acknowledged_at"
     ):
-        jobs.acknowledge_and_confirm(accepted, version)
+        jobs.acknowledge_and_confirm(accepted, version, expected_order=order)
     jobs.close()
     orders.close()
 
@@ -210,11 +214,13 @@ def test_in_memory_acknowledge_rejects_missing_acknowledged_at() -> None:
     )
     jobs.update(accepted)
     version = orders.get_order_version(version_id)
+    order = orders.get_order(order_id)
     assert version is not None
+    assert order is not None
     with pytest.raises(
         ValueError, match="atomic confirmation requires acknowledged_at"
     ):
-        jobs.acknowledge_and_confirm(accepted, version)
+        jobs.acknowledge_and_confirm(accepted, version, expected_order=order)
 
 
 def test_sqlite_acknowledge_rejects_mismatched_confirmation_timestamp(
@@ -231,11 +237,113 @@ def test_sqlite_acknowledge_rejects_mismatched_confirmation_timestamp(
     jobs.update(accepted)
     acknowledged = replace(accepted, acknowledged_at=_NOW + timedelta(seconds=2))
     version = orders.get_order_version(version_id)
+    order = orders.get_order(order_id)
     assert version is not None
+    assert order is not None
     wrong_confirmation = replace(
         version, kitchen_print_confirmed_at=_NOW + timedelta(hours=1)
     )
     with pytest.raises(ValueError, match="confirmation facts must share one timestamp"):
-        jobs.acknowledge_and_confirm(acknowledged, wrong_confirmation)
+        jobs.acknowledge_and_confirm(
+            acknowledged, wrong_confirmation, expected_order=order
+        )
     jobs.close()
     orders.close()
+
+
+def test_ack_activation_rejects_invalid_order_targets_without_partial_writes(
+    tmp_path: Path,
+) -> None:
+    foreign_order_id = "00000000-0000-4000-8000-000000000000"
+
+    memory_orders, memory_jobs, order_id, version_id = _memory_world()
+    pending = _job(order_id, version_id)
+    memory_jobs.save(pending)
+    accepted = replace(
+        pending,
+        accepted_at=_NOW + timedelta(seconds=1),
+        ack_deadline_at=_NOW + timedelta(minutes=1),
+    )
+    memory_jobs.update(accepted)
+    acknowledged = replace(accepted, acknowledged_at=_NOW + timedelta(seconds=2))
+    version = memory_orders.get_order_version(version_id)
+    order = memory_orders.get_order(order_id)
+    assert version is not None
+    assert order is not None
+    confirmed = replace(
+        version, kitchen_print_confirmed_at=acknowledged.acknowledged_at
+    )
+    activated = replace(order, effective_order_version_id=version_id)
+
+    with pytest.raises(ValueError, match="activated order does not belong"):
+        memory_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=order,
+            activated_order=replace(activated, order_id=foreign_order_id),
+        )
+    with pytest.raises(ValueError, match="must select the printed version"):
+        memory_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=order,
+            activated_order=order,
+        )
+    assert memory_jobs.get(JOB_1) == accepted
+    assert memory_orders.get_order_version(version_id) == version
+
+    memory_orders._orders.pop(order_id)
+    with pytest.raises(KeyError, match=order_id):
+        memory_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=order,
+            activated_order=activated,
+        )
+    assert memory_jobs.get(JOB_1) == accepted
+    assert memory_orders.get_order_version(version_id) == version
+
+    sqlite_orders, sqlite_jobs, order_id, version_id = _sqlite_world(tmp_path)
+    pending = _job(order_id, version_id)
+    sqlite_jobs.save(pending)
+    accepted = replace(
+        pending,
+        accepted_at=_NOW + timedelta(seconds=1),
+        ack_deadline_at=_NOW + timedelta(minutes=1),
+    )
+    sqlite_jobs.update(accepted)
+    acknowledged = replace(accepted, acknowledged_at=_NOW + timedelta(seconds=2))
+    version = sqlite_orders.get_order_version(version_id)
+    order = sqlite_orders.get_order(order_id)
+    assert version is not None
+    assert order is not None
+    confirmed = replace(
+        version, kitchen_print_confirmed_at=acknowledged.acknowledged_at
+    )
+    activated = replace(order, effective_order_version_id=version_id)
+
+    with pytest.raises(ValueError, match="expected order does not belong"):
+        sqlite_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=replace(order, order_id=foreign_order_id),
+            activated_order=activated,
+        )
+    with pytest.raises(ValueError, match="activated order does not belong"):
+        sqlite_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=order,
+            activated_order=replace(activated, order_id=foreign_order_id),
+        )
+    with pytest.raises(ValueError, match="must select the printed version"):
+        sqlite_jobs.acknowledge_and_confirm(
+            acknowledged,
+            confirmed,
+            expected_order=order,
+            activated_order=order,
+        )
+    assert sqlite_jobs.get(JOB_1) == accepted
+    assert sqlite_orders.get_order_version(version_id) == version
+    sqlite_jobs.close()
+    sqlite_orders.close()

--- a/tests/unit/test_kitchen_print_service.py
+++ b/tests/unit/test_kitchen_print_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import fields
+from dataclasses import fields, replace
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
@@ -21,7 +21,10 @@ from catering_system.domain.kitchen_print_job import (
     KitchenPrintPolicy,
     derive_kitchen_print_job_state,
 )
-from catering_system.domain.operational_core_events import KitchenPrintConfirmed
+from catering_system.domain.operational_core_events import (
+    KitchenPrintConfirmed,
+    OrderVersionMadeEffective,
+)
 from catering_system.repositories.in_memory_kitchen_print_job_repository import (
     InMemoryKitchenPrintJobRepository,
 )
@@ -30,6 +33,8 @@ from catering_system.repositories.in_memory_order_repository import (
 )
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_service import OrderService
+from catering_system.ui.office_panel import OfficePanel
 from tests.helpers.order_seed import seed_order
 
 _CONTACT_COMPLETE_SNAPSHOT = _CCSnapshot(
@@ -169,9 +174,11 @@ def test_ack_before_deadline_atomically_confirms_version() -> None:
     assert orders.get_order_version(version_id) == version
     assert derive_kitchen_print_job_state(acknowledged, now=clock.now) == "confirmed"
     assert events == [
-        KitchenPrintConfirmed(order_id=order_id, order_version_id=version_id)
+        KitchenPrintConfirmed(order_id=order_id, order_version_id=version_id),
+        OrderVersionMadeEffective(order_id=order_id, order_version_id=version_id),
     ]
-    assert core.evaluate_ready_to_send(order_id).ready is False  # still not effective
+    assert core.evaluate_ready_to_send(order_id).ready is True
+    assert orders.get_order(order_id).effective_order_version_id == version_id
 
 
 def test_ack_after_deadline_is_rejected_and_explicit_reprint_is_possible() -> None:
@@ -211,7 +218,7 @@ def test_repeated_ack_keeps_original_facts_and_emits_once() -> None:
     assert second_job == first_job
     assert second_version == first_version
     assert second_job.acknowledged_at != clock.now
-    assert len(events) == 1
+    assert len(events) == 2
 
 
 def test_reprint_creates_new_job_and_supersedes_live_attempt() -> None:
@@ -260,7 +267,7 @@ def test_multiple_jobs_for_same_version_preserve_attempt_history() -> None:
     assert rows[1].rejection_code == "printer_unavailable"
 
 
-def test_effective_switch_stays_blocked_until_job_ack_then_succeeds() -> None:
+def test_effective_switch_is_automatic_after_job_ack() -> None:
     _orders, service, core, _clock, order_id, version_id, _events = _setup()
     service.request_print(order_id, version_id, print_job_id=JOB_1)
     service.accept_print_job(JOB_1)
@@ -269,8 +276,169 @@ def test_effective_switch_stays_blocked_until_job_ack_then_succeeds() -> None:
         core.make_order_version_effective(order_id, version_id)
 
     service.acknowledge_print_job(JOB_1)
-    updated = core.make_order_version_effective(order_id, version_id)
-    assert updated.effective_order_version_id == version_id
+    assert core.evaluate_ready_to_send(order_id).ready is True
+
+
+def test_ack_activates_current_candidate_version() -> None:
+    orders, service, _core, _clock, order_id, version_id, _events = _setup()
+    order_service = OrderService(orders)
+    order = orders.get_order(order_id)
+    assert order is not None
+    v2 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Kiel",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order_id, v2.order_version_id)
+    service.request_print(order_id, v2.order_version_id, print_job_id=JOB_1)
+    service.accept_print_job(JOB_1)
+
+    _acknowledged, confirmed = service.acknowledge_print_job(JOB_1)
+
+    order = orders.get_order(order_id)
+    assert confirmed.order_version_id == v2.order_version_id
+    assert confirmed.kitchen_print_confirmed_at is not None
+    assert order is not None
+    assert order.effective_order_version_id == v2.order_version_id
+    assert order.candidate_order_version_id is None
+    assert orders.get_order_version(version_id).kitchen_print_confirmed_at is None
+
+
+def test_ack_for_stale_print_confirms_but_does_not_activate_old_candidate() -> None:
+    orders, service, _core, _clock, order_id, _version_id, _events = _setup()
+    order_service = OrderService(orders)
+    order = orders.get_order(order_id)
+    assert order is not None
+    v2 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Kiel",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order_id, v2.order_version_id)
+    service.request_print(order_id, v2.order_version_id, print_job_id=JOB_1)
+    service.accept_print_job(JOB_1)
+    order = orders.get_order(order_id)
+    assert order is not None
+    v3 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 3),
+        time_window_text="mittags",
+        location_text="Lübeck",
+        guest_count_estimate=18,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order_id, v3.order_version_id)
+
+    _acknowledged, confirmed = service.acknowledge_print_job(JOB_1)
+
+    order = orders.get_order(order_id)
+    assert confirmed.order_version_id == v2.order_version_id
+    assert confirmed.kitchen_print_confirmed_at is not None
+    assert order is not None
+    assert order.effective_order_version_id is None
+    assert order.candidate_order_version_id == v3.order_version_id
+
+
+def test_successful_retry_activates_exact_current_candidate() -> None:
+    orders, service, _core, _clock, order_id, _version_id, _events = _setup()
+    order = orders.get_order(order_id)
+    assert order is not None
+    v2 = OrderService(orders).create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Kiel",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+    )
+    OrderService(orders).set_candidate_order_version(order_id, v2.order_version_id)
+    service.request_print(order_id, v2.order_version_id, print_job_id=JOB_1)
+    service.reject_print_job(JOB_1, "spool_rejected")
+    retry = service.reprint(JOB_1, new_print_job_id=JOB_2)
+    service.accept_print_job(JOB_2)
+
+    service.acknowledge_print_job(JOB_2)
+
+    attempts = service.list_print_jobs_for_version(v2.order_version_id)
+    order = orders.get_order(order_id)
+    assert attempts[0].rejection_code == "spool_rejected"
+    assert attempts[1].print_job_id == retry.print_job_id
+    assert order is not None
+    assert order.effective_order_version_id == v2.order_version_id
+    assert order.candidate_order_version_id is None
+
+
+def test_rejected_print_does_not_confirm_or_activate_candidate() -> None:
+    orders, service, _core, clock, order_id, _version_id, _events = _setup()
+    order = orders.get_order(order_id)
+    assert order is not None
+    v2 = OrderService(orders).create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Kiel",
+        guest_count_estimate=12,
+        planning_mode="caterer_suggestion",
+    )
+    OrderService(orders).set_candidate_order_version(order_id, v2.order_version_id)
+
+    service.request_print(order_id, v2.order_version_id, print_job_id=JOB_1)
+    service.reject_print_job(JOB_1, "printer_unavailable")
+
+    order = orders.get_order(order_id)
+    version = orders.get_order_version(v2.order_version_id)
+    assert version is not None
+    assert version.kitchen_print_confirmed_at is None
+    assert order is not None
+    assert order.effective_order_version_id is None
+    assert order.candidate_order_version_id == v2.order_version_id
+    assert (
+        service._activation_after_successful_print(
+            replace(order, cancelled_at=clock.now),
+            version,
+            clock.now,
+        )
+        is None
+    )
+
+
+def test_office_print_status_message_tracks_attempt_lifecycle() -> None:
+    _orders, service, _core, clock, order_id, version_id, _events = _setup()
+    panel = OfficePanel.__new__(OfficePanel)
+    panel.kitchen_print_service = service
+    service.request_print(order_id, version_id, print_job_id=JOB_1)
+    service.accept_print_job(JOB_1)
+
+    assert (
+        panel._kitchen_print_status_message(version_id)
+        == "Druckauftrag wird verarbeitet …"
+    )
+    clock.advance(timedelta(minutes=3))
+    assert (
+        panel._kitchen_print_status_message(version_id)
+        == "Druckauftrag fehlgeschlagen."
+    )
+    service.reject_print_job(JOB_1, "printer_unavailable")
+    assert (
+        panel._kitchen_print_status_message(version_id) == "Drucker nicht erreichbar."
+    )
+
+    _orders, service, _core, _clock, order_id, version_id, _events = _setup()
+    panel.kitchen_print_service = service
+    service.request_print(order_id, version_id, print_job_id=JOB_1)
+    service.accept_print_job(JOB_1)
+    service.acknowledge_print_job(JOB_1)
+
+    assert (
+        panel._kitchen_print_status_message(version_id)
+        == "Küchenzettel erfolgreich gedruckt"
+    )
 
 
 def test_existing_manual_confirmation_flow_is_unchanged() -> None:

--- a/tests/unit/test_kitchen_print_sqlite.py
+++ b/tests/unit/test_kitchen_print_sqlite.py
@@ -23,6 +23,7 @@ from catering_system.repositories.sqlite_kitchen_print_job_repository import (
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.kitchen_print_service import KitchenPrintService
 from catering_system.services.operational_core_service import OperationalCoreService
+from catering_system.services.order_service import OrderService
 
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
@@ -141,6 +142,10 @@ def test_sqlite_jobs_roundtrip_and_ack_confirmation_survive_reconnect(
     reopened_jobs.close()
     reopened_orders = SQLiteOrderRepository(db)
     assert reopened_orders.get_order_version(version_id) == confirmed
+    order = reopened_orders.get_order(order_id)
+    assert order is not None
+    assert order.effective_order_version_id == version_id
+    assert order.candidate_order_version_id is None
     reopened_orders.close()
 
 
@@ -168,9 +173,77 @@ def test_atomic_ack_rolls_back_version_if_job_fact_write_fails(
         service.acknowledge_print_job(JOB_1)
 
     stored_version = orders.get_order_version(version_id)
+    stored_order = orders.get_order(order_id)
     assert stored_version is not None
     assert stored_version.kitchen_print_confirmed_at is None
+    assert stored_order is not None
+    assert stored_order.effective_order_version_id is None
     assert jobs.get(JOB_1) == accepted
+    jobs.close()
+    orders.close()
+
+
+def test_activation_guard_miss_preserves_print_confirmation(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    orders, jobs, service, order_id, _version_id = _sqlite_world(db)
+    order_service = OrderService(orders)
+    order = orders.get_order(order_id)
+    assert order is not None
+    v2 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 2),
+        time_window_text="abends",
+        location_text="Kiel",
+        guest_count_estimate=30,
+        planning_mode="caterer_suggestion",
+    )
+    order_service.set_candidate_order_version(order_id, v2.order_version_id)
+    order = orders.get_order(order_id)
+    assert order is not None
+    v3 = order_service.create_relevant_order_change_version(
+        order,
+        event_date=date(2026, 10, 3),
+        time_window_text="mittags",
+        location_text="Lübeck",
+        guest_count_estimate=40,
+        planning_mode="self_select",
+    )
+    service.request_print(order_id, v2.order_version_id, print_job_id=JOB_1)
+    accepted = service.accept_print_job(JOB_1)
+
+    connection = sqlite3.connect(db)
+    connection.execute(
+        """
+        CREATE TRIGGER simulate_candidate_race
+        BEFORE UPDATE OF kitchen_print_confirmed_at ON order_versions
+        WHEN NEW.order_version_id = '33333333-3333-4333-8333-333333333333'
+        BEGIN
+            UPDATE orders
+            SET candidate_order_version_id = '44444444-4444-4444-8444-444444444444'
+            WHERE order_id = '11111111-1111-4111-8111-111111111111';
+        END
+        """.replace("33333333-3333-4333-8333-333333333333", v2.order_version_id)
+        .replace("44444444-4444-4444-8444-444444444444", v3.order_version_id)
+        .replace("11111111-1111-4111-8111-111111111111", order_id)
+    )
+    connection.commit()
+    connection.close()
+
+    acknowledged, confirmed = service.acknowledge_print_job(JOB_1)
+
+    stored_order = orders.get_order(order_id)
+    stored_v2 = orders.get_order_version(v2.order_version_id)
+    assert acknowledged.acknowledged_at is not None
+    assert confirmed.kitchen_print_confirmed_at is not None
+    assert jobs.get(JOB_1).acknowledged_at == acknowledged.acknowledged_at
+    assert stored_v2 is not None
+    assert stored_v2.kitchen_print_confirmed_at == confirmed.kitchen_print_confirmed_at
+    assert stored_order is not None
+    assert stored_order.effective_order_version_id is None
+    assert stored_order.candidate_order_version_id == v3.order_version_id
+    assert jobs.get(JOB_1) != accepted
     jobs.close()
     orders.close()
 

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -1665,14 +1665,10 @@ def test_versions_expect_and_cancelled_gate(api) -> None:
     )
     assert status == 200
     _ack_next_kitchen_job(db, body["order_version_id"])
-    status, switched, _h = _post(
-        effective_url,
-        args={"order_version_id": body["order_version_id"]},
-        expect=effective_expect,
-    )
+    status, detail, _h = _get(f"{base}/office/v1/orders/{ids['order_ready']}")
     assert status == 200
-    assert switched["effective_order_version_id"] == body["order_version_id"]
-    assert switched["candidate_order_version_id"] is None
+    assert detail["effective_order_version_id"] == body["order_version_id"]
+    assert detail["candidate_order_version_id"] is None
 
     status, body, _h = _post(
         f"{base}/office/v1/orders/{ids['order_cancelled']}/versions",
@@ -1897,6 +1893,9 @@ def test_print_confirm_effective_and_gates(api) -> None:
     )
     assert (status, body["error"]) == (422, "kitchen_print_not_confirmed")
     _ack_next_kitchen_job(db, version_id)
+    status, detail, _h = _get(f"{base}/office/v1/orders/{order_id}")
+    assert status == 200
+    assert detail["effective_order_version_id"] == version_id
     # effective with stale pointer expectation
     status, body, _h = _post(
         f"{base}/office/v1/orders/{order_id}/effective",
@@ -1906,7 +1905,7 @@ def test_print_confirm_effective_and_gates(api) -> None:
             "current_candidate_order_version_id": None,
         },
     )
-    assert (status, body["error"]) == (409, "stale_state")
+    assert status == 200
     status, body, _h = _post(
         f"{base}/office/v1/orders/{order_id}/effective",
         args={"order_version_id": version_id},
@@ -1915,8 +1914,7 @@ def test_print_confirm_effective_and_gates(api) -> None:
             "current_candidate_order_version_id": None,
         },
     )
-    assert status == 200
-    assert body["effective_order_version_id"] == version_id
+    assert (status, body["error"]) == (409, "stale_state")
     # print-confirm on a cancelled order: API-level gate
     status, body, _h = _post(
         f"{base}/office/v1/orders/{ids['order_cancelled']}/print-confirm",
@@ -1965,14 +1963,7 @@ def test_confirmed_old_version_does_not_authorize_new_candidate(api) -> None:
     assert body["kitchen_print_confirmed_at"] is None
     _ack_next_kitchen_job(db, str(v2_id))
 
-    status, body, _h = _post(
-        f"{base}/office/v1/orders/{order_id}/effective",
-        args={"order_version_id": v2_id},
-        expect={
-            "current_effective_order_version_id": v1_id,
-            "current_candidate_order_version_id": v2_id,
-        },
-    )
+    status, body, _h = _get(f"{base}/office/v1/orders/{order_id}")
     assert status == 200
     assert body["effective_order_version_id"] == v2_id
 
@@ -4792,17 +4783,6 @@ def _make_effective_offer_order(
         == 200
     )
     _ack_next_kitchen_job(db, order_version_id)
-    assert (
-        _post(
-            f"{base}/office/v1/orders/{order_id}/effective",
-            args={"order_version_id": order_version_id},
-            expect={
-                "current_effective_order_version_id": None,
-                "current_candidate_order_version_id": None,
-            },
-        )[0]
-        == 200
-    )
     return order_id, order_version_id
 
 

--- a/tests/unit/test_office_api_views.py
+++ b/tests/unit/test_office_api_views.py
@@ -67,6 +67,8 @@ def _panel_action(order: Order, repo: InMemoryOrderRepository) -> dict | None:
         return None
     action = re.search(r"/order/[^/]+/([a-z-]+)\"", html)
     version = re.search(r'name="order_version_id" value="([^"]+)"', html)
+    if action is None and version is None:
+        return None
     assert action and version
     return {"action": action.group(1), "order_version_id": version.group(1)}
 

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -1035,8 +1035,9 @@ def test_order_page_offers_effective_only_after_print_confirmation(panel: str) -
     _simulate_kitchen_agent_ack(panel, vid)
     _status, body = _get(f"{panel}/order/{oid}")
     assert f'action="/order/{oid}/print-confirm"' not in body
-    assert f'action="/order/{oid}/effective"' in body
-    assert "Wirksam machen" in body
+    assert f'action="/order/{oid}/effective"' not in body
+    assert "Wirksam machen" not in body
+    assert "READY_TO_SEND: bereit" in body
 
 
 def test_stale_print_attempt_offers_explicit_reprint(panel: str) -> None:
@@ -1077,10 +1078,6 @@ def test_full_release_flow(panel: str) -> None:
     vid = body.split('name="order_version_id" value="')[1].split('"')[0]
     _post(f"{panel}/order/{oid}/print-confirm", {"order_version_id": vid})
     _simulate_kitchen_agent_ack(panel, vid)
-    _status, _url, body = _post(
-        f"{panel}/order/{oid}/effective", {"order_version_id": vid}
-    )
-    assert "wirksam" in body
     _status, _url, body = _post(f"{panel}/order/{oid}/ready", {})
     assert "READY_TO_SEND: bereit" in body
 
@@ -1147,22 +1144,14 @@ def test_v2_order_detail_guides_print_effective_and_release(
     _simulate_kitchen_agent_ack(premium_panel, version_id)
     _status, printed = _get(f"{premium_panel}/order/{order_id}")
 
-    assert "Stand 1 als Küchenstand festlegen" in printed
+    assert "Vorbereitung vollständig" in printed
+    assert "Die Versandfreigabe ist erfüllt." in printed
     assert f'action="/order/{order_id}/print-confirm"' not in printed
-    assert f'action="/order/{order_id}/effective"' in printed
+    assert f'action="/order/{order_id}/effective"' not in printed
 
-    _post(
-        f"{premium_panel}/order/{order_id}/effective",
-        {"order_version_id": version_id},
-    )
-    _status, effective = _get(f"{premium_panel}/order/{order_id}")
+    assert f'action="/order/{order_id}/ready"' in printed
 
-    assert "Vorbereitung vollständig" in effective
-    assert "Die Versandfreigabe ist erfüllt." in effective
-    assert f'action="/order/{order_id}/effective"' not in effective
-    assert f'action="/order/{order_id}/ready"' in effective
-
-    visible = html.unescape(re.sub(r"<[^>]+>", " ", effective))
+    visible = html.unescape(re.sub(r"<[^>]+>", " ", printed))
     assert order_id[:8] not in visible
     assert inquiry_id[:8] not in visible
     assert "caterer_suggestion" not in visible
@@ -1215,6 +1204,65 @@ def test_v2_order_detail_prefers_new_candidate_over_ready_old_stand(
     assert "Eine Änderung wartet noch auf Küchendruck" in body
     assert "Aktueller Küchenstand" in body
     assert "Aktueller Bearbeitungsstand" in body
+
+
+def test_v2_stale_print_ack_shows_human_warning_without_manual_effective_action(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(premium_panel)
+    order_id = _convert(premium_panel, inquiry_id)
+    _status, initial = _get(f"{premium_panel}/order/{order_id}")
+    v1_id = re.search(r'name="order_version_id" value="([^"]+)"', initial).group(1)
+    _post(
+        f"{premium_panel}/order/{order_id}/print-confirm", {"order_version_id": v1_id}
+    )
+    _simulate_kitchen_agent_ack(premium_panel, v1_id)
+
+    _status, before_v2 = _get(f"{premium_panel}/order/{order_id}")
+    latest_version_number = re.search(
+        r'name="latest_version_number" value="([^"]+)"',
+        before_v2,
+    ).group(1)
+    _post(
+        f"{premium_panel}/order/{order_id}/version",
+        {
+            "latest_version_number": latest_version_number,
+            "event_date": "2026-10-02",
+            "time_window_text": "abends",
+            "location_text": "Kiel",
+            "guest_count_estimate": "30",
+            "planning_mode": "caterer_suggestion",
+        },
+    )
+    _status, v2_page = _get(f"{premium_panel}/order/{order_id}")
+    v2_id = re.search(r'name="order_version_id" value="([^"]+)"', v2_page).group(1)
+    _post(
+        f"{premium_panel}/order/{order_id}/print-confirm", {"order_version_id": v2_id}
+    )
+
+    latest_version_number = re.search(
+        r'name="latest_version_number" value="([^"]+)"',
+        v2_page,
+    ).group(1)
+    _post(
+        f"{premium_panel}/order/{order_id}/version",
+        {
+            "latest_version_number": latest_version_number,
+            "event_date": "2026-10-03",
+            "time_window_text": "mittags",
+            "location_text": "Lübeck",
+            "guest_count_estimate": "40",
+            "planning_mode": "self_select",
+        },
+    )
+
+    _simulate_kitchen_agent_ack(premium_panel, v2_id)
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+
+    assert "Küchendruck nicht übernommen" in body
+    assert "inzwischen gibt es einen neueren Stand" in body
+    assert f'action="/order/{order_id}/effective"' not in body
+    assert "Wirksam machen" not in body
 
 
 def test_v2_create_version_rejects_stale_latest_version_number(
@@ -2086,8 +2134,8 @@ def test_next_step_never_offers_effective_before_print_confirmed() -> None:
     panel.core.confirm_kitchen_print(order.order_id, v1.order_version_id)
     order = panel._orders.get_order(order.order_id)
     action_html = panel._next_step_action(order, context=legacy_office_context())
-    assert "Wirksam machen" in action_html
-    assert f'action="/order/{order.order_id}/effective"' in action_html
+    assert "Küchenzettel wurde gedruckt" in action_html
+    assert f'action="/order/{order.order_id}/effective"' not in action_html
 
 
 def test_next_step_falls_back_to_latest_when_candidate_is_foreign() -> None:

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -1325,8 +1325,8 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
         order_html,
         re.DOTALL,
     )
-    assert f'action="/order/{order_id}/effective"' in order_html
-    assert "Wirksam machen" in order_html
+    assert f'action="/order/{order_id}/effective"' not in order_html
+    assert "Wirksam machen" not in order_html
 
     ready_command_id = _extract_hidden(
         re.search(
@@ -1337,24 +1337,6 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
     status, _body = _post_form(
         f"{base}/order/{order_id}/ready",
         {"_csrf_token": _CSRF_TOKEN, "_command_id": ready_command_id},
-    )
-    assert status == 200  # not yet effective, but the command itself succeeds
-
-    effective_command_id = _extract_hidden(
-        re.search(
-            r'(<form[^>]*action="/order/[^"]*/effective"[^>]*>.*?</form>)', order_html
-        ).group(0),
-        "_command_id",
-    )
-    effective_expect = _extract_hidden(order_html, "_expect_effective_version_id")
-    status, _body = _post_form(
-        f"{base}/order/{order_id}/effective",
-        {
-            "_csrf_token": _CSRF_TOKEN,
-            "_command_id": effective_command_id,
-            "_expect_effective_version_id": effective_expect,
-            "order_version_id": version_id,
-        },
     )
     assert status == 200
 

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -293,7 +293,7 @@ def test_print_confirm_task_emitted() -> None:
     assert print_row.title == "Druck bestätigen"
 
 
-def test_effective_task_emitted() -> None:
+def test_effective_task_not_emitted_after_manual_print_confirmation() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
     inquiry = _save_inquiry(inquiries)
@@ -302,11 +302,7 @@ def test_effective_task_emitted() -> None:
         order.order_id, version.order_version_id
     )
     rows = _service(inquiries=inquiries, orders=orders).list_tasks()
-    assert any(row.category == "order_effective" for row in rows)
-    effective_row = next(row for row in rows if row.category == "order_effective")
-    assert effective_row.task_id == (
-        f"order:{order.order_id}:effective:{version.order_version_id}"
-    )
+    assert not any(row.category == "order_effective" for row in rows)
 
 
 def test_payment_task_emitted_with_overdue_urgency() -> None:


### PR DESCRIPTION
## Summary
- auto-activate the exact printed order version after successful kitchen print ACK when current pointers still match
- preserve print confirmation when activation is stale due to a concurrent candidate change
- remove the manual kitchen effective step from the normal Office workflow

## Tests
- .venv/bin/pytest -q
- git diff --check
- git diff --cached --check