### PR TITLE
Purge order dependencies by foreign-key metadata

### DIFF
--- a/src/catering_system/repositories/core_transaction.py
+++ b/src/catering_system/repositories/core_transaction.py
@@ -101,9 +101,9 @@ class CoreCommandExecutor:
             raise
         try:
             self._conn.execute("COMMIT")
-        except sqlite3.OperationalError as exc:
+        except sqlite3.Error as exc:
             self._rollback()
-            if _is_busy(exc):
+            if isinstance(exc, sqlite3.OperationalError) and _is_busy(exc):
                 raise CoreBusyError from exc
             raise
         self._events.flush()

--- a/src/catering_system/repositories/order_purge.py
+++ b/src/catering_system/repositories/order_purge.py
@@ -29,6 +29,36 @@ def _quote_identifier(value: str) -> str:
     return '"' + value.replace('"', '""') + '"'
 
 
+def _delete_direct_fk_dependents(
+    connection: sqlite3.Connection,
+    table_name: str,
+    order_id: str,
+    version_ids: list[str],
+) -> None:
+    """Delete rows whose declared FK points directly at the target Order/version.
+
+    Production schemas do not guarantee that FK columns are literally named
+    ``order_id`` or ``order_version_id``. Inspect SQLite's FK metadata instead
+    of guessing column names.
+    """
+    quoted_table = _quote_identifier(table_name)
+    for row in connection.execute(f"PRAGMA foreign_key_list({quoted_table})").fetchall():
+        parent_table = str(row[2])
+        child_column = str(row[3])
+        if parent_table == "orders":
+            connection.execute(
+                f"DELETE FROM {quoted_table} WHERE {_quote_identifier(child_column)} = ?",
+                (order_id,),
+            )
+        elif parent_table == "order_versions" and version_ids:
+            placeholders = ",".join("?" for _ in version_ids)
+            connection.execute(
+                f"DELETE FROM {quoted_table} "
+                f"WHERE {_quote_identifier(child_column)} IN ({placeholders})",
+                tuple(version_ids),
+            )
+
+
 def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
     connection = repo._conn
     with repo._write_scope():
@@ -93,6 +123,7 @@ def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
                     f"WHERE order_version_id IN ({placeholders})",
                     tuple(version_ids),
                 )
+            _delete_direct_fk_dependents(connection, table_name, order_id, version_ids)
 
         # Break root references before deleting immutable version history.
         connection.execute(

--- a/tests/unit/test_core_transaction_commit_failure.py
+++ b/tests/unit/test_core_transaction_commit_failure.py
@@ -1,0 +1,27 @@
+import sqlite3
+
+import pytest
+
+from catering_system.repositories.core_transaction import CoreCommandExecutor
+
+
+def test_commit_integrity_error_rolls_back_and_leaves_executor_reusable() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.execute("CREATE TABLE parent (id TEXT PRIMARY KEY)")
+    connection.execute(
+        "CREATE TABLE child ("
+        "id TEXT PRIMARY KEY, parent_id TEXT NOT NULL, "
+        "FOREIGN KEY(parent_id) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED)"
+    )
+    executor = CoreCommandExecutor(connection)
+
+    def violate_deferred_fk() -> None:
+        connection.execute("INSERT INTO child (id, parent_id) VALUES ('c1', 'missing')")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        executor.run(violate_deferred_fk)
+
+    assert not connection.in_transaction
+    assert connection.execute("SELECT COUNT(*) FROM child").fetchone()[0] == 0
+    assert executor.run(lambda: "ok") == "ok"

--- a/tests/unit/test_order_purge_fk_defer.py
+++ b/tests/unit/test_order_purge_fk_defer.py
@@ -47,12 +47,21 @@ def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
         "FOREIGN KEY(parent_id) REFERENCES purge_fk_parent(parent_id))"
     )
     connection.execute(
+        "CREATE TABLE purge_fk_alias ("
+        "alias_id TEXT PRIMARY KEY, linked_version TEXT NOT NULL, "
+        "FOREIGN KEY(linked_version) REFERENCES order_versions(order_version_id))"
+    )
+    connection.execute(
         "INSERT INTO purge_fk_parent (parent_id, order_id) VALUES (?, ?)",
         ("parent-1", order.order_id),
     )
     connection.execute(
         "INSERT INTO purge_fk_child (child_id, order_id, parent_id) VALUES (?, ?, ?)",
         ("child-1", order.order_id, "parent-1"),
+    )
+    connection.execute(
+        "INSERT INTO purge_fk_alias (alias_id, linked_version) VALUES (?, ?)",
+        ("alias-1", version.order_version_id),
     )
     connection.commit()
 
@@ -61,4 +70,5 @@ def test_sqlite_purge_defers_fk_checks_until_all_owned_rows_are_deleted(
     assert repo.get_order(order.order_id) is None
     assert connection.execute("SELECT COUNT(*) FROM purge_fk_parent").fetchone()[0] == 0
     assert connection.execute("SELECT COUNT(*) FROM purge_fk_child").fetchone()[0] == 0
+    assert connection.execute("SELECT COUNT(*) FROM purge_fk_alias").fetchone()[0] == 0
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []


### PR DESCRIPTION
## Summary
- delete order/order-version dependents using SQLite FK metadata instead of relying only on column names
- keep existing direct order_id/order_version_id cleanup
- rollback Core API transactions when COMMIT raises sqlite3.IntegrityError or another sqlite3.Error
- add regressions for nonstandard FK column names and deferred-FK commit failures

This addresses the production sequence where hard delete first failed at COMMIT with a foreign-key violation and the next request then failed with `cannot start a transaction within a transaction`.