### PR TITLE
Sync order status with next-step priority

### DIFF
--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -275,6 +275,10 @@ def _state_copy(
     target: OrderVersion | None,
     next_action: Mapping[str, str] | None,
     ready: ReadyToSendEvaluation,
+    confirmation: OrderConfirmationDocumentEligibility,
+    live_preview: ConfirmationLivePreviewView,
+    source_inquiry: Inquiry | None,
+    operational_data: OrderDetailOperationalData | None,
     operational_pause: Mapping[str, object],
 ) -> tuple[str, str]:
     if order.cancelled_at is not None:
@@ -290,6 +294,16 @@ def _state_copy(
             "Betrieblich pausiert",
             f"Der Auftrag bleibt sichtbar, die Versandfreigabe ist gesperrt. Grund: {reason}.",
         )
+    if _requires_fulfillment_choice(source_inquiry):
+        return (
+            "Auftragsart festlegen",
+            "Bitte auswählen, ob der Auftrag geliefert oder abgeholt wird.",
+        )
+    if _requires_delivery_address(source_inquiry, operational_data):
+        return (
+            "Lieferadresse ergänzen",
+            "Für eine Lieferung muss eine Lieferadresse hinterlegt sein.",
+        )
     if next_action is not None and next_action.get("action") == "print-confirm":
         return (
             "Küchendruck erforderlich",
@@ -299,6 +313,16 @@ def _state_copy(
         return (
             "Küchenstand wird übernommen",
             "Der Ausdruck ist bestätigt. Der geprüfte Stand wird automatisch übernommen.",
+        )
+    if _requires_confirmation_document(confirmation, live_preview):
+        return (
+            "Auftragsbestätigung erstellen",
+            "Der Küchenstand ist bestätigt. Erstellen Sie jetzt die Auftragsbestätigung für den Kunden.",
+        )
+    if confirmation.available and confirmation.snapshot is None:
+        return (
+            "Auftragsbestätigung prüfen",
+            _confirmation_state_label(confirmation.state),
         )
     if ready.ready:
         return (
@@ -530,12 +554,21 @@ def _confirmation_create_action_available(
     *,
     context: OfficePageContext,
 ) -> bool:
+    return _requires_confirmation_document(
+        confirmation,
+        live_preview,
+    ) and context.can("documents.prepare")
+
+
+def _requires_confirmation_document(
+    confirmation: OrderConfirmationDocumentEligibility,
+    live_preview: ConfirmationLivePreviewView,
+) -> bool:
     return (
         confirmation.snapshot is None
         and live_preview.state == "ready"
         and live_preview.preview is not None
         and live_preview.preview.eligible
-        and context.can("documents.prepare")
     )
 
 
@@ -1634,7 +1667,15 @@ def render_order_detail(
         )
     title = f"Auftrag · {customer_label}"
     state_title, state_description = _state_copy(
-        order, target, next_action, ready, pause_view
+        order,
+        target,
+        next_action,
+        ready,
+        confirmation,
+        live_preview,
+        source_inquiry,
+        operational_data,
+        pause_view,
     )
     delivery_address_promoted = (
         order.cancelled_at is None

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -246,6 +246,12 @@ def _next_step_section(body: str) -> str:
     return body.split('<section class="order-next-step', 1)[1].split("</section>", 1)[0]
 
 
+def _status_card_section(body: str) -> str:
+    return body.split(
+        '<section class="order-card order-content-card order-status-card"', 1
+    )[1].split("</section>", 1)[0]
+
+
 def _simulate_kitchen_agent_ack(base: str, order_version_id: str) -> None:
     from catering_system.services.kitchen_print_service import KitchenPrintService
 
@@ -1290,6 +1296,7 @@ def test_v2_order_detail_promotes_confirmation_document_after_print_ready() -> N
         ),
     )
     next_step = _next_step_section(detail.body)
+    status_card = _status_card_section(detail.body)
 
     assert "<h2>Auftragsbestätigung erstellen</h2>" in next_step
     assert f'action="/order/{order.order_id}/confirmation-document"' in next_step
@@ -1298,6 +1305,12 @@ def test_v2_order_detail_promotes_confirmation_document_after_print_ready() -> N
         == 1
     )
     assert f'action="/order/{order.order_id}/ready"' not in next_step
+    assert (
+        '<span class="order-header-badge status">Auftragsbestätigung erstellen</span>'
+        in detail.body
+    )
+    assert "<strong>Auftragsbestätigung erstellen</strong>" in status_card
+    assert "Vorbereitung vollständig" not in status_card
 
 
 def test_v2_order_detail_prioritizes_missing_fulfillment_before_print(
@@ -1308,6 +1321,7 @@ def test_v2_order_detail_prioritizes_missing_fulfillment_before_print(
 
     _status, body = _get(f"{premium_panel}/order/{order_id}")
     next_step = _next_step_section(body)
+    status_card = _status_card_section(body)
 
     assert "<h2>Auftragsart festlegen</h2>" in next_step
     assert "Bitte auswählen, ob der Auftrag geliefert oder abgeholt wird." in next_step
@@ -1316,6 +1330,11 @@ def test_v2_order_detail_prioritizes_missing_fulfillment_before_print(
     assert '<option value="PICKUP">Abholung</option>' in next_step
     assert "print-confirm" not in next_step
     assert "Küchenzettel für den aktuellen Stand drucken" not in next_step
+    assert (
+        '<span class="order-header-badge status">Auftragsart festlegen</span>' in body
+    )
+    assert "<strong>Auftragsart festlegen</strong>" in status_card
+    assert "Küchendruck erforderlich" not in status_card
 
 
 def test_v2_order_detail_prioritizes_delivery_address_for_delivery(
@@ -1328,6 +1347,7 @@ def test_v2_order_detail_prioritizes_delivery_address_for_delivery(
     _status, body = _get(f"{premium_panel}/order/{order_id}")
     version_id = re.search(r'name="parent_order_version_id" value="([^"]+)"', body)
     next_step = _next_step_section(body)
+    status_card = _status_card_section(body)
 
     assert "<h2>Lieferadresse ergänzen</h2>" in next_step
     assert "Für eine Lieferung muss eine Lieferadresse hinterlegt sein." in next_step
@@ -1336,6 +1356,11 @@ def test_v2_order_detail_prioritizes_delivery_address_for_delivery(
     assert version_id is not None
     assert f'value="{version_id.group(1)}"' in next_step
     assert "print-confirm" not in next_step
+    assert (
+        '<span class="order-header-badge status">Lieferadresse ergänzen</span>' in body
+    )
+    assert "<strong>Lieferadresse ergänzen</strong>" in status_card
+    assert "Küchendruck erforderlich" not in status_card
 
 
 def test_v2_order_detail_pickup_and_delivery_with_address_allow_print(
@@ -1347,11 +1372,17 @@ def test_v2_order_detail_pickup_and_delivery_with_address_allow_print(
 
     _status, pickup_body = _get(f"{premium_panel}/order/{pickup_order_id}")
     pickup_next_step = _next_step_section(pickup_body)
+    pickup_status = _status_card_section(pickup_body)
 
     assert "<h2>Lieferadresse ergänzen</h2>" not in pickup_next_step
     assert "Küchenzettel für den aktuellen Stand drucken" in pickup_next_step
     assert f'action="/order/{pickup_order_id}/print-confirm"' in pickup_next_step
     assert f'action="/order/{pickup_order_id}/delivery-address"' in pickup_body
+    assert (
+        '<span class="order-header-badge status">Küchendruck erforderlich</span>'
+        in pickup_body
+    )
+    assert "<strong>Küchendruck erforderlich</strong>" in pickup_status
 
     delivery_inquiry_id = _create_inquiry(premium_panel)
     _set_fulfillment_mode(premium_panel, delivery_inquiry_id, "DELIVERY")
@@ -1401,10 +1432,16 @@ def test_v2_order_detail_pickup_and_delivery_with_address_allow_print(
 
     _status, delivery_body = _get(f"{premium_panel}/order/{delivery_order_id}")
     delivery_next_step = _next_step_section(delivery_body)
+    delivery_status = _status_card_section(delivery_body)
 
     assert "<h2>Lieferadresse ergänzen</h2>" not in delivery_next_step
     assert "Küchenzettel für den aktuellen Stand drucken" in delivery_next_step
     assert f'action="/order/{delivery_order_id}/print-confirm"' in delivery_next_step
+    assert (
+        '<span class="order-header-badge status">Küchendruck erforderlich</span>'
+        in delivery_body
+    )
+    assert "<strong>Küchendruck erforderlich</strong>" in delivery_status
 
 
 def test_v2_order_detail_ready_false_without_action_stays_neutral(
@@ -1604,6 +1641,8 @@ def test_v2_order_detail_pause_and_cancel_outprioritize_missing_fulfillment() ->
     )
 
     assert "Auftragspause klären" in paused.body
+    assert '<span class="order-header-badge status">Pausiert</span>' in paused.body
+    assert "<strong>Betrieblich pausiert</strong>" in _status_card_section(paused.body)
     assert "Auftragsart festlegen" not in _next_step_section(paused.body)
     assert "print-confirm" not in _next_step_section(paused.body)
 
@@ -1634,6 +1673,8 @@ def test_v2_order_detail_pause_and_cancel_outprioritize_missing_fulfillment() ->
     )
 
     assert "Keine weitere Bearbeitung" in cancelled.body
+    assert '<span class="order-header-badge status">Storniert</span>' in cancelled.body
+    assert "<strong>Auftrag storniert</strong>" in _status_card_section(cancelled.body)
     assert "Auftragsart festlegen" not in _next_step_section(cancelled.body)
     assert "print-confirm" not in _next_step_section(cancelled.body)
 
@@ -1736,10 +1777,13 @@ def test_v2_order_detail_hides_unauthorized_priority_actions() -> None:
         context=OfficePageContext(employee_effective_permissions=frozenset()),
     )
     no_documents_prepare_next = _next_step_section(no_documents_prepare.body)
+    no_documents_prepare_status = _status_card_section(no_documents_prepare.body)
 
     assert "Auftragsbestätigung prüfen" in no_documents_prepare_next
     assert "Auftragsbestätigung erstellen" not in no_documents_prepare_next
     assert "Vorbereitung vollständig" not in no_documents_prepare_next
+    assert "Auftragsbestätigung erstellen" in no_documents_prepare_status
+    assert "Vorbereitung vollständig" not in no_documents_prepare_status
 
 
 def test_v2_order_detail_uses_exact_target_delivery_address(


### PR DESCRIPTION
## Summary

- synchronize the order header badge and Status card with the deterministic `Nächster Schritt` priority
- show missing Auftragsart before Kitchen Print
- show missing exact target-version Lieferadresse for DELIVERY before Kitchen Print
- keep PICKUP exempt from delivery-address requirements
- keep cancelled and paused states highest priority
- keep customer-document phase visible instead of falling through to a misleading completion state

## Safety

- presentation-only change
- no backend/business-rule changes
- no API/read-model changes
- no Kitchen Print semantic changes
- no remote print-state changes
- no route, permission, database, or migration changes
- exact DELIVERY address check continues to use `operational_data.delivery_address_lines`

## Validation

- focused Office Panel tests: 122 passed
- full suite: 2911 passed
- mypy: passed
- ruff check: passed
- ruff format --check: passed
- git diff --check: passed

## Diff scope

- `src/catering_system/ui/office_panel_order_detail.py`
- `tests/unit/test_office_panel.py`