### PR TITLE
Use customer name in Angebot header

### DIFF
--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -208,6 +208,7 @@ from catering_system.ui.office_panel_inquiry_detail import (
 )
 from catering_system.ui.office_panel_offer_detail import (
     OfferDetailFormFields,
+    customer_display_from_offer_queue,
     render_offer_detail,
     surface_version_id,
 )
@@ -1030,6 +1031,11 @@ class OfficePanel:
             if offer is None:
                 return None
             detail = api_views.offer_detail(offer, today=api_views.berlin_today())
+        detail = dict(detail)
+        detail["customer_display"] = (
+            customer_display_from_offer_queue(self._offer_queue_snapshot(), offer_id)
+            or ""
+        )
         forms = OfferDetailFormFields(
             csrf_input=_csrf_input(context),
             command_fields=self._command_fields(),

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -904,9 +904,7 @@ def render_offer_detail(
     state_label = offer_state_label(state)  # type: ignore[arg-type]
     customer_display_raw = detail.get("customer_display")
     customer_display = (
-        customer_display_raw.strip()
-        if isinstance(customer_display_raw, str)
-        else ""
+        customer_display_raw.strip() if isinstance(customer_display_raw, str) else ""
     )
     hero_title = (
         f"Angebot · {customer_display}"

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -339,6 +339,31 @@ def surface_version_id(detail: dict[str, object]) -> str:
     return str(_surface_version(detail).get("offer_version_id", ""))
 
 
+def customer_display_from_offer_queue(
+    snapshot: dict[str, object], offer_id: str
+) -> str | None:
+    """Read the queue's canonical human customer label for one offer."""
+
+    sections = snapshot.get("sections")
+    if not isinstance(sections, list):
+        return None
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        items = section.get("items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict) or str(item.get("offer_id", "")) != offer_id:
+                continue
+            raw = item.get("customer_display")
+            if not isinstance(raw, str):
+                return None
+            display = raw.strip()
+            return display if display and display != "–" else None
+    return None
+
+
 def _version_list(detail: dict[str, object]) -> str:
     versions = cast(list[dict[str, object]], detail["versions"])
     current_id = str(detail["offer_version_id"])
@@ -877,6 +902,17 @@ def render_offer_detail(
     variants = cast(list[dict[str, object]], surface["variants"])
     version_number = int(cast(int, surface.get("version", 1)))
     state_label = offer_state_label(state)  # type: ignore[arg-type]
+    customer_display_raw = detail.get("customer_display")
+    customer_display = (
+        customer_display_raw.strip()
+        if isinstance(customer_display_raw, str)
+        else ""
+    )
+    hero_title = (
+        f"Angebot · {customer_display}"
+        if customer_display and customer_display != "–"
+        else "Angebot"
+    )
 
     next_title, next_copy, next_action = _next_step(
         detail,
@@ -907,7 +943,7 @@ def render_offer_detail(
         '<header class="offer-hero">'
         "<div>"
         '<p class="offer-eyebrow">Angebot</p>'
-        f"<h1>Angebot {_e(offer_id[:8])}</h1>"
+        f"<h1>{_e(hero_title)}</h1>"
         f'<p class="offer-hero-meta">Version {version_number} · '
         f"{_e(_long_date(str(surface['event_date'])))} · "
         f"{_e(str(surface['location_text']))}</p>"

--- a/tests/unit/test_office_panel_offer_detail_guided.py
+++ b/tests/unit/test_office_panel_offer_detail_guided.py
@@ -6,6 +6,7 @@ import re
 
 from catering_system.ui.office_panel_offer_detail import (
     OfferDetailFormFields,
+    customer_display_from_offer_queue,
     render_offer_detail,
 )
 from tests.helpers.office_panel_context import legacy_office_context
@@ -67,9 +68,17 @@ def _detail(state: str) -> dict[str, object]:
     return detail
 
 
-def _render(state: str, *, revision_url: str | None = "/configurator/revision") -> str:
+def _render(
+    state: str,
+    *,
+    revision_url: str | None = "/configurator/revision",
+    customer_display: str | None = None,
+) -> str:
+    detail = _detail(state)
+    if customer_display is not None:
+        detail["customer_display"] = customer_display
     return render_offer_detail(
-        _detail(state),
+        detail,
         context=legacy_office_context(),
         forms=OfferDetailFormFields(
             csrf_input='<input type="hidden" name="csrf" value="x">',
@@ -124,3 +133,32 @@ def test_accepted_and_converted_keep_existing_lifecycle_targets() -> None:
     assert "Auftrag erstellt" in converted
     assert "/order/66666666-6666-4666-8666-666666666666" in converted
     assert "/convert" not in converted
+
+
+def test_title_uses_human_customer_display_without_offer_id() -> None:
+    html = _render("Sent", customer_display="Art.draw GmbH")
+
+    assert "<h1>Angebot · Art.draw GmbH</h1>" in html
+    assert f"<h1>Angebot {_OFFER_ID[:8]}</h1>" not in html
+    assert "<h1>Angebot</h1>" in _render("Sent", customer_display="–")
+    assert "<h1>Angebot</h1>" in _render("Sent")
+
+
+def test_customer_display_comes_from_matching_offer_queue_item() -> None:
+    snapshot: dict[str, object] = {
+        "sections": [
+            {
+                "items": [
+                    {"offer_id": "other", "customer_display": "Andere GmbH"},
+                    {"offer_id": _OFFER_ID, "customer_display": " Art.draw GmbH "},
+                ]
+            }
+        ]
+    }
+
+    assert customer_display_from_offer_queue(snapshot, _OFFER_ID) == "Art.draw GmbH"
+    assert customer_display_from_offer_queue(snapshot, "missing") is None
+    snapshot["sections"] = [
+        {"items": [{"offer_id": _OFFER_ID, "customer_display": "–"}]}
+    ]
+    assert customer_display_from_offer_queue(snapshot, _OFFER_ID) is None


### PR DESCRIPTION
## Business problem
The redesigned Angebot detail still shows a technical short offer UUID in the main header instead of the customer identity.

## Change
- reuse the existing Angebot queue `customer_display` as the canonical human label
- render `Angebot · <Kunde>` when available
- fall back to plain `Angebot` when no human label exists
- never fall back to the offer UUID in the main title
- preserve direct/remote behavior and all existing offer lifecycle semantics

## Hard boundary
Production files: 2
- `src/catering_system/ui/office_panel.py`
- `src/catering_system/ui/office_panel_offer_detail.py`

Test files: 1
- `tests/unit/test_office_panel_offer_detail_guided.py`

No API, domain, repository, database, migration, permission, or workflow-state changes.

Focused validation before PR: Ruff green, mypy green, 8 targeted tests passed.