### PR TITLE
Redesign office order detail workflow

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -63,6 +63,9 @@ from catering_system.domain.offer_pdf import (
     OfferPdfUnsupportedCharacterError,
 )
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_commercial_snapshot import (
+    MissingCommercialSnapshotError,
+)
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHOD_LABELS,
     PAYMENT_METHODS,
@@ -173,6 +176,10 @@ from catering_system.services.order_confirmation_outbound_service import (
     OrderConfirmationOutboundService,
 )
 from catering_system.services.order_service import OrderService
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjectionService,
+    PrintProjectionNotFoundError,
+)
 from catering_system.services.payment_reminder_service import PaymentReminderService
 from catering_system.services.progression_service import ProgressionService
 from catering_system.services.task_projection_service import TaskProjectionService
@@ -214,6 +221,7 @@ from catering_system.ui.office_panel_order_detail import (
     _DOCUMENT_BLOCKER_LABELS,
     ConfirmationLivePreviewView,
     OrderDetailFormFields,
+    OrderDetailOperationalData,
     render_confirmation_card,
     render_confirmation_outbound_card,
     render_customer_addresses_card,
@@ -741,14 +749,30 @@ class OfficePanel:
             return "Erneut drucken"
         return "Küchendruck starten"
 
-    def _kitchen_print_status_message(self, order_version_id: str) -> str:
+    def _kitchen_print_is_processing(self, order_version_id: str) -> bool:
         if self.kitchen_print_service is None:
-            return "Druckauftrag wird verarbeitet …"
+            return False
         attempts = self.kitchen_print_service.list_print_jobs_for_version(
             order_version_id
         )
         if not attempts:
-            return "Druckauftrag wird verarbeitet …"
+            return False
+        latest = attempts[-1]
+        return (
+            latest.acknowledged_at is None
+            and latest.rejected_at is None
+            and latest.superseded_at is None
+            and not self.kitchen_print_service.is_ack_overdue(latest)
+        )
+
+    def _kitchen_print_status_message(self, order_version_id: str) -> str:
+        if self.kitchen_print_service is None:
+            return ""
+        attempts = self.kitchen_print_service.list_print_jobs_for_version(
+            order_version_id
+        )
+        if not attempts:
+            return ""
         latest = attempts[-1]
         if latest.acknowledged_at is not None:
             return "Küchenzettel erfolgreich gedruckt"
@@ -762,6 +786,76 @@ class OfficePanel:
         if latest.accepted_at is not None:
             return "Druckauftrag wird verarbeitet …"
         return "Druckauftrag wird verarbeitet …"
+
+    @staticmethod
+    def _order_address_lines(address: CustomerAddress | None) -> tuple[str, ...]:
+        if address is None:
+            return ()
+        city_line = " ".join(
+            part
+            for part in (
+                (address.postal_code or "").strip(),
+                (address.city or "").strip(),
+            )
+            if part
+        )
+        return tuple(
+            value
+            for value in (
+                (address.street or "").strip(),
+                city_line,
+                (address.country or "").strip(),
+            )
+            if value
+        )
+
+    def _order_detail_operational_data(
+        self, order_id: str, order_version_id: str
+    ) -> OrderDetailOperationalData | None:
+        if self._remote is not None:
+            projection = self._remote.print_data(order_id, order_version_id)
+            if projection is None:
+                return None
+            return OrderDetailOperationalData(
+                company_name=projection.customer.company_name,
+                contact_name=projection.customer.contact_name,
+                phone=projection.customer.phone,
+                delivery_address_lines=projection.customer.delivery_address_lines,
+                operational_context_available=True,
+                variant_label=projection.commercial.variant_label,
+                positions=projection.commercial.positions,
+                positions_available=True,
+            )
+
+        operational_context = self._orders.get_operational_context(order_version_id)
+        try:
+            projection = OrderPrintProjectionService(
+                self._orders, self._commercial_snapshots
+            ).resolve(order_id, order_version_id)
+        except PrintProjectionNotFoundError:
+            return None
+        except MissingCommercialSnapshotError:
+            if operational_context is None:
+                return None
+            return OrderDetailOperationalData(
+                company_name=operational_context.recipient_company,
+                contact_name=operational_context.recipient_name,
+                phone=operational_context.recipient_phone,
+                delivery_address_lines=self._order_address_lines(
+                    operational_context.delivery_address
+                ),
+                operational_context_available=True,
+            )
+        return OrderDetailOperationalData(
+            company_name=projection.customer.company_name,
+            contact_name=projection.customer.contact_name,
+            phone=projection.customer.phone,
+            delivery_address_lines=projection.customer.delivery_address_lines,
+            operational_context_available=operational_context is not None,
+            variant_label=projection.commercial.variant_label,
+            positions=projection.commercial.positions,
+            positions_available=True,
+        )
 
     @staticmethod
     def _missed_calls_open(
@@ -3297,6 +3391,7 @@ class OfficePanel:
             print_confirm_fields: dict[str, str] = {}
             print_confirm_labels: dict[str, str] = {}
             print_status_messages: dict[str, str] = {}
+            print_action_available: dict[str, bool] = {}
             effective_fields: dict[str, str] = {}
             target = next(
                 (
@@ -3327,6 +3422,11 @@ class OfficePanel:
                         print_status_messages[version.order_version_id] = (
                             self._kitchen_print_status_message(version.order_version_id)
                         )
+                        print_action_available[
+                            version.order_version_id
+                        ] = not self._kitchen_print_is_processing(
+                            version.order_version_id
+                        )
                     # Successful kitchen-agent ACK now activates the safe/current
                     # printed stand automatically; the old manual effective action
                     # is kept out of the normal Office workflow.
@@ -3337,6 +3437,13 @@ class OfficePanel:
                 order,
                 versions,
                 latest_version_number=latest_version_number,
+            )
+            operational_data = (
+                self._order_detail_operational_data(
+                    order.order_id, target.order_version_id
+                )
+                if target is not None
+                else None
             )
             detail = render_order_detail(
                 order,
@@ -3464,11 +3571,13 @@ class OfficePanel:
                     version_change_prefill=change_prefill if not cancelled else None,
                     print_confirm_button_labels=print_confirm_labels,
                     print_status_messages=print_status_messages,
+                    print_action_available=print_action_available,
                 ),
                 confirmation=confirmation,
                 live_preview=live_preview,
                 outbound=outbound,
                 source_inquiry=source_inquiry,
+                operational_data=operational_data,
                 operational_pause=pause_view,
                 versions_total_count=versions_total_count,
                 versions_truncated=versions_truncated,

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -30,6 +30,7 @@ from catering_system.services.order_confirmation_document_service import (
 from catering_system.services.order_confirmation_outbound_service import (
     OutboundSendEligibility,
 )
+from catering_system.services.order_print_projection_service import PrintPositionLine
 from catering_system.ui.office_panel_views import OfficePageContext
 from catering_system.ui.operational_pause_labels import (
     PAUSE_REASON_LABELS,
@@ -101,9 +102,7 @@ _READY_BLOCKER_LABELS = {
     "kitchen_print_not_confirmed": (
         "Für den aktuellen Küchenstand fehlt die Druckbestätigung."
     ),
-    "pending_order_version_change": (
-        "Eine Änderung wartet noch auf Küchendruck und Wirksamstellung."
-    ),
+    "pending_order_version_change": ("Eine Änderung wartet noch auf Küchendruck."),
     "operational_pause": "Der Auftrag ist betrieblich pausiert.",
 }
 
@@ -171,6 +170,7 @@ class OrderDetailFormFields:
     confirmation_command_fields: str = ""
     print_confirm_button_labels: Mapping[str, str] = field(default_factory=dict)
     print_status_messages: Mapping[str, str] = field(default_factory=dict)
+    print_action_available: Mapping[str, bool] = field(default_factory=dict)
     send_command_fields: str = ""
     pause_command_fields: str = ""
     resume_command_fields: str = ""
@@ -186,6 +186,20 @@ class OrderDetailPage:
 
     title: str
     body: str
+
+
+@dataclass(frozen=True)
+class OrderDetailOperationalData:
+    """Exact target-version data prepared by the Office Panel read boundary."""
+
+    company_name: str | None = None
+    contact_name: str | None = None
+    phone: str | None = None
+    delivery_address_lines: tuple[str, ...] = ()
+    operational_context_available: bool = False
+    variant_label: str | None = None
+    positions: tuple[PrintPositionLine, ...] = ()
+    positions_available: bool = False
 
 
 def _e(value: object) -> str:
@@ -269,12 +283,8 @@ def _state_copy(
             "Historie und Küchenzettel bleiben zur Einsicht verfügbar.",
         )
     if operational_pause.get("active"):
-        reason = _e(
-            str(
-                operational_pause.get("reason_code")
-                or operational_pause.get("reason")
-                or "–"
-            )
+        reason = _pause_reason_label(
+            operational_pause.get("reason_code") or operational_pause.get("reason")
         )
         return (
             "Betrieblich pausiert",
@@ -307,6 +317,8 @@ def _primary_action(
     next_action: Mapping[str, str] | None,
     forms: OrderDetailFormFields,
     *,
+    ready: ReadyToSendEvaluation,
+    operational_pause: Mapping[str, object],
     context: OfficePageContext,
 ) -> str:
     if order.cancelled_at is not None:
@@ -317,12 +329,53 @@ def _primary_action(
             "<p>Der Auftrag ist storniert und bleibt schreibgeschützt.</p>"
             "</section>"
         )
-    if target is None or next_action is None:
+    if operational_pause.get("active"):
+        pause_action = (
+            '<a class="order-button" href="#order-pause-controls">Pause aufheben</a>'
+            if context.can("orders.pause")
+            else ""
+        )
+        return (
+            '<section class="order-next-step muted">'
+            '<div class="order-eyebrow">Nächster Schritt</div>'
+            "<h2>Auftragspause klären</h2>"
+            "<p>Prüfen Sie den Pausengrund und setzen Sie den Auftrag anschließend fort.</p>"
+            f'<div class="order-next-actions">{pause_action}</div></section>'
+        )
+    if target is None:
+        return (
+            '<section class="order-next-step muted">'
+            '<div class="order-eyebrow">Nächster Schritt</div>'
+            "<h2>Auftragsdaten prüfen</h2>"
+            "<p>Für diesen Auftrag ist kein gültiger Stand verfügbar.</p>"
+            "</section>"
+        )
+    if next_action is None:
+        if not ready.ready:
+            blockers = " ".join(
+                _ready_blocker_label(reason) for reason in ready.reasons
+            )
+            return (
+                '<section class="order-next-step muted">'
+                '<div class="order-eyebrow">Nächster Schritt</div>'
+                "<h2>Auftragsdaten prüfen</h2>"
+                f"<p>{_e(blockers)}</p>"
+                "</section>"
+            )
+        ready_action = ""
+        if context.can("orders.ready.release"):
+            ready_action = (
+                f'<form method="post" action="/order/{_e(order.order_id)}/ready">'
+                f"{forms.csrf_input}{forms.ready_command_fields}"
+                '<button class="order-button" type="submit">'
+                "Versandfreigabe prüfen</button></form>"
+            )
         return (
             '<section class="order-next-step complete">'
             '<div class="order-eyebrow">Nächster Schritt</div>'
-            "<h2>Kein offener Vorbereitungsschritt</h2>"
-            "<p>Prüfen Sie die Versandfreigabe und den separaten Zahlungsbereich.</p>"
+            "<h2>Vorbereitung vollständig</h2>"
+            "<p>Der Küchenstand ist bestätigt. Prüfen Sie jetzt die Versandfreigabe.</p>"
+            f'<div class="order-next-actions">{ready_action}</div>'
             "</section>"
         )
     action = next_action.get("action")
@@ -331,7 +384,13 @@ def _primary_action(
             not context.can("orders.print.confirm")
             or target.order_version_id not in forms.print_confirm_command_fields
         ):
-            return ""
+            return (
+                '<section class="order-next-step muted">'
+                '<div class="order-eyebrow">Nächster Schritt</div>'
+                "<h2>Küchendruck erforderlich</h2>"
+                "<p>Der aktuelle Stand muss vor der weiteren Bearbeitung gedruckt werden.</p>"
+                "</section>"
+            )
         command_fields = forms.print_confirm_command_fields.get(
             target.order_version_id, ""
         )
@@ -340,31 +399,35 @@ def _primary_action(
         )
         status_message = forms.print_status_messages.get(
             target.order_version_id,
-            "Druckauftrag wird verarbeitet …",
+            "",
         )
-        heading = (
-            "Druck fehlgeschlagen"
-            if button_label == "Erneut drucken"
-            else f"Küchendruck für Stand {target.version_number} starten"
+        status_html = f"<p>{_e(status_message)}</p>" if status_message else ""
+        heading = "Küchenzettel für den aktuellen Stand drucken"
+        action_available = forms.print_action_available.get(
+            target.order_version_id, True
         )
-        return (
-            '<section class="order-next-step">'
-            '<div class="order-eyebrow">Nächster Schritt</div>'
-            f"<h2>{heading}</h2>"
-            f"<p>{_e(status_message)}</p>"
-            '<div class="order-next-actions">'
-            f'<a class="order-button secondary" target="_blank" rel="noopener" '
-            f'href="/order/{_e(order.order_id)}/print?version='
-            f'{_e(target.order_version_id)}">Küchenzettel öffnen</a>'
-            f'<a class="order-button secondary" target="_blank" rel="noopener" '
-            f'href="/order/{_e(order.order_id)}/buffet-cards?version='
-            f'{_e(target.order_version_id)}">Buffetschilder öffnen</a>'
+        primary = (
             f'<form method="post" action="/order/{_e(order.order_id)}/print-confirm">'
             f"{forms.csrf_input}{command_fields}"
             f'<input type="hidden" name="order_version_id" '
             f'value="{_e(target.order_version_id)}">'
             f'<button class="order-button" type="submit">{_e(button_label)}</button>'
-            "</form></div></section>"
+            "</form>"
+            if button_label and action_available
+            else ""
+        )
+        secondary = (
+            f'<a class="order-button secondary" target="_blank" rel="noopener" '
+            f'href="/order/{_e(order.order_id)}/print?version='
+            f'{_e(target.order_version_id)}">Küchenzettel öffnen</a>'
+        )
+        return (
+            '<section class="order-next-step">'
+            '<div class="order-eyebrow">Nächster Schritt</div>'
+            f"<h2>{heading}</h2>"
+            f"{status_html}"
+            '<div class="order-next-actions">'
+            f"{primary}{secondary}</div></section>"
         )
     if action == "effective":
         return (
@@ -503,10 +566,16 @@ def _version_actions(
         f'{_e(version.order_version_id)}">Buffetschilder öffnen</a>',
     ]
     print_fields = forms.print_confirm_command_fields.get(version.order_version_id)
-    if print_fields is not None and context.can("orders.print.confirm"):
-        button_label = forms.print_confirm_button_labels.get(
-            version.order_version_id, "Küchendruck starten"
-        )
+    button_label = forms.print_confirm_button_labels.get(
+        version.order_version_id, "Küchendruck starten"
+    )
+    action_available = forms.print_action_available.get(version.order_version_id, True)
+    if (
+        print_fields is not None
+        and button_label
+        and action_available
+        and context.can("orders.print.confirm")
+    ):
         actions.append(
             f'<form method="post" action="/order/{_e(order.order_id)}/print-confirm">'
             f"{forms.csrf_input}{print_fields}"
@@ -514,16 +583,6 @@ def _version_actions(
             f'value="{_e(version.order_version_id)}">'
             '<button class="order-button ghost" type="submit">'
             f"{_e(button_label)}</button></form>"
-        )
-    effective_fields = forms.effective_command_fields.get(version.order_version_id)
-    if effective_fields is not None and context.can("orders.effective.set"):
-        actions.append(
-            f'<form method="post" action="/order/{_e(order.order_id)}/effective">'
-            f"{forms.csrf_input}{effective_fields}"
-            f'<input type="hidden" name="order_version_id" '
-            f'value="{_e(version.order_version_id)}">'
-            '<button class="order-button ghost" type="submit">'
-            "Als Küchenstand festlegen</button></form>"
         )
     return '<div class="order-version-actions">' + "".join(actions) + "</div>"
 
@@ -701,6 +760,7 @@ def _confirmation_card(
     forms: OrderDetailFormFields,
     live_preview: ConfirmationLivePreviewView,
     *,
+    compact: bool = False,
     context: OfficePageContext,
 ) -> str:
     state_label = _confirmation_state_label(confirmation.state)
@@ -711,11 +771,7 @@ def _confirmation_card(
             [
                 ("Referenz", snapshot.document_reference),
                 ("Empfänger", snapshot.recipient_email_masked or "–"),
-                ("Hash", snapshot.document_hash_short),
-                (
-                    "Wirksamer Stand",
-                    f"Version {snapshot.effective_version_number}",
-                ),
+                ("Stand", f"Version {snapshot.effective_version_number}"),
                 (
                     "Summe brutto",
                     f"{snapshot.gross_total_cents / 100:.2f} €".replace(".", ","),
@@ -723,6 +779,8 @@ def _confirmation_card(
                 ("Erstellt", snapshot.created_at.strftime("%d.%m.%Y · %H:%M")),
             ]
         )
+        if not compact:
+            facts.insert(3, ("Hash", snapshot.document_hash_short))
     live_html = _live_preview_diagnostics(live_preview)
     actions: list[str] = []
     can_create = (
@@ -859,7 +917,7 @@ def _customer_addresses_form(
 ) -> str:
     delivery: CustomerAddress | None = None
     return (
-        '<details class="order-edit"><summary>Lieferadresse ändern</summary>'
+        '<details class="order-edit"><summary>Ändern</summary>'
         '<div class="order-edit-body">'
         f'<form method="post" action="/order/{_e(order.order_id)}/delivery-address" '
         'onsubmit="return confirm('
@@ -870,7 +928,7 @@ def _customer_addresses_form(
         f'value="{_e(target_version.order_version_id)}">'
         "<fieldset>"
         + _address_input_block("delivery", delivery)
-        + '<p><button type="submit">Neuen Stand mit Lieferadresse anlegen</button></p>'
+        + '<p><button type="submit">Lieferadresse speichern</button></p>'
         "</fieldset></form></div></details>"
     )
 
@@ -1024,6 +1082,8 @@ def render_confirmation_outbound_card(
 ) -> str:
     """Fake-outbox test send card — never implies real customer delivery."""
     page_context = context or OfficePageContext()
+    if not page_context.can("documents.send"):
+        return ""
     pause_view = operational_pause or {"active": False}
     state_label = _OUTBOUND_STATE_LABELS.get(outbound.state, outbound.state)
     facts: list[tuple[str, str]] = [("Status", state_label)]
@@ -1068,8 +1128,8 @@ def render_confirmation_outbound_card(
             f'href="/order/{_e(order.order_id)}/confirmation-document/fake-outbox" '
             f'target="_blank" rel="noopener">Testnachricht ansehen</a></p>'
         )
-    return (
-        '<section class="order-card order-content-card order-confirmation-outbound-card">'
+    card = (
+        '<section class="order-technical-card order-confirmation-outbound-card">'
         '<div class="order-section-kicker">Testversand</div>'
         "<h2>Fake Outbox</h2>"
         '<dl class="order-payment-facts">'
@@ -1080,6 +1140,10 @@ def render_confirmation_outbound_card(
         + "</dl>"
         + "".join(actions)
         + "</section>"
+    )
+    return (
+        '<details class="order-technical"><summary>Technik / Test</summary>'
+        f'<div class="order-technical-body">{card}</div></details>'
     )
 
 
@@ -1222,9 +1286,10 @@ def _operational_pause_controls(
     *,
     context: OfficePageContext,
 ) -> str:
-    return render_operational_pause_card(
+    controls = render_operational_pause_card(
         order, operational_pause, forms, context=context
     )
+    return f'<div id="order-pause-controls">{controls}</div>' if controls else ""
 
 
 def _secondary_actions(
@@ -1240,9 +1305,9 @@ def _secondary_actions(
     )
     if order.cancelled_at is not None:
         return (
-            '<section class="order-card order-content-card">'
-            "<h2>Weitere Informationen</h2>"
-            f"<p>{inquiry_link}</p></section>"
+            '<details class="order-lower-section order-more-actions">'
+            "<summary>Weitere Aktionen</summary>"
+            f'<div class="order-lower-body"><p>{inquiry_link}</p></div></details>'
         )
     cancel_block = ""
     if context.can("orders.cancel"):
@@ -1256,13 +1321,160 @@ def _secondary_actions(
             "</form></details>"
         )
     return (
-        '<section class="order-card order-content-card">'
-        "<h2>Weitere Aktionen</h2>"
-        f"<p>{inquiry_link}</p>"
+        '<details class="order-lower-section order-more-actions">'
+        "<summary>Weitere Aktionen</summary>"
+        f'<div class="order-lower-body"><p>{inquiry_link}</p>'
         + _version_change_form(order, forms, context=context)
         + _operational_pause_controls(order, operational_pause, forms, context=context)
         + cancel_block
-        + "</section>"
+        + "</div></details>"
+    )
+
+
+def _event_card(target: OrderVersion | None) -> str:
+    if target is None:
+        content = '<p class="order-section-note">Nicht verfügbar.</p>'
+    else:
+        content = (
+            '<dl class="order-facts-list">'
+            f"<div><dt>Uhrzeit</dt><dd>{_e(target.time_window_text or 'Noch offen')}</dd></div>"
+            f"<div><dt>Ort</dt><dd>{_e(target.location_text or 'Noch offen')}</dd></div>"
+            f"<div><dt>Planung</dt><dd>{_e(_planning_label(target.planning_mode))}</dd></div>"
+            f"<div><dt>Stand erstellt</dt><dd>{_e(_created_text(target))}</dd></div>"
+            "</dl>"
+        )
+    return (
+        '<section class="order-card order-content-card order-event-card">'
+        "<h2>Veranstaltung</h2>"
+        f"{content}</section>"
+    )
+
+
+def _customer_delivery_card(
+    order: Order,
+    target: OrderVersion | None,
+    operational_data: OrderDetailOperationalData | None,
+    source_inquiry: Inquiry | None,
+    forms: OrderDetailFormFields,
+    *,
+    context: OfficePageContext,
+) -> str:
+    company = operational_data.company_name if operational_data is not None else None
+    contact = operational_data.contact_name if operational_data is not None else None
+    phone = operational_data.phone if operational_data is not None else None
+    customer_lines = [value for value in (company, contact, phone) if value]
+    customer_html = (
+        "<br>".join(_e(value) for value in customer_lines)
+        if customer_lines
+        else '<span class="order-unavailable">Nicht verfügbar</span>'
+    )
+    address_lines = (
+        operational_data.delivery_address_lines
+        if operational_data is not None
+        and operational_data.operational_context_available
+        else ()
+    )
+    address_html = (
+        "<br>".join(_e(line) for line in address_lines)
+        if address_lines
+        else '<span class="order-unavailable">Nicht verfügbar</span>'
+    )
+    fulfillment = (
+        _FULFILLMENT_MODE_LABELS.get(
+            source_inquiry.fulfillment_mode, source_inquiry.fulfillment_mode
+        )
+        if source_inquiry is not None
+        else "Nicht verfügbar"
+    )
+    edit = (
+        _customer_addresses_form(order, target, forms)
+        if (
+            target is not None
+            and order.cancelled_at is None
+            and context.can("inquiries.view")
+            and context.can("orders.version.create")
+        )
+        else ""
+    )
+    return (
+        '<section class="order-card order-content-card order-customer-card">'
+        "<h2>Kunde &amp; Lieferung</h2>"
+        '<div class="order-customer-grid">'
+        f'<div><span class="order-field-label">Kunde</span><p>{customer_html}</p></div>'
+        f'<div><span class="order-field-label">Auftragsart</span><p>{_e(fulfillment)}</p></div>'
+        '<div class="order-delivery-address">'
+        '<span class="order-field-label">Lieferadresse</span>'
+        f"<address>{address_html}</address>{edit}</div></div></section>"
+    )
+
+
+def _positions_card(operational_data: OrderDetailOperationalData | None) -> str:
+    if operational_data is None or not operational_data.positions_available:
+        content = '<p class="order-section-note">Bestellung nicht verfügbar.</p>'
+    elif not operational_data.positions:
+        content = '<p class="order-section-note">Keine Positionen vorhanden.</p>'
+    else:
+        rows = []
+        for position in operational_data.positions:
+            details = [
+                value
+                for value in (
+                    position.description,
+                    position.composition,
+                    position.notes,
+                )
+                if value
+            ]
+            quantity = (
+                f'<span class="order-position-quantity">{_e(position.quantity_display)}</span>'
+                if position.quantity_display
+                else ""
+            )
+            detail_html = f"<p>{_e(' · '.join(details))}</p>" if details else ""
+            rows.append(
+                '<li class="order-position-row">'
+                f"<div><strong>{_e(position.name)}</strong>{detail_html}</div>"
+                f"{quantity}</li>"
+            )
+        variant = (
+            f'<p class="order-section-note">{_e(operational_data.variant_label)}</p>'
+            if operational_data.variant_label
+            else ""
+        )
+        content = f'{variant}<ul class="order-position-list">{"".join(rows)}</ul>'
+    return (
+        '<section class="order-card order-content-card order-positions-card">'
+        f"<h2>Bestellung</h2>{content}</section>"
+    )
+
+
+def _changes_card(target: OrderVersion | None, ready: ReadyToSendEvaluation) -> str:
+    items: list[str] = []
+    if target is not None and target.change_reason:
+        items.append(f"Änderung: {target.change_reason}")
+    if target is not None and target.changed_fields:
+        labels = ", ".join(
+            _CHANGED_FIELD_LABELS.get(field, field) for field in target.changed_fields
+        )
+        items.append(f"Geändert: {labels}")
+    if not ready.ready:
+        items.extend(_ready_blocker_label(reason) for reason in ready.reasons)
+    content = (
+        "<ul>" + "".join(f"<li>{_e(item)}</li>" for item in items) + "</ul>"
+        if items
+        else '<p class="order-section-note">Keine offenen Hinweise.</p>'
+    )
+    return (
+        '<section class="order-card order-content-card order-changes-card">'
+        f"<h2>Hinweise / Änderungen</h2>{content}</section>"
+    )
+
+
+def _status_card(state_title: str, state_description: str) -> str:
+    return (
+        '<section class="order-card order-content-card order-status-card">'
+        "<h2>Status</h2>"
+        f"<strong>{_e(state_title)}</strong><p>{_e(state_description)}</p></section>"
     )
 
 
@@ -1278,6 +1490,7 @@ def render_order_detail(
     live_preview: ConfirmationLivePreviewView,
     *,
     source_inquiry: Inquiry | None = None,
+    operational_data: OrderDetailOperationalData | None = None,
     operational_pause: Mapping[str, object] | None = None,
     versions_total_count: int,
     versions_truncated: bool,
@@ -1288,7 +1501,14 @@ def render_order_detail(
 
     pause_view = operational_pause or {"active": False}
     target = _target_version(order, versions)
-    title = f"Auftrag für den {_date_text(target)}" if target is not None else "Auftrag"
+    customer_label = "Kunde nicht verfügbar"
+    if operational_data is not None:
+        customer_label = (
+            operational_data.company_name
+            or operational_data.contact_name
+            or customer_label
+        )
+    title = f"Auftrag · {customer_label}"
     state_title, state_description = _state_copy(
         order, target, next_action, ready, pause_view
     )
@@ -1300,91 +1520,81 @@ def render_order_detail(
         else ""
     )
     if target is None:
-        hero_facts = "<span>Keine Veranstaltungsdaten vorhanden</span>"
-        event_facts = (
-            '<p class="order-section-note">Keine Auftragsstände vorhanden.</p>'
-        )
-        stand_label = "Auftrag"
+        meta = "Veranstaltungsdaten nicht verfügbar"
+        stand_badge = ""
     else:
         guests = (
-            f"ca. {target.guest_count_estimate} Gäste"
+            f"{target.guest_count_estimate} Gäste"
             if target.guest_count_estimate is not None
-            else "Gästezahl noch offen"
+            else "Gästezahl offen"
         )
-        hero_facts = (
-            f"<span>Datum: {_e(_date_text(target))}</span>"
-            f"<span>Zeit: {_e(target.time_window_text or 'Noch offen')}</span>"
-            f"<span>Ort: {_e(target.location_text or 'Noch offen')}</span>"
-            f"<span>{_e(guests)}</span>"
+        meta = f"{_date_text(target)} · {guests}"
+        stand_badge = (
+            f'<span class="order-header-badge">Stand {_e(target.version_number)}</span>'
         )
-        event_facts = (
-            '<dl class="order-facts-list">'
-            f"<div><dt>Datum</dt><dd>{_e(_date_text(target))}</dd></div>"
-            f"<div><dt>Zeit</dt><dd>{_e(target.time_window_text or 'Noch offen')}</dd></div>"
-            f"<div><dt>Ort</dt><dd>{_e(target.location_text or 'Noch offen')}</dd></div>"
-            f"<div><dt>Gäste</dt><dd>{_e(guests)}</dd></div>"
-            f"<div><dt>Planung</dt><dd>{_e(_planning_label(target.planning_mode))}</dd></div>"
-            f"<div><dt>Stand erstellt</dt><dd>{_e(_created_text(target))}</dd></div>"
-            "</dl>"
-        )
-        stand_label = f"Auftrag · Stand {target.version_number}"
-    cancelled_banner = (
-        '<div class="order-cancelled-banner">STORNIERT</div>'
+    status_badge = (
+        "Storniert"
         if order.cancelled_at is not None
-        else ""
-    )
-    paused_banner = (
-        '<div class="order-paused-banner">PAUSIERT</div>'
+        else "Pausiert"
         if pause_view.get("active")
-        else ""
+        else state_title
+    )
+    technical = render_confirmation_outbound_card(
+        order,
+        confirmation,
+        outbound,
+        forms,
+        operational_pause=pause_view,
+        context=page_context,
     )
     body = (
         '<a class="order-back" href="/auftraege">← Zurück zu den Aufträgen</a>'
-        + cancelled_banner
-        + paused_banner
-        + truncation_warning
-        + _stale_print_notice(order, versions)
-        + '<section class="order-hero"><div>'
-        f'<div class="order-eyebrow">{_e(stand_label)}</div>'
-        f"<h1>{_e(title)}</h1>"
-        f'<div class="order-hero-facts">{hero_facts}</div></div>'
-        '<div class="order-state-panel"><span>Arbeitsstand</span>'
-        f"<strong>{_e(state_title)}</strong><p>{_e(state_description)}</p></div>"
-        "</section>"
-        '<div class="order-detail-layout"><div class="order-detail-main">'
-        '<section class="order-card order-content-card">'
-        "<h2>Aktueller Veranstaltungsstand</h2>"
-        f"{event_facts}</section>"
-        + _operational_progress(order, target, ready, forms, context=page_context)
-        + _version_history(order, versions, forms, context=page_context)
-        + "</div>"
-        '<aside class="order-detail-side">'
-        + _primary_action(order, target, next_action, forms, context=page_context)
-        + render_fulfillment_mode_card(
-            source_inquiry, order, forms, context=page_context
-        )
-        + render_customer_addresses_card(
-            source_inquiry,
+        + '<header class="order-header"><div class="order-header-main">'
+        f"<h1>{_e(title)}</h1><p>{_e(meta)}</p></div>"
+        '<div class="order-header-badges">'
+        f'<span class="order-header-badge status">{_e(status_badge)}</span>'
+        f"{stand_badge}</div></header>"
+        + _primary_action(
             order,
+            target,
+            next_action,
             forms,
-            target_version=target,
-            context=page_context,
-        )
-        + _confirmation_card(
-            order, confirmation, forms, live_preview, context=page_context
-        )
-        + render_confirmation_outbound_card(
-            order,
-            confirmation,
-            outbound,
-            forms,
+            ready=ready,
             operational_pause=pause_view,
             context=page_context,
         )
+        + truncation_warning
+        + _stale_print_notice(order, versions)
+        + '<div class="order-work-layout"><div class="order-main-stack">'
+        + _event_card(target)
+        + _customer_delivery_card(
+            order,
+            target,
+            operational_data,
+            source_inquiry,
+            forms,
+            context=page_context,
+        )
+        + _positions_card(operational_data)
+        + _changes_card(target, ready)
+        + '</div><aside class="order-sidebar">'
+        + _status_card(state_title, state_description)
+        + _confirmation_card(
+            order,
+            confirmation,
+            forms,
+            live_preview,
+            compact=True,
+            context=page_context,
+        )
         + _payment_card(order, payment, forms, context=page_context)
+        + "</aside></div>"
+        + '<div class="order-lower-sections">'
+        + _version_history(order, versions, forms, context=page_context)
         + _secondary_actions(
             order, forms, operational_pause=pause_view, context=page_context
         )
-        + "</aside></div>"
+        + technical
+        + "</div>"
     )
     return OrderDetailPage(title=title, body=body)

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -1472,6 +1472,135 @@ button.office-account-link:hover {
   color: #fff;
   background: var(--danger);
 }
+.order-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 12px;
+  padding: 16px 0 17px;
+  border-bottom: 1px solid var(--line);
+}
+.office-content .order-header h1 {
+  margin: 0;
+  font-size: 25px;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+.order-header-main p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+.order-header-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 7px;
+}
+.order-header-badge {
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--ink);
+  background: var(--surface);
+  font-size: 11px;
+  font-weight: 800;
+}
+.order-header-badge.status {
+  border-color: var(--accent-soft);
+  color: var(--accent-deep);
+  background: var(--accent-soft);
+}
+.order-header + .order-next-step { margin-top: 15px; }
+.order-work-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(270px, 340px);
+  gap: 18px;
+  margin-top: 18px;
+  align-items: start;
+}
+.order-main-stack,
+.order-sidebar,
+.order-lower-sections {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+.order-sidebar .order-content-card { padding: 16px; }
+.order-sidebar .order-section-kicker { margin-bottom: 5px; }
+.order-sidebar .order-payment-facts { gap: 6px; }
+.order-sidebar .order-payment-facts > div { padding-bottom: 6px; }
+.order-status-card strong { display: block; font-size: 13px; }
+.order-status-card p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.order-customer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 22px;
+}
+.order-customer-grid p,
+.order-delivery-address address { margin: 5px 0 0; font-style: normal; }
+.order-field-label {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+.order-delivery-address { grid-column: 1 / -1; }
+.order-unavailable { color: var(--muted); }
+.order-edit { margin-top: 9px; }
+.order-edit summary {
+  color: var(--accent-deep);
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.order-edit-body { margin-top: 12px; }
+.order-position-list {
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.order-position-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+}
+.order-position-row:last-child { padding-bottom: 0; border-bottom: 0; }
+.order-position-row p { margin: 3px 0 0; color: var(--muted); font-size: 11px; }
+.order-position-quantity { color: var(--accent-deep); font-size: 12px; font-weight: 800; }
+.order-changes-card ul { margin: 0; padding-left: 18px; }
+.order-lower-sections { margin-top: 16px; }
+.order-lower-section,
+.order-technical {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+}
+.order-lower-section > summary,
+.order-technical > summary {
+  padding: 15px 18px;
+  color: var(--accent-deep);
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.order-lower-section[open] > summary,
+.order-technical[open] > summary { border-bottom: 1px solid var(--line); }
+.order-lower-body,
+.order-technical-body { padding: 16px 18px; }
+.order-lower-body > p:first-child,
+.order-technical-card > :first-child { margin-top: 0; }
+.order-lower-body .order-pause-card {
+  margin-top: 15px;
+  box-shadow: none;
+}
+.order-technical-card .order-payment-facts { margin-top: 10px; }
 .chat-layout {
   display: grid;
   grid-template-columns: minmax(280px, .8fr) minmax(0, 1.6fr);
@@ -1631,6 +1760,8 @@ button.office-account-link:hover {
   .order-detail-layout { grid-template-columns: 1fr; }
   .order-detail-side { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .order-next-step { grid-column: 1 / -1; }
+  .order-work-layout { grid-template-columns: 1fr; }
+  .order-sidebar { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .chat-layout { grid-template-columns: 1fr; }
 }
 @media (max-width: 620px) {
@@ -1667,6 +1798,12 @@ button.office-account-link:hover {
   .order-version-head { display: grid; }
   .order-version-statuses { justify-content: flex-start; }
   .order-version-facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .order-header { align-items: flex-start; flex-direction: column; }
+  .order-header-badges { justify-content: flex-start; }
+  .order-sidebar,
+  .order-customer-grid { grid-template-columns: 1fr; }
+  .order-delivery-address { grid-column: auto; }
+  .order-position-row { grid-template-columns: 1fr; gap: 5px; }
 }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }

--- a/tests/unit/test_customer_address_source_v1_b_panel.py
+++ b/tests/unit/test_customer_address_source_v1_b_panel.py
@@ -134,7 +134,7 @@ def test_address_card_separate_shows_stored_and_effective() -> None:
     assert "Gespeicherte Lieferadresse" in card
     assert "Eventplatz 9" in card
     assert "Effektive Lieferadresse" in card
-    assert "Lieferadresse ändern" in card
+    assert "<summary>Ändern</summary>" in card
     assert f'action="/order/{order.order_id}/delivery-address"' in card
     assert 'action="/inquiry/' not in card
     assert "customer-addresses" not in card
@@ -358,7 +358,7 @@ def test_panel_change_delivery_address_preserves_stale_state_gate(
         )
 
 
-def test_order_detail_shows_separate_addresses_after_service_write(
+def test_order_detail_ignores_live_inquiry_addresses_after_service_write(
     tmp_path: Path,
 ) -> None:
     db, order_id, inquiry_id = _seed_order_world(tmp_path)
@@ -371,16 +371,21 @@ def test_order_detail_shows_separate_addresses_after_service_write(
     )
     page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
-    assert "Kundenadressen" in page
-    assert "Bürostraße 1" in page
-    assert "Eventplatz 9" in page
-    assert "Abweichende Lieferadresse" in page
+    customer_section = page.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+    assert "Bürostraße 1" not in page
+    assert "Eventplatz 9" not in page
+    assert "Abweichende Lieferadresse" not in customer_section
+    assert "Nicht verfügbar" in customer_section
     assert f'action="/order/{order_id}/delivery-address"' in page
     assert f'action="/inquiry/{inquiry_id}/customer-addresses"' not in page
     assert 'name="parent_order_version_id"' in page
 
 
-def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None:
+def test_inquiry_address_mode_changes_do_not_change_v2_order_address(
+    tmp_path: Path,
+) -> None:
     db, order_id, inquiry_id = _seed_order_world(tmp_path)
     panel = _panel(db)
     panel.inquiry_service.set_inquiry_customer_addresses(
@@ -397,9 +402,13 @@ def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None
     )
     page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
-    assert "Wie Rechnungsadresse" in page
-    assert "keine separate Adresse" in page
+    customer_section = page.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+    assert "Wie Rechnungsadresse" not in customer_section
+    assert "keine separate Adresse" not in customer_section
     assert "Eventplatz 9" not in page
+    assert "Nicht verfügbar" in customer_section
 
     panel.inquiry_service.set_inquiry_customer_addresses(
         inquiry_id,
@@ -409,8 +418,12 @@ def test_mode_changes_update_stored_and_effective_labels(tmp_path: Path) -> None
     )
     page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
-    assert "Unbekannt" in page
-    assert "nicht festgelegt" in page
+    customer_section = page.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+    assert "Unbekannt" not in customer_section
+    assert "nicht festgelegt" not in customer_section
+    assert "Nicht verfügbar" in customer_section
 
 
 def test_contact_completion_after_address_form_preserves_addresses(
@@ -447,8 +460,12 @@ def test_contact_completion_after_address_form_preserves_addresses(
     )
     page = panel.render_order(order_id, context=legacy_office_context())
     assert page is not None
-    assert "Eventplatz 9" in page
-    assert "Abweichende Lieferadresse" in page
+    customer_section = page.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+    assert "Eventplatz 9" not in page
+    assert "Abweichende Lieferadresse" not in customer_section
+    assert "Nicht verfügbar" in customer_section
     loaded = panel._inquiries.get_by_id(inquiry_id)
     assert loaded is not None
     assert loaded.customer_snapshot is not None
@@ -520,8 +537,8 @@ def test_panel_http_order_delivery_address_form_uses_order_action(
     try:
         status, page = _get(f"{base}/order/{order_id}")
         assert status == 200
-        assert "Kundenadressen" in page
-        assert "Lieferadresse ändern" in page
+        assert "Kunde &amp; Lieferung" in page
+        assert "<summary>Ändern</summary>" in page
         assert f'action="/order/{order_id}/delivery-address"' in page
         assert f'action="/inquiry/{inquiry_id}/customer-addresses"' not in page
         assert 'name="parent_order_version_id"' in page
@@ -530,7 +547,7 @@ def test_panel_http_order_delivery_address_form_uses_order_action(
         server.server_close()
 
 
-def test_legacy_and_v2_show_same_address_facts(tmp_path: Path) -> None:
+def test_legacy_and_v2_use_their_respective_address_sources(tmp_path: Path) -> None:
     db, order_id, inquiry_id = _seed_order_world(tmp_path)
     connection = open_core_connection(db)
     inquiries = SQLiteInquiryRepository.from_connection(connection)
@@ -545,8 +562,15 @@ def test_legacy_and_v2_show_same_address_facts(tmp_path: Path) -> None:
     v2 = _panel(db, ui_version="v2").render_order(order_id)
     legacy = _panel(db, ui_version="legacy").render_order(order_id)
     assert v2 is not None and legacy is not None
-    for page in (v2, legacy):
-        assert "Kundenadressen" in page
-        assert "Bürostraße 1" in page
-        assert "Eventplatz 9" in page
-        assert "Abweichende Lieferadresse" in page
+    assert "Kundenadressen" in legacy
+    assert "Bürostraße 1" in legacy
+    assert "Eventplatz 9" in legacy
+    assert "Abweichende Lieferadresse" in legacy
+
+    customer_section = v2.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+    assert "Bürostraße 1" not in v2
+    assert "Eventplatz 9" not in v2
+    assert "Abweichende Lieferadresse" not in customer_section
+    assert "Nicht verfügbar" in customer_section

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -10,12 +10,20 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from datetime import UTC, date, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
 from catering_system.domain.kitchen_print_job import KitchenPrintJob
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
+from catering_system.domain.order_payment_reminder import derive_payment_reminder
+from catering_system.domain.ready_to_send import ReadyToSendEvaluation
 from catering_system.intake.website_form_adapter import intake_from_website_form
 from catering_system.repositories.in_memory_inquiry_repository import (
     InMemoryInquiryRepository,
@@ -29,12 +37,24 @@ from catering_system.repositories.in_memory_order_commercial_snapshot_repository
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.services.order_confirmation_document_service import (
+    OrderConfirmationDocumentEligibility,
+)
+from catering_system.services.order_confirmation_outbound_service import (
+    OutboundSendEligibility,
+)
 from catering_system.ui import office_api_views
 from catering_system.ui.office_panel import (
     OfficePanel,
     create_office_panel_server,
 )
 from catering_system.ui.office_panel_http import csrf_token_for_password
+from catering_system.ui.office_panel_order_detail import (
+    ConfirmationLivePreviewView,
+    OrderDetailFormFields,
+    render_order_detail,
+)
 from catering_system.ui.office_panel_shell import OFFICE_PANEL_STYLE
 from catering_system.ui.office_panel_views import _page
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
@@ -1129,23 +1149,36 @@ def test_v2_order_detail_guides_print_effective_and_release(
     _status, initial = _get(f"{premium_panel}/order/{order_id}")
     version_id = re.search(r'name="order_version_id" value="([^"]+)"', initial).group(1)
 
-    assert "order-hero" in initial
-    assert "<h1>Auftrag für den 01.10.2026</h1>" in initial
-    assert "Küchendruck für Stand 1 starten" in initial
+    assert '<header class="order-header">' in initial
+    assert '<section class="order-next-step">' in initial
+    assert "<h1>Auftrag · Kunde nicht verfügbar</h1>" in initial
+    assert "01.10.2026 · 25 Gäste" in initial
+    assert "Küchenzettel für den aktuellen Stand drucken" in initial
+    assert "Küchendruck starten" in initial
     assert f'action="/order/{order_id}/print-confirm"' in initial
     assert f'action="/order/{order_id}/effective"' not in initial
-    assert "Noch kein Stand ist als aktueller Küchenstand festgelegt." in initial
+    assert "Als Küchenstand festlegen" not in initial
+    assert "<h2>Veranstaltung</h2>" in initial
+    assert "<h2>Kunde &amp; Lieferung</h2>" in initial
+    assert "<h2>Bestellung</h2>" in initial
+    assert "Seeded Menü" in initial
+    assert '<details class="order-history">' in initial
+    assert '<details class="order-lower-section order-more-actions">' in initial
     assert "READY_TO_SEND" not in initial
 
     _post(
         f"{premium_panel}/order/{order_id}/print-confirm",
         {"order_version_id": version_id},
     )
+    _status, processing = _get(f"{premium_panel}/order/{order_id}")
+    assert "Druckauftrag wird verarbeitet" in processing
+    assert f'action="/order/{order_id}/print-confirm"' not in processing
     _simulate_kitchen_agent_ack(premium_panel, version_id)
     _status, printed = _get(f"{premium_panel}/order/{order_id}")
 
     assert "Vorbereitung vollständig" in printed
-    assert "Die Versandfreigabe ist erfüllt." in printed
+    assert '<section class="order-next-step complete">' in printed
+    assert "Der Küchenstand ist bestätigt." in printed
     assert f'action="/order/{order_id}/print-confirm"' not in printed
     assert f'action="/order/{order_id}/effective"' not in printed
 
@@ -1156,6 +1189,243 @@ def test_v2_order_detail_guides_print_effective_and_release(
     assert inquiry_id[:8] not in visible
     assert "caterer_suggestion" not in visible
     assert "READY_TO_SEND" not in visible
+
+
+def test_v2_order_detail_ready_false_without_action_stays_neutral(
+    premium_panel: str,
+) -> None:
+    from dataclasses import replace
+
+    inquiry_id = _create_inquiry(premium_panel)
+    order_id = _convert(premium_panel, inquiry_id)
+    _inquiries, orders, _snapshots = _PANEL_REPOS[premium_panel]
+    version = orders.list_order_versions(order_id)[0]
+    orders.update_order_version(
+        replace(version, kitchen_print_confirmed_at=datetime.now(UTC))
+    )
+
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+
+    assert '<section class="order-next-step muted">' in body
+    assert "<h2>Auftragsdaten prüfen</h2>" in body
+    assert "Noch kein Stand ist als aktueller Küchenstand festgelegt." in body
+    assert "Vorbereitung vollständig" not in body
+    assert f'action="/order/{order_id}/ready"' not in body
+
+
+def test_v2_order_detail_renders_automatic_effective_transition_notice() -> None:
+    now = datetime.now(UTC)
+    order = Order(
+        order_id="order-awaiting-auto-effective",
+        source_inquiry_id="inquiry-awaiting-auto-effective",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-awaiting-auto-effective",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        kitchen_print_confirmed_at=now,
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+    )
+
+    detail = render_order_detail(
+        order,
+        [version],
+        ReadyToSendEvaluation(
+            order_id=order.order_id,
+            ready=False,
+            reasons=("no_effective_version",),
+        ),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        {"action": "effective", "order_version_id": version.order_version_id},
+        OrderConfirmationDocumentEligibility(
+            available=False,
+            state="nicht_verfuegbar",
+        ),
+        OutboundSendEligibility(
+            state="dokument_fehlt",
+            can_send=False,
+        ),
+        forms,
+        ConfirmationLivePreviewView(state="not_found"),
+        versions_total_count=1,
+        versions_truncated=False,
+    )
+
+    assert "Küchenstand wird automatisch übernommen" in detail.body
+    assert "ohne weiteren manuellen Schritt" in detail.body
+    assert f'action="/order/{order.order_id}/effective"' not in detail.body
+    assert "Als Küchenstand festlegen" not in detail.body
+
+
+def test_v2_order_detail_without_versions_stays_review_only() -> None:
+    now = datetime.now(UTC)
+    order = Order(
+        order_id="order-without-versions",
+        source_inquiry_id="inquiry-without-versions",
+        created_at=now,
+        updated_at=now,
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+    )
+
+    detail = render_order_detail(
+        order,
+        [],
+        ReadyToSendEvaluation(
+            order_id=order.order_id,
+            ready=False,
+            reasons=("effective_version_not_resolvable",),
+        ),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        None,
+        OrderConfirmationDocumentEligibility(
+            available=False,
+            state="nicht_verfuegbar",
+        ),
+        OutboundSendEligibility(
+            state="dokument_fehlt",
+            can_send=False,
+        ),
+        forms,
+        ConfirmationLivePreviewView(state="not_found"),
+        versions_total_count=0,
+        versions_truncated=False,
+    )
+
+    assert "Veranstaltungsdaten nicht verfügbar" in detail.body
+    assert "Für diesen Auftrag ist kein gültiger Stand verfügbar." in detail.body
+    assert "Keine Auftragsstände vorhanden." in detail.body
+    assert "Vorbereitung vollständig" not in detail.body
+    assert "Küchendruck starten" not in detail.body
+
+
+def test_v2_order_detail_uses_exact_target_delivery_address(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(
+        premium_panel,
+        company_name="Live Inquiry GmbH",
+        contact_name="Live Contact",
+    )
+    inquiries, orders, snapshots = _PANEL_REPOS[premium_panel]
+    inquiry_service = InquiryService(inquiries)
+    live_address = CustomerAddress(
+        street="Liveweg 9",
+        postal_code="10115",
+        city="Berlin",
+        country="Deutschland",
+    )
+    inquiry_service.set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=live_address,
+        delivery_address=live_address,
+        delivery_address_mode="SEPARATE",
+    )
+    inquiry_service.set_inquiry_fulfillment_mode(
+        inquiry_id, fulfillment_mode="DELIVERY"
+    )
+    inquiry = inquiries.get_by_id(inquiry_id)
+    assert inquiry is not None
+    now = datetime.now(UTC)
+    order_id = str(uuid.uuid4())
+    version_id = str(uuid.uuid4())
+    order = Order(
+        order_id=order_id,
+        source_inquiry_id=inquiry_id,
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id=version_id,
+        order_id=order_id,
+        version_number=1,
+        created_at=now,
+        event_date=inquiry.event_date,
+        time_window_text=inquiry.time_window_text,
+        location_text=inquiry.location_text,
+        guest_count_estimate=inquiry.guest_count_estimate,
+        planning_mode=inquiry.planning_mode,
+    )
+    exact_address = CustomerAddress(
+        street="Musterstraße 1",
+        postal_code="20095",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    context = OrderVersionOperationalContextSnapshot(
+        order_version_id=version_id,
+        order_id=order_id,
+        recipient_company="Grant Hotel",
+        recipient_name="Fr. Garent",
+        recipient_phone="+4940235649",
+        delivery_address=exact_address,
+        created_at=now,
+        source="initial_inquiry_snapshot",
+    )
+    orders.save_order_with_initial_version(order, version, context)
+    seed_commercial_snapshot(snapshots, order_id)
+
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+
+    assert "Auftrag · Grant Hotel" in body
+    assert "Musterstraße 1" in body
+    assert "20095 Hamburg" in body
+    assert "+4940235649" in body
+    assert "Liveweg 9" not in body
+    assert "effektive Lieferadresse" not in body
+    assert "gespeicherte Lieferadresse" not in body
+
+
+def test_v2_order_detail_never_falls_back_to_live_inquiry_delivery_address(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(premium_panel)
+    inquiries, _orders, _snapshots = _PANEL_REPOS[premium_panel]
+    live_address = CustomerAddress(
+        street="Nur-in-der-Anfrage 7",
+        postal_code="24103",
+        city="Kiel",
+        country="Deutschland",
+    )
+    InquiryService(inquiries).set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=live_address,
+        delivery_address=live_address,
+        delivery_address_mode="SEPARATE",
+    )
+    order_id = _convert(premium_panel, inquiry_id)
+
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+    customer_section = body.split("<h2>Kunde &amp; Lieferung</h2>", 1)[1].split(
+        "</section>", 1
+    )[0]
+
+    assert "Nur-in-der-Anfrage 7" not in body
+    assert "Lieferadresse" in customer_section
+    assert "Nicht verfügbar" in customer_section
 
 
 def test_v2_order_detail_prefers_new_candidate_over_ready_old_stand(
@@ -1196,8 +1466,8 @@ def test_v2_order_detail_prefers_new_candidate_over_ready_old_stand(
 
     _status, body = _get(f"{premium_panel}/order/{order_id}")
 
-    assert "<h1>Auftrag für den 03.10.2026</h1>" in body
-    assert "Küchendruck für Stand 2 starten" in body
+    assert "03.10.2026 · 40 Gäste" in body
+    assert "Küchenzettel für den aktuellen Stand drucken" in body
     assert "Hamburg-Altona" in body
     assert "Auswahl durch den Kunden" in body
     assert "Nächster Stand" in body
@@ -1326,12 +1596,12 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
     assert "Reminder-Status" in body
     assert "RE-UI4-1" in body
     assert f'action="/order/{order_id}/payment-reminder"' in body
-    assert "Küchendruck für Stand 1 starten" in body
+    assert "Küchenzettel für den aktuellen Stand drucken" in body
 
     _post(f"{premium_panel}/order/{order_id}/cancel", {})
     _status, cancelled = _get(f"{premium_panel}/order/{order_id}")
 
-    assert "STORNIERT" in cancelled
+    assert "Storniert" in cancelled
     assert "Keine weitere Bearbeitung" in cancelled
     assert "RE-UI4-1" in cancelled
     assert f"/order/{order_id}/print?version=" in cancelled

--- a/tests/unit/test_office_panel_auth_2d3.py
+++ b/tests/unit/test_office_panel_auth_2d3.py
@@ -797,6 +797,8 @@ def test_confirmation_send_hidden_without_documents_send() -> None:
         forms,
         context=_employee_context("documents.view", "documents.prepare"),
     )
+    assert hidden == ""
+    assert "Fake Outbox" not in hidden
     assert "/confirmation-document/send" not in hidden
     assert "Testversand erzeugen" not in hidden
 
@@ -807,6 +809,9 @@ def test_confirmation_send_hidden_without_documents_send() -> None:
         forms,
         context=_employee_context("documents.send"),
     )
+    assert '<details class="order-technical">' in allowed
+    assert "<summary>Technik / Test</summary>" in allowed
+    assert "Fake Outbox" in allowed
     assert "/confirmation-document/send" in allowed
     assert "Testversand erzeugen" in allowed
 

--- a/tests/unit/test_office_panel_confirmation_outbound.py
+++ b/tests/unit/test_office_panel_confirmation_outbound.py
@@ -230,7 +230,7 @@ def test_panel_test_send_persists_evidence_and_shows_protokolliert(
         server.server_close()
 
 
-def test_missing_recipient_blocks_testversand_button(tmp_path: Path) -> None:
+def test_fake_outbox_hidden_without_send_permission(tmp_path: Path) -> None:
     db, doc_service, _core, _orders, order_id, order_version_id = _sqlite_world(
         tmp_path,
         clear_recipient_email_after_convert=True,
@@ -239,7 +239,8 @@ def test_missing_recipient_blocks_testversand_button(tmp_path: Path) -> None:
     panel = _panel_with_outbound(db)
     page = panel.render_order(order_id)
     assert page is not None
-    assert "Empfänger-E-Mail fehlt" in page
+    assert "Fake Outbox" not in page
+    assert "Empfänger-E-Mail fehlt" not in page
     assert "Testversand erzeugen" not in page
 
 

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -867,8 +867,15 @@ def test_v2_order_detail_parity_direct_vs_remote(tmp_path: Path) -> None:
             r_status, r_html = _get(f"{remote_url}/order/{order_id}")
             assert d_status == r_status == 200
             _assert_same_modulo_remote_fields(d_html, r_html)
-            assert "order-hero" in d_html
+            assert '<header class="order-header">' in d_html
+            assert '<section class="order-next-step' in d_html
+            assert "<h2>Bestellung</h2>" in d_html
+            assert "Seeded Menü" in d_html
             assert 'name="_command_id"' not in d_html
+            if key == "order_unprinted":
+                assert "Druckauftrag wird verarbeitet" not in r_html
+                assert f'action="/order/{order_id}/print-confirm"' in r_html
+                assert "Küchendruck starten" in r_html
             if key != "order_cancelled":
                 assert 'name="_command_id"' in r_html
                 assert 'name="_expect_updated_at"' in r_html

--- a/tests/unit/test_operational_pause_enforcement.py
+++ b/tests/unit/test_operational_pause_enforcement.py
@@ -108,7 +108,7 @@ def test_legacy_and_v2_pause_card_parity(tmp_path: Path) -> None:
         assert "&lt;script&gt;" in page
 
 
-def test_outbound_card_blocks_send_button_when_paused(tmp_path: Path) -> None:
+def test_outbound_card_hidden_without_send_permission(tmp_path: Path) -> None:
     db, doc_service, _core, orders, order_id, order_version_id = _sqlite_world(tmp_path)
     snapshot = doc_service.prepare_snapshot(order_id, order_version_id, "office-panel")
     panel = _panel(db)
@@ -141,8 +141,7 @@ def test_outbound_card_blocks_send_button_when_paused(tmp_path: Path) -> None:
         ),
         operational_pause=pause_view,
     )
-    assert "Testversand blockiert: Auftrag pausiert" in card
-    assert "Testversand erzeugen" not in card
+    assert card == ""
 
 
 def test_existing_send_evidence_remains_visible_after_pause(tmp_path: Path) -> None:
@@ -171,10 +170,16 @@ def test_existing_send_evidence_remains_visible_after_pause(tmp_path: Path) -> N
         actor_reference="office-panel",
         command_id=str(uuid4()),
     )
-    page = panel.render_order(order_id)
-    assert page is not None
-    assert "Testversand protokolliert" in page
-    assert "Testversand blockiert: Auftrag pausiert" in page
+    hidden_page = panel.render_order(order_id)
+    assert hidden_page is not None
+    assert "Fake Outbox" not in hidden_page
+    assert "Testversand protokolliert" not in hidden_page
+    assert "Testversand blockiert: Auftrag pausiert" not in hidden_page
+
+    permitted_page = panel.render_order(order_id, context=legacy_office_context())
+    assert permitted_page is not None
+    assert "Testversand protokolliert" in permitted_page
+    assert "Testversand blockiert: Auftrag pausiert" in permitted_page
 
 
 def test_b1_preview_link_still_available_during_pause(tmp_path: Path) -> None:


### PR DESCRIPTION
Redesigns Auftrag Detail around a compact header, one clear next step, balanced working layout, exact OrderVersion delivery/order data, compact sidebar, and lower-priority history/actions. No backend or business-logic changes.