### PR TITLE
Avoid duplicate CI runs on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary
- run `push` CI only for `main`
- keep full CI on every pull request
- avoid duplicate `push` + `pull_request` runs for the same feature-branch commit

## Result
Feature branches are checked once through the PR. After merge, `main` is checked once again via the `push` trigger.

No test, application, or deployment logic changed.