### PR TITLE
Increase CI timeout for full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       # uv provides both the resolver and the Python interpreter, so the


### PR DESCRIPTION
## Scope
CI infrastructure only.

The Python suite currently passes in about 14m48s, while the whole `quality` job has a hard 15-minute timeout. The job is canceled after tests/coverage before the remaining verification steps can run.

## Change
- increase `quality.timeout-minutes` from 15 to 25

No production code, tests, workflow semantics, or deployment behavior changed.