### PR TITLE
Show kitchen print waiting state

### DIFF
--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -270,6 +270,19 @@ def _target_version(
     return max(versions, key=lambda version: version.version_number, default=None)
 
 
+def _kitchen_print_waiting(
+    target: OrderVersion | None,
+    next_action: Mapping[str, str] | None,
+    forms: OrderDetailFormFields,
+) -> bool:
+    return (
+        target is not None
+        and next_action is not None
+        and next_action.get("action") == "print-confirm"
+        and not forms.print_action_available.get(target.order_version_id, True)
+    )
+
+
 def _state_copy(
     order: Order,
     target: OrderVersion | None,
@@ -490,11 +503,23 @@ def _primary_action(
             target.order_version_id,
             "",
         )
-        status_html = f"<p>{_e(status_message)}</p>" if status_message else ""
-        heading = "Küchenzettel für den aktuellen Stand drucken"
         action_available = forms.print_action_available.get(
             target.order_version_id, True
         )
+        if action_available:
+            heading = "Küchenzettel für den aktuellen Stand drucken"
+            status_html = f"<p>{_e(status_message)}</p>" if status_message else ""
+            auto_refresh = ""
+        else:
+            heading = "Druckauftrag gesendet"
+            status_html = (
+                '<p aria-live="polite">Druckauftrag gesendet – '
+                "warte auf Druckbestätigung…</p>"
+            )
+            auto_refresh = (
+                "<script>window.setTimeout(function () { "
+                "window.location.reload(); }, 1500);</script>"
+            )
         primary = (
             f'<form method="post" action="/order/{_e(order.order_id)}/print-confirm">'
             f"{forms.csrf_input}{command_fields}"
@@ -517,6 +542,7 @@ def _primary_action(
             f"{status_html}"
             '<div class="order-next-actions">'
             f"{primary}{secondary}</div></section>"
+            f"{auto_refresh}"
         )
     if next_action_name == "effective":
         return (
@@ -1677,6 +1703,9 @@ def render_order_detail(
         operational_data,
         pause_view,
     )
+    if _kitchen_print_waiting(target, next_action, forms):
+        state_title = "Druckauftrag gesendet"
+        state_description = "Warte auf die Druckbestätigung der Küche."
     delivery_address_promoted = (
         order.cancelled_at is None
         and not pause_view.get("active")

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -513,7 +513,7 @@ def _primary_action(
         else:
             heading = "Druckauftrag gesendet"
             status_html = (
-                '<p aria-live="polite">Druckauftrag gesendet – '
+                '<p aria-live="polite">Druckauftrag wird verarbeitet – '
                 "warte auf Druckbestätigung…</p>"
             )
             auto_refresh = (

--- a/tests/unit/test_order_detail_kitchen_print_waiting.py
+++ b/tests/unit/test_order_detail_kitchen_print_waiting.py
@@ -1,0 +1,64 @@
+"""Regression coverage for the asynchronous kitchen-print waiting state."""
+
+from types import SimpleNamespace
+
+from catering_system.ui.office_panel_order_detail import (
+    OrderDetailFormFields,
+    _primary_action,
+)
+
+
+class _PrintContext:
+    def can(self, permission: str) -> bool:
+        return permission == "orders.print.confirm"
+
+
+def _forms(*, action_available: bool) -> OrderDetailFormFields:
+    return OrderDetailFormFields(
+        csrf_input="<input name='csrf'>",
+        print_confirm_command_fields={"version-1": "<input name='command'>"},
+        effective_command_fields={},
+        ready_command_fields="",
+        cancel_command_fields="",
+        version_command_fields="",
+        payment_command_fields="",
+        print_confirm_button_labels={"version-1": "Küchendruck starten"},
+        print_status_messages={"version-1": "Druckauftrag wird verarbeitet …"},
+        print_action_available={"version-1": action_available},
+    )
+
+
+def _render_print_action(*, action_available: bool) -> str:
+    return _primary_action(
+        SimpleNamespace(cancelled_at=None, order_id="order-1"),
+        SimpleNamespace(order_version_id="version-1"),
+        {"action": "print-confirm"},
+        _forms(action_available=action_available),
+        ready=None,
+        confirmation=None,
+        live_preview=None,
+        source_inquiry=None,
+        operational_data=None,
+        operational_pause={"active": False},
+        context=_PrintContext(),
+    )
+
+
+def test_processing_print_job_shows_waiting_state_and_auto_refresh() -> None:
+    html = _render_print_action(action_available=False)
+
+    assert "Druckauftrag gesendet" in html
+    assert "warte auf Druckbestätigung" in html
+    assert "window.location.reload()" in html
+    assert "1500" in html
+    assert 'action="/order/order-1/print-confirm"' not in html
+    assert "Küchenzettel öffnen" in html
+
+
+def test_available_print_job_keeps_single_start_action_without_auto_refresh() -> None:
+    html = _render_print_action(action_available=True)
+
+    assert "Küchenzettel für den aktuellen Stand drucken" in html
+    assert "Küchendruck starten" in html
+    assert 'action="/order/order-1/print-confirm"' in html
+    assert "window.location.reload()" not in html


### PR DESCRIPTION
## Summary
- show an explicit waiting state after the kitchen print request has been queued
- hide the repeat print action while the existing print job is still processing
- automatically refresh Order Detail every 1.5s while waiting for the kitchen-agent ACK
- after ACK, rely on the existing server-side progression to surface the next action
- preserve existing retry behavior after rejection/timeout

## Scope
Presentation-layer UX only. No Core workflow/state changes, no print queue semantics changes, no ACK semantics changes, and no new approval/confirmation step.

## Verification
- branch starts from current main `9bf3835e159a90be36096cddec29e5e3efdd35f0`
- diff limited to `office_panel_order_detail.py` plus focused regression tests
- existing `print_action_available` remains the source of truth for processing state
