### PR TITLE
CAP-1: persist explicit production station capacity facts

### DIFF
--- a/src/catering_system/domain/production_capacity.py
+++ b/src/catering_system/domain/production_capacity.py
@@ -1,0 +1,50 @@
+"""Explicit kitchen station capacity facts for CAP-1 / issue #163."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class ProductionStation:
+    station_id: str
+    name: str
+    active: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.station_id.strip():
+            raise ValueError("station_id must not be empty")
+        if not self.name.strip():
+            raise ValueError("station name must not be empty")
+
+
+@dataclass(frozen=True)
+class CatalogStationRequirement:
+    catalog_item_id: str
+    station_id: str
+    load_units_per_item: int
+
+    def __post_init__(self) -> None:
+        if not self.catalog_item_id.strip():
+            raise ValueError("catalog_item_id must not be empty")
+        if not self.station_id.strip():
+            raise ValueError("station_id must not be empty")
+        if self.load_units_per_item <= 0:
+            raise ValueError("load_units_per_item must be positive")
+
+
+@dataclass(frozen=True)
+class ProductionStationCapacityDay:
+    event_date: date
+    station_id: str
+    capacity_units: int
+    unavailable: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.station_id.strip():
+            raise ValueError("station_id must not be empty")
+        if self.capacity_units < 0:
+            raise ValueError("capacity_units must be non-negative")
+        if self.unavailable and self.capacity_units != 0:
+            raise ValueError("unavailable station must have zero capacity")

--- a/src/catering_system/repositories/sqlite_production_capacity_repository.py
+++ b/src/catering_system/repositories/sqlite_production_capacity_repository.py
@@ -112,7 +112,9 @@ class SQLiteProductionCapacityRepository:
             """
         ).fetchall()
         return [
-            ProductionStation(station_id=str(row[0]), name=str(row[1]), active=bool(row[2]))
+            ProductionStation(
+                station_id=str(row[0]), name=str(row[1]), active=bool(row[2])
+            )
             for row in rows
         ]
 

--- a/src/catering_system/repositories/sqlite_production_capacity_repository.py
+++ b/src/catering_system/repositories/sqlite_production_capacity_repository.py
@@ -1,0 +1,198 @@
+"""SQLite persistence for explicit kitchen station capacity facts."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from datetime import date
+from pathlib import Path
+
+from catering_system.domain.production_capacity import (
+    CatalogStationRequirement,
+    ProductionStation,
+    ProductionStationCapacityDay,
+)
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+
+def _migration_1_create_capacity_tables(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS production_stations (
+            station_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            active INTEGER NOT NULL CHECK (active IN (0, 1))
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS catalog_station_requirements (
+            catalog_item_id TEXT NOT NULL,
+            station_id TEXT NOT NULL,
+            load_units_per_item INTEGER NOT NULL CHECK (load_units_per_item > 0),
+            PRIMARY KEY (catalog_item_id, station_id),
+            FOREIGN KEY (station_id) REFERENCES production_stations (station_id)
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_catalog_station_requirements_station
+        ON catalog_station_requirements (station_id, catalog_item_id)
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS production_station_capacity_days (
+            event_date TEXT NOT NULL,
+            station_id TEXT NOT NULL,
+            capacity_units INTEGER NOT NULL CHECK (capacity_units >= 0),
+            unavailable INTEGER NOT NULL CHECK (unavailable IN (0, 1)),
+            PRIMARY KEY (event_date, station_id),
+            FOREIGN KEY (station_id) REFERENCES production_stations (station_id),
+            CHECK (unavailable = 0 OR capacity_units = 0)
+        )
+        """
+    )
+
+
+_MIGRATIONS = ((1, "production_capacity_v1", _migration_1_create_capacity_tables),)
+
+
+class SQLiteProductionCapacityRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "production_capacity", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> "SQLiteProductionCapacityRepository":
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._manage_transactions = False
+        apply_migrations(connection, "production_capacity", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def upsert_station(self, station: ProductionStation) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO production_stations (station_id, name, active)
+                VALUES (?, ?, ?)
+                ON CONFLICT(station_id) DO UPDATE SET
+                    name = excluded.name,
+                    active = excluded.active
+                """,
+                (station.station_id, station.name, int(station.active)),
+            )
+            if self._manage_transactions:
+                self._conn.commit()
+
+    def list_stations(self, *, active_only: bool = False) -> list[ProductionStation]:
+        where = "WHERE active = 1" if active_only else ""
+        rows = self._conn.execute(
+            f"""
+            SELECT station_id, name, active
+            FROM production_stations
+            {where}
+            ORDER BY station_id ASC
+            """
+        ).fetchall()
+        return [
+            ProductionStation(station_id=str(row[0]), name=str(row[1]), active=bool(row[2]))
+            for row in rows
+        ]
+
+    def set_catalog_requirement(self, requirement: CatalogStationRequirement) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO catalog_station_requirements (
+                    catalog_item_id, station_id, load_units_per_item
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(catalog_item_id, station_id) DO UPDATE SET
+                    load_units_per_item = excluded.load_units_per_item
+                """,
+                (
+                    requirement.catalog_item_id,
+                    requirement.station_id,
+                    requirement.load_units_per_item,
+                ),
+            )
+            if self._manage_transactions:
+                self._conn.commit()
+
+    def list_catalog_requirements(
+        self, catalog_item_id: str
+    ) -> list[CatalogStationRequirement]:
+        rows = self._conn.execute(
+            """
+            SELECT catalog_item_id, station_id, load_units_per_item
+            FROM catalog_station_requirements
+            WHERE catalog_item_id = ?
+            ORDER BY station_id ASC
+            """,
+            (catalog_item_id,),
+        ).fetchall()
+        return [
+            CatalogStationRequirement(
+                catalog_item_id=str(row[0]),
+                station_id=str(row[1]),
+                load_units_per_item=int(row[2]),
+            )
+            for row in rows
+        ]
+
+    def set_capacity_day(self, capacity: ProductionStationCapacityDay) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO production_station_capacity_days (
+                    event_date, station_id, capacity_units, unavailable
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT(event_date, station_id) DO UPDATE SET
+                    capacity_units = excluded.capacity_units,
+                    unavailable = excluded.unavailable
+                """,
+                (
+                    capacity.event_date.isoformat(),
+                    capacity.station_id,
+                    capacity.capacity_units,
+                    int(capacity.unavailable),
+                ),
+            )
+            if self._manage_transactions:
+                self._conn.commit()
+
+    def get_capacity_day(
+        self, event_date: date, station_id: str
+    ) -> ProductionStationCapacityDay | None:
+        row = self._conn.execute(
+            """
+            SELECT event_date, station_id, capacity_units, unavailable
+            FROM production_station_capacity_days
+            WHERE event_date = ? AND station_id = ?
+            """,
+            (event_date.isoformat(), station_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return ProductionStationCapacityDay(
+            event_date=date.fromisoformat(str(row[0])),
+            station_id=str(row[1]),
+            capacity_units=int(row[2]),
+            unavailable=bool(row[3]),
+        )

--- a/tests/unit/test_production_capacity_repository.py
+++ b/tests/unit/test_production_capacity_repository.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+
+import pytest
+
+from catering_system.domain.production_capacity import (
+    CatalogStationRequirement,
+    ProductionStation,
+    ProductionStationCapacityDay,
+)
+from catering_system.repositories.sqlite_production_capacity_repository import (
+    SQLiteProductionCapacityRepository,
+)
+
+
+def test_capacity_source_round_trips_explicit_facts(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    repo = SQLiteProductionCapacityRepository(db_path)
+    try:
+        repo.upsert_station(ProductionStation("cold-kitchen", "Kalte Küche"))
+        repo.set_catalog_requirement(
+            CatalogStationRequirement(
+                catalog_item_id="dish-1",
+                station_id="cold-kitchen",
+                load_units_per_item=3,
+            )
+        )
+        repo.set_capacity_day(
+            ProductionStationCapacityDay(
+                event_date=date(2026, 8, 31),
+                station_id="cold-kitchen",
+                capacity_units=240,
+            )
+        )
+
+        assert repo.list_stations(active_only=True) == [
+            ProductionStation("cold-kitchen", "Kalte Küche")
+        ]
+        assert repo.list_catalog_requirements("dish-1") == [
+            CatalogStationRequirement("dish-1", "cold-kitchen", 3)
+        ]
+        assert repo.get_capacity_day(date(2026, 8, 31), "cold-kitchen") == (
+            ProductionStationCapacityDay(
+                date(2026, 8, 31), "cold-kitchen", 240, unavailable=False
+            )
+        )
+    finally:
+        repo.close()
+
+
+def test_capacity_source_preserves_explicit_unavailable_day(tmp_path) -> None:
+    repo = SQLiteProductionCapacityRepository(tmp_path / "core.db")
+    try:
+        repo.upsert_station(ProductionStation("hot-kitchen", "Warme Küche"))
+        repo.set_capacity_day(
+            ProductionStationCapacityDay(
+                date(2026, 9, 1), "hot-kitchen", 0, unavailable=True
+            )
+        )
+        assert repo.get_capacity_day(date(2026, 9, 1), "hot-kitchen") == (
+            ProductionStationCapacityDay(
+                date(2026, 9, 1), "hot-kitchen", 0, unavailable=True
+            )
+        )
+    finally:
+        repo.close()
+
+
+def test_capacity_domain_rejects_fake_or_invalid_precision() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        CatalogStationRequirement("dish-1", "cold-kitchen", 0)
+    with pytest.raises(ValueError, match="non-negative"):
+        ProductionStationCapacityDay(date(2026, 8, 31), "cold-kitchen", -1)
+    with pytest.raises(ValueError, match="zero capacity"):
+        ProductionStationCapacityDay(
+            date(2026, 8, 31), "cold-kitchen", 10, unavailable=True
+        )
+
+
+def test_capacity_migration_is_registered_separately(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    repo = SQLiteProductionCapacityRepository(db_path)
+    repo.close()
+
+    connection = sqlite3.connect(db_path)
+    try:
+        row = connection.execute(
+            """
+            SELECT version, name
+            FROM schema_migrations
+            WHERE component = 'production_capacity'
+            """
+        ).fetchone()
+        assert row == (1, "production_capacity_v1")
+    finally:
+        connection.close()


### PR DESCRIPTION
Implements the first persistence slice for #163 / #162.

Scope:
- explicit `ProductionStation`, `CatalogStationRequirement`, and date-scoped `ProductionStationCapacityDay` domain facts
- dedicated SQLite migration/component `production_capacity`
- tables for stations, catalog-to-station load requirements, and per-day capacity/unavailable state
- deterministic validation, including positive load units and fail-closed unavailable capacity semantics
- focused repository/migration tests

Deliberately not included yet:
- `/office/v1/recommendation-capacity`
- Configurator scoring integration
- any capacity inferred from order counts or AI

This establishes the source of truth required before #162 can expose capacity to #151.