### PR TITLE
CAP: measure overall kitchen load by guests

### DIFF
--- a/src/catering_system/services/recommendation_capacity_service.py
+++ b/src/catering_system/services/recommendation_capacity_service.py
@@ -33,8 +33,6 @@ class RecommendationCapacityRow:
     feasible: bool
     overload_penalty: int
     reason_code: CapacityReasonCode | None = None
-    used_capacity_units: int | None = None
-    capacity_units: int | None = None
 
 
 class RecommendationCapacityService:
@@ -119,58 +117,38 @@ class RecommendationCapacityService:
 
             penalty = 0
             blocked_reason: CapacityReasonCode | None = None
-            selected_used: int | None = None
-            selected_capacity: int | None = None
             for requirement in requirements:
                 station = stations.get(requirement.station_id)
                 if station is None or not station.active:
                     blocked_reason = "STATION_INACTIVE"
                     break
-
-                used = used_by_station.get(requirement.station_id, 0)
                 capacity_day = capacity_days.get(requirement.station_id)
                 if capacity_day is None:
-                    selected_used = used
                     blocked_reason = "CAPACITY_UNSET"
                     break
-
-                selected_used = used
-                selected_capacity = capacity_day.capacity_units
                 if capacity_day.unavailable:
                     blocked_reason = "STATION_UNAVAILABLE"
                     break
                 if capacity_day.capacity_units == 0:
                     blocked_reason = "NO_CAPACITY"
                     break
+                used = used_by_station.get(requirement.station_id, 0)
                 if used >= capacity_day.capacity_units:
                     blocked_reason = "CAPACITY_EXHAUSTED"
                     break
-
-                current_penalty = min(
-                    100, (used * 100) // capacity_day.capacity_units
+                penalty = max(
+                    penalty,
+                    min(100, (used * 100) // capacity_day.capacity_units),
                 )
-                if current_penalty >= penalty:
-                    penalty = current_penalty
-                    selected_used = used
-                    selected_capacity = capacity_day.capacity_units
 
             if blocked_reason is not None:
-                rows.append(
-                    self._blocked(
-                        dish.dish_id,
-                        blocked_reason,
-                        used_capacity_units=selected_used,
-                        capacity_units=selected_capacity,
-                    )
-                )
+                rows.append(self._blocked(dish.dish_id, blocked_reason))
             else:
                 rows.append(
                     RecommendationCapacityRow(
                         catalog_item_id=dish.dish_id,
                         feasible=True,
                         overload_penalty=penalty,
-                        used_capacity_units=selected_used,
-                        capacity_units=selected_capacity,
                     )
                 )
 
@@ -187,17 +165,11 @@ class RecommendationCapacityService:
 
     @staticmethod
     def _blocked(
-        catalog_item_id: str,
-        reason_code: CapacityReasonCode,
-        *,
-        used_capacity_units: int | None = None,
-        capacity_units: int | None = None,
+        catalog_item_id: str, reason_code: CapacityReasonCode
     ) -> RecommendationCapacityRow:
         return RecommendationCapacityRow(
             catalog_item_id=catalog_item_id,
             feasible=False,
             overload_penalty=100,
             reason_code=reason_code,
-            used_capacity_units=used_capacity_units,
-            capacity_units=capacity_units,
         )

--- a/src/catering_system/services/recommendation_capacity_service.py
+++ b/src/catering_system/services/recommendation_capacity_service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
 from typing import Literal
 
 from catering_system.domain.order import Order, OrderVersion
@@ -34,12 +33,20 @@ class RecommendationCapacityRow:
     feasible: bool
     overload_penalty: int
     reason_code: CapacityReasonCode | None = None
+    used_capacity_units: int | None = None
+    capacity_units: int | None = None
 
 
 class RecommendationCapacityService:
-    """Project explicit station facts plus accepted/confirmed demand into item rows.
+    """Project explicit capacity facts plus committed guest demand into item rows.
 
-    Sent/open offers are deliberately excluded from capacity consumption. They are a
+    Capacity units represent guests for the overall production model. Each accepted
+    or confirmed order contributes its ``guest_count_estimate`` once to every
+    production station touched by at least one catalog position. Catalog position
+    quantities are deliberately not summed: five dishes for 100 guests are 100
+    guests of kitchen load, not 500 independent capacity units.
+
+    Sent/open offers remain excluded from committed capacity consumption. They are a
     weak production-overlap signal, not committed kitchen load.
     """
 
@@ -74,24 +81,31 @@ class RecommendationCapacityService:
             if snapshot is None:
                 global_demand_unknown = True
                 continue
+            guest_count = version.guest_count_estimate
+            if guest_count is None or guest_count < 0:
+                global_demand_unknown = True
+                continue
+
+            station_ids_for_order: set[str] = set()
             for position in snapshot.positions:
                 if position.kind != "catalog" or position.catalog_item_id is None:
                     continue
-                quantity = self._whole_quantity(position.quantity)
                 requirements = self._capacity.list_catalog_requirements(
                     position.catalog_item_id
                 )
-                if quantity is None or not requirements:
+                if not requirements:
                     global_demand_unknown = True
                     continue
                 for requirement in requirements:
                     if requirement.station_id not in stations:
                         global_demand_unknown = True
                         continue
-                    used_by_station[requirement.station_id] = (
-                        used_by_station.get(requirement.station_id, 0)
-                        + quantity * requirement.load_units_per_item
-                    )
+                    station_ids_for_order.add(requirement.station_id)
+
+            for station_id in station_ids_for_order:
+                used_by_station[station_id] = (
+                    used_by_station.get(station_id, 0) + guest_count
+                )
 
         rows: list[RecommendationCapacityRow] = []
         for dish in self._catalog.list_dishes(active=True, limit=10_000):
@@ -105,38 +119,58 @@ class RecommendationCapacityService:
 
             penalty = 0
             blocked_reason: CapacityReasonCode | None = None
+            selected_used: int | None = None
+            selected_capacity: int | None = None
             for requirement in requirements:
                 station = stations.get(requirement.station_id)
                 if station is None or not station.active:
                     blocked_reason = "STATION_INACTIVE"
                     break
+
+                used = used_by_station.get(requirement.station_id, 0)
                 capacity_day = capacity_days.get(requirement.station_id)
                 if capacity_day is None:
+                    selected_used = used
                     blocked_reason = "CAPACITY_UNSET"
                     break
+
+                selected_used = used
+                selected_capacity = capacity_day.capacity_units
                 if capacity_day.unavailable:
                     blocked_reason = "STATION_UNAVAILABLE"
                     break
                 if capacity_day.capacity_units == 0:
                     blocked_reason = "NO_CAPACITY"
                     break
-                used = used_by_station.get(requirement.station_id, 0)
                 if used >= capacity_day.capacity_units:
                     blocked_reason = "CAPACITY_EXHAUSTED"
                     break
-                penalty = max(
-                    penalty,
-                    min(100, (used * 100) // capacity_day.capacity_units),
+
+                current_penalty = min(
+                    100, (used * 100) // capacity_day.capacity_units
                 )
+                if current_penalty >= penalty:
+                    penalty = current_penalty
+                    selected_used = used
+                    selected_capacity = capacity_day.capacity_units
 
             if blocked_reason is not None:
-                rows.append(self._blocked(dish.dish_id, blocked_reason))
+                rows.append(
+                    self._blocked(
+                        dish.dish_id,
+                        blocked_reason,
+                        used_capacity_units=selected_used,
+                        capacity_units=selected_capacity,
+                    )
+                )
             else:
                 rows.append(
                     RecommendationCapacityRow(
                         catalog_item_id=dish.dish_id,
                         feasible=True,
                         overload_penalty=penalty,
+                        used_capacity_units=selected_used,
+                        capacity_units=selected_capacity,
                     )
                 )
 
@@ -152,18 +186,18 @@ class RecommendationCapacityService:
         return max(versions, key=lambda item: item.version_number, default=None)
 
     @staticmethod
-    def _whole_quantity(value: Decimal | None) -> int | None:
-        if value is None or value < 0 or value != value.to_integral_value():
-            return None
-        return int(value)
-
-    @staticmethod
     def _blocked(
-        catalog_item_id: str, reason_code: CapacityReasonCode
+        catalog_item_id: str,
+        reason_code: CapacityReasonCode,
+        *,
+        used_capacity_units: int | None = None,
+        capacity_units: int | None = None,
     ) -> RecommendationCapacityRow:
         return RecommendationCapacityRow(
             catalog_item_id=catalog_item_id,
             feasible=False,
             overload_penalty=100,
             reason_code=reason_code,
+            used_capacity_units=used_capacity_units,
+            capacity_units=capacity_units,
         )

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date
-from decimal import Decimal
 from types import SimpleNamespace
 
 from catering_system.domain.production_capacity import (
@@ -30,20 +29,26 @@ def _order(order_id: str, version_id: str) -> SimpleNamespace:
     )
 
 
-def _version(order_id: str, version_id: str) -> SimpleNamespace:
+def _version(
+    order_id: str,
+    version_id: str,
+    *,
+    guest_count_estimate: int | None = 0,
+) -> SimpleNamespace:
     return SimpleNamespace(
         order_id=order_id,
         order_version_id=version_id,
         version_number=1,
         event_date=EVENT_DATE,
+        guest_count_estimate=guest_count_estimate,
     )
 
 
-def _position(catalog_item_id: str, quantity: str | None) -> SimpleNamespace:
+def _position(catalog_item_id: str) -> SimpleNamespace:
     return SimpleNamespace(
         kind="catalog",
         catalog_item_id=catalog_item_id,
-        quantity=None if quantity is None else Decimal(quantity),
+        quantity=None,
     )
 
 
@@ -133,15 +138,19 @@ def _service(
     )
 
 
-def test_capacity_penalty_uses_committed_order_load() -> None:
+def test_capacity_penalty_uses_committed_guest_count() -> None:
     requirement = CatalogStationRequirement("dish-a", "cold", 1)
     order = _order("order-1", "version-1")
     service = _service(
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
-        snapshots={"order-1": _snapshot(_position("dish-a", "40"))},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=40
+            )
+        },
+        snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -150,6 +159,33 @@ def test_capacity_penalty_uses_committed_order_load() -> None:
     assert row.feasible is True
     assert row.overload_penalty == 40
     assert row.reason_code is None
+
+
+def test_multiple_positions_do_not_multiply_guest_capacity() -> None:
+    requirements = {
+        "dish-a": [CatalogStationRequirement("dish-a", "cold", 1)],
+        "dish-b": [CatalogStationRequirement("dish-b", "cold", 1)],
+    }
+    order = _order("order-1", "version-1")
+    service = _service(
+        dish_ids=("dish-a", "dish-b"),
+        requirements=requirements,
+        capacity_days=[CapacityDay(EVENT_DATE, "cold", 500)],
+        orders=[order],
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=100
+            )
+        },
+        snapshots={
+            "order-1": _snapshot(_position("dish-a"), _position("dish-b"))
+        },
+    )
+
+    rows = service.list_for_date(EVENT_DATE)
+
+    assert len(rows) == 2
+    assert {row.overload_penalty for row in rows} == {20}
 
 
 def test_capacity_fails_closed_when_capacity_day_missing() -> None:
@@ -166,15 +202,19 @@ def test_capacity_fails_closed_when_capacity_day_missing() -> None:
     assert row.reason_code == "CAPACITY_UNSET"
 
 
-def test_capacity_exhausted_when_committed_load_reaches_limit() -> None:
-    requirement = CatalogStationRequirement("dish-a", "cold", 2)
+def test_capacity_exhausted_when_committed_guests_reach_limit() -> None:
+    requirement = CatalogStationRequirement("dish-a", "cold", 1)
     order = _order("order-1", "version-1")
     service = _service(
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 20)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
-        snapshots={"order-1": _snapshot(_position("dish-a", "10"))},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=20
+            )
+        },
+        snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -191,8 +231,12 @@ def test_capacity_fails_closed_when_demand_is_incomplete() -> None:
         requirements={"candidate": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
-        snapshots={"order-1": _snapshot(_position("legacy-unmapped", "10"))},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=10
+            )
+        },
+        snapshots={"order-1": _snapshot(_position("legacy-unmapped"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -218,8 +262,12 @@ def test_cancelled_order_does_not_consume_capacity() -> None:
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
-        snapshots={"order-1": _snapshot(_position("dish-a", "100"))},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=100
+            )
+        },
+        snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -235,7 +283,11 @@ def test_capacity_fails_closed_when_committed_snapshot_is_missing() -> None:
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=10
+            )
+        },
         snapshots={},
     )
 
@@ -245,15 +297,19 @@ def test_capacity_fails_closed_when_committed_snapshot_is_missing() -> None:
     assert row.reason_code == "DEMAND_SOURCE_INCOMPLETE"
 
 
-def test_capacity_fails_closed_when_committed_quantity_is_not_whole() -> None:
+def test_capacity_fails_closed_when_guest_count_is_missing() -> None:
     requirement = CatalogStationRequirement("dish-a", "cold", 1)
     order = _order("order-1", "version-1")
     service = _service(
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
-        versions={"version-1": _version("order-1", "version-1")},
-        snapshots={"order-1": _snapshot(_position("dish-a", "1.5"))},
+        versions={
+            "version-1": _version(
+                "order-1", "version-1", guest_count_estimate=None
+            )
+        },
+        snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]
@@ -315,19 +371,21 @@ def test_capacity_falls_back_to_latest_order_version() -> None:
         order_version_id="version-1",
         version_number=1,
         event_date=date(2026, 8, 30),
+        guest_count_estimate=50,
     )
     latest = SimpleNamespace(
         order_id="order-1",
         order_version_id="version-2",
         version_number=2,
         event_date=EVENT_DATE,
+        guest_count_estimate=10,
     )
     service = _service(
         requirements={"dish-a": [requirement]},
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={"version-1": older, "version-2": latest},
-        snapshots={"order-1": _snapshot(_position("dish-a", "10"))},
+        snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
 
     row = service.list_for_date(EVENT_DATE)[0]

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -146,9 +146,7 @@ def test_capacity_penalty_uses_committed_guest_count() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=40
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=40)
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -173,9 +171,7 @@ def test_multiple_positions_do_not_multiply_guest_capacity() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 500)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=100
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=100)
         },
         snapshots={
             "order-1": _snapshot(_position("dish-a"), _position("dish-b"))
@@ -210,9 +206,7 @@ def test_capacity_exhausted_when_committed_guests_reach_limit() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 20)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=20
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=20)
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -232,9 +226,7 @@ def test_capacity_fails_closed_when_demand_is_incomplete() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=10
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=10)
         },
         snapshots={"order-1": _snapshot(_position("legacy-unmapped"))},
     )
@@ -263,9 +255,7 @@ def test_cancelled_order_does_not_consume_capacity() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=100
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=100)
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -284,9 +274,7 @@ def test_capacity_fails_closed_when_committed_snapshot_is_missing() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=10
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=10)
         },
         snapshots={},
     )
@@ -305,9 +293,7 @@ def test_capacity_fails_closed_when_guest_count_is_missing() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version(
-                "order-1", "version-1", guest_count_estimate=None
-            )
+            "version-1": _version("order-1", "version-1", guest_count_estimate=None)
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )

--- a/tests/unit/test_issue162_recommendation_capacity.py
+++ b/tests/unit/test_issue162_recommendation_capacity.py
@@ -146,7 +146,7 @@ def test_capacity_penalty_uses_committed_guest_count() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=40)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=40),
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -171,10 +171,10 @@ def test_multiple_positions_do_not_multiply_guest_capacity() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 500)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=100)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=100),
         },
         snapshots={
-            "order-1": _snapshot(_position("dish-a"), _position("dish-b"))
+            "order-1": _snapshot(_position("dish-a"), _position("dish-b")),
         },
     )
 
@@ -206,7 +206,7 @@ def test_capacity_exhausted_when_committed_guests_reach_limit() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 20)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=20)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=20),
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -226,7 +226,7 @@ def test_capacity_fails_closed_when_demand_is_incomplete() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=10)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=10),
         },
         snapshots={"order-1": _snapshot(_position("legacy-unmapped"))},
     )
@@ -255,7 +255,7 @@ def test_cancelled_order_does_not_consume_capacity() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=100)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=100),
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )
@@ -274,7 +274,7 @@ def test_capacity_fails_closed_when_committed_snapshot_is_missing() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=10)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=10),
         },
         snapshots={},
     )
@@ -293,7 +293,7 @@ def test_capacity_fails_closed_when_guest_count_is_missing() -> None:
         capacity_days=[CapacityDay(EVENT_DATE, "cold", 100)],
         orders=[order],
         versions={
-            "version-1": _version("order-1", "version-1", guest_count_estimate=None)
+            "version-1": _version("order-1", "version-1", guest_count_estimate=None),
         },
         snapshots={"order-1": _snapshot(_position("dish-a"))},
     )


### PR DESCRIPTION
Capacity threshold semantics are changed from summed catalog-position quantities to committed guest count.

For each accepted/confirmed order on the target date, `guest_count_estimate` is counted once per touched production station. Multiple catalog positions no longer multiply the order's capacity load. This makes a configured capacity of 500 mean 500 guests for the current single `production` / `Gesamtproduktion` model.

The existing PII-free endpoint shape is unchanged. Missing business facts remain visible through the existing reason codes.

This PR only corrects Core's capacity measurement. Consumer behavior is changed separately so capacity becomes advisory-only and never a hard recommendation block.