### PR TITLE
Defer foreign key checks during order purge

### DIFF
--- a/src/catering_system/repositories/order_purge.py
+++ b/src/catering_system/repositories/order_purge.py
@@ -32,6 +32,13 @@ def _quote_identifier(value: str) -> str:
 def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
     connection = repo._conn
     with repo._write_scope():
+        # The purge spans many tables whose FK dependencies are not guaranteed
+        # to follow sqlite_master ordering. Keep foreign_keys enabled, but defer
+        # their validation until the surrounding atomic transaction commits.
+        # This allows all owned rows to disappear before SQLite checks the final
+        # graph and still fails closed if any reference survives the purge.
+        connection.execute("PRAGMA defer_foreign_keys = ON")
+
         if (
             connection.execute(
                 "SELECT 1 FROM orders WHERE order_id = ?", (order_id,)

--- a/src/catering_system/repositories/order_purge.py
+++ b/src/catering_system/repositories/order_purge.py
@@ -32,11 +32,12 @@ def _quote_identifier(value: str) -> str:
 def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
     connection = repo._conn
     with repo._write_scope():
-        # The purge spans many tables whose FK dependencies are not guaranteed
-        # to follow sqlite_master ordering. Keep foreign_keys enabled, but defer
-        # their validation until the surrounding atomic transaction commits.
-        # This allows all owned rows to disappear before SQLite checks the final
-        # graph and still fails closed if any reference survives the purge.
+        # sqlite3 starts transactions lazily. `defer_foreign_keys` only applies
+        # to the active transaction, so explicitly begin one in standalone
+        # repository mode before enabling deferred FK validation. Core API mode
+        # already enters this helper with its coordinator transaction active.
+        if not connection.in_transaction:
+            connection.execute("BEGIN")
         connection.execute("PRAGMA defer_foreign_keys = ON")
 
         if (

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -8,6 +8,7 @@ from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepo
 def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
     tmp_path,
 ) -> None:
+    # Regression for the production hard-delete FK failure.
     repo = SQLiteOrderRepository(tmp_path / "core.db")
     connection = repo._conn
     connection.execute("PRAGMA foreign_keys = ON")

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -1,0 +1,61 @@
+from datetime import UTC, date, datetime
+
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.repositories.order_purge import purge_order_with_dependencies
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+
+
+def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(tmp_path) -> None:
+    repo = SQLiteOrderRepository(tmp_path / "core.db")
+    connection = repo._conn
+    connection.execute("PRAGMA foreign_keys = ON")
+
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+    order = Order(
+        order_id="order-fk",
+        source_inquiry_id="inquiry-fk",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-fk",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 9, 1),
+        time_window_text="12:00",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
+    )
+    repo.save_order_with_initial_version(order, version)
+
+    # Parent is deliberately created before child, so sqlite_master iteration
+    # attempts to delete the referenced row first. Immediate FK checking would
+    # fail here even though both rows belong to the same order and are removed
+    # by the same purge transaction.
+    connection.execute(
+        "CREATE TABLE purge_fk_parent ("
+        "parent_id TEXT PRIMARY KEY, order_id TEXT NOT NULL)"
+    )
+    connection.execute(
+        "CREATE TABLE purge_fk_child ("
+        "child_id TEXT PRIMARY KEY, order_id TEXT NOT NULL, parent_id TEXT NOT NULL, "
+        "FOREIGN KEY(parent_id) REFERENCES purge_fk_parent(parent_id))"
+    )
+    connection.execute(
+        "INSERT INTO purge_fk_parent (parent_id, order_id) VALUES (?, ?)",
+        ("parent-1", order.order_id),
+    )
+    connection.execute(
+        "INSERT INTO purge_fk_child (child_id, order_id, parent_id) VALUES (?, ?, ?)",
+        ("child-1", order.order_id, "parent-1"),
+    )
+    connection.commit()
+
+    purge_order_with_dependencies(repo, order.order_id)
+
+    assert repo.get_order(order.order_id) is None
+    assert connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
+    assert connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -5,7 +5,9 @@ from catering_system.repositories.order_purge import purge_order_with_dependenci
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 
 
-def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(tmp_path) -> None:
+def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
+    tmp_path,
+) -> None:
     repo = SQLiteOrderRepository(tmp_path / "core.db")
     connection = repo._conn
     connection.execute("PRAGMA foreign_keys = ON")
@@ -56,6 +58,8 @@ def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(tmp_path
     purge_order_with_dependencies(repo, order.order_id)
 
     assert repo.get_order(order.order_id) is None
-    assert connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
+    assert (
+        connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
+    )
     assert connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -61,5 +61,7 @@ def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
     assert (
         connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
     )
-    assert connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
+    assert (
+        connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
+    )
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -58,10 +58,6 @@ def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
     purge_order_with_dependencies(repo, order.order_id)
 
     assert repo.get_order(order.order_id) is None
-    assert (
-        connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
-    )
-    assert (
-        connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
-    )
+    assert connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
+    assert connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []


### PR DESCRIPTION
## Summary
- keep SQLite foreign key enforcement enabled
- defer FK validation until the surrounding hard-delete transaction commits
- allow dependent order rows to be deleted regardless of sqlite_master table ordering
- still fail closed if any foreign-key reference survives the purge

This fixes the production `sqlite3.IntegrityError: FOREIGN KEY constraint failed` seen during `/office/v1/orders/{id}/delete`.