### PR TITLE
CAP-5: import explicit production capacity facts

### DIFF
--- a/scripts/import_production_capacity.py
+++ b/scripts/import_production_capacity.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Import explicit production station requirements and date capacities into Core.
+
+The input file is declarative business truth. This command never infers station
+assignments, load units, or capacity from catalog categories or order history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from catering_system.services.production_capacity_import import (
+    apply_production_capacity_config,
+    parse_production_capacity_config,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", required=True, help="Path to core.db")
+    parser.add_argument("--config", required=True, help="Path to explicit capacity JSON")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the entire config and references without writing facts",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = Path(args.db)
+    config_path = Path(args.config)
+    if not db_path.exists():
+        print(f"database not found: {db_path}", file=sys.stderr)
+        return 1
+    if not config_path.exists():
+        print(f"config file not found: {config_path}", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+        plan = parse_production_capacity_config(payload)
+        result = apply_production_capacity_config(
+            db_path,
+            plan,
+            dry_run=args.dry_run,
+        )
+    except (ValueError, json.JSONDecodeError, sqlite3.DatabaseError) as exc:
+        print(f"capacity import failed: {exc}", file=sys.stderr)
+        return 1
+
+    action = "validated" if args.dry_run else "applied"
+    print(
+        f"capacity config {action}: "
+        f"stations={result.stations} "
+        f"requirements={result.requirements} "
+        f"capacity_days={result.capacity_days}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/catering_system/services/production_capacity_import.py
+++ b/src/catering_system/services/production_capacity_import.py
@@ -12,7 +12,9 @@ from catering_system.domain.production_capacity import (
     ProductionStation,
     ProductionStationCapacityDay,
 )
-from catering_system.repositories.sqlite_catalog_repository import SQLiteCatalogRepository
+from catering_system.repositories.sqlite_catalog_repository import (
+    SQLiteCatalogRepository,
+)
 from catering_system.repositories.sqlite_production_capacity_repository import (
     SQLiteProductionCapacityRepository,
 )

--- a/src/catering_system/services/production_capacity_import.py
+++ b/src/catering_system/services/production_capacity_import.py
@@ -1,0 +1,224 @@
+"""Fail-closed import of explicit production-capacity facts for CAP-5."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from catering_system.domain.production_capacity import (
+    CatalogStationRequirement,
+    ProductionStation,
+    ProductionStationCapacityDay,
+)
+from catering_system.repositories.sqlite_catalog_repository import SQLiteCatalogRepository
+from catering_system.repositories.sqlite_production_capacity_repository import (
+    SQLiteProductionCapacityRepository,
+)
+
+
+@dataclass(frozen=True)
+class ProductionCapacityImportPlan:
+    stations: tuple[ProductionStation, ...]
+    requirements: tuple[CatalogStationRequirement, ...]
+    capacity_days: tuple[ProductionStationCapacityDay, ...]
+
+
+@dataclass(frozen=True)
+class ProductionCapacityImportResult:
+    stations: int
+    requirements: int
+    capacity_days: int
+
+
+def _object(value: object, *, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _array(value: object, *, label: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a list")
+    return value
+
+
+def _exact_keys(row: dict[str, object], expected: set[str], *, label: str) -> None:
+    keys = set(row)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        extra = sorted(keys - expected)
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ",".join(missing))
+        if extra:
+            details.append("unknown=" + ",".join(extra))
+        raise ValueError(f"{label} has invalid fields ({'; '.join(details)})")
+
+
+def _text(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _boolean(value: object, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be boolean")
+    return value
+
+
+def _integer(value: object, *, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    return value
+
+
+def _date(value: object, *, label: str) -> date:
+    text = _text(value, label=label)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be YYYY-MM-DD") from exc
+    if parsed.isoformat() != text:
+        raise ValueError(f"{label} must be YYYY-MM-DD")
+    return parsed
+
+
+def parse_production_capacity_config(payload: object) -> ProductionCapacityImportPlan:
+    """Parse a strict JSON-shaped config without inventing defaults."""
+
+    root = _object(payload, label="config")
+    _exact_keys(root, {"stations", "requirements", "capacity_days"}, label="config")
+
+    stations: list[ProductionStation] = []
+    station_ids: set[str] = set()
+    for index, raw in enumerate(_array(root["stations"], label="stations")):
+        row = _object(raw, label=f"stations[{index}]")
+        _exact_keys(row, {"station_id", "name", "active"}, label=f"stations[{index}]")
+        station = ProductionStation(
+            station_id=_text(row["station_id"], label=f"stations[{index}].station_id"),
+            name=_text(row["name"], label=f"stations[{index}].name"),
+            active=_boolean(row["active"], label=f"stations[{index}].active"),
+        )
+        if station.station_id in station_ids:
+            raise ValueError(f"duplicate station_id: {station.station_id}")
+        station_ids.add(station.station_id)
+        stations.append(station)
+
+    requirements: list[CatalogStationRequirement] = []
+    requirement_keys: set[tuple[str, str]] = set()
+    for index, raw in enumerate(_array(root["requirements"], label="requirements")):
+        row = _object(raw, label=f"requirements[{index}]")
+        _exact_keys(
+            row,
+            {"catalog_item_id", "station_id", "load_units_per_item"},
+            label=f"requirements[{index}]",
+        )
+        requirement = CatalogStationRequirement(
+            catalog_item_id=_text(
+                row["catalog_item_id"], label=f"requirements[{index}].catalog_item_id"
+            ),
+            station_id=_text(
+                row["station_id"], label=f"requirements[{index}].station_id"
+            ),
+            load_units_per_item=_integer(
+                row["load_units_per_item"],
+                label=f"requirements[{index}].load_units_per_item",
+            ),
+        )
+        key = (requirement.catalog_item_id, requirement.station_id)
+        if key in requirement_keys:
+            raise ValueError(
+                "duplicate requirement: "
+                f"{requirement.catalog_item_id}/{requirement.station_id}"
+            )
+        requirement_keys.add(key)
+        requirements.append(requirement)
+
+    capacity_days: list[ProductionStationCapacityDay] = []
+    capacity_keys: set[tuple[date, str]] = set()
+    for index, raw in enumerate(_array(root["capacity_days"], label="capacity_days")):
+        row = _object(raw, label=f"capacity_days[{index}]")
+        _exact_keys(
+            row,
+            {"event_date", "station_id", "capacity_units", "unavailable"},
+            label=f"capacity_days[{index}]",
+        )
+        capacity = ProductionStationCapacityDay(
+            event_date=_date(
+                row["event_date"], label=f"capacity_days[{index}].event_date"
+            ),
+            station_id=_text(
+                row["station_id"], label=f"capacity_days[{index}].station_id"
+            ),
+            capacity_units=_integer(
+                row["capacity_units"], label=f"capacity_days[{index}].capacity_units"
+            ),
+            unavailable=_boolean(
+                row["unavailable"], label=f"capacity_days[{index}].unavailable"
+            ),
+        )
+        key = (capacity.event_date, capacity.station_id)
+        if key in capacity_keys:
+            raise ValueError(
+                f"duplicate capacity day: {capacity.event_date}/{capacity.station_id}"
+            )
+        capacity_keys.add(key)
+        capacity_days.append(capacity)
+
+    return ProductionCapacityImportPlan(
+        stations=tuple(stations),
+        requirements=tuple(requirements),
+        capacity_days=tuple(capacity_days),
+    )
+
+
+def apply_production_capacity_config(
+    db_path: str | Path,
+    plan: ProductionCapacityImportPlan,
+    *,
+    dry_run: bool = False,
+) -> ProductionCapacityImportResult:
+    """Validate references, then atomically upsert explicit capacity facts."""
+
+    connection = sqlite3.connect(str(db_path))
+    connection.execute("PRAGMA foreign_keys = ON")
+    try:
+        capacity_repo = SQLiteProductionCapacityRepository.from_connection(connection)
+        catalog_repo = SQLiteCatalogRepository.from_connection(connection)
+
+        known_station_ids = {
+            station.station_id for station in capacity_repo.list_stations()
+        } | {station.station_id for station in plan.stations}
+
+        for requirement in plan.requirements:
+            if requirement.station_id not in known_station_ids:
+                raise ValueError(f"unknown station_id: {requirement.station_id}")
+            if catalog_repo.get_dish(requirement.catalog_item_id) is None:
+                raise ValueError(
+                    f"unknown catalog_item_id: {requirement.catalog_item_id}"
+                )
+        for capacity in plan.capacity_days:
+            if capacity.station_id not in known_station_ids:
+                raise ValueError(f"unknown station_id: {capacity.station_id}")
+
+        result = ProductionCapacityImportResult(
+            stations=len(plan.stations),
+            requirements=len(plan.requirements),
+            capacity_days=len(plan.capacity_days),
+        )
+        if dry_run:
+            return result
+
+        with connection:
+            for station in plan.stations:
+                capacity_repo.upsert_station(station)
+            for requirement in plan.requirements:
+                capacity_repo.set_catalog_requirement(requirement)
+            for capacity in plan.capacity_days:
+                capacity_repo.set_capacity_day(capacity)
+        return result
+    finally:
+        connection.close()

--- a/src/catering_system/services/production_capacity_import.py
+++ b/src/catering_system/services/production_capacity_import.py
@@ -130,13 +130,13 @@ def parse_production_capacity_config(payload: object) -> ProductionCapacityImpor
                 label=f"requirements[{index}].load_units_per_item",
             ),
         )
-        key = (requirement.catalog_item_id, requirement.station_id)
-        if key in requirement_keys:
+        requirement_key = (requirement.catalog_item_id, requirement.station_id)
+        if requirement_key in requirement_keys:
             raise ValueError(
                 "duplicate requirement: "
                 f"{requirement.catalog_item_id}/{requirement.station_id}"
             )
-        requirement_keys.add(key)
+        requirement_keys.add(requirement_key)
         requirements.append(requirement)
 
     capacity_days: list[ProductionStationCapacityDay] = []
@@ -162,12 +162,12 @@ def parse_production_capacity_config(payload: object) -> ProductionCapacityImpor
                 row["unavailable"], label=f"capacity_days[{index}].unavailable"
             ),
         )
-        key = (capacity.event_date, capacity.station_id)
-        if key in capacity_keys:
+        capacity_key = (capacity.event_date, capacity.station_id)
+        if capacity_key in capacity_keys:
             raise ValueError(
                 f"duplicate capacity day: {capacity.event_date}/{capacity.station_id}"
             )
-        capacity_keys.add(key)
+        capacity_keys.add(capacity_key)
         capacity_days.append(capacity)
 
     return ProductionCapacityImportPlan(

--- a/tests/unit/test_production_capacity_import.py
+++ b/tests/unit/test_production_capacity_import.py
@@ -6,7 +6,9 @@ from datetime import UTC, date, datetime
 import pytest
 
 from catering_system.domain.catalog import CatalogDish
-from catering_system.repositories.sqlite_catalog_repository import SQLiteCatalogRepository
+from catering_system.repositories.sqlite_catalog_repository import (
+    SQLiteCatalogRepository,
+)
 from catering_system.repositories.sqlite_production_capacity_repository import (
     SQLiteProductionCapacityRepository,
 )

--- a/tests/unit/test_production_capacity_import.py
+++ b/tests/unit/test_production_capacity_import.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime
+
+import pytest
+
+from catering_system.domain.catalog import CatalogDish
+from catering_system.repositories.sqlite_catalog_repository import SQLiteCatalogRepository
+from catering_system.repositories.sqlite_production_capacity_repository import (
+    SQLiteProductionCapacityRepository,
+)
+from catering_system.services.production_capacity_import import (
+    apply_production_capacity_config,
+    parse_production_capacity_config,
+)
+
+
+def _dish_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_dish(db_path, dish_id: str) -> None:  # noqa: ANN001
+    now = datetime.now(tz=UTC)
+    repo = SQLiteCatalogRepository(db_path)
+    try:
+        assert repo.insert_dish_if_absent(
+            CatalogDish(
+                dish_id=dish_id,
+                name="Test dish",
+                description=None,
+                composition=None,
+                notes=None,
+                current_unit_net_cents=1000,
+                allergens=(),
+                active=True,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    finally:
+        repo.close()
+
+
+def _payload(dish_id: str) -> dict[str, object]:
+    return {
+        "stations": [
+            {"station_id": "cold", "name": "Cold kitchen", "active": True}
+        ],
+        "requirements": [
+            {
+                "catalog_item_id": dish_id,
+                "station_id": "cold",
+                "load_units_per_item": 2,
+            }
+        ],
+        "capacity_days": [
+            {
+                "event_date": "2026-08-25",
+                "station_id": "cold",
+                "capacity_units": 120,
+                "unavailable": False,
+            }
+        ],
+    }
+
+
+def test_import_applies_explicit_facts_and_is_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    dish_id = _dish_id()
+    _seed_dish(db_path, dish_id)
+    plan = parse_production_capacity_config(_payload(dish_id))
+
+    first = apply_production_capacity_config(db_path, plan)
+    second = apply_production_capacity_config(db_path, plan)
+
+    assert first == second
+    assert first.stations == 1
+    assert first.requirements == 1
+    assert first.capacity_days == 1
+
+    repo = SQLiteProductionCapacityRepository(db_path)
+    try:
+        stations = repo.list_stations()
+        assert [(row.station_id, row.name, row.active) for row in stations] == [
+            ("cold", "Cold kitchen", True)
+        ]
+        requirements = repo.list_catalog_requirements(dish_id)
+        assert len(requirements) == 1
+        assert requirements[0].load_units_per_item == 2
+        capacity = repo.get_capacity_day(date(2026, 8, 25), "cold")
+        assert capacity is not None
+        assert capacity.capacity_units == 120
+        assert capacity.unavailable is False
+    finally:
+        repo.close()
+
+
+def test_dry_run_validates_without_writing(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    dish_id = _dish_id()
+    _seed_dish(db_path, dish_id)
+    plan = parse_production_capacity_config(_payload(dish_id))
+
+    result = apply_production_capacity_config(db_path, plan, dry_run=True)
+
+    assert result.stations == 1
+    repo = SQLiteProductionCapacityRepository(db_path)
+    try:
+        assert repo.list_stations() == []
+    finally:
+        repo.close()
+
+
+def test_unknown_catalog_item_fails_before_any_fact_is_written(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    _seed_dish(db_path, _dish_id())
+    payload = _payload(_dish_id())
+    plan = parse_production_capacity_config(payload)
+
+    with pytest.raises(ValueError, match="unknown catalog_item_id"):
+        apply_production_capacity_config(db_path, plan)
+
+    repo = SQLiteProductionCapacityRepository(db_path)
+    try:
+        assert repo.list_stations() == []
+    finally:
+        repo.close()
+
+
+def test_unknown_station_reference_fails_closed(tmp_path) -> None:
+    db_path = tmp_path / "core.db"
+    dish_id = _dish_id()
+    _seed_dish(db_path, dish_id)
+    payload = _payload(dish_id)
+    payload["requirements"] = []
+    payload["capacity_days"] = [
+        {
+            "event_date": "2026-08-25",
+            "station_id": "hot",
+            "capacity_units": 1,
+            "unavailable": False,
+        }
+    ]
+    plan = parse_production_capacity_config(payload)
+
+    with pytest.raises(ValueError, match="unknown station_id: hot"):
+        apply_production_capacity_config(db_path, plan)
+
+
+def test_parser_rejects_duplicates_and_unknown_fields() -> None:
+    dish_id = _dish_id()
+    payload = _payload(dish_id)
+    payload["stations"] = [
+        {"station_id": "cold", "name": "Cold", "active": True},
+        {"station_id": "cold", "name": "Cold again", "active": True},
+    ]
+    with pytest.raises(ValueError, match="duplicate station_id"):
+        parse_production_capacity_config(payload)
+
+    payload = _payload(dish_id)
+    assert isinstance(payload["stations"], list)
+    payload["stations"][0]["surprise"] = True  # type: ignore[index]
+    with pytest.raises(ValueError, match="unknown=surprise"):
+        parse_production_capacity_config(payload)
+
+
+def test_parser_rejects_implicit_or_malformed_business_facts() -> None:
+    dish_id = _dish_id()
+    payload = _payload(dish_id)
+    assert isinstance(payload["requirements"], list)
+    payload["requirements"][0]["load_units_per_item"] = True  # type: ignore[index]
+    with pytest.raises(ValueError, match="must be an integer"):
+        parse_production_capacity_config(payload)
+
+    payload = _payload(dish_id)
+    assert isinstance(payload["capacity_days"], list)
+    payload["capacity_days"][0]["event_date"] = "25.08.2026"  # type: ignore[index]
+    with pytest.raises(ValueError, match="must be YYYY-MM-DD"):
+        parse_production_capacity_config(payload)
+
+    payload = _payload(dish_id)
+    payload["capacity_days"][0]["capacity_units"] = 1  # type: ignore[index]
+    payload["capacity_days"][0]["unavailable"] = True  # type: ignore[index]
+    with pytest.raises(ValueError, match="unavailable station"):
+        parse_production_capacity_config(payload)

--- a/tests/unit/test_production_capacity_import.py
+++ b/tests/unit/test_production_capacity_import.py
@@ -45,26 +45,36 @@ def _seed_dish(db_path, dish_id: str) -> None:  # noqa: ANN001
 
 
 def _payload(dish_id: str) -> dict[str, object]:
-    return {
-        "stations": [
-            {"station_id": "cold", "name": "Cold kitchen", "active": True}
-        ],
-        "requirements": [
-            {
-                "catalog_item_id": dish_id,
-                "station_id": "cold",
-                "load_units_per_item": 2,
-            }
-        ],
-        "capacity_days": [
-            {
-                "event_date": "2026-08-25",
-                "station_id": "cold",
-                "capacity_units": 120,
-                "unavailable": False,
-            }
-        ],
+    station = {
+        "station_id": "cold",
+        "name": "Cold kitchen",
+        "active": True,
     }
+    requirement = {
+        "catalog_item_id": dish_id,
+        "station_id": "cold",
+        "load_units_per_item": 2,
+    }
+    capacity_day = {
+        "event_date": "2026-08-25",
+        "station_id": "cold",
+        "capacity_units": 120,
+        "unavailable": False,
+    }
+    return {
+        "stations": [station],
+        "requirements": [requirement],
+        "capacity_days": [capacity_day],
+    }
+
+
+def _first_row(payload: dict[str, object], key: str) -> dict[str, object]:
+    rows = payload[key]
+    assert isinstance(rows, list)
+    assert rows
+    row = rows[0]
+    assert isinstance(row, dict)
+    return row
 
 
 def test_import_applies_explicit_facts_and_is_idempotent(tmp_path) -> None:
@@ -117,8 +127,7 @@ def test_dry_run_validates_without_writing(tmp_path) -> None:
 def test_unknown_catalog_item_fails_before_any_fact_is_written(tmp_path) -> None:
     db_path = tmp_path / "core.db"
     _seed_dish(db_path, _dish_id())
-    payload = _payload(_dish_id())
-    plan = parse_production_capacity_config(payload)
+    plan = parse_production_capacity_config(_payload(_dish_id()))
 
     with pytest.raises(ValueError, match="unknown catalog_item_id"):
         apply_production_capacity_config(db_path, plan)
@@ -161,28 +170,27 @@ def test_parser_rejects_duplicates_and_unknown_fields() -> None:
         parse_production_capacity_config(payload)
 
     payload = _payload(dish_id)
-    assert isinstance(payload["stations"], list)
-    payload["stations"][0]["surprise"] = True  # type: ignore[index]
+    _first_row(payload, "stations")["surprise"] = True
     with pytest.raises(ValueError, match="unknown=surprise"):
         parse_production_capacity_config(payload)
 
 
 def test_parser_rejects_implicit_or_malformed_business_facts() -> None:
     dish_id = _dish_id()
+
     payload = _payload(dish_id)
-    assert isinstance(payload["requirements"], list)
-    payload["requirements"][0]["load_units_per_item"] = True  # type: ignore[index]
+    _first_row(payload, "requirements")["load_units_per_item"] = True
     with pytest.raises(ValueError, match="must be an integer"):
         parse_production_capacity_config(payload)
 
     payload = _payload(dish_id)
-    assert isinstance(payload["capacity_days"], list)
-    payload["capacity_days"][0]["event_date"] = "25.08.2026"  # type: ignore[index]
+    _first_row(payload, "capacity_days")["event_date"] = "25.08.2026"
     with pytest.raises(ValueError, match="must be YYYY-MM-DD"):
         parse_production_capacity_config(payload)
 
     payload = _payload(dish_id)
-    payload["capacity_days"][0]["capacity_units"] = 1  # type: ignore[index]
-    payload["capacity_days"][0]["unavailable"] = True  # type: ignore[index]
+    capacity_day = _first_row(payload, "capacity_days")
+    capacity_day["capacity_units"] = 1
+    capacity_day["unavailable"] = True
     with pytest.raises(ValueError, match="unavailable station"):
         parse_production_capacity_config(payload)


### PR DESCRIPTION
Closes #167.

Adds the operational bridge needed after CAP-3 production verification showed every active catalog item blocked by `MISSING_STATION_REQUIREMENT`.

This PR:
- adds a strict JSON parser for explicit `stations`, `requirements`, and `capacity_days`
- rejects missing/unknown fields, duplicate keys, malformed dates/types, unknown stations, and unknown catalog item ids
- validates all references before business-fact writes
- applies station/requirement/date-capacity upserts atomically on one SQLite transaction
- supports `--dry-run` validation before touching production facts
- adds `scripts/import_production_capacity.py`
- adds focused tests for idempotent import, dry-run, fail-closed references, and strict business-fact parsing

No station taxonomy, dish assignment, load unit, or capacity value is invented or inferred. The actual Silberlöffel facts remain an explicit operational input. Configurator CAP-4 should remain undeployed until approved facts are loaded and `/office/v1/recommendation-capacity` returns usable rows.