### PR TITLE
Fix transitive FK order purge rollback

### DIFF
--- a/src/catering_system/repositories/core_transaction.py
+++ b/src/catering_system/repositories/core_transaction.py
@@ -106,6 +106,9 @@ class CoreCommandExecutor:
             if _is_busy(exc):
                 raise CoreBusyError from exc
             raise
+        except BaseException:
+            self._rollback()
+            raise
         self._events.flush()
         return result
 

--- a/src/catering_system/repositories/order_purge.py
+++ b/src/catering_system/repositories/order_purge.py
@@ -25,8 +25,68 @@ class _PurgeCapableOrderRepository(Protocol):
     def purge_order(self, order_id: str) -> None: ...
 
 
+_ForeignKeyViolation = tuple[str, int | None, str, int]
+
+
 def _quote_identifier(value: str) -> str:
     return '"' + value.replace('"', '""') + '"'
+
+
+def _foreign_key_violations(
+    connection: sqlite3.Connection,
+) -> set[_ForeignKeyViolation]:
+    return {
+        (
+            str(row[0]),
+            int(row[1]) if row[1] is not None else None,
+            str(row[2]),
+            int(row[3]),
+        )
+        for row in connection.execute("PRAGMA foreign_key_check").fetchall()
+    }
+
+
+def _purge_new_fk_dependents(
+    connection: sqlite3.Connection,
+    baseline: set[_ForeignKeyViolation],
+) -> None:
+    """Delete rows orphaned transitively by the maintenance purge.
+
+    Direct order-owned rows are discovered by ``order_id`` /
+    ``order_version_id`` below. Some of those rows own child rows only through
+    another key (for example snapshot_id). Deferred FK checking lets the root
+    delete finish first; this loop then follows the actual FK violations until
+    the whole dependent closure is gone.
+
+    Pre-existing unrelated FK violations are deliberately left untouched.
+    """
+
+    while True:
+        new_violations = _foreign_key_violations(connection) - baseline
+        if not new_violations:
+            return
+
+        targets: set[tuple[str, int]] = set()
+        for table_name, rowid, parent_table, fk_id in new_violations:
+            if rowid is None:
+                raise sqlite3.IntegrityError(
+                    "maintenance purge cannot resolve dependent row in "
+                    f"WITHOUT ROWID table {table_name!r} "
+                    f"(parent={parent_table!r}, fk_id={fk_id})"
+                )
+            targets.add((table_name, rowid))
+
+        deleted = 0
+        for table_name, rowid in sorted(targets):
+            deleted += connection.execute(
+                f"DELETE FROM {_quote_identifier(table_name)} WHERE rowid = ?",
+                (rowid,),
+            ).rowcount
+
+        if deleted == 0:
+            raise sqlite3.IntegrityError(
+                "maintenance purge could not remove newly orphaned FK dependents"
+            )
 
 
 def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
@@ -39,6 +99,7 @@ def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
         if not connection.in_transaction:
             connection.execute("BEGIN")
         connection.execute("PRAGMA defer_foreign_keys = ON")
+        baseline_fk_violations = _foreign_key_violations(connection)
 
         if (
             connection.execute(
@@ -86,7 +147,7 @@ def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
                 connection.execute(
                     f"DELETE FROM {quoted_table} WHERE order_id = ?", (order_id,)
                 )
-            elif "order_version_id" in columns and version_ids:
+            if "order_version_id" in columns and version_ids:
                 placeholders = ",".join("?" for _ in version_ids)
                 connection.execute(
                     f"DELETE FROM {quoted_table} "
@@ -107,12 +168,14 @@ def _sqlite_purge(repo: _SQLiteBackedOrderRepository, order_id: str) -> None:
         if deleted != 1:
             raise KeyError(order_id)
 
+        _purge_new_fk_dependents(connection, baseline_fk_violations)
+
         for _trigger_name, trigger_sql in triggers:
             connection.execute(trigger_sql)
 
 
 def purge_order_with_dependencies(repo: OrderRepository, order_id: str) -> None:
-    """Purge one Order and every row directly owned by its id/version ids.
+    """Purge one Order and every row directly or transitively owned by it.
 
     Inquiry/Offer rows are intentionally untouched because they are keyed by
     their own aggregate identifiers, not by ``order_id``.

--- a/tests/unit/test_order_delete_production_regressions.py
+++ b/tests/unit/test_order_delete_production_regressions.py
@@ -40,14 +40,26 @@ def _seed_order(repo: SQLiteOrderRepository) -> Order:
     return order
 
 
+def _count_rows(connection: sqlite3.Connection, table_name: str) -> int:
+    row = connection.execute(f'SELECT COUNT(*) FROM "{table_name}"').fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _commit_parent_ids(connection: sqlite3.Connection) -> list[str]:
+    rows = connection.execute(
+        "SELECT parent_id FROM commit_parent ORDER BY parent_id"
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
 def test_purge_removes_transitive_fk_children_without_order_id(tmp_path) -> None:
     repo = SQLiteOrderRepository(tmp_path / "core.db")
     connection = repo._conn
     connection.execute("PRAGMA foreign_keys = ON")
     order = _seed_order(repo)
 
-    # Production-shaped chain:
-    # order-owned snapshot -> position(snapshot_id only) -> grandchild(position_id only).
+    # Production-shaped chain: order -> snapshot -> position -> grandchild.
     connection.executescript(
         """
         CREATE TABLE purge_owned_snapshot (
@@ -85,15 +97,9 @@ def test_purge_removes_transitive_fk_children_without_order_id(tmp_path) -> None
     purge_order_with_dependencies(repo, order.order_id)
 
     assert repo.get_order(order.order_id) is None
-    assert connection.execute(
-        "SELECT COUNT(*) FROM purge_owned_snapshot"
-    ).fetchone()[0] == 0
-    assert connection.execute(
-        "SELECT COUNT(*) FROM purge_snapshot_position"
-    ).fetchone()[0] == 0
-    assert connection.execute(
-        "SELECT COUNT(*) FROM purge_position_note"
-    ).fetchone()[0] == 0
+    assert _count_rows(connection, "purge_owned_snapshot") == 0
+    assert _count_rows(connection, "purge_snapshot_position") == 0
+    assert _count_rows(connection, "purge_position_note") == 0
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
 
 
@@ -133,18 +139,13 @@ def test_commit_integrity_error_rolls_back_and_connection_is_reusable(tmp_path) 
 
     assert connection.in_transaction is False
     assert delivered == []
-    assert connection.execute(
-        "SELECT parent_id FROM commit_parent"
-    ).fetchall() == [("parent-1",)]
+    assert _commit_parent_ids(connection) == ["parent-1"]
 
-    # The same shared connection must accept the next command.
     executor.run(
         lambda: connection.execute(
             "INSERT INTO commit_parent (parent_id) VALUES (?)",
             ("parent-2",),
         )
     )
-    assert connection.execute(
-        "SELECT parent_id FROM commit_parent ORDER BY parent_id"
-    ).fetchall() == [("parent-1",), ("parent-2",)]
+    assert _commit_parent_ids(connection) == ["parent-1", "parent-2"]
     connection.close()

--- a/tests/unit/test_order_delete_production_regressions.py
+++ b/tests/unit/test_order_delete_production_regressions.py
@@ -1,0 +1,150 @@
+"""Regression tests for production Order hard-delete failures."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, date, datetime
+
+import pytest
+
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.repositories.core_transaction import (
+    CoreCommandExecutor,
+    DeferredEventSink,
+    open_core_connection,
+)
+from catering_system.repositories.order_purge import purge_order_with_dependencies
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+
+
+def _seed_order(repo: SQLiteOrderRepository) -> Order:
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+    order = Order(
+        order_id="order-transitive-fk",
+        source_inquiry_id="inquiry-transitive-fk",
+        created_at=now,
+        updated_at=now,
+    )
+    version = OrderVersion(
+        order_version_id="version-transitive-fk",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=now,
+        event_date=date(2026, 9, 1),
+        time_window_text="12:00",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
+    )
+    repo.save_order_with_initial_version(order, version)
+    return order
+
+
+def test_purge_removes_transitive_fk_children_without_order_id(tmp_path) -> None:
+    repo = SQLiteOrderRepository(tmp_path / "core.db")
+    connection = repo._conn
+    connection.execute("PRAGMA foreign_keys = ON")
+    order = _seed_order(repo)
+
+    # Production-shaped chain:
+    # order-owned snapshot -> position(snapshot_id only) -> grandchild(position_id only).
+    connection.executescript(
+        """
+        CREATE TABLE purge_owned_snapshot (
+            snapshot_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL
+        );
+        CREATE TABLE purge_snapshot_position (
+            position_id TEXT PRIMARY KEY,
+            snapshot_id TEXT NOT NULL,
+            FOREIGN KEY (snapshot_id)
+                REFERENCES purge_owned_snapshot(snapshot_id)
+        );
+        CREATE TABLE purge_position_note (
+            note_id TEXT PRIMARY KEY,
+            position_id TEXT NOT NULL,
+            FOREIGN KEY (position_id)
+                REFERENCES purge_snapshot_position(position_id)
+        );
+        """
+    )
+    connection.execute(
+        "INSERT INTO purge_owned_snapshot (snapshot_id, order_id) VALUES (?, ?)",
+        ("snapshot-1", order.order_id),
+    )
+    connection.execute(
+        "INSERT INTO purge_snapshot_position (position_id, snapshot_id) VALUES (?, ?)",
+        ("position-1", "snapshot-1"),
+    )
+    connection.execute(
+        "INSERT INTO purge_position_note (note_id, position_id) VALUES (?, ?)",
+        ("note-1", "position-1"),
+    )
+    connection.commit()
+
+    purge_order_with_dependencies(repo, order.order_id)
+
+    assert repo.get_order(order.order_id) is None
+    assert connection.execute(
+        "SELECT COUNT(*) FROM purge_owned_snapshot"
+    ).fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM purge_snapshot_position"
+    ).fetchone()[0] == 0
+    assert connection.execute(
+        "SELECT COUNT(*) FROM purge_position_note"
+    ).fetchone()[0] == 0
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_commit_integrity_error_rolls_back_and_connection_is_reusable(tmp_path) -> None:
+    connection = open_core_connection(tmp_path / "core.db")
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.executescript(
+        """
+        CREATE TABLE commit_parent (
+            parent_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE commit_child (
+            child_id TEXT PRIMARY KEY,
+            parent_id TEXT NOT NULL,
+            FOREIGN KEY (parent_id) REFERENCES commit_parent(parent_id)
+        );
+        INSERT INTO commit_parent (parent_id) VALUES ('parent-1');
+        INSERT INTO commit_child (child_id, parent_id)
+        VALUES ('child-1', 'parent-1');
+        """
+    )
+
+    delivered: list[object] = []
+    events = DeferredEventSink(delivered.append)
+    executor = CoreCommandExecutor(connection, events)
+
+    def violate_at_commit() -> None:
+        connection.execute("PRAGMA defer_foreign_keys = ON")
+        connection.execute(
+            "DELETE FROM commit_parent WHERE parent_id = ?",
+            ("parent-1",),
+        )
+        events("must-not-escape")
+
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+        executor.run(violate_at_commit)
+
+    assert connection.in_transaction is False
+    assert delivered == []
+    assert connection.execute(
+        "SELECT parent_id FROM commit_parent"
+    ).fetchall() == [("parent-1",)]
+
+    # The same shared connection must accept the next command.
+    executor.run(
+        lambda: connection.execute(
+            "INSERT INTO commit_parent (parent_id) VALUES (?)",
+            ("parent-2",),
+        )
+    )
+    assert connection.execute(
+        "SELECT parent_id FROM commit_parent ORDER BY parent_id"
+    ).fetchall() == [("parent-1",), ("parent-2",)]
+    connection.close()


### PR DESCRIPTION
## Summary
- roll back the shared Core transaction on any COMMIT failure, including deferred foreign-key `IntegrityError`
- remove transitively orphaned FK dependents during maintenance Order purge via `PRAGMA foreign_key_check`
- handle tables containing both `order_id` and `order_version_id`
- add regression coverage for transitive FK chains and post-COMMIT-error connection reuse

## Production failure addressed
The hard-delete path could delete an order-owned parent row while leaving children that only referenced it through an intermediate key such as `snapshot_id`. Because FK validation was deferred, the failure surfaced at COMMIT. The COMMIT handler then failed to roll back `sqlite3.IntegrityError`, leaving the shared connection inside a transaction and causing the next command to fail with `cannot start a transaction within a transaction`.

## Validation
The patch was syntax-checked and the FK behavior was exercised against a minimal SQLite model before publishing. GitHub CI should provide the repository-level validation.