### PR TITLE
Redesign Angebot detail as guided workflow

### DIFF
--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -1,4 +1,4 @@
-"""Angebot detail presentation — commercial history and lifecycle actions (5B-3)."""
+"""Guided Angebot detail presentation for the Office Panel."""
 
 from __future__ import annotations
 
@@ -34,6 +34,265 @@ _ACCEPTANCE_CHANNEL_LABELS = {
     "in_person": "Persönlich",
     "other": "Sonstiges",
 }
+
+_OFFER_DETAIL_STYLE = """
+<style>
+.offer-guided {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+.offer-guided h1,
+.offer-guided h2,
+.offer-guided h3,
+.offer-guided p { overflow-wrap: anywhere; }
+.offer-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 0 0 22px;
+  padding: 24px 26px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.offer-eyebrow {
+  margin: 0 0 5px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.offer-hero h1 {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 38px);
+  line-height: 1.12;
+  letter-spacing: -.025em;
+}
+.offer-hero-meta { margin: 8px 0 0; color: var(--muted); }
+.offer-status-badge {
+  flex: 0 0 auto;
+  padding: 7px 11px;
+  border-radius: 999px;
+  color: var(--accent-deep);
+  background: var(--accent-soft);
+  font-size: 12px;
+  font-weight: 800;
+}
+.offer-next-step,
+.offer-card,
+.offer-secondary-panel {
+  margin: 0 0 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.offer-next-step {
+  padding: 22px 24px;
+  border-color: #d7e3da;
+  background: #f2f6f3;
+}
+.offer-next-label {
+  margin: 0 0 4px;
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 850;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.offer-next-step h2,
+.offer-card h2 { margin: 0 0 8px; }
+.offer-next-copy { margin: 0 0 16px; color: var(--muted); }
+.offer-card { padding: 22px 24px; }
+.offer-facts {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+.offer-fact {
+  min-width: 0;
+  padding: 13px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--canvas);
+}
+.offer-fact span {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.offer-fact strong { display: block; font-size: 14px; }
+.offer-form { margin: 0; }
+.offer-form fieldset {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0 0 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.offer-form label {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  color: #3c4640;
+  font-size: 13px;
+  font-weight: 700;
+}
+.offer-form label.offer-form-wide { grid-column: 1 / -1; }
+.offer-form input,
+.offer-form select,
+.offer-form textarea { width: 100%; min-width: 0; }
+.offer-form textarea { resize: vertical; }
+.offer-primary-button,
+.offer-guided button { min-height: 42px; }
+.offer-secondary-actions {
+  margin: 0 0 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.offer-secondary-actions > summary,
+.offer-secondary-panel > summary,
+.offer-position-detail > summary {
+  cursor: pointer;
+  list-style: none;
+}
+.offer-secondary-actions > summary::-webkit-details-marker,
+.offer-secondary-panel > summary::-webkit-details-marker,
+.offer-position-detail > summary::-webkit-details-marker { display: none; }
+.offer-secondary-actions > summary,
+.offer-secondary-panel > summary {
+  padding: 17px 20px;
+  color: var(--accent-deep);
+  font-weight: 800;
+}
+.offer-secondary-actions > summary::after,
+.offer-secondary-panel > summary::after,
+.offer-position-detail > summary::after {
+  content: "＋";
+  float: right;
+  color: var(--muted);
+}
+.offer-secondary-actions[open] > summary::after,
+.offer-secondary-panel[open] > summary::after,
+.offer-position-detail[open] > summary::after { content: "−"; }
+.offer-secondary-content {
+  display: grid;
+  gap: 14px;
+  padding: 0 20px 20px;
+}
+.offer-secondary-content .offer-action-section {
+  margin: 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--canvas);
+}
+.offer-secondary-content .offer-action-section h2 {
+  margin: 0 0 10px;
+  font-size: 16px;
+}
+.offer-variant-grid {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+.offer-variant-card {
+  padding: 15px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--canvas);
+}
+.offer-variant-card h3 { margin: 0; font-size: 16px; }
+.offer-variant-card p { margin: 5px 0 0; color: var(--muted); }
+.offer-position-list {
+  display: grid;
+  gap: 10px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.offer-position-detail {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+}
+.offer-position-detail > summary { padding: 13px 15px; font-weight: 750; }
+.offer-position-detail > summary span {
+  color: var(--muted);
+  font-weight: 550;
+}
+.offer-position-detail-body {
+  padding: 0 15px 14px;
+  color: #303732;
+}
+.offer-position-detail-body > :first-child { margin-top: 0; }
+.offer-version-list,
+.offer-history-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.offer-version-item,
+.offer-history-list li {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--canvas);
+}
+.offer-version-item h3 { margin: 0 0 6px; font-size: 15px; }
+.offer-version-item p { margin: 3px 0; }
+.offer-version-item p span { color: var(--muted); margin-right: 6px; }
+.offer-version-current { color: var(--accent-deep); font-weight: 750; }
+.offer-budget-section {
+  margin: 0 0 18px;
+  padding: 22px 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+.offer-budget-section h2 { margin: 0 0 10px; }
+.offer-budget-section p { display: flex; gap: 8px; margin: 5px 0; }
+.offer-budget-section p span { min-width: 90px; color: var(--muted); }
+.offer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  margin: 22px 0 0;
+}
+.offer-links a { font-weight: 700; }
+.offer-pdf-link { display: inline-block; margin-top: 10px; font-weight: 750; }
+@media (max-width: 900px) {
+  .offer-facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 650px) {
+  .offer-hero { display: grid; padding: 19px; }
+  .offer-status-badge { justify-self: start; }
+  .offer-next-step,
+  .offer-card,
+  .offer-budget-section { padding: 18px; }
+  .offer-facts,
+  .offer-form fieldset { grid-template-columns: 1fr; }
+  .offer-form label.offer-form-wide { grid-column: auto; }
+}
+</style>
+"""
 
 
 @dataclass(frozen=True)
@@ -75,10 +334,8 @@ def _surface_version(detail: dict[str, object]) -> dict[str, object]:
 
 
 def surface_version_id(detail: dict[str, object]) -> str:
-    """Public wrapper: the OfferVersion id actually displayed for this
-    detail (same resolution render_offer_detail uses internally) — needed
-    by the caller before rendering, to decide whether a PDF download link
-    exists for exactly the version about to be shown."""
+    """Return the OfferVersion id actually displayed by this detail page."""
+
     return str(_surface_version(detail).get("offer_version_id", ""))
 
 
@@ -98,7 +355,10 @@ def _version_list(detail: dict[str, object]) -> str:
         sent_at = version.get("sent_at")
         sent_line = ""
         if isinstance(sent_at, str) and sent_at:
-            sent_line = f"<p><span>Gesendet</span><strong>{_e(_history_date(sent_at))}</strong></p>"
+            sent_line = (
+                f"<p><span>Gesendet</span>"
+                f"<strong>{_e(_history_date(sent_at))}</strong></p>"
+            )
         rows.append(
             '<li class="offer-version-item">'
             f"<h3>Version {number}</h3>"
@@ -107,10 +367,11 @@ def _version_list(detail: dict[str, object]) -> str:
             "</li>"
         )
     return (
-        '<section class="offer-detail-section">'
-        "<h2>Angebotsversionen</h2>"
+        '<details class="offer-secondary-panel">'
+        "<summary>Angebotsversionen</summary>"
+        '<div class="offer-secondary-content">'
         f'<ul class="offer-version-list">{"".join(rows)}</ul>'
-        "</section>"
+        "</div></details>"
     )
 
 
@@ -135,7 +396,9 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
             name = _e(str(position.get("name", "Position")))
             unit_cents = position.get("unit_net_cents")
             unit_text = (
-                f"{int(unit_cents) / 100:.2f} €" if isinstance(unit_cents, int) else "–"
+                f"{int(unit_cents) / 100:.2f} €"
+                if isinstance(unit_cents, int)
+                else "–"
             )
             description = position.get("description")
             description_html = (
@@ -154,13 +417,11 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
                 unknown=bool(position.get("allergens_unknown")),
             )
             rows.append(
-                "<li>"
-                f"<strong>{name}</strong> "
-                f"<span>({_e(unit_text)} netto / Einheit)</span>"
-                f"{description_html}"
-                f"{composition_html}"
-                f"{allergen_html}"
-                "</li>"
+                '<li><details class="offer-position-detail">'
+                f"<summary>{name} <span>({_e(unit_text)} netto / Einheit)</span></summary>"
+                '<div class="offer-position-detail-body">'
+                f"{description_html}{composition_html}{allergen_html}"
+                "</div></details></li>"
             )
     return "".join(rows) or "<li>Keine Positionen</li>"
 
@@ -179,22 +440,23 @@ def _budget_cents(cents: object) -> str:
 
 
 def _budget_block(surface: dict[str, object]) -> str:
-    """OFFER_BUDGET_DEFINITION_V1 — compact internal-only planning block.
+    """Render the existing internal-only budget comparison, when present."""
 
-    Office Panel only, never the customer document. Omitted entirely (no
-    empty section) when this OfferVersion has no budget_definition — covers
-    both "operator never enabled budget tracking" and "Offer predates this
-    feature" the same way.
-    """
     budget = surface.get("budget_definition")
     if not isinstance(budget, dict):
         return ""
     per_person = budget.get("type") == "PER_PERSON"
     suffix = " / Person" if per_person else ""
-    amount_line = f"<p><span>Budget</span><strong>{_e(_budget_cents(budget.get('amount_cents')))}{suffix}</strong></p>"
+    amount_line = (
+        f"<p><span>Budget</span><strong>"
+        f"{_e(_budget_cents(budget.get('amount_cents')))}{suffix}</strong></p>"
+    )
     basis_label = _BUDGET_TAX_BASIS_LABELS.get(str(budget.get("tax_basis")), "–")
     scope_label = _BUDGET_COST_SCOPE_LABELS.get(str(budget.get("cost_scope")), "–")
-    basis_line = f"<p><span>Basis</span><strong>{_e(basis_label)} · {_e(scope_label)}</strong></p>"
+    basis_line = (
+        f"<p><span>Basis</span><strong>"
+        f"{_e(basis_label)} · {_e(scope_label)}</strong></p>"
+    )
     comparison = budget.get("comparison_amount_cents")
     if comparison is None:
         comparison_line = (
@@ -202,7 +464,10 @@ def _budget_block(surface: dict[str, object]) -> str:
         )
         remaining_line = ""
     else:
-        comparison_line = f"<p><span>Aktuell</span><strong>{_e(_budget_cents(comparison))}{suffix}</strong></p>"
+        comparison_line = (
+            f"<p><span>Aktuell</span><strong>"
+            f"{_e(_budget_cents(comparison))}{suffix}</strong></p>"
+        )
         remaining = budget.get("remaining_cents")
         over = bool(budget.get("over"))
         remaining_abs = abs(remaining) if isinstance(remaining, int) else None
@@ -212,7 +477,7 @@ def _budget_block(surface: dict[str, object]) -> str:
             f"<strong>{_e(_budget_cents(remaining_abs))}{suffix}</strong></p>"
         )
     return (
-        '<section class="offer-detail-section offer-budget-section">'
+        '<section class="offer-budget-section">'
         "<h2>Budget (intern)</h2>"
         f"{amount_line}{basis_line}{comparison_line}{remaining_line}"
         "</section>"
@@ -241,14 +506,14 @@ def _mark_sent_form(
         return ""
     default_at = default_datetime_local_berlin()
     return (
-        '<section class="offer-detail-section offer-action-section">'
-        "<h2>Als gesendet markieren</h2>"
-        f'<form method="post" action="/offer/{_e(offer_id)}/mark-sent">'
+        '<section class="offer-action-section">'
+        '<form class="offer-form" method="post" '
+        f'action="/offer/{_e(offer_id)}/mark-sent">'
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
         f'<label>Versandzeitpunkt <input type="datetime-local" name="sent_at" '
         f'step="1" value="{_e(default_at)}" required></label>'
-        f'<label>Kanal <select name="channel" required>'
+        '<label>Kanal <select name="channel" required>'
         f"{_select_options(SENT_CHANNELS, _SENT_CHANNEL_LABELS)}"
         "</select></label>"
         '<label>Empfänger <input name="recipient_reference" required '
@@ -256,7 +521,8 @@ def _mark_sent_form(
         '<label>Nachweis / Referenz <input name="evidence_reference" required '
         'maxlength="1000" placeholder="E-Mail vom 16.07.2026"></label>'
         "</fieldset>"
-        '<button type="submit">Als gesendet markieren</button>'
+        '<button class="offer-primary-button" type="submit">'
+        "Als gesendet markieren</button>"
         "</form></section>"
     )
 
@@ -279,25 +545,25 @@ def _record_acceptance_form(
     if not variant_options:
         variant_options = '<option value="">Keine Variante</option>'
     return (
-        '<section class="offer-detail-section offer-action-section">'
-        "<h2>Annahme erfassen</h2>"
-        f'<form method="post" action="/offer/{_e(offer_id)}/record-acceptance">'
+        '<section class="offer-action-section">'
+        '<form class="offer-form" method="post" '
+        f'action="/offer/{_e(offer_id)}/record-acceptance">'
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
-        f'<label>Angenommene Variante <select name="accepted_variant_id" required>'
-        f"{variant_options}"
-        "</select></label>"
+        '<label>Angenommene Variante <select name="accepted_variant_id" required>'
+        f"{variant_options}</select></label>"
         f'<label>Annahmezeitpunkt <input type="datetime-local" name="accepted_at" '
         f'step="1" value="{_e(default_at)}" required></label>'
-        f'<label>Kanal <select name="channel" required>'
+        '<label>Kanal <select name="channel" required>'
         f"{_select_options(ACCEPTANCE_CHANNELS, _ACCEPTANCE_CHANNEL_LABELS)}"
         "</select></label>"
         '<label>Nachweis / Referenz <input name="evidence_reference" required '
         'maxlength="1000" placeholder="Telefonische Bestätigung"></label>'
-        '<label>Notiz (optional) <textarea name="note" rows="3" maxlength="20000">'
-        "</textarea></label>"
+        '<label class="offer-form-wide">Notiz (optional) '
+        '<textarea name="note" rows="3" maxlength="20000"></textarea></label>'
         "</fieldset>"
-        '<button type="submit">Annahme erfassen</button>'
+        '<button class="offer-primary-button" type="submit">'
+        "Annahme erfassen</button>"
         "</form></section>"
     )
 
@@ -309,15 +575,17 @@ def _record_rejection_form(
         return ""
     default_at = default_datetime_local_berlin()
     return (
-        '<section class="offer-detail-section offer-action-section">'
+        '<section class="offer-action-section">'
         "<h2>Kunde lehnt ab</h2>"
-        f'<form method="post" action="/offer/{_e(offer_id)}/record-rejection">'
+        '<form class="offer-form" method="post" '
+        f'action="/offer/{_e(offer_id)}/record-rejection">'
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
         f'<label>Ablehnungszeitpunkt <input type="datetime-local" name="rejected_at" '
         f'step="1" value="{_e(default_at)}" required></label>'
-        '<label>Kommentar / Nachweis (optional) <input name="evidence_reference" '
-        'maxlength="1000" placeholder="Telefonische Absage"></label>'
+        '<label>Kommentar / Nachweis (optional) '
+        '<input name="evidence_reference" maxlength="1000" '
+        'placeholder="Telefonische Absage"></label>'
         "</fieldset>"
         '<button type="submit">Kunde lehnt ab</button>'
         "</form></section>"
@@ -330,13 +598,14 @@ def _record_withdrawal_form(
     if not context.can("offers.status.change"):
         return ""
     return (
-        '<section class="offer-detail-section offer-action-section">'
+        '<section class="offer-action-section">'
         "<h2>Angebot zurückziehen</h2>"
-        f'<form method="post" action="/offer/{_e(offer_id)}/record-withdrawal">'
+        '<form class="offer-form" method="post" '
+        f'action="/offer/{_e(offer_id)}/record-withdrawal">'
         f"{forms.csrf_input}{forms.command_fields}"
         "<fieldset>"
-        '<label>Grund (optional) <textarea name="reason" rows="3" maxlength="20000">'
-        "</textarea></label>"
+        '<label class="offer-form-wide">Grund (optional) '
+        '<textarea name="reason" rows="3" maxlength="20000"></textarea></label>'
         "</fieldset>"
         '<button type="submit">Angebot zurückziehen</button>'
         "</form></section>"
@@ -350,37 +619,49 @@ def _prepare_next_version_cta(
         return ""
     if not revision_prefill_url:
         return (
-            '<section class="offer-detail-section offer-action-section">'
-            "<h2>Neue Version vorbereiten</h2>"
+            '<section class="offer-action-section">'
             "<p>Eine neue Angebotsversion wird im Angebots-Editor vorbereitet.</p>"
             "</section>"
         )
     return (
-        '<section class="offer-detail-section offer-action-section">'
-        "<h2>Neue Version vorbereiten</h2>"
-        "<p>Eine neue Angebotsversion wird im Angebots-Editor vorbereitet und "
-        "anschließend als nächste Version übernommen.</p>"
+        '<section class="offer-action-section">'
+        "<p>Eine neue Angebotsversion wird im Angebots-Editor vorbereitet "
+        "und anschließend als nächste Version übernommen.</p>"
         f'<p><a class="offer-revision-link" href="{_e(revision_prefill_url)}">'
         "Neue Version vorbereiten</a></p>"
         "</section>"
     )
 
 
-def _sent_offer_actions(
+def _secondary_sent_actions(
     offer_id: str,
-    variants: list[dict[str, object]],
     *,
     forms: OfferDetailFormFields,
-    revision_prefill_url: str | None = None,
+    revision_prefill_url: str | None,
     context: OfficePageContext,
 ) -> str:
-    return (
-        _record_acceptance_form(offer_id, variants, forms=forms, context=context)
-        + _record_rejection_form(offer_id, forms=forms, context=context)
-        + _record_withdrawal_form(offer_id, forms=forms, context=context)
-        + _prepare_next_version_cta(
-            revision_prefill_url=revision_prefill_url, context=context
+    parts = [
+        _record_rejection_form(offer_id, forms=forms, context=context),
+        _record_withdrawal_form(offer_id, forms=forms, context=context),
+    ]
+    next_version = _prepare_next_version_cta(
+        revision_prefill_url=revision_prefill_url, context=context
+    )
+    if next_version:
+        parts.append(
+            '<section class="offer-action-section">'
+            "<h2>Neue Version vorbereiten</h2>"
+            f"{next_version}"
+            "</section>"
         )
+    content = "".join(part for part in parts if part)
+    if not content:
+        return ""
+    return (
+        '<details class="offer-secondary-actions">'
+        "<summary>Weitere Aktionen</summary>"
+        f'<div class="offer-secondary-content">{content}</div>'
+        "</details>"
     )
 
 
@@ -395,18 +676,182 @@ def _convert_form(
     if not (context.can("offers.view") and context.can("orders.version.create")):
         return ""
     return (
-        '<section class="offer-detail-section offer-action-section">'
-        "<h2>In Auftrag umwandeln</h2>"
+        '<section class="offer-action-section">'
         "<p>Das angenommene Angebot wird in einen Auftrag überführt.</p>"
-        f'<form method="post" action="/offer/{_e(offer_id)}/convert" '
+        '<form class="offer-form" method="post" '
+        f'action="/offer/{_e(offer_id)}/convert" '
         'onsubmit="return confirm('
         "'Das angenommene Angebot wird jetzt in einen Auftrag umgewandelt.'"
         ');">'
         f"{forms.csrf_input}{forms.command_fields}"
-        f'<input type="hidden" name="accepted_variant_id" value="{_e(accepted_variant_id)}">'
+        f'<input type="hidden" name="accepted_variant_id" '
+        f'value="{_e(accepted_variant_id)}">'
         f'<input type="hidden" name="acceptance_id" value="{_e(acceptance_id)}">'
-        '<button type="submit">In Auftrag umwandeln</button>'
+        '<button class="offer-primary-button" type="submit">'
+        "In Auftrag umwandeln</button>"
         "</form></section>"
+    )
+
+
+def _next_step(
+    detail: dict[str, object],
+    *,
+    offer_id: str,
+    state: str,
+    variants: list[dict[str, object]],
+    forms: OfferDetailFormFields,
+    revision_prefill_url: str | None,
+    context: OfficePageContext,
+) -> tuple[str, str, str]:
+    if state == "Prepared":
+        return (
+            "Angebot als gesendet markieren",
+            "Sobald das Angebot tatsächlich versendet wurde, den Versand hier dokumentieren.",
+            _mark_sent_form(offer_id, forms=forms, context=context),
+        )
+    if state == "Sent":
+        return (
+            "Kundenentscheidung erfassen",
+            "Wenn der Kunde zugesagt hat, die angenommene Variante und den Nachweis erfassen.",
+            _record_acceptance_form(
+                offer_id, variants, forms=forms, context=context
+            ),
+        )
+    if state == "Accepted":
+        acceptance_id = detail.get("acceptance_id")
+        acceptance = cast(dict[str, object] | None, detail.get("acceptance"))
+        if (
+            isinstance(acceptance_id, str)
+            and acceptance is not None
+            and acceptance.get("accepted_variant_id") is not None
+        ):
+            return (
+                "In Auftrag umwandeln",
+                "Die Kundenannahme ist erfasst. Jetzt den verbindlichen Auftrag anlegen.",
+                _convert_form(
+                    offer_id,
+                    accepted_variant_id=str(acceptance["accepted_variant_id"]),
+                    acceptance_id=acceptance_id,
+                    forms=forms,
+                    context=context,
+                ),
+            )
+    if state in ("Expired", "Rejected", "Withdrawn"):
+        return (
+            "Neue Version vorbereiten",
+            "Für die weitere Bearbeitung eine neue Angebotsversion im Angebots-Editor vorbereiten.",
+            _prepare_next_version_cta(
+                revision_prefill_url=revision_prefill_url, context=context
+            ),
+        )
+    if state == "Converted":
+        order_id = detail.get("order_id")
+        action = (
+            f'<a href="/order/{_e(str(order_id))}"><strong>Auftrag öffnen</strong></a>'
+            if order_id is not None
+            else ""
+        )
+        return (
+            "Auftrag erstellt",
+            "Dieses Angebot wurde bereits in einen Auftrag umgewandelt.",
+            action,
+        )
+    return (
+        offer_state_label(state),  # type: ignore[arg-type]
+        "Für diesen Angebotsstatus ist derzeit kein weiterer Schritt erforderlich.",
+        "",
+    )
+
+
+def _next_step_card(title: str, copy: str, action: str) -> str:
+    return (
+        '<section class="offer-next-step">'
+        '<p class="offer-next-label">Nächster Schritt</p>'
+        f"<h2>{_e(title)}</h2>"
+        f'<p class="offer-next-copy">{_e(copy)}</p>'
+        f"{action}"
+        "</section>"
+    )
+
+
+def _event_card(surface: dict[str, object], planning: str, guest_text: str) -> str:
+    facts = (
+        ("Datum", _long_date(str(surface["event_date"]))),
+        ("Zeit", str(surface["time_window_text"])),
+        ("Ort", str(surface["location_text"])),
+        ("Gäste", guest_text),
+        ("Planung", planning),
+    )
+    fact_html = "".join(
+        '<div class="offer-fact">'
+        f"<span>{_e(label)}</span><strong>{_e(value)}</strong>"
+        "</div>"
+        for label, value in facts
+    )
+    return (
+        '<section class="offer-card">'
+        "<h2>Veranstaltung</h2>"
+        '<div class="offer-facts">'
+        f"{fact_html}"
+        "</div></section>"
+    )
+
+
+def _variant_card(variants: list[dict[str, object]]) -> str:
+    cards: list[str] = []
+    total_positions = 0
+    for variant in variants:
+        positions = variant.get("positions")
+        count = len(positions) if isinstance(positions, list) else 0
+        total_positions += count
+        cards.append(
+            '<div class="offer-variant-card">'
+            f"<h3>{_e(str(variant.get('name', 'Variante')))}</h3>"
+            f"<p>{count} Position{'en' if count != 1 else ''}</p>"
+            "</div>"
+        )
+    if not cards:
+        cards.append(
+            '<div class="offer-variant-card"><h3>Keine Varianten</h3></div>'
+        )
+    variant_suffix = "n" if len(variants) != 1 else ""
+    position_suffix = "en" if total_positions != 1 else ""
+    return (
+        '<section class="offer-card">'
+        "<h2>Angebot</h2>"
+        f'<p class="offer-next-copy">{len(variants)} Variante{variant_suffix} · '
+        f"{total_positions} Position{position_suffix}</p>"
+        f'<div class="offer-variant-grid">{"".join(cards)}</div>'
+        "</section>"
+    )
+
+
+def _positions_panel(variants: list[dict[str, object]]) -> str:
+    return (
+        '<section class="offer-card">'
+        "<h2>Positionen</h2>"
+        '<p class="offer-next-copy">'
+        "Details, Zusammensetzung und Allergene nur bei Bedarf öffnen.</p>"
+        f'<ul class="offer-position-list">{_position_rows(variants)}</ul>'
+        "</section>"
+    )
+
+
+def _history_panel(detail: dict[str, object]) -> str:
+    history_rows = (
+        "".join(
+            f"<li><span>{_e(_history_date(str(entry['at'])))}</span> "
+            f"<strong>{_e(str(entry['label']))}</strong></li>"
+            for entry in cast(list[dict[str, object]], detail["history"])
+        )
+        or "<li>Noch keine Historie</li>"
+    )
+    return (
+        '<details class="offer-secondary-panel">'
+        "<summary>Angebotshistorie</summary>"
+        '<div class="offer-secondary-content">'
+        f'<ul class="offer-history-list">{history_rows}</ul>'
+        "</div></details>"
     )
 
 
@@ -425,95 +870,86 @@ def render_offer_detail(
     guest_count = surface.get("guest_count")
     guest_text = str(guest_count) if guest_count is not None else "noch offen"
     planning = _PLANNING_LABELS.get(
-        str(surface.get("planning_mode", "")), str(surface.get("planning_mode", "–"))
+        str(surface.get("planning_mode", "")),
+        str(surface.get("planning_mode", "–")),
     )
     variants = cast(list[dict[str, object]], surface["variants"])
-    variant_rows = (
-        "".join(f"<li>{_e(str(variant['name']))}</li>" for variant in variants)
-        or "<li>Keine Varianten</li>"
+    version_number = int(cast(int, surface.get("version", 1)))
+    state_label = offer_state_label(state)  # type: ignore[arg-type]
+
+    next_title, next_copy, next_action = _next_step(
+        detail,
+        offer_id=offer_id,
+        state=state,
+        variants=variants,
+        forms=forms,
+        revision_prefill_url=revision_prefill_url,
+        context=context,
     )
-    history_rows = (
-        "".join(
-            f"<li><span>{_e(_history_date(str(entry['at'])))}</span> "
-            f"<strong>{_e(str(entry['label']))}</strong></li>"
-            for entry in cast(list[dict[str, object]], detail["history"])
-        )
-        or "<li>Noch keine Historie</li>"
-    )
-    order_id = detail.get("order_id")
-    order_link = (
-        f'<p><a href="/order/{_e(str(order_id))}">Auftrag öffnen</a></p>'
-        if order_id is not None
-        else ""
-    )
-    action_section = ""
-    if state == "Prepared":
-        action_section = _mark_sent_form(offer_id, forms=forms, context=context)
-    elif state == "Sent":
-        action_section = _sent_offer_actions(
+
+    secondary_actions = ""
+    if state == "Sent":
+        secondary_actions = _secondary_sent_actions(
             offer_id,
-            variants,
             forms=forms,
             revision_prefill_url=revision_prefill_url,
             context=context,
         )
-    elif state in ("Expired", "Rejected", "Withdrawn"):
-        action_section = _prepare_next_version_cta(
-            revision_prefill_url=revision_prefill_url, context=context
-        )
-    elif state == "Accepted":
-        acceptance_id = detail.get("acceptance_id")
-        acceptance = cast(dict[str, object] | None, detail.get("acceptance"))
-        if (
-            isinstance(acceptance_id, str)
-            and acceptance is not None
-            and acceptance.get("accepted_variant_id") is not None
-        ):
-            action_section = _convert_form(
-                offer_id,
-                accepted_variant_id=str(acceptance["accepted_variant_id"]),
-                acceptance_id=acceptance_id,
-                forms=forms,
-                context=context,
-            )
+
     pdf_link = (
-        f'<p><a href="{_e(pdf_download_url)}">PDF herunterladen</a></p>'
+        f'<a class="offer-pdf-link" href="{_e(pdf_download_url)}">'
+        "PDF herunterladen</a>"
         if pdf_download_url is not None and context.can("offers.pdf.generate")
         else ""
     )
+
+    hero = (
+        '<header class="offer-hero">'
+        "<div>"
+        '<p class="offer-eyebrow">Angebot</p>'
+        f"<h1>Angebot {_e(offer_id[:8])}</h1>"
+        f'<p class="offer-hero-meta">Version {version_number} · '
+        f'{_e(_long_date(str(surface["event_date"])))} · '
+        f'{_e(str(surface["location_text"]))}</p>'
+        f"{pdf_link}"
+        "</div>"
+        f'<span class="offer-status-badge">{_e(state_label)}</span>'
+        "</header>"
+    )
+
+    order_id = detail.get("order_id")
+    order_link = (
+        f'<a href="/order/{_e(str(order_id))}">Auftrag öffnen</a>'
+        if order_id is not None
+        else ""
+    )
+    footer_links = (
+        '<nav class="offer-links">'
+        f"{order_link}"
+        f'<a href="/inquiry/{_e(inquiry_id)}">Anfrage öffnen</a>'
+        '<a href="/angebote">← Zurück zu Angeboten</a>'
+        "</nav>"
+    )
+
     body = (
-        f'<p class="subtitle">Angebot {_e(offer_id[:8])}</p>'
-        + pdf_link
-        + action_section
-        + '<section class="offer-detail-section">'
-        "<h2>Status</h2>"
-        f"<p><strong>{_e(offer_state_label(state))}</strong></p>"  # type: ignore[arg-type]
-        "</section>" + _version_list(detail) + '<section class="offer-detail-section">'
-        "<h2>Veranstaltung</h2>"
-        f"<p><span>Datum</span><strong>{_e(_long_date(str(surface['event_date'])))}</strong></p>"
-        f"<p><span>Ort</span><strong>{_e(str(surface['location_text']))}</strong></p>"
-        f"<p><span>Gäste</span><strong>{_e(guest_text)}</strong></p>"
-        f"<p><span>Zeitfenster</span><strong>{_e(str(surface['time_window_text']))}</strong></p>"
-        f"<p><span>Planung</span><strong>{_e(planning)}</strong></p>"
-        "</section>" + _budget_block(surface) + '<section class="offer-detail-section">'
-        "<h2>Positionen (Snapshot)</h2>"
-        f'<ul class="offer-position-list">{_position_rows(variants)}</ul>'
-        "</section>"
-        '<section class="offer-detail-section">'
-        "<h2>Angebotsvarianten</h2>"
-        f'<ul class="offer-variant-list">{variant_rows}</ul>'
-        "</section>"
-        '<section class="offer-detail-section">'
-        "<h2>Angebotshistorie</h2>"
-        f'<ul class="offer-history-list">{history_rows}</ul>'
-        "</section>"
-        + order_link
-        + f'<p><a href="/inquiry/{_e(inquiry_id)}">Anfrage öffnen</a></p>'
-        + '<p><a href="/angebote">← Zurück zu Angeboten</a></p>'
+        _OFFER_DETAIL_STYLE
+        + '<div class="offer-guided">'
+        + hero
+        + _next_step_card(next_title, next_copy, next_action)
+        + secondary_actions
+        + _event_card(surface, planning, guest_text)
+        + _budget_block(surface)
+        + _variant_card(variants)
+        + _positions_panel(variants)
+        + _version_list(detail)
+        + _history_panel(detail)
+        + footer_links
+        + "</div>"
     )
     return _page(
         "Angebot",
         body,
-        active_section="inquiries",
+        active_section="offers",
         context=context,
+        show_title=False,
     )

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -721,16 +721,23 @@ def _next_step(
             and acceptance is not None
             and acceptance.get("accepted_variant_id") is not None
         ):
+            action = _convert_form(
+                offer_id,
+                accepted_variant_id=str(acceptance["accepted_variant_id"]),
+                acceptance_id=acceptance_id,
+                forms=forms,
+                context=context,
+            )
+            if action:
+                return (
+                    "In Auftrag umwandeln",
+                    "Die Kundenannahme ist erfasst. Jetzt den verbindlichen Auftrag anlegen.",
+                    action,
+                )
             return (
-                "In Auftrag umwandeln",
-                "Die Kundenannahme ist erfasst. Jetzt den verbindlichen Auftrag anlegen.",
-                _convert_form(
-                    offer_id,
-                    accepted_variant_id=str(acceptance["accepted_variant_id"]),
-                    acceptance_id=acceptance_id,
-                    forms=forms,
-                    context=context,
-                ),
+                "Kundenannahme erfasst",
+                "Das Angebot wurde vom Kunden angenommen.",
+                "",
             )
     if state in ("Expired", "Rejected", "Withdrawn"):
         return (
@@ -812,7 +819,7 @@ def _variant_card(variants: list[dict[str, object]]) -> str:
     position_suffix = "en" if total_positions != 1 else ""
     return (
         '<section class="offer-card">'
-        "<h2>Angebot</h2>"
+        "<h2>Angebotsvarianten</h2>"
         f'<p class="offer-next-copy">{len(variants)} Variante{variant_suffix} · '
         f"{total_positions} Position{position_suffix}</p>"
         f'<div class="offer-variant-grid">{"".join(cards)}</div>'

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -396,9 +396,7 @@ def _position_rows(variants: list[dict[str, object]]) -> str:
             name = _e(str(position.get("name", "Position")))
             unit_cents = position.get("unit_net_cents")
             unit_text = (
-                f"{int(unit_cents) / 100:.2f} €"
-                if isinstance(unit_cents, int)
-                else "–"
+                f"{int(unit_cents) / 100:.2f} €" if isinstance(unit_cents, int) else "–"
             )
             description = position.get("description")
             description_html = (
@@ -583,7 +581,7 @@ def _record_rejection_form(
         "<fieldset>"
         f'<label>Ablehnungszeitpunkt <input type="datetime-local" name="rejected_at" '
         f'step="1" value="{_e(default_at)}" required></label>'
-        '<label>Kommentar / Nachweis (optional) '
+        "<label>Kommentar / Nachweis (optional) "
         '<input name="evidence_reference" maxlength="1000" '
         'placeholder="Telefonische Absage"></label>'
         "</fieldset>"
@@ -713,9 +711,7 @@ def _next_step(
         return (
             "Kundenentscheidung erfassen",
             "Wenn der Kunde zugesagt hat, die angenommene Variante und den Nachweis erfassen.",
-            _record_acceptance_form(
-                offer_id, variants, forms=forms, context=context
-            ),
+            _record_acceptance_form(offer_id, variants, forms=forms, context=context),
         )
     if state == "Accepted":
         acceptance_id = detail.get("acceptance_id")
@@ -811,9 +807,7 @@ def _variant_card(variants: list[dict[str, object]]) -> str:
             "</div>"
         )
     if not cards:
-        cards.append(
-            '<div class="offer-variant-card"><h3>Keine Varianten</h3></div>'
-        )
+        cards.append('<div class="offer-variant-card"><h3>Keine Varianten</h3></div>')
     variant_suffix = "n" if len(variants) != 1 else ""
     position_suffix = "en" if total_positions != 1 else ""
     return (
@@ -897,8 +891,7 @@ def render_offer_detail(
         )
 
     pdf_link = (
-        f'<a class="offer-pdf-link" href="{_e(pdf_download_url)}">'
-        "PDF herunterladen</a>"
+        f'<a class="offer-pdf-link" href="{_e(pdf_download_url)}">PDF herunterladen</a>'
         if pdf_download_url is not None and context.can("offers.pdf.generate")
         else ""
     )
@@ -909,8 +902,8 @@ def render_offer_detail(
         '<p class="offer-eyebrow">Angebot</p>'
         f"<h1>Angebot {_e(offer_id[:8])}</h1>"
         f'<p class="offer-hero-meta">Version {version_number} · '
-        f'{_e(_long_date(str(surface["event_date"])))} · '
-        f'{_e(str(surface["location_text"]))}</p>'
+        f"{_e(_long_date(str(surface['event_date'])))} · "
+        f"{_e(str(surface['location_text']))}</p>"
         f"{pdf_link}"
         "</div>"
         f'<span class="offer-status-badge">{_e(state_label)}</span>'

--- a/tests/unit/test_office_panel_offer_detail_guided.py
+++ b/tests/unit/test_office_panel_offer_detail_guided.py
@@ -1,0 +1,126 @@
+"""Focused presentation tests for the guided Angebot detail page."""
+
+from __future__ import annotations
+
+import re
+
+from catering_system.ui.office_panel_offer_detail import (
+    OfferDetailFormFields,
+    render_offer_detail,
+)
+from tests.helpers.office_panel_context import legacy_office_context
+
+_OFFER_ID = "11111111-1111-4111-8111-111111111111"
+_VERSION_ID = "22222222-2222-4222-8222-222222222222"
+_VARIANT_ID = "33333333-3333-4333-8333-333333333333"
+
+
+def _detail(state: str) -> dict[str, object]:
+    detail: dict[str, object] = {
+        "offer_id": _OFFER_ID,
+        "inquiry_id": "44444444-4444-4444-8444-444444444444",
+        "offer_version_id": _VERSION_ID,
+        "commercial_state": state,
+        "acceptance_id": None,
+        "acceptance": None,
+        "versions": [
+            {
+                "offer_version_id": _VERSION_ID,
+                "version": 1,
+                "state": state,
+                "sent_at": "2026-08-19T14:00:00+00:00" if state != "Prepared" else None,
+                "event_date": "2026-09-01",
+                "time_window_text": "13:00",
+                "location_text": "Glinde",
+                "guest_count": 120,
+                "planning_mode": "caterer_suggestion",
+                "variants": [
+                    {
+                        "variant_id": _VARIANT_ID,
+                        "name": "Variante A",
+                        "positions": [
+                            {
+                                "name": "Fingerfood Paket",
+                                "unit_net_cents": 1290,
+                                "description": "Frozen description",
+                                "composition": "Frozen composition",
+                                "allergen_labels": ["Gluten", "Milch"],
+                                "allergens_unknown": False,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "history": [
+            {
+                "at": "2026-08-19T13:00:00+00:00",
+                "label": "Version 1 vorbereitet",
+            }
+        ],
+    }
+    if state == "Accepted":
+        detail["acceptance_id"] = "55555555-5555-4555-8555-555555555555"
+        detail["acceptance"] = {"accepted_variant_id": _VARIANT_ID}
+    if state == "Converted":
+        detail["order_id"] = "66666666-6666-4666-8666-666666666666"
+    return detail
+
+
+def _render(state: str, *, revision_url: str | None = "/configurator/revision") -> str:
+    return render_offer_detail(
+        _detail(state),
+        context=legacy_office_context(),
+        forms=OfferDetailFormFields(
+            csrf_input='<input type="hidden" name="csrf" value="x">',
+            command_fields='<input type="hidden" name="command_id" value="y">',
+        ),
+        revision_prefill_url=revision_url,
+    )
+
+
+def test_prepared_is_status_first_with_one_guided_next_step() -> None:
+    html = _render("Prepared")
+
+    assert 'class="offer-status-badge">Vorbereitet<' in html
+    assert 'class="offer-next-label">Nächster Schritt<' in html
+    assert "Angebot als gesendet markieren" in html
+    assert "/mark-sent" in html
+    assert "/record-acceptance" not in html
+    assert html.index("Vorbereitet") < html.index("Als gesendet markieren")
+    assert re.search(r'href="/angebote"[^>]*aria-current="page"', html)
+
+
+def test_sent_keeps_acceptance_primary_and_subordinates_other_actions() -> None:
+    html = _render("Sent")
+
+    assert "Kundenentscheidung erfassen" in html
+    assert "/record-acceptance" in html
+    assert '<summary>Weitere Aktionen</summary>' in html
+    assert "/record-rejection" in html
+    assert "/record-withdrawal" in html
+    assert "Neue Version vorbereiten" in html
+    assert html.index("/record-acceptance") < html.index("Weitere Aktionen")
+
+
+def test_positions_are_collapsed_without_losing_frozen_content() -> None:
+    html = _render("Sent")
+
+    assert '<details class="offer-position-detail">' in html
+    assert "Fingerfood Paket" in html
+    assert "Frozen description" in html
+    assert "Zusammensetzung:</strong> Frozen composition" in html
+    assert "Gluten" in html
+    assert "Details, Zusammensetzung und Allergene nur bei Bedarf öffnen." in html
+
+
+def test_accepted_and_converted_keep_existing_lifecycle_targets() -> None:
+    accepted = _render("Accepted")
+    assert "In Auftrag umwandeln" in accepted
+    assert "/convert" in accepted
+    assert "/record-acceptance" not in accepted
+
+    converted = _render("Converted")
+    assert "Auftrag erstellt" in converted
+    assert "/order/66666666-6666-4666-8666-666666666666" in converted
+    assert "/convert" not in converted

--- a/tests/unit/test_office_panel_offer_detail_guided.py
+++ b/tests/unit/test_office_panel_offer_detail_guided.py
@@ -96,7 +96,7 @@ def test_sent_keeps_acceptance_primary_and_subordinates_other_actions() -> None:
 
     assert "Kundenentscheidung erfassen" in html
     assert "/record-acceptance" in html
-    assert '<summary>Weitere Aktionen</summary>' in html
+    assert "<summary>Weitere Aktionen</summary>" in html
     assert "/record-rejection" in html
     assert "/record-withdrawal" in html
     assert "Neue Version vorbereiten" in html


### PR DESCRIPTION
## Business problem
The Angebot detail page still used the old flat presentation and forced office staff to choose among equally weighted lifecycle actions.

## Scope
Presentation-only redesign of Angebot Detail.

- status/header before actions
- one deterministic `Nächster Schritt`
- Sent keeps acceptance primary; rejection/withdrawal/new version move under `Weitere Aktionen`
- compact Veranstaltung and variant summary
- position details collapsed with `<details>` while preserving frozen description/composition/allergens
- versions/history moved to secondary disclosures
- Angebot sidebar entry is selected correctly
- existing POST endpoints and permission checks preserved

## Hard boundary
Production files: 1
- `src/catering_system/ui/office_panel_offer_detail.py`

Test files: 1
- `tests/unit/test_office_panel_offer_detail_guided.py`

No domain, API, repository, database, migration, permission, or workflow-state changes.