### PR TITLE
Document production operations, secrets and recovery

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,12 +19,23 @@ Never commit or document values for:
 - `OFFICE_PANEL_PASSWORD`
 - `WEBSITE_INTAKE_TOKEN`
 - `UPSTREAM_TOKEN`
+- `OFFICE_API_TOKEN` / `CORE_OFFICE_API_TOKEN`
+- employee-introspection service tokens
+- Kitchen API / print-agent bearer tokens
+- kiosk/courier pickup-signal tokens
 - `AUERSWALD_SYNC_PASSWORD`
-- SSH private keys
-- Cloudflare, GitHub, CRM, email, or hosting credentials
+- SSH or GPG private keys
+- Cloudflare, GitHub, CRM, email, hosting, or recovery credentials
 
-Production values belong in root-readable environment files or the relevant
-provider's secret store. `.env.example` lists names only.
+The master human recovery store is the password-manager vault
+`Bitwarden / Silberloeffel Catering`. Production runtime values belong in
+root-readable environment files or the relevant provider's secret store.
+`.env.example` lists names only; `docs/operations/secrets-registry.md` records
+secret names, consumers and locations without values.
+
+A production host must not be the only recoverable copy of a credential required
+to rebuild itself. Conversely, do not copy secrets from the host into GitHub,
+issues, logs, screenshots, or chat to create an ad-hoc backup.
 
 ## Network exposure
 
@@ -33,11 +44,26 @@ provider's secret store. `.env.example` lists names only.
 | Office panel `8081` | private LAN/Tailscale only |
 | Kitchen kiosk `8082` | private LAN/Tailscale only |
 | Website intake `8083` | Lenovo loopback only |
+| Core Office API `8084` | Tailscale only |
+| Kitchen API `8086` | Lenovo loopback only |
 | VPS staging `8080` | temporary public HTTP; fake data only |
 | VPS staging intake forward `18083` | VPS loopback only; restricted reverse SSH |
 
-The production public website must reach Lenovo only through the Cloudflare
-Worker/Tunnel intake path. Never proxy office or kiosk routes.
+The production public website must reach Lenovo only through the approved
+Cloudflare/ingress path. Never proxy office, Core API, Kitchen API or kiosk routes
+onto the public Internet.
+
+## Privileged automation
+
+The private `silberloeffel-ops` self-hosted runner runs as unprivileged user
+`chatops`. It must never receive unrestricted sudo or be attached to untrusted
+pull-request code. Privileged actions are restricted to exact commands exposed by
+the root-owned `/usr/local/sbin/catering-ops` wrapper and an explicit sudoers
+allowlist.
+
+Automation output must be designed not to print environment values, customer
+payloads, private keys or bearer tokens. Revoking the runner must not stop the
+application itself.
 
 ## Data handling
 
@@ -57,7 +83,8 @@ Worker/Tunnel intake path. Never proxy office or kiosk routes.
 
 ## Application controls
 
-- Office panel uses HTTP Basic authentication and CSRF tokens for POST actions.
+- Office panel uses its configured authentication mode and CSRF tokens for POST
+  actions.
 - Public production intake uses field allowlisting, body limits, bearer-token
   authentication between Worker and receiver, and idempotency keys.
 - Staging forwarding accepts only the exact loopback receiver URL, refuses
@@ -71,8 +98,9 @@ Worker/Tunnel intake path. Never proxy office or kiosk routes.
 
 1. Remove or block the exposed surface.
 2. Preserve relevant journals without customer payloads.
-3. Rotate affected credentials.
+3. Rotate affected credentials and update the password-manager recovery record.
 4. Verify database integrity and backup availability.
 5. Patch and test locally/CI.
 6. Deploy through the production runbook.
-7. Record the incident, impact window, rotation, and verification privately.
+7. Record the incident, impact window, rotation names (never values), and
+   verification privately.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,66 @@
 # Project documentation
 
-This directory is the maintained source of truth for understanding and
-operating the Silberlöffel Catering System. Start with the current documents;
-use the archive only when the reasoning behind an older implementation is
-needed.
+This directory is the maintained source of truth for understanding and operating
+the Silberlöffel Catering System. Start with the current documents; use the
+archive only when the reasoning behind an older implementation is needed.
 
 ## Current documentation
 
 | Area | Document | Purpose |
 |---|---|---|
-| Status | [Current status](current-status.md) | Live services, verified facts, open risks |
+| Status | [Current status](current-status.md) | Verified production snapshot and open risks |
+| Operations | [Operations hub](operations/README.md) | Service inventory, secrets registry, deployment evidence, recovery |
+| Operations | [Service inventory](operations/service-inventory.md) | Live services, ports, paths, env-file locations and drift |
+| Operations | [Secrets registry](operations/secrets-registry.md) | Credential names, runtime locations and rotation rules, never values |
+| Operations | [Deployment log](operations/deployment-log.md) | What actually reached production and how it was verified |
+| Recovery | [Disaster recovery](operations/disaster-recovery.md) | Rebuild order for a lost production host |
 | Design | [Architecture](architecture.md) | Components, data flow, invariants |
 | Production | [Lenovo runbook](runbooks/lenovo-production.md) | Deploy, verify, troubleshoot, roll back |
-| Staging | [VPS runbook](runbooks/vps-staging.md) | Temporary site at the public IP |
-| Staging | [6D-3a smoke test](runbooks/STAGING_SMOKE_6D3A.md) | Catalog → Configurator → Offer → Print manual checklist |
 | Data safety | [Backup and restore](runbooks/backup-restore.md) | SQLite backup, verification, recovery |
+| Staging | [VPS runbook](runbooks/vps-staging.md) | Temporary/staging site operations |
+| Staging | [6D-3a smoke test](runbooks/STAGING_SMOKE_6D3A.md) | Catalog → Configurator → Offer → Print manual checklist |
 | Integration | [Website intake API](api/website-intake.md) | Payloads, responses, authentication |
 | Integration | [Kiosk order feed API](api/kiosk-order-feed.md) | Per-date courier feed contract |
-| Integration | [Core Office API](api/core-office-api.md) | Office panel commands and reads (Phase 1, dormant) |
+| Integration | [Core Office API](api/core-office-api.md) | Office panel commands and reads |
 | Integration | [Kiosk pickup signal API](api/kiosk-pickup-signal.md) | Open equipment-return feed and kiosk cache |
 | Design | [Offer contract V1](proposals/offer_contract_v1.md) | Draft commercial snapshot and acceptance boundary |
 | Design | [Office Panel UI v2 implementation pack](proposals/OFFICE_PANEL_UI_V2_IMPLEMENTATION_PACK_V1.md) | Presentation-only migration plan and invariants |
 | Users | [Office panel guide](user/office-panel.md) | Daily office workflow and gates |
 | Decisions | [Decision register](decisions/README.md) | Durable architectural decisions |
-| Releases | [Changelog](../CHANGELOG.md) | User-visible and operational changes |
+| Releases | [Changelog](../CHANGELOG.md) | User-visible and architectural changes |
 | Security | [Security policy](../SECURITY.md) | Exposure rules and credential handling |
 
 ## Documentation rules
 
-1. **Facts beat plans.** Runbooks describe the configuration actually running.
-2. **No secrets.** Use variable names and paths, never values.
+1. **Facts beat plans.** `current-status.md` and runbooks describe verified reality,
+   not an intended future state.
+2. **No secrets.** Git stores variable names, paths and procedures, never real
+   passwords, tokens, recovery codes or private keys.
 3. **One owner per fact.** Architecture explains why; runbooks explain how;
-   changelog records when.
-4. **Every production change updates docs.** At minimum update current status,
-   the affected runbook, and the changelog.
-5. **Historical packs stay immutable.** Superseded plans move to the archive and
+   service inventory explains where; deployment log proves what reached production;
+   changelog explains product/release changes.
+4. **Every production deployment leaves evidence.** Update current status and the
+   deployment log; update the affected runbook/inventory when runtime structure
+   changes; update the changelog when the product or architecture changes.
+5. **Current status stays short.** Move superseded operational facts to the
+   deployment log, changelog, worklog or archive instead of accumulating years of
+   archaeology on the status page.
+6. **Configuration drift is documented, not hidden.** If live systemd/config differs
+   from tracked source, record the drift and do not claim `main` can reproduce the
+   host until it is reconciled.
+7. **Historical packs stay immutable.** Superseded plans move to the archive and
    are not silently rewritten as current truth.
+
+## Secret-storage rule
+
+The target master recovery vault is `Bitwarden / Silberloeffel Catering`.
+Production services consume root-readable env files or provider secret stores.
+See `operations/secrets-registry.md` for the inventory and naming convention.
 
 ## Historical material
 
 - [Implementation and execution packs](archive/packs/README.md)
 - [Chronological legacy worklog](../WORKLOG.md)
 
-The legacy worklog is useful for archaeology but is no longer the primary
-status page. New current-state information belongs in `current-status.md` and
-release information belongs in `CHANGELOG.md`.
+`WORKLOG.md` remains useful for archaeology, but it is not an operational status
+page. Start with `current-status.md` and `operations/README.md` during incidents.

--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,313 +1,163 @@
 # Current status
 
-Operational truth last verified: **2026-07-28T18:42:33Z** (PDF runtime
-production migration — see "Deployed and closed" below — and independent
-post-migration verification, including `infra/deploy/verify_pdf_runtime.py
---host-runtime`).
+Operational truth last verified: **2026-08-21 08:11 CEST** by a read-only audit
+running on the production host `debiancatering` through the restricted private
+operations runner.
 
-This document separates **repository state** (what is on `origin/main`) from
-**production state** (what is actually deployed and running on Lenovo
-`debiancatering`, Tailscale `100.109.6.74`). A commit on `origin/main` is not
-deployed until the relevant services have restarted while that commit (or a
-descendant loaded at restart) is on disk, and post-deploy checks are
-recorded. See `docs/runbooks/deployment-truth-checklist.md`.
+This page is intentionally short. It describes what is true now. Historical
+production detail belongs in `docs/operations/deployment-log.md`, `CHANGELOG.md`
+and `WORKLOG.md`.
 
-## Repository state
+## Production identity
 
-| Item | Value |
+| Item | Current verified value |
 |---|---|
-| `origin/main` HEAD | `ab0743f229b525b348ebdc6cfd71c2fac7ba153e` (`ab0743f`) |
-| Latest merged functional PRs | [#45 — Add reproducible runtime dependency locking](https://github.com/VikJo1978/silberloeffel-catering/pull/45), [#46 — Align tracked office units with the running venv interpreter](https://github.com/VikJo1978/silberloeffel-catering/pull/46), [#48 — Add read-only PDF runtime verification](https://github.com/VikJo1978/silberloeffel-catering/pull/48) |
-| Latest merged PR (docs-only) | this update (branch `docs/runtime-migration-status`, issue #49) — documentation-only; does not itself change production state |
-| CI on the latest functional merges | `quality` — **pass** (required check green at merge time for #45, #46, #48) |
+| Host | `debiancatering` |
+| Tailscale IPv4 | `100.109.6.74` |
+| Application checkout | `/home/viktor/projects/silberloeffel-catering` |
+| Production checkout revision | `4eadf014654992619be317c8b3b079c5d8dcd26b` |
+| Core database | `/home/viktor/catering-runtime/core.db` |
+| Restricted ops wrapper | `/usr/local/sbin/catering-ops` |
+| Private ops repository | `VikJo1978/silberloeffel-ops` |
+| Actions runner user | `chatops` |
 
-**Do not treat the SHA above as permanent:** query Git for the current value;
-repository HEAD advances with every merge. Docs-only commits change
-repository HEAD but are **not** application deployments — production state
-below remains authoritative until services restart.
+A later documentation-only merge can advance `origin/main` without changing the
+application code loaded by running services. Do not equate GitHub HEAD with a
+production deployment; use the deployment log and live revision check.
 
-## Production state
+## Live services
 
-| Item | Value |
+Read-only systemd and listener audit on 2026-08-21:
+
+| Component | Enabled | Active | Listener / exposure |
+|---|---|---|---|
+| `catering-office-panel.service` | yes | yes | `0.0.0.0:8081` |
+| `catering-office-api.service` | yes | yes | `100.109.6.74:8084` |
+| `catering-kiosk.service` | yes | yes | `0.0.0.0:8082` |
+| `catering-website-intake.service` | yes | yes | `127.0.0.1:8083` |
+| `kitchen-print-agent.service` | yes | yes | client process, no dedicated HTTP listener |
+| `catering-kitchen-api.service` | yes | yes | `127.0.0.1:8086` |
+| GitHub Actions runner for `silberloeffel-ops` | n/a | yes | outbound GitHub connection |
+| Courier application | not audited in this pass | listener observed | `0.0.0.0:8090` |
+| `catering-intake-vps-tunnel.service` | unit not found | no | no `18083` listener observed |
+
+See `docs/operations/service-inventory.md` for exact live `ExecStart`, env-file
+paths and known drift.
+
+## Latest production deployment
+
+On **2026-08-21 08:03 CEST**, production was fast-forwarded from
+`60f50c8ddd0bb5532bd673290d7d0b248819d4da` to
+`4eadf014654992619be317c8b3b079c5d8dcd26b`, deploying PR #145 for the Order
+hard-delete foreign-key failure.
+
+Pre-restart database backup:
+
+```text
+/home/viktor/catering-runtime/core.db.backup-20260821-080351
+```
+
+`catering-office-api.service` restarted successfully and remained active.
+
+At **2026-08-21 08:05:28 CEST**, a real production hard-delete completed with:
+
+```text
+command committed route=/office/v1/orders/{id}/delete status=200
+```
+
+No new `FOREIGN KEY constraint failed` or
+`cannot start a transaction within a transaction` error followed the deployment.
+The older occurrences remain in the journal as historical evidence from
+2026-08-20.
+
+See `docs/operations/deployment-log.md` for the durable deployment record.
+
+## Production database and backups
+
+| Item | State |
 |---|---|
-| Deployed commit | `ab0743f229b525b348ebdc6cfd71c2fac7ba153e` (`ab0743f`) |
-| Previous deployed commit | `a67875d800deff7a954e9c83d42174c41b647326` (`a67875d`) |
-| Relationship to `origin/main` | **matches** — production is a clean fast-forward of `origin/main`, including PR #42, #45, #46, #48 |
-| Merged-but-not-yet-deployed changes | none |
-| Release discipline (proven) | deployment user can direct-push to `main`; prior pushes were not blocked by required green `quality`; branch protection may be absent or the user may have bypass — exact settings require authenticated owner/admin verification (see `docs/runbooks/release-discipline.md`) |
+| Core DB path | `/home/viktor/catering-runtime/core.db` |
+| Production owner expectation | `viktor:viktor` |
+| Production mode expectation | `600` |
+| Latest deployment backup verified in this audit trail | `core.db.backup-20260821-080351` |
+| Scheduled local/off-host backup jobs | documented in backup runbook, **not re-verified in the 2026-08-21 service audit** |
+| Restore procedure | `docs/runbooks/backup-restore.md` |
 
-## Production services
+Do not infer backup health from the existence of an old backup. Scheduled backup
+freshness still needs an explicit health check/alerting mechanism.
 
-Last verified observation: **2026-07-28**, immediately after the PDF runtime
-production migration (see "Deployed and closed" below) and its independent
-post-migration verification pass. **These are a point-in-time snapshot, not
-permanent expected values** — re-verify with `systemctl show` before relying
-on them.
+## Secrets
 
-| Service | PID | Started (CEST) |
-|---|---|---|
-| `catering-office-api` | 458270 | 2026-07-28 20:42:33 |
-| `catering-office-panel` | 458277 | 2026-07-28 20:42:33 |
-| `catering-website-intake` | 362683 | 2026-07-22 22:50:09 |
-| `catering-kiosk` | 332509 | 2026-07-21 00:36:38 |
+Real secret values are forbidden in Git. The operational model is:
 
-Only `catering-office-api` and `catering-office-panel` were restarted for the
-PDF runtime migration; `catering-website-intake` and `catering-kiosk`
-retained their prior PID/start time, confirming they were not touched.
+- master human recovery copy: `Bitwarden / Silberloeffel Catering`;
+- runtime copies: root-readable env files such as `/etc/catering/*.env` and
+  `/etc/kitchen-print-agent.env`, or provider-managed secret stores;
+- Git: variable names, paths, consumers and rotation procedures only.
 
-## Deployment verification (`ab0743f`)
+See `docs/operations/secrets-registry.md` and `SECURITY.md`.
 
-- HTTP checks: Office API `401`, Office Panel `401`, Kiosk `200`, Website
-  Intake `GET /intake/website-form` `405`, unauthenticated
-  `POST /intake/website-form` `401` — all matched the expected/documented
-  contract (the GET/POST difference is expected; the two methods exercise
-  different validation paths).
-- Database integrity: `PRAGMA integrity_check` = `ok`.
-- Runtime verifier: `infra/deploy/verify_pdf_runtime.py --host-runtime`
-  (with `/home/viktor/.local/uv-bootstrap-venv/bin` on `PATH`) reported
-  `OVERALL: OK`, `READY_WITHOUT_OVERRIDE` for both `catering-office-api` and
-  `catering-office-panel`.
-- Pre-migration database backup:
-  `/home/viktor/catering-runtime/predeploy-backups/core-pre-runtime-migration-20260728-191432.db`
-  — 471040 bytes, SHA-256
-  `82afe9dd5c758279446ce426c49adf3673adfd52f5a45dea6f3f42e99ce1642e`,
-  `integrity_check: ok`.
-- Rollback: **not required.** Rollback assets (database backup above,
-  previous venv at `.venv.pre-runtime-migration.20260728-191831`, and the
-  removed systemd overrides archived at
-  `/home/viktor/catering-runtime/backups/systemd-runtime-migration.20260728-191449/`)
-  were retained, not deleted.
+## Remote operations / ChatOps
 
-## Resolved — systemd interpreter mismatch
+A private self-hosted GitHub Actions runner is installed on `debiancatering`:
 
-The previously-tracked risk here (tracked units declaring
-`ExecStart=/usr/bin/python3 ...` while production ran `.venv/bin/python3`
-through an untracked drop-in override) is **resolved** as of the PDF runtime
-migration below. The tracked unit files now declare the venv interpreter
-directly (PR #46), production runtime is reproduced from a committed
-`uv.lock` (PR #45), and the untracked overrides have been removed —
-`DropInPaths` is empty for both office services, confirmed by
-`infra/deploy/verify_pdf_runtime.py --host-runtime` (PR #48). See "Deployed
-and closed" below for full detail.
+```text
+runner repo: VikJo1978/silberloeffel-ops
+runner name: debiancatering
+runner labels: self-hosted, Linux, X64, catering-prod
+runner OS user: chatops
+runner home: /home/chatops/actions-runner
+```
 
-## Next action
+`chatops` does not have general access to Viktor's project directory and does not
+have unrestricted sudo. Privileged production operations are restricted to the
+root-owned wrapper `/usr/local/sbin/catering-ops` through
+`/etc/sudoers.d/chatops-catering`.
 
-1. Run the artificial end-to-end pre-launch validation.
+The private ops repository must remain private. Do not attach this privileged
+runner to pull-request workflows from the public/main application repository.
 
-### Deployed and closed
+## Known configuration drift
 
-**PDF_RUNTIME_VENV_AND_SYSTEMD_MIGRATION_V1 — DEPLOYED, CLOSED**
+### Kitchen Print Phase 3B
 
-- Production fast-forwarded **2026-07-28** from `a67875d800deff7a954e9c83d42174c41b647326`
-  to `ab0743f229b525b348ebdc6cfd71c2fac7ba153e`, deploying PR #42 (PDF startup
-  ordering and error handling), PR #45 (committed `uv.lock` and uv-based
-  reproducibility), PR #46 (tracked office units use the project `.venv`),
-  and PR #48 (read-only PDF runtime/systemd verifier).
-- Runtime reproduced from the committed `uv.lock` via
-  `uv sync --frozen --no-dev` (Python `3.13.5`, `reportlab==5.0.0`); dev
-  dependencies are not required in the production runtime.
-- `uv 0.11.32` is installed separately in
-  `/home/viktor/.local/uv-bootstrap-venv` (an isolated bootstrap venv, not a
-  system-wide install); the host-runtime verifier requires that path on
-  `PATH`.
-- Tracked systemd units for both office services now declare
-  `/home/viktor/projects/silberloeffel-catering/.venv/bin/python3`; the
-  previously-installed compatible overrides were removed from the active
-  systemd configuration and archived (not deleted) — see "Deployment
-  verification" above.
-- Restart scope: `catering-office-api` and `catering-office-panel` only, at
-  `2026-07-28 20:42:33 CEST`; `catering-kiosk` and `catering-website-intake`
-  were **not** restarted.
-- Production now has repository-specific, read-only GitHub access
-  configured through repo-local `core.sshCommand`; the remote URL was not
-  changed.
+The live host currently runs `kitchen-print-agent.service` and
+`catering-kitchen-api.service`, but the exact source changes used to activate
+those services are not on `main`.
 
-**PR #42 — PDF startup preflight ordering and configuration documentation —
-DEPLOYED, CLOSED**
+They were preserved before the 2026-08-21 production fast-forward on branch:
 
-- Merged **2026-07-27** into `main` (merge commit `03a3780e699357c30e36049f1293f5a93a214f6f`); issue #41 closed.
-- Fixes direct-mode Office Panel validating `OFFICE_PDF_*` configuration
-  *after* opening `core.db` and applying migrations; hardens
-  `OFFICE_PDF_LOGO_PATH` error handling; documents the full `OFFICE_PDF_*`
-  contract in `.env.example` and the Lenovo runbook.
-- Deployed to production as part of the `ab0743f` fast-forward above.
+```text
+wip/kitchen-print-lenovo-phase3b
+```
 
-**PR #38 — catalog price-history response handling — DEPLOYED, CLOSED**
+Observed live Kitchen Print Agent uses the project checkout and `.venv`, while
+tracked `main` still describes the older `/opt/kitchen-print-agent` runtime.
+`catering-kitchen-api.service` is also absent from `main` at this snapshot.
 
-- Merged **2026-07-27**; issue #37 closed.
-- Deployed to production as part of the `a67875d` fast-forward (same
-  deployment as PR #40 below).
-- Fixes `RemoteCoreClient.catalog_dish_detail` rejecting any dish that has
-  price history.
+**Operational rule:** do not reinstall Kitchen systemd units from `main` until
+that branch is reviewed and reconciled.
 
-**PR #40 — structured Offer/PDF error handling — DEPLOYED, CLOSED**
+## Open operational risks
 
-- Merged **2026-07-27**; issue #39 closed.
-- Deployed to production as part of the `a67875d` fast-forward.
-- Fixes `RemoteCoreClient` masking structured Offer/PDF business errors
-  (`offer_document_blocked`, `confirmation_document_blocked`,
-  `order_not_ready_to_send`) as a generic `502`.
+1. Kitchen systemd/source drift described above.
+2. Scheduled backup freshness and off-host backup alerting were not re-verified
+   in the 2026-08-21 audit.
+3. Port `8090` is listening, but the courier user-service ownership/state was not
+   re-audited by the system-level runner pass.
+4. The current restricted deploy wrapper creates the SQLite backup after the Git
+   fast-forward but before service restart. This keeps the running process on the
+   old loaded code until the backup exists, but the wrapper should eventually be
+   tightened so backup creation precedes any checkout mutation.
+5. One-off recovery commands added to the ops wrapper during the 2026-08-21
+   migration should be removed when no longer needed.
 
-**INQUIRY_CUSTOMER_REFERENCE_AND_SNAPSHOT_DEPLOY_V1 — CLOSED**
+## Next operational actions
 
-- Deployed **2026-07-20**: application commit `ad810b4`; inquiries migration **v4**
-  `add_customer_reference` applied via canonical `SQLiteInquiryRepository` path.
-- Restart scope: Office API + Office Panel only; kiosk **not restarted**.
-- Additive columns on `inquiries`: `customer_id`, `snapshot_company_name`,
-  `snapshot_contact_name`, `snapshot_email`, `snapshot_phone` (all nullable).
-- `schema_migrations` **24 → 25**; all **33** existing Inquiry rows have NULL in
-  new columns; no automatic matching or CustomerIdentity creation.
-- CustomerIdentity tables remain **0/0**; Order/OrderVersion schema unchanged.
-- Rollback backup:
-  `/home/viktor/catering-runtime/backups/core.db.before-inquiry-customer-reference-20260720T081400Z`
-  (mode 600, integrity ok).
-- Post-deploy acceptance: API queue/inquiries/detail HTTP **200**;
-  `customer_id`/`customer_snapshot` null on legacy Inquiry; contacts API **200**;
-  Panel `/` and `/rueckruf` **200**; kiosk **200**; ContactProjection **17**
-  contacts; journals since restart clean.
-
-**DASHBOARD_CALENDAR_WEEK_FIX_V1 — CLOSED**
-
-- Deployed **2026-07-20** via `catering-office-panel.service` restart only.
-- Application commits loaded: `5000d6f` (Berlin operating date in direct
-  Startseite), `cf2edb5` (test alignment; no additional runtime behavior).
-- Source disk HEAD at restart: `5d47c8e` (includes docs-only lineage; no extra
-  application behavior vs `cf2edb5`).
-- Office API **not restarted** — unchanged code path; already used
-  `office_api_views.berlin_today()`.
-- Kiosk **not restarted** (PID unchanged).
-- No DB migration; aggregate counts unchanged (33/24/33); CustomerIdentity
-  tables remain empty (0/0); `schema_migrations` **24**.
-- Production acceptance: dashboard `/` and `/rueckruf` HTTP **200**; dashboard
-  KW matches `Europe/Berlin` operating date (verified KW **30/2026** on
-  2026-07-20); direct/remote parity tests green; journal since restart clean.
-
-
-**CORE_DB_PERMISSION_FIX_V1 — CLOSED**
-
-- Applied **2026-07-20**: `chmod` on production DB only — mode **644 → 600**.
-- Owner/group unchanged: **viktor:viktor**.
-- DB SHA-256 unchanged:
-  `dc501fae0259b6a791ad6ab3ebddea8a1db81a470db934820bc71b48032a5ba0`.
-- Size unchanged (**700416**); `PRAGMA integrity_check` **ok**; no SQL writes.
-- Services **not restarted** (Office API, Office Panel, kiosk PIDs unchanged).
-- Post-change smoke: API read, dashboard `/`, `/rueckruf`, kiosk — HTTP **200**;
-  journals without new database permission errors.
-
-**CORE_CUSTOMER_IDENTITY_FOUNDATION_V1 — CLOSED**
-
-- Office API and Office Panel restarted on `924f1c0` (2026-07-20 ~00:24 CEST).
-- Production DB has additive schema: `customer_identities`, `phone_contact_points`.
-- Migration markers present (one per component); tables **empty** (0/0).
-- Inquiry/Order row counts unchanged from pre-migration baseline (33/24/33).
-- Rollback backup:
-  `/home/viktor/catering-runtime/backups/core.db.before-customer-identity-20260719T221452Z`
-  (mode 600, integrity ok).
-
-**AUERSWALD_SELF_FAX_CALLBACK_EXCLUSION_V1 — CLOSED**
-
-- Container `auerswald-sync-auerswald-sync-1` running; active `main.py` SHA-256
-  `f6ded6233cd815760a8b417699e868baf3097ea4ee7557d2bad2f30b1835d3b6`.
-- Self-fax excluded from callback board (deployed 2026-07-19).
-
-**Auerswald missed-board compatibility — CLOSED** (runtime stable; Office
-Rückruf pull path operational).
-
-## Production database (aggregate)
-
-| Item | Value |
-|---|---|
-| Path | `/home/viktor/catering-runtime/core.db` |
-| Owner / group | **viktor:viktor** |
-| File mode | **600** (hardened 2026-07-20; was 644) |
-| SHA-256 (verified unchanged) | `dc501fae0259b6a791ad6ab3ebddea8a1db81a470db934820bc71b48032a5ba0` |
-| Integrity | ok |
-| `customer_identities` | 0 rows |
-| `phone_contact_points` | 0 rows |
-| inquiries / orders / order_versions | **33 / 24 / 33** |
-| `schema_migrations` | **25** (+ inquiries v4 customer reference; +2 CustomerIdentity markers vs pre-foundation 22) |
-
-## Backups (Core)
-
-| Control | State |
-|---|---|
-| Daily local cron | 03:15, 14-day retention |
-| Encrypted offsite cron | 03:25 |
-| Last verified offsite log | **2026-07-19** (`core-2026-07-19.db.gpg`) |
-| Backup alerting / stale detection | **not implemented** — see `docs/proposals/BACKUP_HEALTH_AND_ALERTING_V1.md` |
-
-Manual restore drill last verified: **2026-07-12**.
-
-## Auerswald runtime
-
-| Item | Value |
-|---|---|
-| Container | `auerswald-sync-auerswald-sync-1` (python:3.12-slim), up ~4h at audit |
-| HubSpot | `HUBSPOT_ACCESS_TOKEN` **present** in container; manual HTTP endpoints in code; **no automated outbound** observed in logs |
-| Auth/direct exposure | accepted operational debt |
-
-Core HubSpot intake remains disabled.
-
-## Courier and Fingerfood
-
-| Project | Repo HEAD | Runtime |
-|---|---|---|
-| Courier (`courier-app`) | `f2c51a0` | `catering-courier-app.service` **inactive** |
-| Fingerfood (`fingerfood-app`) | `74af846` | backup artifacts **2026-07-19**; `fingerfood-backup.timer` **inactive** |
-
-## Quality baseline (repository)
-
-On `03a3780` (historical — see "Repository state" above for the current
-`origin/main` HEAD) locally and in GitHub Actions: **2212 passed**, coverage
-**90.7%** (≥90% threshold), Ruff and mypy clean. Not re-run at `ab0743f` as
-part of this documentation-only update. Documented pre-push gate in
-`docs/runbooks/release-discipline.md`.
-
-## Operational risks (open)
-
-### Accepted — Office API process not restarted for calendar-week slice
-
-Office API runtime remains `924f1c0`; functional calendar-week paths already
-used `berlin_today()`. Restart was not required for this deploy.
-
-### High — release discipline not server-enforced
-
-Proven: deployment user can direct-push to `main`; prior pushes were not
-blocked by required green `quality`. Branch protection may be absent or bypass
-may apply — exact configuration requires authenticated owner/admin verification.
-Required check target: **`quality`**. Force push must be prohibited. Preferred
-flow: PR + required green `quality` (see release discipline runbook).
-
-### High — no backup health alerting
-
-Cron runs, but failure/stale backup does not notify anyone.
-
-### Accepted — HubSpot credential retained in Auerswald
-
-Token configured; automated outbound not observed. Revoke/remove is a separate slice.
-
-### Accepted — Auerswald direct/auth exposure
-
-Unchanged operational debt.
-
-### Accepted — Courier inactive / Fingerfood timer inactive
-
-Non-blocking for Core; noted for operational awareness.
-
-### Accepted — kiosk and website intake stale runtime
-
-Not restarted with recent Core changes; CustomerIdentity bootstrap not invoked there
-(kiosk has no bootstrap helper).
-
-## Verified recovery controls
-
-Recovery-key protection verified on **2026-07-12** (unchanged):
-
-- working private key on Mac only;
-- password-protected AES-256 recovery archive restore-tested;
-- no private key or archive password in Git, Lenovo, or VPS.
-
-## Next milestones
-
-1. **Branch protection verification** — owner/admin authenticated review; require green `quality`; block force push.
-2. **BACKUP_HEALTH_AND_ALERTING_V1** — failure/stale notification.
+1. Populate the Bitwarden `Silberloeffel Catering` vault from the secret registry.
+2. Reconcile and review `wip/kitchen-print-lenovo-phase3b` into a tracked source
+   of truth or deliberately replace it.
+3. Verify local and encrypted off-host backup schedules and add stale-backup
+   detection.
+4. Remove one-off ops permissions after the Kitchen/deployment cleanup.
+5. Keep future deployment evidence in `docs/operations/deployment-log.md`.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,54 @@
+# Operations
+
+This directory is the operational entry point for the live Silberlöffel Catering system.
+It answers four questions: what is running, where configuration lives, where secret
+values are recovered from, and how to rebuild the system when a host fails.
+
+## Start here
+
+1. `../current-status.md` — current verified production state and open drift.
+2. `service-inventory.md` — services, ports, runtime paths and ownership.
+3. `secrets-registry.md` — names and locations of credentials, never their values.
+4. `deployment-log.md` — production deployment evidence and rollback anchors.
+5. `disaster-recovery.md` — recovery order for a lost or rebuilt Lenovo host.
+6. `../runbooks/lenovo-production.md` — detailed production commands and checks.
+7. `../runbooks/backup-restore.md` — database backup and restore procedure.
+
+## Source-of-truth rules
+
+- Git documents configuration structure, paths, commands and recovery procedures.
+- A password manager is the master recovery store for human-managed production
+  credentials. The target vault is `Bitwarden / Silberloeffel Catering`.
+- Runtime copies of secrets live only in root-readable environment files or in the
+  provider's own secret store.
+- GitHub contains secret *names* only. Never commit, paste into issues, or record
+  real secret values.
+- `docs/current-status.md` is a snapshot, not a history book. Old deployment facts
+  belong in `deployment-log.md`, `CHANGELOG.md`, or `WORKLOG.md`.
+- Every production deployment must leave an evidence record containing the target
+  commit, database backup path, restarted services and verification result.
+- Configuration drift between `/etc/systemd/system` and tracked unit files is an
+  explicit operational risk and must be recorded until eliminated.
+
+## Password-manager naming convention
+
+Use one folder/collection named `Silberloeffel Catering`, with records grouped as:
+
+- `01 GitHub`
+- `02 Debian - debiancatering`
+- `03 Tailscale`
+- `04 Cloudflare`
+- `05 Office Panel`
+- `06 Core Office API`
+- `07 Website Intake`
+- `08 Kiosk`
+- `09 Kitchen Print`
+- `10 Courier`
+- `11 Auerswald`
+- `12 Email / external services`
+- `13 Backup / GPG`
+- `14 Recovery Codes`
+
+Each record should include the environment-variable name, runtime file path, service,
+creation date, last rotation date and a short statement of what consumes the secret.
+Do not duplicate a secret into free-form notes when a password field can hold it.

--- a/docs/operations/deployment-log.md
+++ b/docs/operations/deployment-log.md
@@ -1,0 +1,62 @@
+# Production deployment log
+
+This is the concise operational history for production changes. It supplements
+`CHANGELOG.md`: the changelog explains what changed in the product; this file
+records what actually reached production, what was backed up and how it was
+verified.
+
+Never record credentials, customer payloads, bearer tokens or private keys here.
+
+## 2026-08-21 — Order hard-delete FK fix
+
+| Item | Evidence |
+|---|---|
+| Host | `debiancatering` |
+| Previous production commit | `60f50c8ddd0bb5532bd673290d7d0b248819d4da` |
+| Deployed commit | `4eadf014654992619be317c8b3b079c5d8dcd26b` |
+| Main change | PR #145, transitive FK purge + rollback after COMMIT failure |
+| Pre-restart DB backup | `/home/viktor/catering-runtime/core.db.backup-20260821-080351` |
+| Restarted service | `catering-office-api.service` |
+| Service result | `active` |
+| Production functional proof | `POST /office/v1/orders/{id}/delete` committed with HTTP/status `200` at `2026-08-21 08:05:28 CEST` |
+| Regression symptom after deploy | no new `FOREIGN KEY constraint failed`; no new `cannot start a transaction within a transaction` |
+| Deployment path | private `VikJo1978/silberloeffel-ops` self-hosted runner → restricted `/usr/local/sbin/catering-ops` wrapper |
+| Result | **SUCCESS** |
+
+Before deployment, four unrelated local Kitchen Phase 3B changes were discovered
+on the production checkout. They were preserved on branch
+`wip/kitchen-print-lenovo-phase3b` before the checkout was cleaned and
+fast-forwarded. Live Kitchen units remain active and are tracked as configuration
+drift until that branch is reviewed and reconciled with `main`.
+
+## Record template
+
+Copy this block for future deployments:
+
+```text
+## YYYY-MM-DD — <short purpose>
+
+Host:
+Previous production commit:
+Target/deployed commit:
+Pull request(s):
+Database backup path:
+Services restarted:
+Migration(s):
+Smoke/functional checks:
+Journal result:
+Rollback required: yes/no
+Result: SUCCESS / ROLLED BACK / PARTIAL
+Operator notes:
+```
+
+## Minimum evidence rule
+
+A deployment is not considered documented until these four facts exist:
+
+1. exact deployed commit;
+2. exact database backup path for Core-writing changes;
+3. exact services restarted;
+4. at least one post-restart health or functional verification result.
+
+GitHub merge time alone is not deployment evidence.

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -1,0 +1,152 @@
+# Disaster recovery: rebuild production from zero
+
+Use this when the Lenovo production host is lost, replaced, or too damaged to
+repair safely. This is an ordering guide, not a substitute for the detailed
+backup and production runbooks.
+
+The recovery objective is to rebuild from versioned code + a verified Core DB
+backup + the password-manager vault. No single production host should be the
+only copy of a credential required to rebuild itself.
+
+## Recovery inputs
+
+Before starting, obtain:
+
+- access to GitHub repositories;
+- access to `Bitwarden / Silberloeffel Catering`;
+- Tailscale account/recovery access;
+- a verified Core database backup, preferably encrypted off-host;
+- the off-host GPG private key from its operator-side encrypted backup;
+- SSH/deploy key recovery material where keys are intentionally persistent;
+- current service inventory and latest successful deployment record.
+
+If any one of these is missing, record the gap before improvising a replacement.
+
+## Rebuild order
+
+### 1. Base host
+
+- install the supported Debian release;
+- create the `viktor` operator account;
+- apply OS updates;
+- install Git, SQLite, systemd dependencies, Tailscale and the supported Python
+  runtime/bootstrap tooling;
+- join Tailscale and verify the expected private network reachability.
+
+Do not expose application ports publicly as a shortcut during recovery.
+
+### 2. Application code
+
+Clone `VikJo1978/silberloeffel-catering` to:
+
+```text
+/home/viktor/projects/silberloeffel-catering
+```
+
+Check out the exact production target commit from the latest approved deployment
+record. Build `.venv` from the committed dependency lock according to the Lenovo
+runbook. Do not reconstruct Python packages from memory.
+
+### 3. Core database
+
+Restore the selected verified backup to:
+
+```text
+/home/viktor/catering-runtime/core.db
+```
+
+Set owner/mode according to the backup runbook and run SQLite integrity checks
+before starting any writer service.
+
+Never use a stale development or staging database as a production substitute.
+
+### 4. Secrets and configuration
+
+Recreate root-owned environment files from Bitwarden/provider records. Use the
+names and paths in `secrets-registry.md` and `.env.example`.
+
+Typical files include:
+
+```text
+/etc/catering/office-api.env
+/etc/catering/office-panel.env
+/etc/catering/website-intake.env
+/etc/catering/kiosk.env
+/etc/catering/kitchen-api.env
+/etc/kitchen-print-agent.env
+```
+
+Set restrictive permissions. Do not copy values through GitHub, tickets or chat.
+If the vault lacks a required value, rotate/create a new credential at the
+provider instead of trying to recover it from logs.
+
+### 5. Install systemd units
+
+Install only reviewed, tracked unit files that match the intended production
+revision. Run `systemctl daemon-reload`, enable required units and verify effective
+`ExecStart`, `WorkingDirectory`, `EnvironmentFiles` and exposure before starting.
+
+The current Kitchen Print configuration has documented drift from `main`; resolve
+that drift before using `main` as the source for Kitchen unit reinstallation.
+
+### 6. Start in dependency order
+
+Suggested order:
+
+1. Core Office API;
+2. Office Panel;
+3. Website Intake;
+4. Kiosk;
+5. Courier / pickup-signal components;
+6. Kitchen API;
+7. Kitchen Print Agent;
+8. auxiliary integrations.
+
+Start only the components required for the current recovery scope. A partially
+recovered system with clear disabled components is safer than an unverified
+full-stack start.
+
+### 7. Verify
+
+At minimum:
+
+- all intended services are `active`;
+- listeners match `service-inventory.md`;
+- `PRAGMA quick_check`/documented DB verification passes;
+- unauthenticated protected endpoints reject access as expected;
+- Office Panel reads the restored Core data;
+- one safe business-flow smoke test succeeds;
+- journals contain no crash loop, traceback or repeated authentication failure.
+
+Do not test recovery by creating real customer data unless the system is already
+approved for live traffic.
+
+### 8. Restore automation last
+
+Only after the application is stable:
+
+- restore local and encrypted off-host backup schedules;
+- verify a new backup can be created and restored/read;
+- install the private GitHub Actions self-hosted runner if remote operations are
+  still desired;
+- recreate `/usr/local/sbin/catering-ops` and its narrow sudo policy from the
+  documented ops design, never by granting the runner unrestricted sudo.
+
+## Loss of GitHub runner only
+
+The runner is not required for application operation. If it fails, production
+continues. Reinstall/re-register it from the private `silberloeffel-ops` repository
+and verify it runs as unprivileged user `chatops`. Do not solve runner failure by
+making it run as root.
+
+## Loss of Bitwarden access
+
+Treat this as an infrastructure incident. Do not dump `/etc/catering/*.env` into
+an insecure location to create an emergency vault. Recover Bitwarden access or
+rotate credentials provider-by-provider, then rebuild the vault deliberately.
+
+## Recovery completion record
+
+Create a new entry in `deployment-log.md` containing the restored DB backup,
+application commit, services started, verification evidence and any credentials
+that were rotated (names only, never values).

--- a/docs/operations/secrets-registry.md
+++ b/docs/operations/secrets-registry.md
@@ -1,0 +1,83 @@
+# Secrets registry
+
+This is an inventory of secret *identifiers and storage locations only*.
+Real values must never appear in this repository, GitHub issues, deployment logs,
+shell history, screenshots, or chat transcripts.
+
+The target human recovery store is **Bitwarden → `Silberloeffel Catering`**.
+Runtime copies remain in root-readable environment files or the provider's own
+secret store.
+
+`Master vault record` entries below are naming targets. Populate the actual
+Bitwarden records without copying their values into Git.
+
+## Application secrets
+
+| Secret / variable | Consumer | Runtime location | Master vault record | Rotation notes |
+|---|---|---|---|---|
+| `OFFICE_PANEL_PASSWORD` | Office Panel legacy/basic auth where enabled | `/etc/catering/office-panel.env` | `05 Office Panel` | Rotate when shared access changes; employee auth may supersede it |
+| `OFFICE_API_TOKEN` | Core Office API bearer authentication | `/etc/catering/office-api.env` | `06 Core Office API` | Rotate together with every configured client |
+| `CORE_OFFICE_API_TOKEN` | Office Panel client of Core API | `/etc/catering/office-panel.env` | `06 Core Office API` | Must match the API-side bearer used for the panel |
+| `EMPLOYEE_INTROSPECTION_SERVICE_TOKENS_JSON` | trusted employee-auth service clients | `/etc/catering/office-api.env` | `06 Core Office API / introspection clients` | Use separate random secret per client; revoke individually |
+| `WEBSITE_INTAKE_TOKEN` | website intake receiver | `/etc/catering/website-intake.env` | `07 Website Intake` | Rotate with upstream sender/Worker configuration |
+| `UPSTREAM_TOKEN` | public Worker/upstream integration where configured | provider secret store | `04 Cloudflare / website upstream` | Never place in local `.env.example` with a real value |
+| `PICKUP_SIGNAL_TOKEN` | kiosk client of courier pickup signal | `/etc/catering/kiosk.env` | `08 Kiosk / pickup signal` | Paired with courier-side signal token |
+| `KIOSK_SIGNAL_TOKEN` | courier-side pickup signal endpoint | courier runtime env | `10 Courier / kiosk signal` | Rotate as a pair with kiosk consumer |
+| `KITCHEN_API_TOKEN` | Kitchen API bearer authentication | `/etc/catering/kitchen-api.env` | `09 Kitchen Print / API token` | Paired with agent token |
+| `KITCHEN_PRINT_AGENT_TOKEN` | Kitchen Print Agent client | `/etc/kitchen-print-agent.env` | `09 Kitchen Print / API token` | Must match Kitchen API token unless architecture changes |
+| `AUERSWALD_SYNC_PASSWORD` | Auerswald callback/sync integration | integration runtime env | `11 Auerswald` | Rotate at source and runtime together |
+| `AUERSWALD_SYNC_USER` | Auerswald integration account name | integration runtime env | `11 Auerswald` | Treat as credential metadata even if not secret alone |
+| `HUBSPOT_ACCESS_TOKEN` | Auerswald/HubSpot integration where active | container/runtime secret | `12 External services / HubSpot` | Rotate in HubSpot and runtime; do not expose in logs |
+
+## Infrastructure credentials
+
+| Credential | Runtime location | Master / recovery location | Notes |
+|---|---|---|---|
+| Lenovo SSH private key(s) used by operators | operator machines, `~/.ssh` | `02 Debian - debiancatering` plus encrypted key backup | Never commit private keys |
+| Repository deploy key for `silberloeffel-catering` | Lenovo `~/.ssh` | `01 GitHub / catering deploy key` | GitHub deploy key should remain read-only |
+| Courier repository deploy key | Lenovo `/home/viktor/.ssh/courier_app_github` | `01 GitHub / courier deploy key` | GitHub write access disabled |
+| GitHub self-hosted runner registration | GitHub + `/home/chatops/actions-runner` | `01 GitHub / ops runner` metadata only | Registration tokens are short-lived; do not archive them as passwords |
+| Tailscale account/recovery access | Tailscale provider | `03 Tailscale` | Record owner account and recovery method, not reusable ephemeral auth keys unless deliberately managed |
+| Cloudflare account/recovery access | Cloudflare provider | `04 Cloudflare` | Store recovery codes separately under `14 Recovery Codes` |
+| Off-host backup GPG private key | operator Mac only | `13 Backup / GPG` encrypted backup | Must not be copied to Lenovo; Lenovo needs only public encryption material |
+| Email/SMTP credentials, if configured | provider/runtime secret store | `12 Email / external services` | Document exact consumer when added |
+
+## Non-secret configuration
+
+Do not put ordinary configuration into the password manager just because it is in
+an `.env` file. URLs, ports, company PDF text and feature switches belong in Git
+or the service inventory when they are not sensitive. `.env.example` remains the
+canonical list of application environment-variable names.
+
+## Bitwarden record template
+
+For every production credential create a record with:
+
+```text
+Name: <system / purpose>
+Username: <if applicable>
+Password / token: <secret value, Bitwarden only>
+Environment variable: <VARIABLE_NAME>
+Runtime path: <path on host/provider>
+Consumer: <service/component>
+Created: <date>
+Last rotated: <date>
+Recovery / rotation notes: <short procedure or link to runbook>
+```
+
+## Rotation procedure
+
+1. Take a production database backup when the affected service can write Core.
+2. Create the replacement secret in Bitwarden/provider first.
+3. Update all producer and consumer runtime copies without printing the value.
+4. Restart only affected services.
+5. Verify authentication succeeds and old credentials fail where feasible.
+6. Revoke the previous credential.
+7. Record the rotation date here or in the relevant deployment log without
+   recording the value.
+
+## Emergency rule
+
+If a real credential is ever committed to Git or posted in an issue, deleting the
+text is not sufficient. Treat it as compromised, rotate it immediately, and then
+remove/redact the exposed material.

--- a/docs/operations/service-inventory.md
+++ b/docs/operations/service-inventory.md
@@ -1,0 +1,117 @@
+# Production service inventory
+
+Last read-only audit: **2026-08-21 08:11 CEST** on `debiancatering`.
+Tailscale IPv4 observed: `100.109.6.74`.
+Application checkout revision observed: `4eadf014654992619be317c8b3b079c5d8dcd26b`.
+
+This file contains no credentials. Environment-file paths are safe to document;
+their contents are not.
+
+## Core host
+
+| Service / component | State at audit | Listen / exposure | Runtime / data | Environment |
+|---|---|---|---|---|
+| `catering-office-panel.service` | enabled, active | `0.0.0.0:8081` | repo `/home/viktor/projects/silberloeffel-catering`; `core.db` | `/etc/catering/office-panel.env` |
+| `catering-office-api.service` | enabled, active | `100.109.6.74:8084` | project `.venv`; `core.db` | `/etc/catering/office-api.env` |
+| `catering-kiosk.service` | enabled, active | `0.0.0.0:8082` | system Python; read-only Core use | `/etc/catering/kiosk.env` optional |
+| `catering-website-intake.service` | enabled, active | `127.0.0.1:8083` | system Python; Inquiry writes | `/etc/catering/website-intake.env` |
+| `kitchen-print-agent.service` | enabled, active | no HTTP listener of its own | project `.venv`; module `kitchen_print_agent` | `/etc/kitchen-print-agent.env` |
+| `catering-kitchen-api.service` | enabled, active | `127.0.0.1:8086` | project `.venv`; `core.db` | `/etc/catering/kitchen-api.env` |
+| GitHub Actions self-hosted runner | active | outbound GitHub connection | `/home/chatops/actions-runner` | runner registration managed by GitHub |
+| courier listener | listener observed | `0.0.0.0:8090` | separate courier runtime | ownership/unit not re-audited in this pass |
+| `catering-intake-vps-tunnel.service` | unit not found, inactive | none observed at `18083` | tracked template exists, live unit absent | n/a |
+
+## Exact live commands verified on 2026-08-21
+
+### Office API
+
+```text
+/home/viktor/projects/silberloeffel-catering/.venv/bin/python3
+  -m catering_system.ui.office_api
+  --db /home/viktor/catering-runtime/core.db
+  --host 100.109.6.74
+  --port 8084
+```
+
+### Office Panel
+
+```text
+/home/viktor/projects/silberloeffel-catering/.venv/bin/python3
+  -m catering_system.ui.office_panel
+  --db /home/viktor/catering-runtime/core.db
+  --port 8081
+```
+
+### Kiosk
+
+```text
+/usr/bin/python3
+  -m catering_system.ui.kiosk_server
+  --db /home/viktor/catering-runtime/core.db
+  --port 8082
+```
+
+### Website intake
+
+```text
+/usr/bin/python3
+  -m catering_system.ui.website_intake_endpoint
+  --db /home/viktor/catering-runtime/core.db
+  --host 127.0.0.1
+  --port 8083
+```
+
+### Kitchen Print Agent
+
+```text
+/home/viktor/projects/silberloeffel-catering/.venv/bin/python3
+  -m kitchen_print_agent
+```
+
+### Kitchen API
+
+```text
+/home/viktor/projects/silberloeffel-catering/.venv/bin/python3
+  -m catering_system.ui.kitchen_api
+  --db /home/viktor/catering-runtime/core.db
+  --host 127.0.0.1
+  --port 8086
+```
+
+## Shared production paths
+
+| Purpose | Path |
+|---|---|
+| Application checkout | `/home/viktor/projects/silberloeffel-catering` |
+| Python runtime | `/home/viktor/projects/silberloeffel-catering/.venv` |
+| Core SQLite DB | `/home/viktor/catering-runtime/core.db` |
+| Production env directory | `/etc/catering/` |
+| Restricted ops wrapper | `/usr/local/sbin/catering-ops` |
+| ChatOps sudo policy | `/etc/sudoers.d/chatops-catering` |
+| Actions runner home | `/home/chatops/actions-runner` |
+
+## Known configuration drift
+
+As of this audit, both Kitchen Print Agent and Kitchen API are active from live
+systemd units under `/etc/systemd/system`, while the exact Lenovo Phase 3B source
+changes that produced those units are preserved on GitHub branch
+`wip/kitchen-print-lenovo-phase3b` and are not yet merged into `main`.
+
+In particular, tracked `main` still has the older `kitchen-print-agent.service`
+using `/opt/kitchen-print-agent`, while the live service uses the main project
+checkout and `.venv`. `catering-kitchen-api.service` is not present on `main` at
+this snapshot. Do not reinstall Kitchen units from `main` until this drift is
+resolved through a reviewed merge.
+
+## Verification commands
+
+Safe read-only checks:
+
+```bash
+systemctl is-active catering-office-api catering-office-panel \
+  catering-kiosk catering-website-intake kitchen-print-agent catering-kitchen-api
+ss -ltn
+sudo -n /usr/local/sbin/catering-ops revision
+```
+
+Never use a service inventory command that prints environment variable values.


### PR DESCRIPTION
## Summary
- replace the stale, history-heavy current status page with a concise production snapshot verified on 2026-08-21
- add an operations hub with service inventory, secrets registry, deployment evidence and disaster-recovery order
- record the 2026-08-21 hard-delete production deployment and backup evidence
- document the live Kitchen Print configuration drift preserved on `wip/kitchen-print-lenovo-phase3b`
- align `SECURITY.md` with the Bitwarden recovery-vault model and restricted `chatops` runner boundary

## Verification basis
The production inventory was collected read-only from `debiancatering` through the private self-hosted runner. It verified the application revision, Tailscale address, active/enabled system services, effective service commands/env-file paths, listener ports and runner service. No environment values or database/customer payloads were read into the documentation.

## Runtime impact
Documentation only. No application code, database schema, systemd unit, secret value or production service is changed by this PR.