### PR TITLE
CAP-2: add deterministic recommendation capacity projection

### DIFF
--- a/src/catering_system/repositories/sqlite_production_capacity_repository.py
+++ b/src/catering_system/repositories/sqlite_production_capacity_repository.py
@@ -199,7 +199,9 @@ class SQLiteProductionCapacityRepository:
             unavailable=bool(row[3]),
         )
 
-    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
+    def list_capacity_days(
+        self, event_date: date
+    ) -> list[ProductionStationCapacityDay]:
         rows = self._conn.execute(
             """
             SELECT event_date, station_id, capacity_units, unavailable

--- a/src/catering_system/repositories/sqlite_production_capacity_repository.py
+++ b/src/catering_system/repositories/sqlite_production_capacity_repository.py
@@ -198,3 +198,23 @@ class SQLiteProductionCapacityRepository:
             capacity_units=int(row[2]),
             unavailable=bool(row[3]),
         )
+
+    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
+        rows = self._conn.execute(
+            """
+            SELECT event_date, station_id, capacity_units, unavailable
+            FROM production_station_capacity_days
+            WHERE event_date = ?
+            ORDER BY station_id ASC
+            """,
+            (event_date.isoformat(),),
+        ).fetchall()
+        return [
+            ProductionStationCapacityDay(
+                event_date=date.fromisoformat(str(row[0])),
+                station_id=str(row[1]),
+                capacity_units=int(row[2]),
+                unavailable=bool(row[3]),
+            )
+            for row in rows
+        ]

--- a/src/catering_system/services/recommendation_capacity_service.py
+++ b/src/catering_system/services/recommendation_capacity_service.py
@@ -62,7 +62,6 @@ class RecommendationCapacityService:
             for item in self._capacity.list_capacity_days(event_date)
         }
         used_by_station: dict[str, int] = {}
-        unknown_stations: set[str] = set()
         global_demand_unknown = False
 
         for order in self._orders.list_orders():
@@ -110,9 +109,6 @@ class RecommendationCapacityService:
                 station = stations.get(requirement.station_id)
                 if station is None or not station.active:
                     blocked_reason = "STATION_INACTIVE"
-                    break
-                if requirement.station_id in unknown_stations:
-                    blocked_reason = "DEMAND_SOURCE_INCOMPLETE"
                     break
                 capacity_day = capacity_days.get(requirement.station_id)
                 if capacity_day is None:

--- a/src/catering_system/services/recommendation_capacity_service.py
+++ b/src/catering_system/services/recommendation_capacity_service.py
@@ -1,0 +1,173 @@
+"""PII-free deterministic production-capacity read model for recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.repositories.catalog_repository import CatalogRepository
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
+    SQLiteOrderCommercialSnapshotRepository,
+)
+from catering_system.repositories.sqlite_production_capacity_repository import (
+    SQLiteProductionCapacityRepository,
+)
+
+CapacityReasonCode = Literal[
+    "MISSING_STATION_REQUIREMENT",
+    "STATION_INACTIVE",
+    "CAPACITY_UNSET",
+    "STATION_UNAVAILABLE",
+    "NO_CAPACITY",
+    "CAPACITY_EXHAUSTED",
+    "DEMAND_SOURCE_INCOMPLETE",
+]
+
+
+@dataclass(frozen=True)
+class RecommendationCapacityRow:
+    catalog_item_id: str
+    feasible: bool
+    overload_penalty: int
+    reason_code: CapacityReasonCode | None = None
+
+
+class RecommendationCapacityService:
+    """Project explicit station facts plus accepted/confirmed demand into item rows.
+
+    Sent/open offers are deliberately excluded from capacity consumption. They are a
+    weak production-overlap signal, not committed kitchen load.
+    """
+
+    def __init__(
+        self,
+        catalog: CatalogRepository,
+        capacity: SQLiteProductionCapacityRepository,
+        orders: OrderRepository,
+        commercial_snapshots: SQLiteOrderCommercialSnapshotRepository,
+    ) -> None:
+        self._catalog = catalog
+        self._capacity = capacity
+        self._orders = orders
+        self._commercial_snapshots = commercial_snapshots
+
+    def list_for_date(self, event_date: date) -> tuple[RecommendationCapacityRow, ...]:
+        stations = {item.station_id: item for item in self._capacity.list_stations()}
+        capacity_days = {
+            item.station_id: item
+            for item in self._capacity.list_capacity_days(event_date)
+        }
+        used_by_station: dict[str, int] = {}
+        unknown_stations: set[str] = set()
+        global_demand_unknown = False
+
+        for order in self._orders.list_orders():
+            if order.cancelled_at is not None:
+                continue
+            version = self._target_order_version(order)
+            if version is None or version.event_date != event_date:
+                continue
+            snapshot = self._commercial_snapshots.get_by_order_id(order.order_id)
+            if snapshot is None:
+                global_demand_unknown = True
+                continue
+            for position in snapshot.positions:
+                if position.kind != "catalog" or position.catalog_item_id is None:
+                    continue
+                quantity = self._whole_quantity(position.quantity)
+                requirements = self._capacity.list_catalog_requirements(
+                    position.catalog_item_id
+                )
+                if quantity is None or not requirements:
+                    global_demand_unknown = True
+                    continue
+                for requirement in requirements:
+                    if requirement.station_id not in stations:
+                        global_demand_unknown = True
+                        continue
+                    used_by_station[requirement.station_id] = (
+                        used_by_station.get(requirement.station_id, 0)
+                        + quantity * requirement.load_units_per_item
+                    )
+
+        rows: list[RecommendationCapacityRow] = []
+        for dish in self._catalog.list_dishes(active=True, limit=10_000):
+            requirements = self._capacity.list_catalog_requirements(dish.dish_id)
+            if not requirements:
+                rows.append(self._blocked(dish.dish_id, "MISSING_STATION_REQUIREMENT"))
+                continue
+            if global_demand_unknown:
+                rows.append(self._blocked(dish.dish_id, "DEMAND_SOURCE_INCOMPLETE"))
+                continue
+
+            penalty = 0
+            blocked_reason: CapacityReasonCode | None = None
+            for requirement in requirements:
+                station = stations.get(requirement.station_id)
+                if station is None or not station.active:
+                    blocked_reason = "STATION_INACTIVE"
+                    break
+                if requirement.station_id in unknown_stations:
+                    blocked_reason = "DEMAND_SOURCE_INCOMPLETE"
+                    break
+                capacity_day = capacity_days.get(requirement.station_id)
+                if capacity_day is None:
+                    blocked_reason = "CAPACITY_UNSET"
+                    break
+                if capacity_day.unavailable:
+                    blocked_reason = "STATION_UNAVAILABLE"
+                    break
+                if capacity_day.capacity_units == 0:
+                    blocked_reason = "NO_CAPACITY"
+                    break
+                used = used_by_station.get(requirement.station_id, 0)
+                if used >= capacity_day.capacity_units:
+                    blocked_reason = "CAPACITY_EXHAUSTED"
+                    break
+                penalty = max(
+                    penalty,
+                    min(100, (used * 100) // capacity_day.capacity_units),
+                )
+
+            if blocked_reason is not None:
+                rows.append(self._blocked(dish.dish_id, blocked_reason))
+            else:
+                rows.append(
+                    RecommendationCapacityRow(
+                        catalog_item_id=dish.dish_id,
+                        feasible=True,
+                        overload_penalty=penalty,
+                    )
+                )
+
+        return tuple(sorted(rows, key=lambda row: row.catalog_item_id))
+
+    def _target_order_version(self, order: Order) -> OrderVersion | None:
+        target_id = order.effective_order_version_id or order.candidate_order_version_id
+        if target_id is not None:
+            version = self._orders.get_order_version(target_id)
+            if version is not None and version.order_id == order.order_id:
+                return version
+        versions = self._orders.list_order_versions(order.order_id)
+        return max(versions, key=lambda item: item.version_number, default=None)
+
+    @staticmethod
+    def _whole_quantity(value: Decimal | None) -> int | None:
+        if value is None or value < 0 or value != value.to_integral_value():
+            return None
+        return int(value)
+
+    @staticmethod
+    def _blocked(
+        catalog_item_id: str, reason_code: CapacityReasonCode
+    ) -> RecommendationCapacityRow:
+        return RecommendationCapacityRow(
+            catalog_item_id=catalog_item_id,
+            feasible=False,
+            overload_penalty=100,
+            reason_code=reason_code,
+        )

--- a/tests/unit/test_issue162_capacity_coverage.py
+++ b/tests/unit/test_issue162_capacity_coverage.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date
-from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -45,14 +44,12 @@ def test_sqlite_capacity_repository_roundtrip_and_filters(tmp_path) -> None:
     try:
         repo.upsert_station(ProductionStation("cold", "Cold", active=True))
         repo.upsert_station(ProductionStation("hot", "Hot", active=False))
-        assert [
-            station.station_id for station in repo.list_stations(active_only=True)
-        ] == ["cold"]
+        active = repo.list_stations(active_only=True)
+        assert [station.station_id for station in active] == ["cold"]
 
-        repo.set_catalog_requirement(CatalogStationRequirement("dish", "cold", 2))
-        assert repo.list_catalog_requirements("dish") == [
-            CatalogStationRequirement("dish", "cold", 2)
-        ]
+        requirement = CatalogStationRequirement("dish", "cold", 2)
+        repo.set_catalog_requirement(requirement)
+        assert repo.list_catalog_requirements("dish") == [requirement]
 
         capacity = ProductionStationCapacityDay(EVENT_DATE, "cold", 50)
         repo.set_capacity_day(capacity)
@@ -64,178 +61,76 @@ def test_sqlite_capacity_repository_roundtrip_and_filters(tmp_path) -> None:
 
 
 class _Catalog:
-    def __init__(self, *dish_ids: str) -> None:
-        self._dish_ids = dish_ids
-
     def list_dishes(self, **_kwargs: object) -> list[SimpleNamespace]:
-        return [SimpleNamespace(dish_id=dish_id) for dish_id in self._dish_ids]
+        return [SimpleNamespace(dish_id="dish")]
 
 
 class _Capacity:
     def __init__(
         self,
-        requirements: dict[str, list[CatalogStationRequirement]],
-        stations: list[ProductionStation],
-        days: list[ProductionStationCapacityDay],
+        station: ProductionStation,
+        capacity: ProductionStationCapacityDay | None,
     ) -> None:
-        self.requirements = requirements
-        self.stations = stations
-        self.days = days
+        self.station = station
+        self.capacity = capacity
 
     def list_stations(self) -> list[ProductionStation]:
-        return self.stations
+        return [self.station]
 
     def list_capacity_days(
         self, _event_date: date
     ) -> list[ProductionStationCapacityDay]:
-        return self.days
+        if self.capacity is None:
+            return []
+        return [self.capacity]
 
     def list_catalog_requirements(
         self, catalog_item_id: str
     ) -> list[CatalogStationRequirement]:
-        return self.requirements.get(catalog_item_id, [])
+        return [CatalogStationRequirement(catalog_item_id, "cold", 1)]
 
 
 class _Orders:
-    def __init__(self, orders: list[SimpleNamespace]) -> None:
-        self.orders = orders
-
-    def list_orders(self) -> list[SimpleNamespace]:
-        return self.orders
-
-    def get_order_version(self, version_id: str) -> SimpleNamespace | None:
-        for order in self.orders:
-            version = getattr(order, "version", None)
-            if version is not None and version.order_version_id == version_id:
-                return version
-        return None
-
-    def list_order_versions(self, order_id: str) -> list[SimpleNamespace]:
-        return [
-            order.version
-            for order in self.orders
-            if order.order_id == order_id and getattr(order, "version", None) is not None
-        ]
+    def list_orders(self) -> list[object]:
+        return []
 
 
-class _Snapshots:
-    def __init__(self, values: dict[str, SimpleNamespace]) -> None:
-        self.values = values
-
-    def get_by_order_id(self, order_id: str) -> SimpleNamespace | None:
-        return self.values.get(order_id)
-
-
-def _service(
-    *,
-    requirements: dict[str, list[CatalogStationRequirement]],
-    stations: list[ProductionStation],
-    days: list[ProductionStationCapacityDay],
-    orders: list[SimpleNamespace] | None = None,
-    snapshots: dict[str, SimpleNamespace] | None = None,
-) -> RecommendationCapacityService:
-    return RecommendationCapacityService(  # type: ignore[arg-type]
-        _Catalog("dish"),
-        _Capacity(requirements, stations, days),
-        _Orders(orders or []),
-        _Snapshots(snapshots or {}),
+def _row(
+    station: ProductionStation,
+    capacity: ProductionStationCapacityDay | None,
+):
+    service = RecommendationCapacityService(  # type: ignore[arg-type]
+        _Catalog(),
+        _Capacity(station, capacity),
+        _Orders(),
+        object(),
     )
+    return service.list_for_date(EVENT_DATE)[0]
 
 
-def test_capacity_blocks_inactive_unavailable_and_zero_capacity() -> None:
-    requirement = CatalogStationRequirement("dish", "cold", 1)
-
-    inactive = _service(
-        requirements={"dish": [requirement]},
-        stations=[ProductionStation("cold", "Cold", active=False)],
-        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
-    ).list_for_date(EVENT_DATE)[0]
-    assert inactive.reason_code == "STATION_INACTIVE"
-
-    unavailable = _service(
-        requirements={"dish": [requirement]},
-        stations=[ProductionStation("cold", "Cold")],
-        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 0, unavailable=True)],
-    ).list_for_date(EVENT_DATE)[0]
-    assert unavailable.reason_code == "STATION_UNAVAILABLE"
-
-    zero = _service(
-        requirements={"dish": [requirement]},
-        stations=[ProductionStation("cold", "Cold")],
-        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 0)],
-    ).list_for_date(EVENT_DATE)[0]
-    assert zero.reason_code == "NO_CAPACITY"
+def test_capacity_blocks_inactive_station() -> None:
+    station = ProductionStation("cold", "Cold", active=False)
+    capacity = ProductionStationCapacityDay(EVENT_DATE, "cold", 10)
+    assert _row(station, capacity).reason_code == "STATION_INACTIVE"
 
 
-def test_capacity_ignores_cancelled_and_non_catalog_positions() -> None:
-    requirement = CatalogStationRequirement("dish", "cold", 1)
-    version = SimpleNamespace(
-        order_id="o1",
-        order_version_id="v1",
-        version_number=1,
-        event_date=EVENT_DATE,
+def test_capacity_blocks_missing_day_capacity() -> None:
+    station = ProductionStation("cold", "Cold")
+    assert _row(station, None).reason_code == "CAPACITY_UNSET"
+
+
+def test_capacity_blocks_unavailable_station() -> None:
+    station = ProductionStation("cold", "Cold")
+    capacity = ProductionStationCapacityDay(
+        EVENT_DATE,
+        "cold",
+        0,
+        unavailable=True,
     )
-    cancelled = SimpleNamespace(
-        order_id="o1",
-        cancelled_at=object(),
-        effective_order_version_id="v1",
-        candidate_order_version_id="v1",
-        version=version,
-    )
-    row = _service(
-        requirements={"dish": [requirement]},
-        stations=[ProductionStation("cold", "Cold")],
-        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
-        orders=[cancelled],
-        snapshots={
-            "o1": SimpleNamespace(
-                positions=(
-                    SimpleNamespace(kind="text", catalog_item_id=None, quantity=None),
-                )
-            )
-        },
-    ).list_for_date(EVENT_DATE)[0]
-    assert row.feasible is True
-    assert row.overload_penalty == 0
+    assert _row(station, capacity).reason_code == "STATION_UNAVAILABLE"
 
 
-def test_capacity_fails_closed_for_missing_snapshot_and_invalid_quantity() -> None:
-    requirement = CatalogStationRequirement("dish", "cold", 1)
-    version = SimpleNamespace(
-        order_id="o1",
-        order_version_id="v1",
-        version_number=1,
-        event_date=EVENT_DATE,
-    )
-    order = SimpleNamespace(
-        order_id="o1",
-        cancelled_at=None,
-        effective_order_version_id="v1",
-        candidate_order_version_id="v1",
-        version=version,
-    )
-    base = dict(
-        requirements={"dish": [requirement]},
-        stations=[ProductionStation("cold", "Cold")],
-        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
-        orders=[order],
-    )
-
-    missing_snapshot = _service(**base).list_for_date(EVENT_DATE)[0]
-    assert missing_snapshot.reason_code == "DEMAND_SOURCE_INCOMPLETE"
-
-    invalid_quantity = _service(
-        **base,
-        snapshots={
-            "o1": SimpleNamespace(
-                positions=(
-                    SimpleNamespace(
-                        kind="catalog",
-                        catalog_item_id="dish",
-                        quantity=Decimal("1.5"),
-                    ),
-                )
-            )
-        },
-    ).list_for_date(EVENT_DATE)[0]
-    assert invalid_quantity.reason_code == "DEMAND_SOURCE_INCOMPLETE"
+def test_capacity_blocks_zero_capacity() -> None:
+    station = ProductionStation("cold", "Cold")
+    capacity = ProductionStationCapacityDay(EVENT_DATE, "cold", 0)
+    assert _row(station, capacity).reason_code == "NO_CAPACITY"

--- a/tests/unit/test_issue162_capacity_coverage.py
+++ b/tests/unit/test_issue162_capacity_coverage.py
@@ -45,9 +45,9 @@ def test_sqlite_capacity_repository_roundtrip_and_filters(tmp_path) -> None:
     try:
         repo.upsert_station(ProductionStation("cold", "Cold", active=True))
         repo.upsert_station(ProductionStation("hot", "Hot", active=False))
-        assert [station.station_id for station in repo.list_stations(active_only=True)] == [
-            "cold"
-        ]
+        assert [
+            station.station_id for station in repo.list_stations(active_only=True)
+        ] == ["cold"]
 
         repo.set_catalog_requirement(CatalogStationRequirement("dish", "cold", 2))
         assert repo.list_catalog_requirements("dish") == [
@@ -85,7 +85,9 @@ class _Capacity:
     def list_stations(self) -> list[ProductionStation]:
         return self.stations
 
-    def list_capacity_days(self, _event_date: date) -> list[ProductionStationCapacityDay]:
+    def list_capacity_days(
+        self, _event_date: date
+    ) -> list[ProductionStationCapacityDay]:
         return self.days
 
     def list_catalog_requirements(
@@ -187,7 +189,9 @@ def test_capacity_ignores_cancelled_and_non_catalog_positions() -> None:
         orders=[cancelled],
         snapshots={
             "o1": SimpleNamespace(
-                positions=(SimpleNamespace(kind="text", catalog_item_id=None, quantity=None),)
+                positions=(
+                    SimpleNamespace(kind="text", catalog_item_id=None, quantity=None),
+                )
             )
         },
     ).list_for_date(EVENT_DATE)[0]

--- a/tests/unit/test_issue162_capacity_coverage.py
+++ b/tests/unit/test_issue162_capacity_coverage.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from catering_system.domain.production_capacity import (
+    CatalogStationRequirement,
+    ProductionStation,
+    ProductionStationCapacityDay,
+)
+from catering_system.repositories.sqlite_production_capacity_repository import (
+    SQLiteProductionCapacityRepository,
+)
+from catering_system.services.recommendation_capacity_service import (
+    RecommendationCapacityService,
+)
+
+EVENT_DATE = date(2026, 8, 31)
+
+
+def test_capacity_domain_rejects_invalid_facts() -> None:
+    with pytest.raises(ValueError):
+        ProductionStation(" ", "Cold")
+    with pytest.raises(ValueError):
+        ProductionStation("cold", " ")
+    with pytest.raises(ValueError):
+        CatalogStationRequirement(" ", "cold", 1)
+    with pytest.raises(ValueError):
+        CatalogStationRequirement("dish", " ", 1)
+    with pytest.raises(ValueError):
+        CatalogStationRequirement("dish", "cold", 0)
+    with pytest.raises(ValueError):
+        ProductionStationCapacityDay(EVENT_DATE, " ", 1)
+    with pytest.raises(ValueError):
+        ProductionStationCapacityDay(EVENT_DATE, "cold", -1)
+    with pytest.raises(ValueError):
+        ProductionStationCapacityDay(EVENT_DATE, "cold", 1, unavailable=True)
+
+
+def test_sqlite_capacity_repository_roundtrip_and_filters(tmp_path) -> None:
+    repo = SQLiteProductionCapacityRepository(tmp_path / "capacity.db")
+    try:
+        repo.upsert_station(ProductionStation("cold", "Cold", active=True))
+        repo.upsert_station(ProductionStation("hot", "Hot", active=False))
+        assert [station.station_id for station in repo.list_stations(active_only=True)] == [
+            "cold"
+        ]
+
+        repo.set_catalog_requirement(CatalogStationRequirement("dish", "cold", 2))
+        assert repo.list_catalog_requirements("dish") == [
+            CatalogStationRequirement("dish", "cold", 2)
+        ]
+
+        capacity = ProductionStationCapacityDay(EVENT_DATE, "cold", 50)
+        repo.set_capacity_day(capacity)
+        assert repo.get_capacity_day(EVENT_DATE, "cold") == capacity
+        assert repo.get_capacity_day(EVENT_DATE, "missing") is None
+        assert repo.list_capacity_days(EVENT_DATE) == [capacity]
+    finally:
+        repo.close()
+
+
+class _Catalog:
+    def __init__(self, *dish_ids: str) -> None:
+        self._dish_ids = dish_ids
+
+    def list_dishes(self, **_kwargs: object) -> list[SimpleNamespace]:
+        return [SimpleNamespace(dish_id=dish_id) for dish_id in self._dish_ids]
+
+
+class _Capacity:
+    def __init__(
+        self,
+        requirements: dict[str, list[CatalogStationRequirement]],
+        stations: list[ProductionStation],
+        days: list[ProductionStationCapacityDay],
+    ) -> None:
+        self.requirements = requirements
+        self.stations = stations
+        self.days = days
+
+    def list_stations(self) -> list[ProductionStation]:
+        return self.stations
+
+    def list_capacity_days(self, _event_date: date) -> list[ProductionStationCapacityDay]:
+        return self.days
+
+    def list_catalog_requirements(
+        self, catalog_item_id: str
+    ) -> list[CatalogStationRequirement]:
+        return self.requirements.get(catalog_item_id, [])
+
+
+class _Orders:
+    def __init__(self, orders: list[SimpleNamespace]) -> None:
+        self.orders = orders
+
+    def list_orders(self) -> list[SimpleNamespace]:
+        return self.orders
+
+    def get_order_version(self, version_id: str) -> SimpleNamespace | None:
+        for order in self.orders:
+            version = getattr(order, "version", None)
+            if version is not None and version.order_version_id == version_id:
+                return version
+        return None
+
+    def list_order_versions(self, order_id: str) -> list[SimpleNamespace]:
+        return [
+            order.version
+            for order in self.orders
+            if order.order_id == order_id and getattr(order, "version", None) is not None
+        ]
+
+
+class _Snapshots:
+    def __init__(self, values: dict[str, SimpleNamespace]) -> None:
+        self.values = values
+
+    def get_by_order_id(self, order_id: str) -> SimpleNamespace | None:
+        return self.values.get(order_id)
+
+
+def _service(
+    *,
+    requirements: dict[str, list[CatalogStationRequirement]],
+    stations: list[ProductionStation],
+    days: list[ProductionStationCapacityDay],
+    orders: list[SimpleNamespace] | None = None,
+    snapshots: dict[str, SimpleNamespace] | None = None,
+) -> RecommendationCapacityService:
+    return RecommendationCapacityService(  # type: ignore[arg-type]
+        _Catalog("dish"),
+        _Capacity(requirements, stations, days),
+        _Orders(orders or []),
+        _Snapshots(snapshots or {}),
+    )
+
+
+def test_capacity_blocks_inactive_unavailable_and_zero_capacity() -> None:
+    requirement = CatalogStationRequirement("dish", "cold", 1)
+
+    inactive = _service(
+        requirements={"dish": [requirement]},
+        stations=[ProductionStation("cold", "Cold", active=False)],
+        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
+    ).list_for_date(EVENT_DATE)[0]
+    assert inactive.reason_code == "STATION_INACTIVE"
+
+    unavailable = _service(
+        requirements={"dish": [requirement]},
+        stations=[ProductionStation("cold", "Cold")],
+        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 0, unavailable=True)],
+    ).list_for_date(EVENT_DATE)[0]
+    assert unavailable.reason_code == "STATION_UNAVAILABLE"
+
+    zero = _service(
+        requirements={"dish": [requirement]},
+        stations=[ProductionStation("cold", "Cold")],
+        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 0)],
+    ).list_for_date(EVENT_DATE)[0]
+    assert zero.reason_code == "NO_CAPACITY"
+
+
+def test_capacity_ignores_cancelled_and_non_catalog_positions() -> None:
+    requirement = CatalogStationRequirement("dish", "cold", 1)
+    version = SimpleNamespace(
+        order_id="o1",
+        order_version_id="v1",
+        version_number=1,
+        event_date=EVENT_DATE,
+    )
+    cancelled = SimpleNamespace(
+        order_id="o1",
+        cancelled_at=object(),
+        effective_order_version_id="v1",
+        candidate_order_version_id="v1",
+        version=version,
+    )
+    row = _service(
+        requirements={"dish": [requirement]},
+        stations=[ProductionStation("cold", "Cold")],
+        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
+        orders=[cancelled],
+        snapshots={
+            "o1": SimpleNamespace(
+                positions=(SimpleNamespace(kind="text", catalog_item_id=None, quantity=None),)
+            )
+        },
+    ).list_for_date(EVENT_DATE)[0]
+    assert row.feasible is True
+    assert row.overload_penalty == 0
+
+
+def test_capacity_fails_closed_for_missing_snapshot_and_invalid_quantity() -> None:
+    requirement = CatalogStationRequirement("dish", "cold", 1)
+    version = SimpleNamespace(
+        order_id="o1",
+        order_version_id="v1",
+        version_number=1,
+        event_date=EVENT_DATE,
+    )
+    order = SimpleNamespace(
+        order_id="o1",
+        cancelled_at=None,
+        effective_order_version_id="v1",
+        candidate_order_version_id="v1",
+        version=version,
+    )
+    base = dict(
+        requirements={"dish": [requirement]},
+        stations=[ProductionStation("cold", "Cold")],
+        days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 10)],
+        orders=[order],
+    )
+
+    missing_snapshot = _service(**base).list_for_date(EVENT_DATE)[0]
+    assert missing_snapshot.reason_code == "DEMAND_SOURCE_INCOMPLETE"
+
+    invalid_quantity = _service(
+        **base,
+        snapshots={
+            "o1": SimpleNamespace(
+                positions=(
+                    SimpleNamespace(
+                        kind="catalog",
+                        catalog_item_id="dish",
+                        quantity=Decimal("1.5"),
+                    ),
+                )
+            )
+        },
+    ).list_for_date(EVENT_DATE)[0]
+    assert invalid_quantity.reason_code == "DEMAND_SOURCE_INCOMPLETE"

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -39,11 +39,11 @@ def _version(order_id: str, version_id: str) -> SimpleNamespace:
     )
 
 
-def _position(catalog_item_id: str, quantity: str) -> SimpleNamespace:
+def _position(catalog_item_id: str, quantity: str | None) -> SimpleNamespace:
     return SimpleNamespace(
         kind="catalog",
         catalog_item_id=catalog_item_id,
-        quantity=Decimal(quantity),
+        quantity=None if quantity is None else Decimal(quantity),
     )
 
 
@@ -208,3 +208,129 @@ def test_capacity_fails_closed_for_missing_station_requirement() -> None:
 
     assert row.feasible is False
     assert row.reason_code == "MISSING_STATION_REQUIREMENT"
+
+
+def test_cancelled_order_does_not_consume_capacity() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    order = _order("order-1", "version-1")
+    order.cancelled_at = object()
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={"order-1": _snapshot(_position("dish-a", "100"))},
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is True
+    assert row.overload_penalty == 0
+
+
+def test_capacity_fails_closed_when_committed_snapshot_is_missing() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    order = _order("order-1", "version-1")
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={},
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "DEMAND_SOURCE_INCOMPLETE"
+
+
+def test_capacity_fails_closed_when_committed_quantity_is_not_whole() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    order = _order("order-1", "version-1")
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={"order-1": _snapshot(_position("dish-a", "1.5"))},
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "DEMAND_SOURCE_INCOMPLETE"
+
+
+def test_capacity_blocks_inactive_station() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
+        stations=[ProductionStation("cold", "Kalte Küche", active=False)],
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "STATION_INACTIVE"
+
+
+def test_capacity_blocks_unavailable_station() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 0, unavailable=True)],
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "STATION_UNAVAILABLE"
+
+
+def test_capacity_blocks_zero_station_capacity() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 0)],
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "NO_CAPACITY"
+
+
+def test_capacity_falls_back_to_latest_order_version() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    order = SimpleNamespace(
+        order_id="order-1",
+        cancelled_at=None,
+        effective_order_version_id=None,
+        candidate_order_version_id=None,
+    )
+    older = SimpleNamespace(
+        order_id="order-1",
+        order_version_id="version-1",
+        version_number=1,
+        event_date=date(2026, 8, 30),
+    )
+    latest = SimpleNamespace(
+        order_id="order-1",
+        order_version_id="version-2",
+        version_number=2,
+        event_date=EVENT_DATE,
+    )
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": older, "version-2": latest},
+        snapshots={"order-1": _snapshot(_position("dish-a", "10"))},
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is True
+    assert row.overload_penalty == 10

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+from catering_system.domain.production_capacity import (
+    CatalogStationRequirement,
+    ProductionStation,
+    ProductionStationCapacityDay,
+)
+from catering_system.services.recommendation_capacity_service import (
+    RecommendationCapacityService,
+)
+
+EVENT_DATE = date(2026, 8, 31)
+
+
+def _dish(dish_id: str) -> SimpleNamespace:
+    return SimpleNamespace(dish_id=dish_id)
+
+
+def _order(order_id: str, version_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        order_id=order_id,
+        cancelled_at=None,
+        effective_order_version_id=version_id,
+        candidate_order_version_id=version_id,
+    )
+
+
+def _version(order_id: str, version_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        order_id=order_id,
+        order_version_id=version_id,
+        version_number=1,
+        event_date=EVENT_DATE,
+    )
+
+
+def _position(catalog_item_id: str, quantity: Decimal | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind="catalog",
+        catalog_item_id=catalog_item_id,
+        quantity=quantity,
+    )
+
+
+class _Catalog:
+    def __init__(self, *dish_ids: str) -> None:
+        self._dishes = [_dish(dish_id) for dish_id in dish_ids]
+
+    def list_dishes(self, **_kwargs: object) -> list[SimpleNamespace]:
+        return self._dishes
+
+
+class _Capacity:
+    def __init__(
+        self,
+        *,
+        requirements: dict[str, list[CatalogStationRequirement]],
+        capacity_days: list[ProductionStationCapacityDay],
+        stations: list[ProductionStation] | None = None,
+    ) -> None:
+        self._requirements = requirements
+        self._capacity_days = capacity_days
+        self._stations = stations or [ProductionStation("cold", "Kalte Küche")]
+
+    def list_stations(self) -> list[ProductionStation]:
+        return self._stations
+
+    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
+        assert event_date == EVENT_DATE
+        return self._capacity_days
+
+    def list_catalog_requirements(
+        self, catalog_item_id: str
+    ) -> list[CatalogStationRequirement]:
+        return self._requirements.get(catalog_item_id, [])
+
+
+class _Orders:
+    def __init__(
+        self,
+        orders: list[SimpleNamespace],
+        versions: dict[str, SimpleNamespace],
+    ) -> None:
+        self._orders = orders
+        self._versions = versions
+
+    def list_orders(self) -> list[SimpleNamespace]:
+        return self._orders
+
+    def get_order_version(self, version_id: str) -> SimpleNamespace | None:
+        return self._versions.get(version_id)
+
+    def list_order_versions(self, order_id: str) -> list[SimpleNamespace]:
+        return [
+            version
+            for version in self._versions.values()
+            if version.order_id == order_id
+        ]
+
+
+class _Snapshots:
+    def __init__(self, snapshots: dict[str, SimpleNamespace]) -> None:
+        self._snapshots = snapshots
+
+    def get_by_order_id(self, order_id: str) -> SimpleNamespace | None:
+        return self._snapshots.get(order_id)
+
+
+def _service(
+    *,
+    dish_ids: tuple[str, ...] = ("dish-a",),
+    requirements: dict[str, list[CatalogStationRequirement]],
+    capacity_days: list[ProductionStationCapacityDay],
+    orders: list[SimpleNamespace] | None = None,
+    versions: dict[str, SimpleNamespace] | None = None,
+    snapshots: dict[str, SimpleNamespace] | None = None,
+    stations: list[ProductionStation] | None = None,
+) -> RecommendationCapacityService:
+    return RecommendationCapacityService(  # type: ignore[arg-type]
+        _Catalog(*dish_ids),
+        _Capacity(
+            requirements=requirements,
+            capacity_days=capacity_days,
+            stations=stations,
+        ),
+        _Orders(orders or [], versions or {}),
+        _Snapshots(snapshots or {}),
+    )
+
+
+def test_capacity_penalty_uses_committed_order_load() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
+    order = _order("order-1", "version-1")
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={
+            "order-1": SimpleNamespace(
+                positions=(_position("dish-a", Decimal("40")),)
+            )
+        },
+    )
+
+    rows = service.list_for_date(EVENT_DATE)
+
+    assert len(rows) == 1
+    assert rows[0].catalog_item_id == "dish-a"
+    assert rows[0].feasible is True
+    assert rows[0].overload_penalty == 40
+    assert rows[0].reason_code is None
+
+
+def test_capacity_fails_closed_when_capacity_day_missing() -> None:
+    service = _service(
+        requirements={
+            "dish-a": [CatalogStationRequirement("dish-a", "cold", 1)]
+        },
+        capacity_days=[],
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.overload_penalty == 100
+    assert row.reason_code == "CAPACITY_UNSET"
+
+
+def test_capacity_exhausted_when_committed_load_reaches_limit() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 2)
+    order = _order("order-1", "version-1")
+    service = _service(
+        requirements={"dish-a": [requirement]},
+        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 20)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={
+            "order-1": SimpleNamespace(
+                positions=(_position("dish-a", Decimal("10")),)
+            )
+        },
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "CAPACITY_EXHAUSTED"
+
+
+def test_capacity_fails_closed_when_existing_demand_cannot_be_accounted() -> None:
+    order = _order("order-1", "version-1")
+    service = _service(
+        dish_ids=("candidate",),
+        requirements={
+            "candidate": [CatalogStationRequirement("candidate", "cold", 1)]
+        },
+        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 100)],
+        orders=[order],
+        versions={"version-1": _version("order-1", "version-1")},
+        snapshots={
+            "order-1": SimpleNamespace(
+                positions=(_position("legacy-unmapped", Decimal("10")),)
+            )
+        },
+    )
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "DEMAND_SOURCE_INCOMPLETE"
+
+
+def test_capacity_fails_closed_for_missing_station_requirement() -> None:
+    service = _service(requirements={}, capacity_days=[])
+
+    row = service.list_for_date(EVENT_DATE)[0]
+
+    assert row.feasible is False
+    assert row.reason_code == "MISSING_STATION_REQUIREMENT"

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -14,6 +14,7 @@ from catering_system.services.recommendation_capacity_service import (
 )
 
 EVENT_DATE = date(2026, 8, 31)
+CapacityDay = ProductionStationCapacityDay
 
 
 def _dish(dish_id: str) -> SimpleNamespace:
@@ -38,12 +39,16 @@ def _version(order_id: str, version_id: str) -> SimpleNamespace:
     )
 
 
-def _position(catalog_item_id: str, quantity: Decimal | None) -> SimpleNamespace:
+def _position(catalog_item_id: str, quantity: str) -> SimpleNamespace:
     return SimpleNamespace(
         kind="catalog",
         catalog_item_id=catalog_item_id,
-        quantity=quantity,
+        quantity=Decimal(quantity),
     )
+
+
+def _snapshot(*positions: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(positions=positions)
 
 
 class _Catalog:
@@ -57,9 +62,8 @@ class _Catalog:
 class _Capacity:
     def __init__(
         self,
-        *,
         requirements: dict[str, list[CatalogStationRequirement]],
-        capacity_days: list[ProductionStationCapacityDay],
+        capacity_days: list[CapacityDay],
         stations: list[ProductionStation] | None = None,
     ) -> None:
         self._requirements = requirements
@@ -69,7 +73,7 @@ class _Capacity:
     def list_stations(self) -> list[ProductionStation]:
         return self._stations
 
-    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
+    def list_capacity_days(self, event_date: date) -> list[CapacityDay]:
         assert event_date == EVENT_DATE
         return self._capacity_days
 
@@ -114,19 +118,16 @@ def _service(
     *,
     dish_ids: tuple[str, ...] = ("dish-a",),
     requirements: dict[str, list[CatalogStationRequirement]],
-    capacity_days: list[ProductionStationCapacityDay],
+    capacity_days: list[CapacityDay],
     orders: list[SimpleNamespace] | None = None,
     versions: dict[str, SimpleNamespace] | None = None,
     snapshots: dict[str, SimpleNamespace] | None = None,
     stations: list[ProductionStation] | None = None,
 ) -> RecommendationCapacityService:
+    capacity = _Capacity(requirements, capacity_days, stations)
     return RecommendationCapacityService(  # type: ignore[arg-type]
         _Catalog(*dish_ids),
-        _Capacity(
-            requirements=requirements,
-            capacity_days=capacity_days,
-            stations=stations,
-        ),
+        capacity,
         _Orders(orders or [], versions or {}),
         _Snapshots(snapshots or {}),
     )
@@ -137,26 +138,24 @@ def test_capacity_penalty_uses_committed_order_load() -> None:
     order = _order("order-1", "version-1")
     service = _service(
         requirements={"dish-a": [requirement]},
-        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 100)],
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={"version-1": _version("order-1", "version-1")},
-        snapshots={
-            "order-1": SimpleNamespace(positions=(_position("dish-a", Decimal("40")),))
-        },
+        snapshots={"order-1": _snapshot(_position("dish-a", "40"))},
     )
 
-    rows = service.list_for_date(EVENT_DATE)
+    row = service.list_for_date(EVENT_DATE)[0]
 
-    assert len(rows) == 1
-    assert rows[0].catalog_item_id == "dish-a"
-    assert rows[0].feasible is True
-    assert rows[0].overload_penalty == 40
-    assert rows[0].reason_code is None
+    assert row.catalog_item_id == "dish-a"
+    assert row.feasible is True
+    assert row.overload_penalty == 40
+    assert row.reason_code is None
 
 
 def test_capacity_fails_closed_when_capacity_day_missing() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
     service = _service(
-        requirements={"dish-a": [CatalogStationRequirement("dish-a", "cold", 1)]},
+        requirements={"dish-a": [requirement]},
         capacity_days=[],
     )
 
@@ -172,12 +171,10 @@ def test_capacity_exhausted_when_committed_load_reaches_limit() -> None:
     order = _order("order-1", "version-1")
     service = _service(
         requirements={"dish-a": [requirement]},
-        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 20)],
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 20)],
         orders=[order],
         versions={"version-1": _version("order-1", "version-1")},
-        snapshots={
-            "order-1": SimpleNamespace(positions=(_position("dish-a", Decimal("10")),))
-        },
+        snapshots={"order-1": _snapshot(_position("dish-a", "10"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -186,21 +183,16 @@ def test_capacity_exhausted_when_committed_load_reaches_limit() -> None:
     assert row.reason_code == "CAPACITY_EXHAUSTED"
 
 
-def test_capacity_fails_closed_when_existing_demand_cannot_be_accounted() -> None:
+def test_capacity_fails_closed_when_demand_is_incomplete() -> None:
+    requirement = CatalogStationRequirement("candidate", "cold", 1)
     order = _order("order-1", "version-1")
     service = _service(
         dish_ids=("candidate",),
-        requirements={
-            "candidate": [CatalogStationRequirement("candidate", "cold", 1)]
-        },
-        capacity_days=[ProductionStationCapacityDay(EVENT_DATE, "cold", 100)],
+        requirements={"candidate": [requirement]},
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={"version-1": _version("order-1", "version-1")},
-        snapshots={
-            "order-1": SimpleNamespace(
-                positions=(_position("legacy-unmapped", Decimal("10")),)
-            )
-        },
+        snapshots={"order-1": _snapshot(_position("legacy-unmapped", "10"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -69,9 +69,7 @@ class _Capacity:
     def list_stations(self) -> list[ProductionStation]:
         return self._stations
 
-    def list_capacity_days(
-        self, event_date: date
-    ) -> list[ProductionStationCapacityDay]:
+    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
         assert event_date == EVENT_DATE
         return self._capacity_days
 

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -69,7 +69,9 @@ class _Capacity:
     def list_stations(self) -> list[ProductionStation]:
         return self._stations
 
-    def list_capacity_days(self, event_date: date) -> list[ProductionStationCapacityDay]:
+    def list_capacity_days(
+        self, event_date: date
+    ) -> list[ProductionStationCapacityDay]:
         assert event_date == EVENT_DATE
         return self._capacity_days
 
@@ -141,9 +143,7 @@ def test_capacity_penalty_uses_committed_order_load() -> None:
         orders=[order],
         versions={"version-1": _version("order-1", "version-1")},
         snapshots={
-            "order-1": SimpleNamespace(
-                positions=(_position("dish-a", Decimal("40")),)
-            )
+            "order-1": SimpleNamespace(positions=(_position("dish-a", Decimal("40")),))
         },
     )
 
@@ -158,9 +158,7 @@ def test_capacity_penalty_uses_committed_order_load() -> None:
 
 def test_capacity_fails_closed_when_capacity_day_missing() -> None:
     service = _service(
-        requirements={
-            "dish-a": [CatalogStationRequirement("dish-a", "cold", 1)]
-        },
+        requirements={"dish-a": [CatalogStationRequirement("dish-a", "cold", 1)]},
         capacity_days=[],
     )
 
@@ -180,9 +178,7 @@ def test_capacity_exhausted_when_committed_load_reaches_limit() -> None:
         orders=[order],
         versions={"version-1": _version("order-1", "version-1")},
         snapshots={
-            "order-1": SimpleNamespace(
-                positions=(_position("dish-a", Decimal("10")),)
-            )
+            "order-1": SimpleNamespace(positions=(_position("dish-a", Decimal("10")),))
         },
     )
 


### PR DESCRIPTION
Continues #162 on top of merged CAP-1 (#164).

This slice adds the deterministic PII-free capacity projection itself:
- reads explicit station requirements and date-scoped station capacity facts from CAP-1
- counts only non-cancelled Order demand on the target date as committed kitchen load
- excludes sent/open offers from capacity consumption; they remain production-overlap signals only
- returns deterministic feasibility plus normalized overload penalty
- fails closed for missing station requirements, missing capacity, unavailable/inactive stations, exhausted capacity, and incomplete committed-demand accounting
- adds date-scoped capacity listing to the CAP-1 repository
- adds focused projection tests

The HTTP `/office/v1/recommendation-capacity` wiring is intentionally the next small commit/slice in #162 after this projection is green, rather than mixing transport changes into an unverified domain calculation.