### PR TITLE
Warn kitchen when delivery address differs from invoice

### DIFF
--- a/src/catering_system/services/kitchen_print_pdf_renderer.py
+++ b/src/catering_system/services/kitchen_print_pdf_renderer.py
@@ -22,6 +22,7 @@ from reportlab.platypus import (
 from catering_system.services.order_print_projection_service import OrderPrintProjection
 
 _TITLE = "Küchenzettel"
+_DELIVERY_ADDRESS_WARNING = "⚠ Lieferadresse weicht von Rechnungsadresse ab"
 _PAGE_SIZE = A4
 _LEFT_MARGIN = 18 * mm
 _RIGHT_MARGIN = 18 * mm
@@ -246,9 +247,18 @@ def _customer_story(
 ) -> list[Flowable]:
     customer = projection.customer
     address = "\n".join(customer.delivery_address_lines) or "-"
-    return [
+    story: list[Flowable] = [
         Spacer(1, 5 * mm),
         _p("KUNDE / LIEFERUNG", styles.h2),
+    ]
+    if customer.delivery_address_differs:
+        story.extend(
+            [
+                _p(_DELIVERY_ADDRESS_WARNING, styles.body_bold),
+                Spacer(1, 2 * mm),
+            ]
+        )
+    story.append(
         Table(
             [
                 [
@@ -275,8 +285,9 @@ def _customer_story(
                     ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
                 ]
             ),
-        ),
-    ]
+        )
+    )
+    return story
 
 
 def _planning_mode_label(value: str) -> str:

--- a/src/catering_system/services/order_print_projection_service.py
+++ b/src/catering_system/services/order_print_projection_service.py
@@ -7,7 +7,10 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal, Protocol
 
-from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.customer_document_projection import (
+    CustomerAddress,
+    customer_addresses_equal,
+)
 from catering_system.domain.inquiry import FulfillmentMode
 from catering_system.domain.offer import PositionQuantityMode
 from catering_system.domain.order import Order, OrderVersion
@@ -99,6 +102,7 @@ class PrintCustomerBlock:
     phone: str | None = None
     delivery_address_lines: tuple[str, ...] = ()
     fulfillment_mode: FulfillmentMode = "UNKNOWN"
+    delivery_address_differs: bool = False
 
 
 @dataclass(frozen=True)
@@ -192,6 +196,7 @@ class OrderPrintProjectionService:
             raise PrintFinalRequiresEffectiveError(
                 "final print requires the effective order version"
             )
+        operational_context = self._orders.get_operational_context(order_version_id)
         return OrderPrintProjection(
             event=_event_block(
                 order,
@@ -201,7 +206,8 @@ class OrderPrintProjectionService:
             commercial=commercial,
             flags=flags,
             customer=_customer_block(
-                self._orders.get_operational_context(order_version_id)
+                operational_context,
+                confirmation_snapshot=confirmation_snapshot,
             ),
         )
 
@@ -376,14 +382,39 @@ def _position_line_from_snapshot(
 
 def _customer_block(
     snapshot: OrderVersionOperationalContextSnapshot | None,
+    *,
+    confirmation_snapshot: OrderConfirmationDocumentSnapshot | None = None,
 ) -> PrintCustomerBlock:
     if snapshot is None:
-        return PrintCustomerBlock()
+        return PrintCustomerBlock(
+            fulfillment_mode=(
+                confirmation_snapshot.fulfillment_mode
+                if confirmation_snapshot is not None
+                and confirmation_snapshot.fulfillment_mode is not None
+                else "UNKNOWN"
+            )
+        )
+    delivery_address_differs = (
+        confirmation_snapshot is not None
+        and confirmation_snapshot.invoice_address is not None
+        and snapshot.delivery_address is not None
+        and not customer_addresses_equal(
+            confirmation_snapshot.invoice_address,
+            snapshot.delivery_address,
+        )
+    )
     return PrintCustomerBlock(
         company_name=(snapshot.recipient_company or "").strip() or None,
         contact_name=(snapshot.recipient_name or "").strip() or None,
         phone=(snapshot.recipient_phone or "").strip() or None,
         delivery_address_lines=_address_lines(snapshot.delivery_address),
+        fulfillment_mode=(
+            confirmation_snapshot.fulfillment_mode
+            if confirmation_snapshot is not None
+            and confirmation_snapshot.fulfillment_mode is not None
+            else "UNKNOWN"
+        ),
+        delivery_address_differs=delivery_address_differs,
     )
 
 

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -34,6 +34,9 @@ from catering_system.repositories.sqlite_kitchen_print_job_repository import (
 from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
     SQLiteOrderCommercialSnapshotRepository,
 )
+from catering_system.repositories.sqlite_order_confirmation_document_repository import (
+    SQLiteOrderConfirmationDocumentRepository,
+)
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.services.kitchen_print_application_service import (
     KitchenPrintApplicationService,
@@ -109,13 +112,18 @@ class KitchenApi:
         self._orders = SQLiteOrderRepository(db_path)
         self._jobs = SQLiteKitchenPrintJobRepository(db_path)
         self._snapshots = SQLiteOrderCommercialSnapshotRepository(db_path)
+        self._confirmation_documents = SQLiteOrderConfirmationDocumentRepository(db_path)
         self._print_service = KitchenPrintService(
             self._orders,
             self._jobs,
             policy=self._policy,
             clock=self._clock,
         )
-        projection_service = OrderPrintProjectionService(self._orders, self._snapshots)
+        projection_service = OrderPrintProjectionService(
+            self._orders,
+            self._snapshots,
+            self._confirmation_documents,
+        )
         self._document_factory = KitchenPrintDocumentFactory(
             projection_service,
             self._document_store,
@@ -134,6 +142,7 @@ class KitchenApi:
     def close(self) -> None:
         self._jobs.close()
         self._snapshots.close()
+        self._confirmation_documents.close()
         self._orders.close()
 
     def execute_claim(self, command_id: str) -> tuple[int, str]:

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -112,7 +112,9 @@ class KitchenApi:
         self._orders = SQLiteOrderRepository(db_path)
         self._jobs = SQLiteKitchenPrintJobRepository(db_path)
         self._snapshots = SQLiteOrderCommercialSnapshotRepository(db_path)
-        self._confirmation_documents = SQLiteOrderConfirmationDocumentRepository(db_path)
+        self._confirmation_documents = SQLiteOrderConfirmationDocumentRepository(
+            db_path
+        )
         self._print_service = KitchenPrintService(
             self._orders,
             self._jobs,

--- a/tests/unit/test_issue150_kitchen_delivery_warning.py
+++ b/tests/unit/test_issue150_kitchen_delivery_warning.py
@@ -90,7 +90,9 @@ def _projection(customer: PrintCustomerBlock) -> OrderPrintProjection:
 
 def _pdf_text(projection: OrderPrintProjection) -> str:
     body = render_kitchen_print_pdf(projection, created_at=_NOW)
-    return "\n".join(page.extract_text() or "" for page in PdfReader(io.BytesIO(body)).pages)
+    return "\n".join(
+        page.extract_text() or "" for page in PdfReader(io.BytesIO(body)).pages
+    )
 
 
 def test_print_customer_derives_difference_from_structured_addresses() -> None:

--- a/tests/unit/test_issue150_kitchen_delivery_warning.py
+++ b/tests/unit/test_issue150_kitchen_delivery_warning.py
@@ -1,0 +1,148 @@
+"""Issue #150: kitchen output highlights a delivery address that differs from invoice."""
+
+from __future__ import annotations
+
+import io
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from typing import Any, cast
+
+from pypdf import PdfReader
+
+from catering_system.domain.customer_document_projection import CustomerAddress
+from catering_system.domain.order_operational_context import (
+    OrderVersionOperationalContextSnapshot,
+)
+from catering_system.services.kitchen_print_pdf_renderer import (
+    render_kitchen_print_pdf,
+)
+from catering_system.services.order_print_projection_service import (
+    OrderPrintProjection,
+    PrintCommercialBlock,
+    PrintCustomerBlock,
+    PrintEventBlock,
+    PrintFlagsBlock,
+    _customer_block,
+)
+
+_NOW = datetime(2026, 8, 22, 9, 0, tzinfo=UTC)
+_INVOICE = CustomerAddress(
+    street="Rechnungsweg 1",
+    postal_code="20095",
+    city="Hamburg",
+    country="DE",
+)
+_DELIVERY = CustomerAddress(
+    street="Eventweg 9",
+    postal_code="22767",
+    city="Hamburg",
+    country="DE",
+)
+
+
+def _operational(address: CustomerAddress) -> OrderVersionOperationalContextSnapshot:
+    return OrderVersionOperationalContextSnapshot(
+        order_version_id="22222222-2222-4222-8222-222222222222",
+        order_id="11111111-1111-4111-8111-111111111111",
+        recipient_company="Beispiel GmbH",
+        recipient_name="Ada Beispiel",
+        recipient_phone="+49 40 123456",
+        delivery_address=address,
+        created_at=_NOW,
+        source="initial_inquiry_snapshot",
+    )
+
+
+def _confirmation(invoice_address: CustomerAddress) -> Any:
+    return SimpleNamespace(
+        invoice_address=invoice_address,
+        fulfillment_mode="DELIVERY",
+    )
+
+
+def _projection(customer: PrintCustomerBlock) -> OrderPrintProjection:
+    return OrderPrintProjection(
+        event=PrintEventBlock(
+            order_id="11111111-1111-4111-8111-111111111111",
+            order_version_id="22222222-2222-4222-8222-222222222222",
+            version_number=1,
+            event_date=date(2026, 9, 1),
+            time_window_text="18:00",
+            location_text="Hamburg",
+            guest_count_estimate=20,
+            planning_mode="caterer_suggestion",
+            kitchen_print_confirmed_at=_NOW,
+            order_cancelled_at=None,
+            is_candidate=False,
+            is_effective=True,
+        ),
+        commercial=PrintCommercialBlock(source="offer_conversion"),
+        flags=PrintFlagsBlock(
+            intent="kitchen_job",
+            is_preview=False,
+            is_final_allowed=False,
+            is_stale=False,
+            watermark=None,
+        ),
+        customer=customer,
+    )
+
+
+def _pdf_text(projection: OrderPrintProjection) -> str:
+    body = render_kitchen_print_pdf(projection, created_at=_NOW)
+    return "\n".join(page.extract_text() or "" for page in PdfReader(io.BytesIO(body)).pages)
+
+
+def test_print_customer_derives_difference_from_structured_addresses() -> None:
+    customer = _customer_block(
+        _operational(_DELIVERY),
+        confirmation_snapshot=cast(Any, _confirmation(_INVOICE)),
+    )
+
+    assert customer.delivery_address_differs is True
+    assert customer.delivery_address_lines == ("Eventweg 9", "22767 Hamburg", "DE")
+    assert customer.fulfillment_mode == "DELIVERY"
+
+
+def test_print_customer_normalizes_equal_structured_addresses() -> None:
+    same_invoice = CustomerAddress(
+        street="  EVENTWEG   9 ",
+        postal_code="22767",
+        city="hamburg",
+        country="de",
+    )
+    customer = _customer_block(
+        _operational(_DELIVERY),
+        confirmation_snapshot=cast(Any, _confirmation(same_invoice)),
+    )
+
+    assert customer.delivery_address_differs is False
+
+
+def test_kitchen_pdf_prominently_warns_and_prints_actual_delivery_address() -> None:
+    customer = PrintCustomerBlock(
+        company_name="Beispiel GmbH",
+        contact_name="Ada Beispiel",
+        phone="+49 40 123456",
+        delivery_address_lines=("Eventweg 9", "22767 Hamburg", "DE"),
+        fulfillment_mode="DELIVERY",
+        delivery_address_differs=True,
+    )
+
+    text = _pdf_text(_projection(customer))
+
+    assert "Lieferadresse weicht von Rechnungsadresse ab" in text
+    assert "Eventweg 9" in text
+    assert "22767 Hamburg" in text
+
+
+def test_kitchen_pdf_omits_warning_when_addresses_do_not_differ() -> None:
+    customer = PrintCustomerBlock(
+        delivery_address_lines=("Rechnungsweg 1", "20095 Hamburg", "DE"),
+        fulfillment_mode="DELIVERY",
+        delivery_address_differs=False,
+    )
+
+    text = _pdf_text(_projection(customer))
+
+    assert "Lieferadresse weicht von Rechnungsadresse ab" not in text


### PR DESCRIPTION
Continues issue #150 after the Accepted Offer -> Order fulfillment guard.

## What changes
- derive a kitchen-facing `delivery_address_differs` fact at print-projection time from the frozen invoice address and the effective OrderVersion delivery address
- keep the actual Lieferadresse from the OrderVersion operational context
- render a prominent `⚠ Lieferadresse weicht von Rechnungsadresse ab` warning on the Küchenzettel when the structured addresses differ
- wire the existing SQLite order-confirmation snapshot repository into the production Kitchen API projection path
- add focused projection/PDF tests for differing and normalized-equal addresses

## Data model
No schema or migration changes. No manually maintained warning boolean is persisted. The warning is derived from existing structured address facts.

Closes the remaining kitchen/dispatch acceptance slice of #150.