### PR TITLE
Gate offer preparation on fulfillment and delivery address

### DIFF
--- a/src/catering_system/domain/inquiry_offer_preparation.py
+++ b/src/catering_system/domain/inquiry_offer_preparation.py
@@ -17,6 +17,12 @@ from catering_system.domain.progression_blockers import (
 
 REASON_ACTIVE_ORDER_EXISTS: Literal["active_order_exists"] = "active_order_exists"
 REASON_OFFER_ALREADY_EXISTS: Literal["offer_already_exists"] = "offer_already_exists"
+REASON_FULFILLMENT_MODE_UNRESOLVED: Literal["fulfillment_mode_unresolved"] = (
+    "fulfillment_mode_unresolved"
+)
+REASON_DELIVERY_ADDRESS_UNRESOLVED: Literal["delivery_address_unresolved"] = (
+    "delivery_address_unresolved"
+)
 
 InquiryOfferPreparationBlocker = Literal[
     "inquiry_rejected",
@@ -26,6 +32,8 @@ InquiryOfferPreparationBlocker = Literal[
     "inquiry_contact_missing_email_and_phone",
     "active_order_exists",
     "offer_already_exists",
+    "fulfillment_mode_unresolved",
+    "delivery_address_unresolved",
 ]
 
 _INQUIRY_BLOCKERS = frozenset(
@@ -47,17 +55,34 @@ class InquiryOfferPreparationEligibility:
     reasons: tuple[InquiryOfferPreparationBlocker, ...] = ()
 
 
+def _delivery_context_resolved(inquiry: Inquiry) -> bool:
+    """True when a DELIVERY inquiry has an operationally usable address choice."""
+
+    snapshot = inquiry.customer_snapshot
+    if snapshot is None:
+        return False
+    if snapshot.delivery_address_mode == "SAME_AS_INVOICE":
+        return snapshot.invoice_address is not None
+    if snapshot.delivery_address_mode == "SEPARATE":
+        return snapshot.delivery_address is not None
+    return False
+
+
 def evaluate_inquiry_offer_preparation(
     inquiry: Inquiry,
     *,
     has_active_order: bool,
     has_existing_offer: bool,
 ) -> InquiryOfferPreparationEligibility:
-    """Evaluate only facts that may block creation of OfferVersion 1.
+    """Evaluate facts that may block creation of OfferVersion 1.
 
     Historical cancelled Orders deliberately do not appear in this contract:
     callers pass whether an *active* Order exists, not whether any Order has
     ever existed.
+
+    Fulfillment/address facts are required here because they can affect the
+    customer-visible offer total. A DELIVERY offer must not be prepared while
+    its delivery context is still unknown.
     """
 
     progression = evaluate_inquiry_to_order_progression(inquiry)
@@ -66,6 +91,12 @@ def evaluate_inquiry_offer_preparation(
         for reason in progression.reasons
         if reason in _INQUIRY_BLOCKERS
     ]
+    if inquiry.fulfillment_mode == "UNKNOWN":
+        reasons.append(REASON_FULFILLMENT_MODE_UNRESOLVED)
+    elif inquiry.fulfillment_mode == "DELIVERY" and not _delivery_context_resolved(
+        inquiry
+    ):
+        reasons.append(REASON_DELIVERY_ADDRESS_UNRESOLVED)
     if has_active_order:
         reasons.append(REASON_ACTIVE_ORDER_EXISTS)
     if has_existing_offer:
@@ -80,6 +111,8 @@ __all__ = [
     "InquiryOfferPreparationBlocker",
     "InquiryOfferPreparationEligibility",
     "REASON_ACTIVE_ORDER_EXISTS",
+    "REASON_DELIVERY_ADDRESS_UNRESOLVED",
+    "REASON_FULFILLMENT_MODE_UNRESOLVED",
     "REASON_OFFER_ALREADY_EXISTS",
     "evaluate_inquiry_offer_preparation",
 ]

--- a/tests/unit/test_inquiry_offer_preparation.py
+++ b/tests/unit/test_inquiry_offer_preparation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import UTC, date, datetime
 
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import Inquiry
 from catering_system.domain.inquiry_customer_snapshot import InquiryCustomerSnapshot
 from catering_system.domain.inquiry_offer_preparation import (
@@ -33,6 +34,7 @@ def _inquiry(**overrides: object) -> Inquiry:
             email="kunde@example.test",
             phone="+49401234567",
         ),
+        "fulfillment_mode": "PICKUP",
     }
     values.update(overrides)
     return Inquiry(**values)  # type: ignore[arg-type]
@@ -73,6 +75,62 @@ def test_contact_blocker_uses_existing_progression_reason() -> None:
         customer_snapshot=InquiryCustomerSnapshot(phone="+49401234567"),
     )
     assert _evaluate(inquiry).reasons == ("inquiry_contact_missing_email",)
+
+
+def test_unknown_fulfillment_blocks_offer_preparation() -> None:
+    eligibility = _evaluate(_inquiry(fulfillment_mode="UNKNOWN"))
+    assert eligibility.reasons == ("fulfillment_mode_unresolved",)
+
+
+def test_pickup_does_not_require_delivery_address() -> None:
+    assert _evaluate(_inquiry(fulfillment_mode="PICKUP")).blocked is False
+
+
+def test_delivery_requires_resolved_delivery_context() -> None:
+    unresolved = _inquiry(fulfillment_mode="DELIVERY")
+    assert _evaluate(unresolved).reasons == ("delivery_address_unresolved",)
+
+
+def test_delivery_same_as_invoice_is_resolved_when_invoice_address_exists() -> None:
+    inquiry = _inquiry(
+        fulfillment_mode="DELIVERY",
+        customer_snapshot=InquiryCustomerSnapshot(
+            email="kunde@example.test",
+            phone="+49401234567",
+            invoice_address=CustomerAddress(
+                street="Musterstraße 1",
+                postal_code="20095",
+                city="Hamburg",
+                country="DE",
+            ),
+            delivery_address_mode="SAME_AS_INVOICE",
+        ),
+    )
+    assert _evaluate(inquiry).blocked is False
+
+
+def test_delivery_separate_address_is_resolved() -> None:
+    inquiry = _inquiry(
+        fulfillment_mode="DELIVERY",
+        customer_snapshot=InquiryCustomerSnapshot(
+            email="kunde@example.test",
+            phone="+49401234567",
+            invoice_address=CustomerAddress(
+                street="Musterstraße 1",
+                postal_code="20095",
+                city="Hamburg",
+                country="DE",
+            ),
+            delivery_address=CustomerAddress(
+                street="Eventweg 7",
+                postal_code="22041",
+                city="Hamburg",
+                country="DE",
+            ),
+            delivery_address_mode="SEPARATE",
+        ),
+    )
+    assert _evaluate(inquiry).blocked is False
 
 
 def test_active_order_and_existing_offer_have_distinct_blockers() -> None:


### PR DESCRIPTION
First implementation slice for #150.

What this PR does:
- blocks first-offer preparation while fulfillment is `UNKNOWN`
- allows `PICKUP` without a delivery address
- requires a resolved delivery context for `DELIVERY`
- treats `SAME_AS_INVOICE` as resolved only when an invoice address exists
- treats `SEPARATE` as resolved only when a delivery address exists
- adds focused unit coverage for these cases

What this PR deliberately does not do yet:
- Office questionnaire/UI for choosing Lieferung vs Selbstabholung
- delivery price calculation
- carry-over into the accepted order
- Küchenzettel differing-address warning

Those remain in #150 and will be layered on after this domain gate is green.