### PR TITLE
Fix order next-step priority

### DIFF
--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -354,7 +354,7 @@ def _primary_action(
             "<p>Für diesen Auftrag ist kein gültiger Stand verfügbar.</p>"
             "</section>"
         )
-    if _requires_fulfillment_choice(source_inquiry):
+    if source_inquiry is not None and _requires_fulfillment_choice(source_inquiry):
         action = (
             f'<form method="post" action="/inquiry/{_e(source_inquiry.inquiry_id)}/fulfillment-mode">'
             f"{forms.csrf_input}{forms.fulfillment_mode_command_fields}"
@@ -443,8 +443,8 @@ def _primary_action(
             f'<div class="order-next-actions">{ready_action}</div>'
             "</section>"
         )
-    action = next_action.get("action")
-    if action == "print-confirm":
+    next_action_name = next_action.get("action")
+    if next_action_name == "print-confirm":
         if (
             not context.can("orders.print.confirm")
             or target.order_version_id not in forms.print_confirm_command_fields
@@ -494,7 +494,7 @@ def _primary_action(
             '<div class="order-next-actions">'
             f"{primary}{secondary}</div></section>"
         )
-    if action == "effective":
+    if next_action_name == "effective":
         return (
             '<section class="order-next-step">'
             '<div class="order-eyebrow">Nächster Schritt</div>'

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -318,6 +318,10 @@ def _primary_action(
     forms: OrderDetailFormFields,
     *,
     ready: ReadyToSendEvaluation,
+    confirmation: OrderConfirmationDocumentEligibility,
+    live_preview: ConfirmationLivePreviewView,
+    source_inquiry: Inquiry | None,
+    operational_data: OrderDetailOperationalData | None,
     operational_pause: Mapping[str, object],
     context: OfficePageContext,
 ) -> str:
@@ -350,6 +354,42 @@ def _primary_action(
             "<p>Für diesen Auftrag ist kein gültiger Stand verfügbar.</p>"
             "</section>"
         )
+    if _requires_fulfillment_choice(source_inquiry):
+        action = (
+            f'<form method="post" action="/inquiry/{_e(source_inquiry.inquiry_id)}/fulfillment-mode">'
+            f"{forms.csrf_input}{forms.fulfillment_mode_command_fields}"
+            f'<input type="hidden" name="return_order_id" value="{_e(order.order_id)}">'
+            "<fieldset>"
+            "<p><label>Auftragsart</label>"
+            '<select name="fulfillment_mode">'
+            f'<option value="DELIVERY">{_e(_FULFILLMENT_MODE_LABELS["DELIVERY"])}</option>'
+            f'<option value="PICKUP">{_e(_FULFILLMENT_MODE_LABELS["PICKUP"])}</option>'
+            "</select></p>"
+            '<p><button class="order-button" type="submit">Auftragsart speichern</button></p>'
+            "</fieldset></form>"
+            if context.can("inquiries.edit")
+            else ""
+        )
+        return (
+            '<section class="order-next-step muted">'
+            '<div class="order-eyebrow">Nächster Schritt</div>'
+            "<h2>Auftragsart festlegen</h2>"
+            "<p>Bitte auswählen, ob der Auftrag geliefert oder abgeholt wird.</p>"
+            f'<div class="order-next-actions">{action}</div></section>'
+        )
+    if _requires_delivery_address(source_inquiry, operational_data):
+        action = (
+            _customer_addresses_form(order, target, forms)
+            if context.can("inquiries.view") and context.can("orders.version.create")
+            else ""
+        )
+        return (
+            '<section class="order-next-step muted">'
+            '<div class="order-eyebrow">Nächster Schritt</div>'
+            "<h2>Lieferadresse ergänzen</h2>"
+            "<p>Für eine Lieferung muss eine Lieferadresse hinterlegt sein.</p>"
+            f'<div class="order-next-actions">{action}</div></section>'
+        )
     if next_action is None:
         if not ready.ready:
             blockers = " ".join(
@@ -360,6 +400,31 @@ def _primary_action(
                 '<div class="order-eyebrow">Nächster Schritt</div>'
                 "<h2>Auftragsdaten prüfen</h2>"
                 f"<p>{_e(blockers)}</p>"
+                "</section>"
+            )
+        document_action = _confirmation_create_form(
+            order,
+            confirmation,
+            forms,
+            live_preview,
+            context=context,
+            button_class="order-button",
+        )
+        if document_action:
+            return (
+                '<section class="order-next-step">'
+                '<div class="order-eyebrow">Nächster Schritt</div>'
+                "<h2>Auftragsbestätigung erstellen</h2>"
+                "<p>Der Küchenstand ist bestätigt. Erstellen Sie jetzt die "
+                "Auftragsbestätigung für den Kunden.</p>"
+                f'<div class="order-next-actions">{document_action}</div></section>'
+            )
+        if confirmation.available and confirmation.snapshot is None:
+            return (
+                '<section class="order-next-step muted">'
+                '<div class="order-eyebrow">Nächster Schritt</div>'
+                "<h2>Auftragsbestätigung prüfen</h2>"
+                f"<p>{_e(_confirmation_state_label(confirmation.state))}</p>"
                 "</section>"
             )
         ready_action = ""
@@ -438,6 +503,40 @@ def _primary_action(
             "manuellen Schritt zur Arbeitsgrundlage für die Küche.</p></section>"
         )
     return ""
+
+
+def _requires_fulfillment_choice(source_inquiry: Inquiry | None) -> bool:
+    return source_inquiry is not None and source_inquiry.fulfillment_mode == "UNKNOWN"
+
+
+def _requires_delivery_address(
+    source_inquiry: Inquiry | None,
+    operational_data: OrderDetailOperationalData | None,
+) -> bool:
+    return (
+        source_inquiry is not None
+        and source_inquiry.fulfillment_mode == "DELIVERY"
+        and (
+            operational_data is None
+            or not operational_data.operational_context_available
+            or not operational_data.delivery_address_lines
+        )
+    )
+
+
+def _confirmation_create_action_available(
+    confirmation: OrderConfirmationDocumentEligibility,
+    live_preview: ConfirmationLivePreviewView,
+    *,
+    context: OfficePageContext,
+) -> bool:
+    return (
+        confirmation.snapshot is None
+        and live_preview.state == "ready"
+        and live_preview.preview is not None
+        and live_preview.preview.eligible
+        and context.can("documents.prepare")
+    )
 
 
 def _progress_item(
@@ -754,6 +853,30 @@ def _confirmation_state_label(state: str) -> str:
     return _document_blocker_label(state)
 
 
+def _confirmation_create_form(
+    order: Order,
+    confirmation: OrderConfirmationDocumentEligibility,
+    forms: OrderDetailFormFields,
+    live_preview: ConfirmationLivePreviewView,
+    *,
+    context: OfficePageContext,
+    button_class: str | None = None,
+) -> str:
+    if not _confirmation_create_action_available(
+        confirmation,
+        live_preview,
+        context=context,
+    ):
+        return ""
+    class_attr = f' class="{_e(button_class)}"' if button_class else ""
+    return (
+        f'<form method="post" action="/order/{_e(order.order_id)}/confirmation-document">'
+        f"{forms.csrf_input}{forms.confirmation_command_fields}"
+        f'<button{class_attr} type="submit">Auftragsbestätigung erstellen</button>'
+        "</form>"
+    )
+
+
 def _confirmation_card(
     order: Order,
     confirmation: OrderConfirmationDocumentEligibility,
@@ -761,6 +884,7 @@ def _confirmation_card(
     live_preview: ConfirmationLivePreviewView,
     *,
     compact: bool = False,
+    show_create_action: bool = True,
     context: OfficePageContext,
 ) -> str:
     state_label = _confirmation_state_label(confirmation.state)
@@ -783,18 +907,16 @@ def _confirmation_card(
             facts.insert(3, ("Hash", snapshot.document_hash_short))
     live_html = _live_preview_diagnostics(live_preview)
     actions: list[str] = []
-    can_create = (
-        snapshot is None
-        and live_preview.state == "ready"
-        and live_preview.preview is not None
-        and live_preview.preview.eligible
-    )
-    if can_create and context.can("documents.prepare"):
-        actions.append(
-            f'<form method="post" action="/order/{_e(order.order_id)}/confirmation-document">'
-            f"{forms.csrf_input}{forms.confirmation_command_fields}"
-            '<button type="submit">Auftragsbestätigung erstellen</button></form>'
+    if show_create_action:
+        create_form = _confirmation_create_form(
+            order,
+            confirmation,
+            forms,
+            live_preview,
+            context=context,
         )
+        if create_form:
+            actions.append(create_form)
     if snapshot is not None:
         actions.append(
             f'<p><a class="order-action-link" '
@@ -1357,6 +1479,7 @@ def _customer_delivery_card(
     source_inquiry: Inquiry | None,
     forms: OrderDetailFormFields,
     *,
+    show_edit_action: bool = True,
     context: OfficePageContext,
 ) -> str:
     company = operational_data.company_name if operational_data is not None else None
@@ -1389,7 +1512,8 @@ def _customer_delivery_card(
     edit = (
         _customer_addresses_form(order, target, forms)
         if (
-            target is not None
+            show_edit_action
+            and target is not None
             and order.cancelled_at is None
             and context.can("inquiries.view")
             and context.can("orders.version.create")
@@ -1512,6 +1636,27 @@ def render_order_detail(
     state_title, state_description = _state_copy(
         order, target, next_action, ready, pause_view
     )
+    delivery_address_promoted = (
+        order.cancelled_at is None
+        and not pause_view.get("active")
+        and target is not None
+        and not _requires_fulfillment_choice(source_inquiry)
+        and _requires_delivery_address(source_inquiry, operational_data)
+    )
+    document_creation_promoted = (
+        order.cancelled_at is None
+        and not pause_view.get("active")
+        and target is not None
+        and not _requires_fulfillment_choice(source_inquiry)
+        and not _requires_delivery_address(source_inquiry, operational_data)
+        and next_action is None
+        and ready.ready
+        and _confirmation_create_action_available(
+            confirmation,
+            live_preview,
+            context=page_context,
+        )
+    )
     truncation_warning = (
         '<div class="order-notice blocked"><strong>Unvollständige Ansicht:</strong> '
         f"Es werden {len(versions)} von {_e(versions_total_count)} Auftragsständen "
@@ -1560,6 +1705,10 @@ def render_order_detail(
             next_action,
             forms,
             ready=ready,
+            confirmation=confirmation,
+            live_preview=live_preview,
+            source_inquiry=source_inquiry,
+            operational_data=operational_data,
             operational_pause=pause_view,
             context=page_context,
         )
@@ -1573,6 +1722,7 @@ def render_order_detail(
             operational_data,
             source_inquiry,
             forms,
+            show_edit_action=not delivery_address_promoted,
             context=page_context,
         )
         + _positions_card(operational_data)
@@ -1585,6 +1735,7 @@ def render_order_detail(
             forms,
             live_preview,
             compact=True,
+            show_create_action=not document_creation_promoted,
             context=page_context,
         )
         + _payment_card(order, payment, forms, context=page_context)

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -17,7 +17,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import pytest
 
 from catering_system.domain.kitchen_print_job import KitchenPrintJob
-from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.customer_document_preview import CustomerDocumentPreview
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    CustomerDocumentRecipient,
+)
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_operational_context import (
     OrderVersionOperationalContextSnapshot,
@@ -56,7 +60,7 @@ from catering_system.ui.office_panel_order_detail import (
     render_order_detail,
 )
 from catering_system.ui.office_panel_shell import OFFICE_PANEL_STYLE
-from catering_system.ui.office_panel_views import _page
+from catering_system.ui.office_panel_views import OfficePageContext, _page
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
 from tests.helpers.office_panel_context import legacy_office_context
 from tests.helpers.order_seed import seed_order
@@ -208,6 +212,38 @@ def _convert(base: str, inquiry_id: str) -> str:
         replace(inquiry, crm_stage="Bestätigt / Auftrag")  # type: ignore[arg-type]
     )
     return order.order_id
+
+
+def _set_fulfillment_mode(
+    base: str,
+    inquiry_id: str,
+    fulfillment_mode: str,
+) -> None:
+    inquiries, _orders, _snapshots = _PANEL_REPOS[base]
+    InquiryService(inquiries).set_inquiry_fulfillment_mode(
+        inquiry_id,
+        fulfillment_mode=fulfillment_mode,
+    )
+
+
+def _set_delivery_address(base: str, inquiry_id: str) -> None:
+    inquiries, _orders, _snapshots = _PANEL_REPOS[base]
+    address = CustomerAddress(
+        street="Lieferweg 12",
+        postal_code="20095",
+        city="Hamburg",
+        country="Deutschland",
+    )
+    InquiryService(inquiries).set_inquiry_customer_addresses(
+        inquiry_id,
+        invoice_address=address,
+        delivery_address=address,
+        delivery_address_mode="SEPARATE",
+    )
+
+
+def _next_step_section(body: str) -> str:
+    return body.split('<section class="order-next-step', 1)[1].split("</section>", 1)[0]
 
 
 def _simulate_kitchen_agent_ack(base: str, order_version_id: str) -> None:
@@ -1144,6 +1180,7 @@ def test_v2_order_detail_guides_print_effective_and_release(
     premium_panel: str,
 ) -> None:
     inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "PICKUP")
     order_id = _convert(premium_panel, inquiry_id)
 
     _status, initial = _get(f"{premium_panel}/order/{order_id}")
@@ -1191,12 +1228,192 @@ def test_v2_order_detail_guides_print_effective_and_release(
     assert "READY_TO_SEND" not in visible
 
 
+def test_v2_order_detail_promotes_confirmation_document_after_print_ready() -> None:
+    now = datetime.now(UTC)
+    order = Order(
+        order_id="order-document-next-step",
+        source_inquiry_id="inquiry-document-next-step",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-document-next-step",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        kitchen_print_confirmed_at=now,
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        confirmation_command_fields='<input type="hidden" name="_command_id" value="cmd-doc">',
+    )
+
+    detail = render_order_detail(
+        order,
+        [version],
+        ReadyToSendEvaluation(order_id=order.order_id, ready=True, reasons=()),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        None,
+        OrderConfirmationDocumentEligibility(
+            available=True,
+            state="bereit_zur_vorschau",
+            can_prepare=True,
+        ),
+        OutboundSendEligibility(state="dokument_fehlt", can_send=False),
+        forms,
+        ConfirmationLivePreviewView(
+            state="ready",
+            preview=CustomerDocumentPreview(
+                document_type="ORDER_CONFIRMATION",
+                eligible=True,
+                warnings=(),
+                blockers=(),
+                recipient=CustomerDocumentRecipient(name="Kunde"),
+            ),
+        ),
+        source_inquiry=None,
+        versions_total_count=1,
+        versions_truncated=False,
+        context=OfficePageContext(
+            employee_effective_permissions=frozenset({"documents.prepare"})
+        ),
+    )
+    next_step = _next_step_section(detail.body)
+
+    assert "<h2>Auftragsbestätigung erstellen</h2>" in next_step
+    assert f'action="/order/{order.order_id}/confirmation-document"' in next_step
+    assert (
+        detail.body.count(f'action="/order/{order.order_id}/confirmation-document"')
+        == 1
+    )
+    assert f'action="/order/{order.order_id}/ready"' not in next_step
+
+
+def test_v2_order_detail_prioritizes_missing_fulfillment_before_print(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(premium_panel)
+    order_id = _convert(premium_panel, inquiry_id)
+
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+    next_step = _next_step_section(body)
+
+    assert "<h2>Auftragsart festlegen</h2>" in next_step
+    assert "Bitte auswählen, ob der Auftrag geliefert oder abgeholt wird." in next_step
+    assert f'action="/inquiry/{inquiry_id}/fulfillment-mode"' in next_step
+    assert '<option value="DELIVERY">Lieferung</option>' in next_step
+    assert '<option value="PICKUP">Abholung</option>' in next_step
+    assert "print-confirm" not in next_step
+    assert "Küchenzettel für den aktuellen Stand drucken" not in next_step
+
+
+def test_v2_order_detail_prioritizes_delivery_address_for_delivery(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "DELIVERY")
+    order_id = _convert(premium_panel, inquiry_id)
+
+    _status, body = _get(f"{premium_panel}/order/{order_id}")
+    version_id = re.search(r'name="parent_order_version_id" value="([^"]+)"', body)
+    next_step = _next_step_section(body)
+
+    assert "<h2>Lieferadresse ergänzen</h2>" in next_step
+    assert "Für eine Lieferung muss eine Lieferadresse hinterlegt sein." in next_step
+    assert f'action="/order/{order_id}/delivery-address"' in next_step
+    assert body.count(f'action="/order/{order_id}/delivery-address"') == 1
+    assert version_id is not None
+    assert f'value="{version_id.group(1)}"' in next_step
+    assert "print-confirm" not in next_step
+
+
+def test_v2_order_detail_pickup_and_delivery_with_address_allow_print(
+    premium_panel: str,
+) -> None:
+    pickup_inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, pickup_inquiry_id, "PICKUP")
+    pickup_order_id = _convert(premium_panel, pickup_inquiry_id)
+
+    _status, pickup_body = _get(f"{premium_panel}/order/{pickup_order_id}")
+    pickup_next_step = _next_step_section(pickup_body)
+
+    assert "<h2>Lieferadresse ergänzen</h2>" not in pickup_next_step
+    assert "Küchenzettel für den aktuellen Stand drucken" in pickup_next_step
+    assert f'action="/order/{pickup_order_id}/print-confirm"' in pickup_next_step
+    assert f'action="/order/{pickup_order_id}/delivery-address"' in pickup_body
+
+    delivery_inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, delivery_inquiry_id, "DELIVERY")
+    inquiries, orders, snapshots = _PANEL_REPOS[premium_panel]
+    inquiry = inquiries.get_by_id(delivery_inquiry_id)
+    assert inquiry is not None
+    now = datetime.now(UTC)
+    delivery_order_id = str(uuid.uuid4())
+    delivery_version_id = str(uuid.uuid4())
+    order = Order(
+        order_id=delivery_order_id,
+        source_inquiry_id=delivery_inquiry_id,
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id=delivery_version_id,
+        order_id=delivery_order_id,
+        version_number=1,
+        created_at=now,
+        event_date=inquiry.event_date,
+        time_window_text=inquiry.time_window_text,
+        location_text=inquiry.location_text,
+        guest_count_estimate=inquiry.guest_count_estimate,
+        planning_mode=inquiry.planning_mode,
+    )
+    orders.save_order_with_initial_version(
+        order,
+        version,
+        OrderVersionOperationalContextSnapshot(
+            order_version_id=delivery_version_id,
+            order_id=delivery_order_id,
+            recipient_company="Lieferkunde GmbH",
+            recipient_name="Lieferkunde",
+            recipient_phone="040 123456",
+            delivery_address=CustomerAddress(
+                street="Lieferweg 12",
+                postal_code="20095",
+                city="Hamburg",
+                country="Deutschland",
+            ),
+            created_at=now,
+            source="initial_inquiry_snapshot",
+        ),
+    )
+    seed_commercial_snapshot(snapshots, delivery_order_id)
+
+    _status, delivery_body = _get(f"{premium_panel}/order/{delivery_order_id}")
+    delivery_next_step = _next_step_section(delivery_body)
+
+    assert "<h2>Lieferadresse ergänzen</h2>" not in delivery_next_step
+    assert "Küchenzettel für den aktuellen Stand drucken" in delivery_next_step
+    assert f'action="/order/{delivery_order_id}/print-confirm"' in delivery_next_step
+
+
 def test_v2_order_detail_ready_false_without_action_stays_neutral(
     premium_panel: str,
 ) -> None:
     from dataclasses import replace
 
     inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "PICKUP")
     order_id = _convert(premium_panel, inquiry_id)
     _inquiries, orders, _snapshots = _PANEL_REPOS[premium_panel]
     version = orders.list_order_versions(order_id)[0]
@@ -1322,6 +1539,209 @@ def test_v2_order_detail_without_versions_stays_review_only() -> None:
     assert "Küchendruck starten" not in detail.body
 
 
+def test_v2_order_detail_pause_and_cancel_outprioritize_missing_fulfillment() -> None:
+    now = datetime.now(UTC)
+    order = Order(
+        order_id="order-priority-paused",
+        source_inquiry_id="inquiry-priority-paused",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-priority-paused",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+    )
+    inquiry = intake_from_website_form(
+        InquiryService(InMemoryInquiryRepository()),
+        {
+            "event_date": date(2026, 10, 1),
+            "location_text": "Hamburg",
+            "guest_count_estimate": 25,
+            "company": "Priorität GmbH",
+            "email": "kunde@example.com",
+            "phone": "040 123456",
+            "submission_id": "priority-unknown",
+        },
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={version.order_version_id: ""},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+    )
+
+    paused = render_order_detail(
+        order,
+        [version],
+        ReadyToSendEvaluation(
+            order_id=order.order_id,
+            ready=False,
+            reasons=("operational_pause",),
+        ),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        {"action": "print-confirm", "order_version_id": version.order_version_id},
+        OrderConfirmationDocumentEligibility(available=False, state="nicht_verfuegbar"),
+        OutboundSendEligibility(state="dokument_fehlt", can_send=False),
+        forms,
+        ConfirmationLivePreviewView(state="not_found"),
+        source_inquiry=inquiry,
+        operational_pause={"active": True, "reason_code": "customer_clarification"},
+        versions_total_count=1,
+        versions_truncated=False,
+        context=OfficePageContext(
+            employee_effective_permissions=frozenset({"orders.pause"})
+        ),
+    )
+
+    assert "Auftragspause klären" in paused.body
+    assert "Auftragsart festlegen" not in _next_step_section(paused.body)
+    assert "print-confirm" not in _next_step_section(paused.body)
+
+    cancelled = render_order_detail(
+        Order(
+            order_id="order-priority-cancelled",
+            source_inquiry_id=inquiry.inquiry_id,
+            created_at=now,
+            updated_at=now,
+            cancelled_at=now,
+        ),
+        [version],
+        ReadyToSendEvaluation(
+            order_id="order-priority-cancelled",
+            ready=False,
+            reasons=("order_cancelled",),
+        ),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        {"action": "print-confirm", "order_version_id": version.order_version_id},
+        OrderConfirmationDocumentEligibility(available=False, state="nicht_verfuegbar"),
+        OutboundSendEligibility(state="dokument_fehlt", can_send=False),
+        forms,
+        ConfirmationLivePreviewView(state="not_found"),
+        source_inquiry=inquiry,
+        versions_total_count=1,
+        versions_truncated=False,
+        context=legacy_office_context(),
+    )
+
+    assert "Keine weitere Bearbeitung" in cancelled.body
+    assert "Auftragsart festlegen" not in _next_step_section(cancelled.body)
+    assert "print-confirm" not in _next_step_section(cancelled.body)
+
+
+def test_v2_order_detail_hides_unauthorized_priority_actions() -> None:
+    now = datetime.now(UTC)
+    order = Order(
+        order_id="order-priority-permissions",
+        source_inquiry_id="inquiry-priority-permissions",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-priority-permissions",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 10, 1),
+        time_window_text="mittags",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+    )
+    inquiry = intake_from_website_form(
+        InquiryService(InMemoryInquiryRepository()),
+        {
+            "event_date": date(2026, 10, 1),
+            "location_text": "Hamburg",
+            "guest_count_estimate": 25,
+            "company": "Rechte GmbH",
+            "email": "kunde@example.com",
+            "phone": "040 123456",
+            "submission_id": "priority-permissions",
+        },
+    )
+    forms = OrderDetailFormFields(
+        csrf_input="",
+        print_confirm_command_fields={version.order_version_id: ""},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        confirmation_command_fields="",
+    )
+
+    no_inquiry_edit = render_order_detail(
+        order,
+        [version],
+        ReadyToSendEvaluation(
+            order_id=order.order_id,
+            ready=False,
+            reasons=("kitchen_print_not_confirmed",),
+        ),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        {"action": "print-confirm", "order_version_id": version.order_version_id},
+        OrderConfirmationDocumentEligibility(available=False, state="nicht_verfuegbar"),
+        OutboundSendEligibility(state="dokument_fehlt", can_send=False),
+        forms,
+        ConfirmationLivePreviewView(state="not_found"),
+        source_inquiry=inquiry,
+        versions_total_count=1,
+        versions_truncated=False,
+        context=OfficePageContext(
+            employee_effective_permissions=frozenset({"orders.print.confirm"})
+        ),
+    )
+    no_inquiry_edit_next = _next_step_section(no_inquiry_edit.body)
+
+    assert "Auftragsart festlegen" in no_inquiry_edit_next
+    assert "fulfillment-mode" not in no_inquiry_edit_next
+    assert "print-confirm" not in no_inquiry_edit_next
+
+    no_documents_prepare = render_order_detail(
+        order,
+        [version],
+        ReadyToSendEvaluation(order_id=order.order_id, ready=True, reasons=()),
+        derive_payment_reminder(None, event_date=date(2026, 10, 1), today=date.today()),
+        None,
+        OrderConfirmationDocumentEligibility(
+            available=True,
+            state="bereit_zur_vorschau",
+            can_prepare=True,
+        ),
+        OutboundSendEligibility(state="dokument_fehlt", can_send=False),
+        forms,
+        ConfirmationLivePreviewView(
+            state="ready",
+            preview=CustomerDocumentPreview(
+                document_type="ORDER_CONFIRMATION",
+                eligible=True,
+                warnings=(),
+                blockers=(),
+                recipient=CustomerDocumentRecipient(name="Kunde"),
+            ),
+        ),
+        source_inquiry=None,
+        versions_total_count=1,
+        versions_truncated=False,
+        context=OfficePageContext(employee_effective_permissions=frozenset()),
+    )
+    no_documents_prepare_next = _next_step_section(no_documents_prepare.body)
+
+    assert "Auftragsbestätigung prüfen" in no_documents_prepare_next
+    assert "Auftragsbestätigung erstellen" not in no_documents_prepare_next
+    assert "Vorbereitung vollständig" not in no_documents_prepare_next
+
+
 def test_v2_order_detail_uses_exact_target_delivery_address(
     premium_panel: str,
 ) -> None:
@@ -1432,6 +1852,7 @@ def test_v2_order_detail_prefers_new_candidate_over_ready_old_stand(
     premium_panel: str,
 ) -> None:
     inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "PICKUP")
     order_id = _convert(premium_panel, inquiry_id)
     _status, initial = _get(f"{premium_panel}/order/{order_id}")
     version_id = re.search(r'name="order_version_id" value="([^"]+)"', initial).group(1)
@@ -1576,6 +1997,7 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
     premium_panel: str,
 ) -> None:
     inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "PICKUP")
     order_id = _convert(premium_panel, inquiry_id)
 
     _post(


### PR DESCRIPTION
## Summary

- prioritize missing Auftragsart before Kitchen Print
- require exact target-version Lieferadresse for DELIVERY before Kitchen Print
- allow PICKUP to proceed without delivery-address requirement
- promote Auftragsbestätigung creation after Kitchen Print when existing document eligibility allows it
- preserve existing permission checks and avoid duplicate promoted forms

## Workflow priority

1. cancelled
2. paused
3. Auftragsart missing
4. required Lieferadresse missing
5. Kitchen Print
6. Kundendokument
7. complete / no deterministic action

## Safety

- no backend/business-rule changes
- no API/read-model changes
- no Kitchen Print semantic changes
- no remote print-state changes
- exact target `parent_order_version_id` preserved for delivery-address changes
- duplicate delivery/document POST forms suppressed when promoted to `Nächster Schritt`

## Validation

- focused Office Panel tests: 171 passed
- full suite: 2911 passed
- ruff check: passed
- ruff format --check: passed
- git diff --check: passed