### PR TITLE
Reject stale confirmation snapshot replay

### DIFF
--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -171,8 +171,7 @@ class OrderConfirmationDocumentService:
             raise OrderConfirmationDocumentNotFoundError(order_id)
         if (
             order.effective_order_version_id is not None
-            and order.effective_order_version_id
-            != expected_effective_order_version_id
+            and order.effective_order_version_id != expected_effective_order_version_id
         ):
             raise OrderConfirmationDocumentStaleVersionError(
                 "expected effective order version is stale"
@@ -182,9 +181,7 @@ class OrderConfirmationDocumentService:
         )
         if existing is not None:
             if existing.order_id != order_id:
-                raise OrderConfirmationDocumentNotFoundError(
-                    existing.document_snapshot_id
-                )
+                raise OrderConfirmationDocumentNotFoundError(existing.document_snapshot_id)
             return existing
 
         version, commercial, recipient, fulfillment_mode = self._create_inputs(

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -181,7 +181,9 @@ class OrderConfirmationDocumentService:
         )
         if existing is not None:
             if existing.order_id != order_id:
-                raise OrderConfirmationDocumentNotFoundError(existing.document_snapshot_id)
+                raise OrderConfirmationDocumentNotFoundError(
+                    existing.document_snapshot_id
+                )
             return existing
 
         version, commercial, recipient, fulfillment_mode = self._create_inputs(

--- a/src/catering_system/services/order_confirmation_document_service.py
+++ b/src/catering_system/services/order_confirmation_document_service.py
@@ -169,10 +169,22 @@ class OrderConfirmationDocumentService:
         order = self._orders.get_order(order_id)
         if order is None:
             raise OrderConfirmationDocumentNotFoundError(order_id)
+        if (
+            order.effective_order_version_id is not None
+            and order.effective_order_version_id
+            != expected_effective_order_version_id
+        ):
+            raise OrderConfirmationDocumentStaleVersionError(
+                "expected effective order version is stale"
+            )
         existing = self._documents.get_by_order_version_id(
             expected_effective_order_version_id
         )
         if existing is not None:
+            if existing.order_id != order_id:
+                raise OrderConfirmationDocumentNotFoundError(
+                    existing.document_snapshot_id
+                )
             return existing
 
         version, commercial, recipient, fulfillment_mode = self._create_inputs(

--- a/tests/unit/test_confirmation_snapshot_replay_stale_gate.py
+++ b/tests/unit/test_confirmation_snapshot_replay_stale_gate.py
@@ -44,8 +44,5 @@ def test_prepare_rejects_old_snapshot_replay_after_effective_version_changes() -
     stored = documents.get_by_id(first.document_snapshot_id)
     assert stored is not None
     assert stored.document_snapshot_id == first.document_snapshot_id
-    assert (
-        service.get_snapshot(order.order_id, first.document_snapshot_id)
-        .document_snapshot_id
-        == first.document_snapshot_id
-    )
+    read_back = service.get_snapshot(order.order_id, first.document_snapshot_id)
+    assert read_back.document_snapshot_id == first.document_snapshot_id

--- a/tests/unit/test_confirmation_snapshot_replay_stale_gate.py
+++ b/tests/unit/test_confirmation_snapshot_replay_stale_gate.py
@@ -1,0 +1,51 @@
+"""Regression coverage for confirmation snapshot replay after version changes."""
+
+from datetime import date
+
+import pytest
+
+from catering_system.services.order_confirmation_document_service import (
+    OrderConfirmationDocumentStaleVersionError,
+)
+from catering_system.services.order_service import OrderService
+from tests.unit.test_order_confirmation_document import _effective_order, _services
+
+
+def test_prepare_rejects_old_snapshot_replay_after_effective_version_changes() -> None:
+    services = _services()
+    orders, _offers, _inquiries, documents, service, core, _offer_service = services
+    order, v1 = _effective_order(services)
+    first = service.prepare_snapshot(
+        order.order_id,
+        v1.order_version_id,
+        "office-panel",
+    )
+
+    v2 = OrderService(orders).propose_order_version_change(
+        order.order_id,
+        event_date=date(2026, 9, 2),
+        time_window_text=v1.time_window_text,
+        location_text="Kiel",
+        guest_count_estimate=v1.guest_count_estimate,
+        planning_mode=v1.planning_mode,
+        actor_reference="office-panel",
+        change_reason="Ort geändert",
+    )
+    core.confirm_kitchen_print(order.order_id, v2.order_version_id)
+    core.make_order_version_effective(order.order_id, v2.order_version_id)
+
+    with pytest.raises(OrderConfirmationDocumentStaleVersionError):
+        service.prepare_snapshot(
+            order.order_id,
+            v1.order_version_id,
+            "office-panel",
+        )
+
+    stored = documents.get_by_id(first.document_snapshot_id)
+    assert stored is not None
+    assert stored.document_snapshot_id == first.document_snapshot_id
+    assert (
+        service.get_snapshot(order.order_id, first.document_snapshot_id)
+        .document_snapshot_id
+        == first.document_snapshot_id
+    )


### PR DESCRIPTION
## Summary
- reject `prepare_snapshot()` calls for a stale effective OrderVersion before returning an existing immutable snapshot
- preserve normal idempotent replay for the current effective OrderVersion
- preserve the existing no-effective-version eligibility/blocker behavior
- keep old snapshots readable through the read path after a newer OrderVersion becomes effective
- add focused regression coverage for V1 snapshot replay after V2 becomes effective

## Scope
Service-boundary hardening only. No workflow/state changes, no Kitchen Print changes, no document schema changes, and no changes to customer/contact/fulfillment source-of-truth behavior.

## Verification
- branch starts from main merge commit `396f31b68ce7ff671ffbcb00d426102aa875cc4d`
- diff is limited to `order_confirmation_document_service.py` plus one focused regression-test file
- existing late stale check remains in place before persistence; the new early check specifically closes stale replay
