### PR TITLE
Use effective delivery context for confirmation documents

### DIFF
--- a/src/catering_system/services/customer_document_preview.py
+++ b/src/catering_system/services/customer_document_preview.py
@@ -7,12 +7,16 @@ No persistence. No Offer. No intake parsing. No PDF/HTML/email.
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import UTC, datetime
 
 from catering_system.domain.customer_document_preview import CustomerDocumentPreview
 from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
     CustomerAddress,
     CustomerDocumentEvent,
+    CustomerDocumentRecipient,
+    customer_addresses_equal,
 )
 from catering_system.domain.inquiry import FulfillmentMode, Inquiry
 from catering_system.domain.order import Order, OrderVersion
@@ -52,6 +56,7 @@ def build_customer_document_preview(
     delivery_address: CustomerAddress | None = None,
     payment_reminder: OrderPaymentReminder | None = None,
     now: datetime | None = None,
+    recipient_override: CustomerDocumentRecipient | None = None,
 ) -> CustomerDocumentPreview:
     """Pure assemble of live preview facts + eligibility (no repos)."""
     fulfillment_mode: FulfillmentMode = (
@@ -59,7 +64,7 @@ def build_customer_document_preview(
         if recipient_inquiry is not None
         else "UNKNOWN"
     )
-    recipient = build_customer_document_recipient(
+    recipient = recipient_override or build_customer_document_recipient(
         recipient_inquiry,
         invoice_address=invoice_address,
         delivery_address=delivery_address,
@@ -139,6 +144,43 @@ def _event_from_version(
     )
 
 
+def _recipient_for_order_version(
+    orders: OrderRepository,
+    inquiry: Inquiry | None,
+    version: OrderVersion | None,
+    *,
+    invoice_address: CustomerAddress | None,
+    delivery_address: CustomerAddress | None,
+    fulfillment_mode: FulfillmentMode,
+) -> CustomerDocumentRecipient:
+    recipient = build_customer_document_recipient(
+        inquiry,
+        invoice_address=invoice_address,
+        delivery_address=delivery_address,
+        fulfillment_mode=fulfillment_mode,
+    )
+    if invoice_address is not None or delivery_address is not None:
+        return recipient
+    if version is None or version.parent_order_version_id is None:
+        return recipient
+    context = orders.get_operational_context(version.order_version_id)
+    if context is None:
+        return recipient
+    exact_delivery = None if fulfillment_mode == "PICKUP" else context.delivery_address
+    differs = (
+        recipient.invoice_address is not None
+        and exact_delivery is not None
+        and not customer_addresses_equal(recipient.invoice_address, exact_delivery)
+    )
+    warnings = (WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else ()
+    return replace(
+        recipient,
+        delivery_address=exact_delivery,
+        delivery_address_differs=differs,
+        warnings=warnings,
+    )
+
+
 class CustomerDocumentPreviewService:
     """Load order truth and build a live confirmation preview."""
 
@@ -172,6 +214,17 @@ class CustomerDocumentPreviewService:
             version = self._orders.get_order_version(order.effective_order_version_id)
         commercial = self._commercial_snapshots.get_by_order_id(order.order_id)
         inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+        fulfillment_mode: FulfillmentMode = (
+            inquiry.fulfillment_mode if inquiry is not None else "UNKNOWN"
+        )
+        recipient = _recipient_for_order_version(
+            self._orders,
+            inquiry,
+            version,
+            invoice_address=invoice_address,
+            delivery_address=delivery_address,
+            fulfillment_mode=fulfillment_mode,
+        )
         payment_reminder = (
             self._payment_reminders.get(order.order_id)
             if self._payment_reminders is not None
@@ -186,4 +239,5 @@ class CustomerDocumentPreviewService:
             delivery_address=delivery_address,
             payment_reminder=payment_reminder,
             now=self._now(),
+            recipient_override=recipient,
         )

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 
 from catering_system.domain.customer_document_eligibility import (
@@ -18,9 +18,11 @@ from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentEligibility as DocumentCreateEligibility,
 )
 from catering_system.domain.customer_document_projection import (
+    WARNING_DELIVERY_ADDRESS_DIFFERS,
     CustomerAddress,
     CustomerDocumentProjection,
     CustomerDocumentRecipient,
+    customer_addresses_equal,
 )
 from catering_system.domain.inquiry import FulfillmentMode
 from catering_system.domain.order import Order, OrderVersion
@@ -211,6 +213,7 @@ class OrderConfirmationDocumentService:
             payment_method=payment_method,
             payment_customer_visible_text=payment_customer_visible_text,
         )
+        projection = replace(projection, recipient=recipient)
         draft = _persist_snapshot_from_projection(
             projection,
             created_by=created_by,
@@ -318,6 +321,31 @@ class OrderConfirmationDocumentService:
             delivery_address=delivery_address,
             fulfillment_mode=fulfillment_mode,
         )
+        if (
+            invoice_address is None
+            and delivery_address is None
+            and version is not None
+            and version.parent_order_version_id is not None
+        ):
+            context = self._orders.get_operational_context(version.order_version_id)
+            if context is not None:
+                exact_delivery = (
+                    None if fulfillment_mode == "PICKUP" else context.delivery_address
+                )
+                differs = (
+                    recipient.invoice_address is not None
+                    and exact_delivery is not None
+                    and not customer_addresses_equal(
+                        recipient.invoice_address, exact_delivery
+                    )
+                )
+                warnings = (WARNING_DELIVERY_ADDRESS_DIFFERS,) if differs else ()
+                recipient = replace(
+                    recipient,
+                    delivery_address=exact_delivery,
+                    delivery_address_differs=differs,
+                    warnings=warnings,
+                )
         return version, commercial, recipient, fulfillment_mode
 
     def _payment_reminder(self, order_id: str) -> OrderPaymentReminder | None:

--- a/tests/unit/test_confirmation_effective_delivery_context.py
+++ b/tests/unit/test_confirmation_effective_delivery_context.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from dataclasses import replace
 
 from catering_system.domain.customer_document_projection import CustomerAddress
-from catering_system.domain.inquiry_customer_snapshot import set_inquiry_customer_addresses
-from catering_system.services.customer_document_preview import CustomerDocumentPreviewService
+from catering_system.domain.inquiry_customer_snapshot import (
+    set_inquiry_customer_addresses,
+)
+from catering_system.services.customer_document_preview import (
+    CustomerDocumentPreviewService,
+)
 from catering_system.services.order_service import OrderService
 from tests.unit.test_order_confirmation_document import _effective_order, _services
 
@@ -36,7 +40,9 @@ def _set_delivery_inquiry(
     *,
     delivery_address: CustomerAddress | None,
 ) -> None:
-    inquiry = inquiries.get_by_id(order.source_inquiry_id)  # type: ignore[attr-defined]
+    inquiry = inquiries.get_by_id(  # type: ignore[attr-defined]
+        order.source_inquiry_id  # type: ignore[attr-defined]
+    )
     assert inquiry is not None
     mode = "SEPARATE" if delivery_address is not None else "UNKNOWN"
     updated = set_inquiry_customer_addresses(
@@ -50,7 +56,7 @@ def _set_delivery_inquiry(
     )
 
 
-def test_effective_delivery_change_drives_eligibility_preview_and_snapshot() -> None:
+def test_effective_delivery_change_drives_confirmation_context() -> None:
     services = _services()
     orders, _offers, inquiries, _documents, service, core, offer_service = services
     order, v1 = _effective_order(services)
@@ -123,7 +129,9 @@ def test_effective_delivery_removal_does_not_fall_back_to_stale_inquiry() -> Non
     core.confirm_kitchen_print(order.order_id, v2.order_version_id)
     core.make_order_version_effective(order.order_id, v2.order_version_id)
 
-    decision = service._evaluate_create(orders.get_order(order.order_id))
+    current_order = orders.get_order(order.order_id)
+    assert current_order is not None
+    decision = service._evaluate_create(current_order)
     assert decision.allowed is False
     assert "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY" in {
         blocker.code for blocker in decision.blockers

--- a/tests/unit/test_confirmation_effective_delivery_context.py
+++ b/tests/unit/test_confirmation_effective_delivery_context.py
@@ -1,0 +1,143 @@
+"""Regression coverage for confirmation delivery address from effective OrderVersion."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.inquiry_customer_snapshot import set_inquiry_customer_addresses
+from catering_system.services.customer_document_preview import CustomerDocumentPreviewService
+from catering_system.services.order_service import OrderService
+from tests.unit.test_order_confirmation_document import _effective_order, _services
+
+_INVOICE = CustomerAddress(
+    street="Bürostraße 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="brombeeren str 4",
+    postal_code="22041",
+    city="Hamburg",
+    country="DE",
+)
+_OLD_DELIVERY = CustomerAddress(
+    street="Alter Lieferweg 9",
+    postal_code="20457",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _set_delivery_inquiry(
+    inquiries: object,
+    order: object,
+    *,
+    delivery_address: CustomerAddress | None,
+) -> None:
+    inquiry = inquiries.get_by_id(order.source_inquiry_id)  # type: ignore[attr-defined]
+    assert inquiry is not None
+    mode = "SEPARATE" if delivery_address is not None else "UNKNOWN"
+    updated = set_inquiry_customer_addresses(
+        inquiry,
+        invoice_address=_INVOICE,
+        delivery_address=delivery_address,
+        delivery_address_mode=mode,
+    )
+    inquiries.update(  # type: ignore[attr-defined]
+        replace(updated, fulfillment_mode="DELIVERY")
+    )
+
+
+def test_effective_delivery_change_drives_eligibility_preview_and_snapshot() -> None:
+    services = _services()
+    orders, _offers, inquiries, _documents, service, core, offer_service = services
+    order, v1 = _effective_order(services)
+    _set_delivery_inquiry(inquiries, order, delivery_address=None)
+
+    v2 = OrderService(orders).propose_delivery_address_change(
+        order.order_id,
+        parent_order_version_id=v1.order_version_id,
+        delivery_address=_DELIVERY,
+        actor_reference="office-panel",
+        change_reason="Lieferadresse geändert",
+    )
+
+    candidate_order = orders.get_order(order.order_id)
+    assert candidate_order is not None
+    candidate_decision = service._evaluate_create(candidate_order)
+    assert candidate_decision.allowed is False
+    assert "INVALID_ORDER_STATE" in {
+        blocker.code for blocker in candidate_decision.blockers
+    }
+
+    core.confirm_kitchen_print(order.order_id, v2.order_version_id)
+    core.make_order_version_effective(order.order_id, v2.order_version_id)
+
+    refreshed = orders.get_order(order.order_id)
+    assert refreshed is not None
+    inquiry = inquiries.get_by_id(order.source_inquiry_id)
+    assert inquiry is not None
+    assert inquiry.customer_snapshot is not None
+    assert inquiry.customer_snapshot.delivery_address is None
+    assert inquiry.customer_snapshot.delivery_address_mode == "UNKNOWN"
+
+    eligibility = service.eligibility(order.order_id)
+    assert eligibility.can_prepare is True
+
+    preview_service = CustomerDocumentPreviewService(
+        orders,
+        inquiries,
+        offer_service._commercial_snapshots,
+    )
+    preview = preview_service.preview_order_confirmation(order.order_id)
+    assert preview.eligible is True
+    assert preview.recipient.invoice_address == _INVOICE
+    assert preview.recipient.delivery_address == _DELIVERY
+
+    snapshot = service.prepare_snapshot(
+        order.order_id,
+        v2.order_version_id,
+        "office-panel",
+    )
+    assert snapshot.order_version_id == v2.order_version_id
+    assert snapshot.invoice_address == _INVOICE
+    assert snapshot.delivery_address == _DELIVERY
+    assert snapshot.delivery_address_differs is True
+
+
+def test_effective_delivery_removal_does_not_fall_back_to_stale_inquiry() -> None:
+    services = _services()
+    orders, _offers, inquiries, _documents, service, core, offer_service = services
+    order, v1 = _effective_order(services)
+    _set_delivery_inquiry(inquiries, order, delivery_address=_OLD_DELIVERY)
+
+    v2 = OrderService(orders).propose_delivery_address_change(
+        order.order_id,
+        parent_order_version_id=v1.order_version_id,
+        delivery_address=None,
+        actor_reference="office-panel",
+        change_reason="Lieferadresse entfernt",
+    )
+    core.confirm_kitchen_print(order.order_id, v2.order_version_id)
+    core.make_order_version_effective(order.order_id, v2.order_version_id)
+
+    decision = service._evaluate_create(orders.get_order(order.order_id))
+    assert decision.allowed is False
+    assert "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY" in {
+        blocker.code for blocker in decision.blockers
+    }
+
+    preview_service = CustomerDocumentPreviewService(
+        orders,
+        inquiries,
+        offer_service._commercial_snapshots,
+    )
+    preview = preview_service.preview_order_confirmation(order.order_id)
+    assert preview.eligible is False
+    assert preview.recipient.invoice_address == _INVOICE
+    assert preview.recipient.delivery_address is None
+    assert "DELIVERY_ADDRESS_REQUIRED_FOR_DELIVERY" in {
+        blocker.code for blocker in preview.blockers
+    }


### PR DESCRIPTION
## Summary

Fix the contradiction where Order Detail / Küchenzettel use the exact delivery address of the effective OrderVersion, while Auftragsbestätigung eligibility/live preview still read the stale Inquiry address.

## Behavior

- Keep customer documents bound to `effective_order_version_id`; candidate versions remain blocked.
- For later OrderVersions (versions with a parent), read delivery address from that exact version's frozen operational context.
- Preserve Rechnungsadresse and contact/email semantics from the existing Inquiry customer snapshot.
- Keep PICKUP exempt from delivery-address requirements.
- Use the same resolved recipient for eligibility and persisted confirmation snapshot.
- Apply the same exact-version delivery fact to live confirmation preview.
- Explicit test-only address overrides keep their existing behavior.

## Regression coverage

- V1 effective → V2 candidate with explicit Lieferadresse: candidate remains blocked.
- After V2 Kitchen Print confirmation/activation: eligibility and live preview use V2 exact Lieferadresse and confirmation snapshot persists it.
- If V2 explicitly removes Lieferadresse, stale Inquiry delivery data is not resurrected.

## Scope

Production files: 2

- `src/catering_system/services/order_confirmation_document_service.py`
- `src/catering_system/services/customer_document_preview.py`

Focused test file: 1

- `tests/unit/test_confirmation_effective_delivery_context.py`

No UI redesign, no Kitchen Print backend changes, no API/schema/migration changes, no Lenovo changes.