### PR TITLE
Enforce accepted-offer gate for order creation

### DIFF
--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -577,16 +577,17 @@ class OfferService:
                 f"(inquiry_id={inquiry.inquiry_id!r})"
             )
 
-        order, order_version = self._order_service.create_order_from_offer_version(
-            offer.source_inquiry_id,
-            version,
-            inquiry,
-        )
         acceptance = offer.acceptance_evidence
         if acceptance is None or acceptance.acceptance_id != acceptance_id:
             raise ValueError(
                 f"acceptance_id {acceptance_id!r} does not match offer acceptance"
             )
+        order, order_version = self._order_service.create_order_from_offer_version(
+            offer.source_inquiry_id,
+            version,
+            inquiry,
+            acceptance_evidence=acceptance,
+        )
         variant = next(
             item for item in version.variants if item.variant_id == accepted_variant_id
         )

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -19,7 +19,10 @@ from catering_system.domain.inquiry import (
     Inquiry,
     validate_planning_mode,
 )
-from catering_system.domain.offer import OfferVersion as CommercialOfferVersion
+from catering_system.domain.offer import (
+    AcceptanceEvidence,
+    OfferVersion as CommercialOfferVersion,
+)
 from catering_system.domain.operational_core_events import (
     OrderVersionCandidateSuperseded,
     OrderVersionChangeProposed,
@@ -100,8 +103,25 @@ class OrderService:
         source_inquiry_id: str,
         offer_version: CommercialOfferVersion,
         inquiry: Inquiry | None = None,
+        *,
+        acceptance_evidence: AcceptanceEvidence | None = None,
     ) -> tuple[Order, OrderVersion]:
-        """Create Order + v1 from commercial OfferVersion facts (not Inquiry)."""
+        """Create Order + v1 only from an exactly accepted OfferVersion."""
+        if acceptance_evidence is None:
+            raise ValueError("AcceptanceEvidence required for Order creation")
+        if acceptance_evidence.offer_id != offer_version.offer_id:
+            raise ValueError("acceptance belongs to a different Offer")
+        if (
+            acceptance_evidence.accepted_offer_version_id
+            != offer_version.offer_version_id
+        ):
+            raise ValueError("acceptance does not match OfferVersion")
+        if not any(
+            variant.variant_id == acceptance_evidence.accepted_variant_id
+            for variant in offer_version.variants
+        ):
+            raise ValueError("accepted variant does not belong to OfferVersion")
+
         now = _utc_now()
         order_id = str(uuid.uuid4())
         order = Order(

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -23,7 +23,12 @@ from catering_system.domain.inquiry import (
 from catering_system.domain.inquiry_customer_snapshot import (
     InquiryCustomerSnapshot as _CCSnapshot,
 )
-from catering_system.domain.offer import OfferPosition, OfferVariant, OfferVersion
+from catering_system.domain.offer import (
+    AcceptanceEvidence,
+    OfferPosition,
+    OfferVariant,
+    OfferVersion,
+)
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_operational_context import (
     OrderOperationalContextData,
@@ -127,6 +132,79 @@ def _offer_version_from_inquiry(inquiry: Inquiry) -> OfferVersion:
     )
 
 
+def _acceptance_for_offer_version(offer_version: OfferVersion) -> AcceptanceEvidence:
+    return AcceptanceEvidence(
+        acceptance_id="acceptance-1",
+        offer_id=offer_version.offer_id,
+        accepted_offer_version_id=offer_version.offer_version_id,
+        accepted_variant_id=offer_version.variants[0].variant_id,
+        accepted_at=offer_version.created_at,
+        recorded_at=offer_version.created_at,
+        channel="phone",
+        evidence_reference="unit-test",
+        recorded_by="unit-test",
+    )
+
+
+def _create_initial_order(
+    svc: OrderService, inquiry: Inquiry
+) -> tuple[Order, OrderVersion]:
+    offer_version = _offer_version_from_inquiry(inquiry)
+    return svc.create_order_from_offer_version(
+        inquiry.inquiry_id,
+        offer_version,
+        inquiry,
+        acceptance_evidence=_acceptance_for_offer_version(offer_version),
+    )
+
+
+def test_create_order_from_offer_version_requires_acceptance_before_persistence() -> None:
+    repo = InMemoryOrderRepository()
+    inquiry = _sample_inquiry()
+    offer_version = _offer_version_from_inquiry(inquiry)
+
+    with pytest.raises(ValueError, match="AcceptanceEvidence required"):
+        OrderService(repo).create_order_from_offer_version(
+            inquiry.inquiry_id,
+            offer_version,
+            inquiry,
+        )
+
+    assert repo.list_orders() == []
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "message"),
+    (
+        ("offer_id", "other-offer", "different Offer"),
+        ("accepted_offer_version_id", "other-version", "does not match OfferVersion"),
+        ("accepted_variant_id", "other-variant", "does not belong to OfferVersion"),
+    ),
+)
+def test_create_order_from_offer_version_rejects_mismatched_acceptance_before_persistence(
+    field_name: str,
+    field_value: str,
+    message: str,
+) -> None:
+    repo = InMemoryOrderRepository()
+    inquiry = _sample_inquiry()
+    offer_version = _offer_version_from_inquiry(inquiry)
+    acceptance = replace(
+        _acceptance_for_offer_version(offer_version),
+        **{field_name: field_value},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        OrderService(repo).create_order_from_offer_version(
+            inquiry.inquiry_id,
+            offer_version,
+            inquiry,
+            acceptance_evidence=acceptance,
+        )
+
+    assert repo.list_orders() == []
+
+
 def test_convert_inquiry_to_order_requires_accepted_offer_when_missing() -> None:
     svc = OrderService(InMemoryOrderRepository())
     with pytest.raises(ValueError, match="accepted offer required"):
@@ -173,11 +251,7 @@ def test_create_relevant_order_change_version_second_preserves_first() -> None:
 def test_initial_version_stores_frozen_operational_context() -> None:
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, version = svc.create_order_from_offer_version(
-        _sample_inquiry().inquiry_id,
-        _offer_version_from_inquiry(_sample_inquiry()),
-        _sample_inquiry(),
-    )
+    order, version = _create_initial_order(svc, _sample_inquiry())
 
     context = repo.get_operational_context(version.order_version_id)
     assert context is not None
@@ -194,11 +268,7 @@ def test_child_version_inherits_parent_operational_context_not_live_inquiry() ->
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order, v1 = _create_initial_order(svc, inquiry)
     mutated = replace(
         inquiry,
         customer_snapshot=replace(
@@ -235,11 +305,7 @@ def test_explicit_operational_context_change_and_grandchild_inheritance() -> Non
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order, v1 = _create_initial_order(svc, inquiry)
     new_address = CustomerAddress(
         street="Neuer Weg 5",
         postal_code="20095",
@@ -293,11 +359,7 @@ def test_operational_context_inherits_from_exact_parent_not_latest_branch() -> N
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order, v1 = _create_initial_order(svc, inquiry)
     explicit_b = OrderOperationalContextData(
         recipient_company="Branch B GmbH",
         recipient_name="Berta Branch",
@@ -351,11 +413,7 @@ def test_delivery_address_change_creates_explicit_context_without_inquiry_mutati
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order, v1 = _create_initial_order(svc, inquiry)
     before_context = repo.get_operational_context(v1.order_version_id)
     assert before_context is not None
     new_address = CustomerAddress(
@@ -392,11 +450,7 @@ def test_delivery_address_change_uses_explicit_parent_not_latest_branch() -> Non
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order, v1 = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order, v1 = _create_initial_order(svc, inquiry)
     branch_b = OrderOperationalContextData(
         recipient_company="Branch B GmbH",
         recipient_name="Berta Branch",
@@ -471,17 +525,9 @@ def test_delivery_address_change_rejects_parent_not_owned_without_partial_versio
     inquiry = _sample_inquiry()
     repo = InMemoryOrderRepository()
     svc = OrderService(repo)
-    order_a, v1a = svc.create_order_from_offer_version(
-        inquiry.inquiry_id,
-        _offer_version_from_inquiry(inquiry),
-        inquiry,
-    )
+    order_a, v1a = _create_initial_order(svc, inquiry)
     other_inquiry = replace(inquiry, inquiry_id="22222222-2222-2222-2222-222222222222")
-    order_b, v1b = svc.create_order_from_offer_version(
-        other_inquiry.inquiry_id,
-        _offer_version_from_inquiry(other_inquiry),
-        other_inquiry,
-    )
+    order_b, v1b = _create_initial_order(svc, other_inquiry)
     before_versions = repo.list_order_versions(order_a.order_id)
 
     with pytest.raises(ValueError, match="not a version of order"):


### PR DESCRIPTION
## Summary
- require `AcceptanceEvidence` at the `OrderService.create_order_from_offer_version()` boundary before any Order persistence
- validate that the evidence matches the exact Offer, OfferVersion, and accepted variant
- make `OfferService.convert_accepted_offer()` validate/retrieve acceptance before Order creation and pass the exact evidence through
- update existing OrderService unit setup calls to pass explicit acceptance evidence; add regression coverage for missing/mismatched evidence

## Scope
This is the narrow M1 fix only. It does **not** change Kitchen Print, physical ACK activation, effective/candidate version semantics, Order Detail, PDFs, remote print status, customer documents, or introduce any second customer/internal approval step.

## Verification
- final branch is one commit ahead of baseline `f28331e35e783510061e753b19d628893ea361e8`
- final diff contains only `order_service.py`, `offer_service.py`, and `tests/unit/test_order_service.py`
- temporary `tests/unit/conftest.py` monkeypatch shim and separate temporary regression test file are not present in the final diff
- reconstructed `tests/unit/test_order_service.py` passed Python syntax compilation locally

Targeted/full pytest could not be executed in the local connector environment because the repository checkout is not available there; PR-triggered CI will be checked separately.