### PR TITLE
CI: avoid duplicate runs on pull request branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Что меняется
- `push`-запуск CI теперь ограничен веткой `main`;
- ветки с PR проверяются только событием `pull_request`;
- один и тот же commit больше не должен запускать два одинаковых quality-job параллельно.

Это закрывает #60.

Без изменений приложения, БД и production runtime.