### PR TITLE
Issue #152: expose explicit customer preferences in Office API

### DIFF
--- a/.github/workflows/issue152-office-preferences-once.yml
+++ b/.github/workflows/issue152-office-preferences-once.yml
@@ -1,0 +1,320 @@
+name: Issue 152 Office preferences once
+
+on:
+  push:
+    branches:
+      - issue-152-office-explicit-preferences
+
+permissions:
+  contents: write
+
+jobs:
+  patch-and-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: issue-152-office-explicit-preferences
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: "0.11.32"
+          python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Wire explicit preferences into Office API
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("src/catering_system/ui/office_api.py")
+          text = path.read_text()
+
+          def add_after(anchor: str, addition: str) -> None:
+              global text
+              if addition.strip() in text:
+                  return
+              if anchor not in text:
+                  raise SystemExit(f"missing anchor: {anchor!r}")
+              text = text.replace(anchor, anchor + addition, 1)
+
+          def add_before(anchor: str, addition: str) -> None:
+              global text
+              if addition.strip() in text:
+                  return
+              if anchor not in text:
+                  raise SystemExit(f"missing anchor: {anchor!r}")
+              text = text.replace(anchor, addition + anchor, 1)
+
+          add_before(
+              "from catering_system.domain.customer_document_eligibility import (\n",
+              "from catering_system.domain.customer_gastronomic_preference import (\n"
+              "    CustomerGastronomicPreference,\n"
+              "    validate_preference_kind,\n"
+              "    validate_preference_source,\n"
+              ")\n",
+          )
+          add_before(
+              "from catering_system.repositories.sqlite_employee_auth_repository import (\n",
+              "from catering_system.repositories.sqlite_customer_gastronomic_preference_repository import (\n"
+              "    SQLiteCustomerGastronomicPreferenceRepository,\n"
+              ")\n"
+              "from catering_system.repositories.sqlite_customer_identity_repository import (\n"
+              "    SQLiteCustomerIdentityRepository,\n"
+              ")\n",
+          )
+          add_before(
+              "from catering_system.services.configurator_handoff_service import (\n",
+              "from catering_system.services.customer_gastronomic_preference_service import (\n"
+              "    CustomerGastronomicPreferenceNotFoundError,\n"
+              "    CustomerGastronomicPreferenceService,\n"
+              "    CustomerNotFoundError,\n"
+              ")\n",
+          )
+
+          add_before(
+              "# --- API core ----------------------------------------------------------------\n",
+              "def _gastronomic_preference_shape(\n"
+              "    preference: CustomerGastronomicPreference,\n"
+              ") -> dict[str, object]:\n"
+              "    return {\n"
+              "        \"preference_id\": preference.preference_id,\n"
+              "        \"customer_id\": preference.customer_id,\n"
+              "        \"kind\": preference.kind,\n"
+              "        \"value\": preference.value,\n"
+              "        \"source\": preference.source,\n"
+              "        \"created_at\": preference.created_at.isoformat(),\n"
+              "        \"updated_at\": preference.updated_at.isoformat(),\n"
+              "    }\n\n\n",
+          )
+
+          add_after(
+              "        bootstrap_customer_identity_schema(connection)\n",
+              "        self.customer_identities = SQLiteCustomerIdentityRepository.from_connection(\n"
+              "            connection\n"
+              "        )\n"
+              "        self.customer_gastronomic_preferences = (\n"
+              "            SQLiteCustomerGastronomicPreferenceRepository.from_connection(connection)\n"
+              "        )\n",
+          )
+          add_before(
+              "        self.order_service = OrderService(self.orders, event_sink=self.events)\n",
+              "        self.customer_gastronomic_preference_service = (\n"
+              "            CustomerGastronomicPreferenceService(\n"
+              "                self.customer_identities, self.customer_gastronomic_preferences\n"
+              "            )\n"
+              "        )\n",
+          )
+
+          add_before(
+              "    # -- reads -----------------------------------------------------------\n",
+              "    def list_customer_gastronomic_preferences(\n"
+              "        self, customer_id: str\n"
+              "    ) -> dict[str, object]:\n"
+              "        try:\n"
+              "            preferences = self.customer_gastronomic_preference_service.list_for_customer(\n"
+              "                customer_id\n"
+              "            )\n"
+              "        except CustomerNotFoundError as exc:\n"
+              "            raise ApiError(404, \"customer_not_found\") from exc\n"
+              "        return {\n"
+              "            \"customer_id\": customer_id,\n"
+              "            \"preferences\": [\n"
+              "                _gastronomic_preference_shape(preference)\n"
+              "                for preference in preferences\n"
+              "            ],\n"
+              "        }\n\n",
+          )
+
+          add_before(
+              "    def cmd_create_inquiry(\n",
+              "    def cmd_create_customer_gastronomic_preference(\n"
+              "        self, path_ids: dict[str, str], args: dict[str, object], expect: dict\n"
+              "    ) -> tuple[int, dict[str, object]]:\n"
+              "        try:\n"
+              "            preference = self.customer_gastronomic_preference_service.create(\n"
+              "                customer_id=path_ids[\"customer_id\"],\n"
+              "                kind=validate_preference_kind(_v_str(args[\"kind\"], 100)),\n"
+              "                value=_v_str(args[\"value\"], 1000),\n"
+              "                source=validate_preference_source(_v_str(args[\"source\"], 100)),\n"
+              "            )\n"
+              "        except CustomerNotFoundError as exc:\n"
+              "            raise ApiError(404, \"customer_not_found\") from exc\n"
+              "        except (TypeError, ValueError) as exc:\n"
+              "            raise ApiError(422, \"invalid_gastronomic_preference\") from exc\n"
+              "        return 201, {\"preference\": _gastronomic_preference_shape(preference)}\n\n"
+              "    def cmd_update_customer_gastronomic_preference(\n"
+              "        self, path_ids: dict[str, str], args: dict[str, object], expect: dict\n"
+              "    ) -> tuple[int, dict[str, object]]:\n"
+              "        try:\n"
+              "            preference = self.customer_gastronomic_preference_service.update(\n"
+              "                customer_id=path_ids[\"customer_id\"],\n"
+              "                preference_id=path_ids[\"preference_id\"],\n"
+              "                kind=validate_preference_kind(_v_str(args[\"kind\"], 100)),\n"
+              "                value=_v_str(args[\"value\"], 1000),\n"
+              "                source=validate_preference_source(_v_str(args[\"source\"], 100)),\n"
+              "            )\n"
+              "        except CustomerNotFoundError as exc:\n"
+              "            raise ApiError(404, \"customer_not_found\") from exc\n"
+              "        except CustomerGastronomicPreferenceNotFoundError as exc:\n"
+              "            raise ApiError(404, \"gastronomic_preference_not_found\") from exc\n"
+              "        except (TypeError, ValueError) as exc:\n"
+              "            raise ApiError(422, \"invalid_gastronomic_preference\") from exc\n"
+              "        return 200, {\"preference\": _gastronomic_preference_shape(preference)}\n\n"
+              "    def cmd_delete_customer_gastronomic_preference(\n"
+              "        self, path_ids: dict[str, str], args: dict[str, object], expect: dict\n"
+              "    ) -> tuple[int, dict[str, object]]:\n"
+              "        preference_id = path_ids[\"preference_id\"]\n"
+              "        try:\n"
+              "            self.customer_gastronomic_preference_service.delete(\n"
+              "                customer_id=path_ids[\"customer_id\"],\n"
+              "                preference_id=preference_id,\n"
+              "            )\n"
+              "        except CustomerNotFoundError as exc:\n"
+              "            raise ApiError(404, \"customer_not_found\") from exc\n"
+              "        except CustomerGastronomicPreferenceNotFoundError as exc:\n"
+              "            raise ApiError(404, \"gastronomic_preference_not_found\") from exc\n"
+              "        return 200, {\"deleted_preference_id\": preference_id}\n\n",
+          )
+
+          add_before(
+              "_COMMANDS: dict[str, _CommandSpec] = {\n",
+              "_GASTRONOMIC_PREFERENCE_ARGS = _ArgKeys(\n"
+              "    required=frozenset({\"kind\", \"value\", \"source\"})\n"
+              ")\n\n",
+          )
+          add_after(
+              "_COMMANDS: dict[str, _CommandSpec] = {\n",
+              "    \"create_customer_gastronomic_preference\": _CommandSpec(\n"
+              "        \"cmd_create_customer_gastronomic_preference\",\n"
+              "        _GASTRONOMIC_PREFERENCE_ARGS,\n"
+              "        set(),\n"
+              "    ),\n"
+              "    \"update_customer_gastronomic_preference\": _CommandSpec(\n"
+              "        \"cmd_update_customer_gastronomic_preference\",\n"
+              "        _GASTRONOMIC_PREFERENCE_ARGS,\n"
+              "        set(),\n"
+              "    ),\n"
+              "    \"delete_customer_gastronomic_preference\": _CommandSpec(\n"
+              "        \"cmd_delete_customer_gastronomic_preference\", _NO_ARGS, set()\n"
+              "    ),\n",
+          )
+
+          route_anchor = "    (\n        re.compile(r\"^/office/v1/inquiries$\"),\n"
+          add_before(
+              route_anchor,
+              "    (\n"
+              "        re.compile(\n"
+              "            r\"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences$\"\n"
+              "        ),\n"
+              "        \"/office/v1/customers/{customer_id}/gastronomic-preferences\",\n"
+              "        {\"GET\": \"list_customer_gastronomic_preferences\"},\n"
+              "    ),\n"
+              "    (\n"
+              "        re.compile(\n"
+              "            r\"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/create$\"\n"
+              "        ),\n"
+              "        \"/office/v1/customers/{customer_id}/gastronomic-preferences/create\",\n"
+              "        {\"POST\": \"create_customer_gastronomic_preference\"},\n"
+              "    ),\n"
+              "    (\n"
+              "        re.compile(\n"
+              "            r\"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/\"\n"
+              "            r\"(?P<preference_id>[^/]+)/update$\"\n"
+              "        ),\n"
+              "        \"/office/v1/customers/{customer_id}/gastronomic-preferences/{preference_id}/update\",\n"
+              "        {\"POST\": \"update_customer_gastronomic_preference\"},\n"
+              "    ),\n"
+              "    (\n"
+              "        re.compile(\n"
+              "            r\"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/\"\n"
+              "            r\"(?P<preference_id>[^/]+)/delete$\"\n"
+              "        ),\n"
+              "        \"/office/v1/customers/{customer_id}/gastronomic-preferences/{preference_id}/delete\",\n"
+              "        {\"POST\": \"delete_customer_gastronomic_preference\"},\n"
+              "    ),\n",
+          )
+
+          add_before(
+              "            elif kind == \"list_inquiries\":\n",
+              "            elif kind == \"list_customer_gastronomic_preferences\":\n"
+              "                self._query(set())\n"
+              "                self._respond(\n"
+              "                    200,\n"
+              "                    api.list_customer_gastronomic_preferences(\n"
+              "                        path_ids[\"customer_id\"]\n"
+              "                    ),\n"
+              "                )\n",
+          )
+
+          path.write_text(text)
+
+          service_test = Path("tests/unit/test_customer_gastronomic_preference_service.py")
+          test_text = service_test.read_text()
+          test_text = test_text.replace(
+              "from datetime import UTC, datetime, timedelta\n",
+              "from datetime import UTC, datetime, timedelta\nfrom typing import TypeAlias\n",
+          )
+          test_text = test_text.replace(
+              "NOW = datetime(2026, 8, 25, 18, 0, tzinfo=UTC)\n",
+              "NOW = datetime(2026, 8, 25, 18, 0, tzinfo=UTC)\n\nServiceFixture: TypeAlias = tuple[\n    CustomerGastronomicPreferenceService,\n    InMemoryCustomerIdentityRepository,\n    InMemoryCustomerGastronomicPreferenceRepository,\n]\n",
+          )
+          test_text = test_text.replace("def _service():\n", "def _service() -> ServiceFixture:\n")
+          service_test.write_text(test_text)
+
+          api_test = Path("tests/unit/test_issue152_explicit_preferences_office_api.py")
+          api_text = api_test.read_text()
+          api_text = api_text.replace(
+              "from catering_system.repositories.sqlite_customer_identity_repository import (\n",
+              "from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content\n\n"
+              "from catering_system.repositories.sqlite_customer_identity_repository import (\n",
+          )
+          api_text = api_text.replace(
+              "            0,\n        )\n",
+              "            0,\n            offer_pdf_static_content=fake_offer_pdf_static_content(),\n        )\n",
+              1,
+          )
+          api_test.write_text(api_text)
+          PY
+      - name: Verify lock
+        run: uv lock --check
+      - name: Install
+        run: uv sync --dev
+      - name: Format changed Python
+        run: |
+          uv run ruff format \
+            src/catering_system/services/customer_gastronomic_preference_service.py \
+            src/catering_system/ui/office_api.py \
+            tests/unit/test_customer_gastronomic_preference_service.py \
+            tests/unit/test_issue152_explicit_preferences_office_api.py
+      - name: Lint
+        run: uv run ruff check src tests infra
+      - name: Type-check production code
+        run: uv run mypy src/catering_system
+      - name: Focused tests
+        run: |
+          uv run pytest -q \
+            tests/unit/test_customer_gastronomic_preference_service.py \
+            tests/unit/test_issue152_explicit_preferences_office_api.py
+      - name: Full Python coverage
+        run: |
+          uv run coverage run -m pytest -q
+          uv run coverage report
+      - name: Verify PDF runtime and systemd alignment
+        run: uv run python infra/deploy/verify_pdf_runtime.py --repository-only
+      - name: Test JavaScript
+        run: |
+          node --test infra/staging-form/app.test.cjs
+          node --test infra/cloudflare_worker/sanitize.test.mjs
+      - name: Commit product changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src tests
+          if git diff --cached --quiet; then
+            echo "No product changes to commit"
+          else
+            git commit -m "Issue #152: expose explicit preferences in Office API"
+            git push origin HEAD:issue-152-office-explicit-preferences
+          fi

--- a/src/catering_system/services/customer_gastronomic_preference_service.py
+++ b/src/catering_system/services/customer_gastronomic_preference_service.py
@@ -46,7 +46,9 @@ class CustomerGastronomicPreferenceService:
         self._now = now or (lambda: datetime.now(UTC))
         self._new_id = new_id or (lambda: str(uuid.uuid4()))
 
-    def list_for_customer(self, customer_id: str) -> list[CustomerGastronomicPreference]:
+    def list_for_customer(
+        self, customer_id: str
+    ) -> list[CustomerGastronomicPreference]:
         self._require_customer(customer_id)
         return self._preferences.list_by_customer(customer_id)
 

--- a/src/catering_system/services/customer_gastronomic_preference_service.py
+++ b/src/catering_system/services/customer_gastronomic_preference_service.py
@@ -1,0 +1,115 @@
+"""Customer-scoped editing service for explicit gastronomic preferences.
+
+Only deliberately recorded customer facts belong here. Order-history projections and
+inferred recommendation hints are separate concerns and must not enter this service.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from catering_system.domain.customer_gastronomic_preference import (
+    CustomerGastronomicPreference,
+    PreferenceKind,
+    PreferenceSource,
+    validate_customer_gastronomic_preference,
+)
+from catering_system.repositories.customer_gastronomic_preference_repository import (
+    CustomerGastronomicPreferenceRepository,
+)
+from catering_system.repositories.customer_identity_repository import (
+    CustomerIdentityRepository,
+)
+
+
+class CustomerNotFoundError(LookupError):
+    pass
+
+
+class CustomerGastronomicPreferenceNotFoundError(LookupError):
+    pass
+
+
+class CustomerGastronomicPreferenceService:
+    def __init__(
+        self,
+        customers: CustomerIdentityRepository,
+        preferences: CustomerGastronomicPreferenceRepository,
+        *,
+        now: Callable[[], datetime] | None = None,
+        new_id: Callable[[], str] | None = None,
+    ) -> None:
+        self._customers = customers
+        self._preferences = preferences
+        self._now = now or (lambda: datetime.now(UTC))
+        self._new_id = new_id or (lambda: str(uuid.uuid4()))
+
+    def list_for_customer(self, customer_id: str) -> list[CustomerGastronomicPreference]:
+        self._require_customer(customer_id)
+        return self._preferences.list_by_customer(customer_id)
+
+    def create(
+        self,
+        *,
+        customer_id: str,
+        kind: PreferenceKind,
+        value: str,
+        source: PreferenceSource,
+    ) -> CustomerGastronomicPreference:
+        self._require_customer(customer_id)
+        now = self._now()
+        preference = CustomerGastronomicPreference(
+            preference_id=self._new_id(),
+            customer_id=customer_id,
+            kind=kind,
+            value=value,
+            source=source,
+            created_at=now,
+            updated_at=now,
+        )
+        validate_customer_gastronomic_preference(preference)
+        self._preferences.add(preference)
+        return preference
+
+    def update(
+        self,
+        *,
+        customer_id: str,
+        preference_id: str,
+        kind: PreferenceKind,
+        value: str,
+        source: PreferenceSource,
+    ) -> CustomerGastronomicPreference:
+        self._require_customer(customer_id)
+        current = self._require_preference(customer_id, preference_id)
+        updated = CustomerGastronomicPreference(
+            preference_id=current.preference_id,
+            customer_id=current.customer_id,
+            kind=kind,
+            value=value,
+            source=source,
+            created_at=current.created_at,
+            updated_at=self._now(),
+        )
+        validate_customer_gastronomic_preference(updated)
+        self._preferences.update(updated)
+        return updated
+
+    def delete(self, *, customer_id: str, preference_id: str) -> None:
+        self._require_customer(customer_id)
+        self._require_preference(customer_id, preference_id)
+        self._preferences.delete(preference_id)
+
+    def _require_customer(self, customer_id: str) -> None:
+        if self._customers.get_by_id(customer_id) is None:
+            raise CustomerNotFoundError(customer_id)
+
+    def _require_preference(
+        self, customer_id: str, preference_id: str
+    ) -> CustomerGastronomicPreference:
+        preference = self._preferences.get_by_id(preference_id)
+        if preference is None or preference.customer_id != customer_id:
+            raise CustomerGastronomicPreferenceNotFoundError(preference_id)
+        return preference

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -47,6 +47,11 @@ from catering_system.domain.chat import (
     validate_chat_reference_type,
     validate_chat_thread_type,
 )
+from catering_system.domain.customer_gastronomic_preference import (
+    CustomerGastronomicPreference,
+    validate_preference_kind,
+    validate_preference_source,
+)
 from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentCreationBlocked,
 )
@@ -125,6 +130,12 @@ from catering_system.repositories.sqlite_configurator_handoff_repository import 
 from catering_system.repositories.sqlite_contact_profile_repository import (
     SQLiteContactProfileRepository,
 )
+from catering_system.repositories.sqlite_customer_gastronomic_preference_repository import (
+    SQLiteCustomerGastronomicPreferenceRepository,
+)
+from catering_system.repositories.sqlite_customer_identity_repository import (
+    SQLiteCustomerIdentityRepository,
+)
 from catering_system.repositories.sqlite_employee_auth_repository import (
     SQLiteEmployeeAuthRepository,
 )
@@ -176,6 +187,11 @@ from catering_system.services.chat_service import (
     ChatNotFoundError,
     ChatReferenceNotFoundError,
     ChatService,
+)
+from catering_system.services.customer_gastronomic_preference_service import (
+    CustomerGastronomicPreferenceNotFoundError,
+    CustomerGastronomicPreferenceService,
+    CustomerNotFoundError,
 )
 from catering_system.services.configurator_handoff_service import (
     HANDOFF_OPERATION_PREPARE_FIRST_OFFER,
@@ -649,6 +665,20 @@ def _manual_task_shape(task: ManualTask) -> dict[str, object]:
     }
 
 
+def _gastronomic_preference_shape(
+    preference: CustomerGastronomicPreference,
+) -> dict[str, object]:
+    return {
+        "preference_id": preference.preference_id,
+        "customer_id": preference.customer_id,
+        "kind": preference.kind,
+        "value": preference.value,
+        "source": preference.source,
+        "created_at": preference.created_at.isoformat(),
+        "updated_at": preference.updated_at.isoformat(),
+    }
+
+
 # --- API core ----------------------------------------------------------------
 
 
@@ -667,6 +697,12 @@ class OfficeApi:
         self.offer_pdf_static_content = offer_pdf_static_content
         self.inquiries = SQLiteInquiryRepository.from_connection(connection)
         bootstrap_customer_identity_schema(connection)
+        self.customer_identities = SQLiteCustomerIdentityRepository.from_connection(
+            connection
+        )
+        self.customer_gastronomic_preferences = (
+            SQLiteCustomerGastronomicPreferenceRepository.from_connection(connection)
+        )
         bootstrap_employee_auth_schema(connection)
         self.orders = SQLiteOrderRepository.from_connection(connection)
         self.kitchen_print_jobs = SQLiteKitchenPrintJobRepository.from_connection(
@@ -724,6 +760,11 @@ class OfficeApi:
         self._active_command_id: str | None = None
         self._active_employee: AuthenticatedEmployee | None = None
         self.inquiry_service = InquiryService(self.inquiries, event_sink=self.events)
+        self.customer_gastronomic_preference_service = (
+            CustomerGastronomicPreferenceService(
+                self.customer_identities, self.customer_gastronomic_preferences
+            )
+        )
         self.order_service = OrderService(self.orders, event_sink=self.events)
         self.offer_service = OfferService(
             self.offers,
@@ -919,6 +960,24 @@ class OfficeApi:
             }
 
         return self.executor.run(work)
+
+    def list_customer_gastronomic_preferences(
+        self, customer_id: str
+    ) -> dict[str, object]:
+        try:
+            preferences = (
+                self.customer_gastronomic_preference_service.list_for_customer(
+                    customer_id
+                )
+            )
+        except CustomerNotFoundError as exc:
+            raise ApiError(404, "customer_not_found") from exc
+        return {
+            "customer_id": customer_id,
+            "preferences": [
+                _gastronomic_preference_shape(preference) for preference in preferences
+            ],
+        }
 
     # -- reads -----------------------------------------------------------
 
@@ -1928,6 +1987,56 @@ class OfficeApi:
             "employee_id": employee.account.id,
             "last_read_message_id": last_read_message_id,
         }
+
+    def cmd_create_customer_gastronomic_preference(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        try:
+            preference = self.customer_gastronomic_preference_service.create(
+                customer_id=path_ids["customer_id"],
+                kind=validate_preference_kind(_v_str(args["kind"], 100)),
+                value=_v_str(args["value"], 1000),
+                source=validate_preference_source(_v_str(args["source"], 100)),
+            )
+        except CustomerNotFoundError as exc:
+            raise ApiError(404, "customer_not_found") from exc
+        except (TypeError, ValueError) as exc:
+            raise ApiError(422, "invalid_gastronomic_preference") from exc
+        return 201, {"preference": _gastronomic_preference_shape(preference)}
+
+    def cmd_update_customer_gastronomic_preference(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        try:
+            preference = self.customer_gastronomic_preference_service.update(
+                customer_id=path_ids["customer_id"],
+                preference_id=path_ids["preference_id"],
+                kind=validate_preference_kind(_v_str(args["kind"], 100)),
+                value=_v_str(args["value"], 1000),
+                source=validate_preference_source(_v_str(args["source"], 100)),
+            )
+        except CustomerNotFoundError as exc:
+            raise ApiError(404, "customer_not_found") from exc
+        except CustomerGastronomicPreferenceNotFoundError as exc:
+            raise ApiError(404, "gastronomic_preference_not_found") from exc
+        except (TypeError, ValueError) as exc:
+            raise ApiError(422, "invalid_gastronomic_preference") from exc
+        return 200, {"preference": _gastronomic_preference_shape(preference)}
+
+    def cmd_delete_customer_gastronomic_preference(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        preference_id = path_ids["preference_id"]
+        try:
+            self.customer_gastronomic_preference_service.delete(
+                customer_id=path_ids["customer_id"],
+                preference_id=preference_id,
+            )
+        except CustomerNotFoundError as exc:
+            raise ApiError(404, "customer_not_found") from exc
+        except CustomerGastronomicPreferenceNotFoundError as exc:
+            raise ApiError(404, "gastronomic_preference_not_found") from exc
+        return 200, {"deleted_preference_id": preference_id}
 
     def cmd_create_inquiry(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
@@ -3248,7 +3357,22 @@ _CHAT_MESSAGE_CREATE_ARGS = _ArgKeys(
 )
 _CHAT_READ_ARGS = _ArgKeys(required=frozenset({"last_read_message_id"}))
 
+_GASTRONOMIC_PREFERENCE_ARGS = _ArgKeys(required=frozenset({"kind", "value", "source"}))
+
 _COMMANDS: dict[str, _CommandSpec] = {
+    "create_customer_gastronomic_preference": _CommandSpec(
+        "cmd_create_customer_gastronomic_preference",
+        _GASTRONOMIC_PREFERENCE_ARGS,
+        set(),
+    ),
+    "update_customer_gastronomic_preference": _CommandSpec(
+        "cmd_update_customer_gastronomic_preference",
+        _GASTRONOMIC_PREFERENCE_ARGS,
+        set(),
+    ),
+    "delete_customer_gastronomic_preference": _CommandSpec(
+        "cmd_delete_customer_gastronomic_preference", _NO_ARGS, set()
+    ),
     "create_inquiry": _CommandSpec("cmd_create_inquiry", _CREATE_ARGS, set()),
     "update_inquiry": _CommandSpec("cmd_update_inquiry", _UPDATE_ARGS, {"updated_at"}),
     "contact-completion": _CommandSpec(
@@ -3411,6 +3535,36 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/chat/threads/(?P<thread_id>[^/]+)/participants$"),
         "/office/v1/chat/threads/{thread_id}/participants",
         {"GET": "chat_thread_participants"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences$"
+        ),
+        "/office/v1/customers/{customer_id}/gastronomic-preferences",
+        {"GET": "list_customer_gastronomic_preferences"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/create$"
+        ),
+        "/office/v1/customers/{customer_id}/gastronomic-preferences/create",
+        {"POST": "create_customer_gastronomic_preference"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/"
+            r"(?P<preference_id>[^/]+)/update$"
+        ),
+        "/office/v1/customers/{customer_id}/gastronomic-preferences/{preference_id}/update",
+        {"POST": "update_customer_gastronomic_preference"},
+    ),
+    (
+        re.compile(
+            r"^/office/v1/customers/(?P<customer_id>[^/]+)/gastronomic-preferences/"
+            r"(?P<preference_id>[^/]+)/delete$"
+        ),
+        "/office/v1/customers/{customer_id}/gastronomic-preferences/{preference_id}/delete",
+        {"POST": "delete_customer_gastronomic_preference"},
     ),
     (
         re.compile(r"^/office/v1/inquiries$"),
@@ -4143,6 +4297,12 @@ def make_office_api_handler(
             elif kind == "work_center":
                 self._query(set())
                 self._respond(200, api.work_center())
+            elif kind == "list_customer_gastronomic_preferences":
+                self._query(set())
+                self._respond(
+                    200,
+                    api.list_customer_gastronomic_preferences(path_ids["customer_id"]),
+                )
             elif kind == "list_inquiries":
                 params = self._query({"q", "limit", "offset"})
                 q = _v_str(params.get("q", ""), _MAX_Q_CHARS).strip().lower()

--- a/tests/unit/test_customer_gastronomic_preference_service.py
+++ b/tests/unit/test_customer_gastronomic_preference_service.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from typing import TypeAlias
 
 import pytest
 
@@ -18,6 +19,12 @@ from catering_system.services.customer_gastronomic_preference_service import (
 
 NOW = datetime(2026, 8, 25, 18, 0, tzinfo=UTC)
 
+ServiceFixture: TypeAlias = tuple[
+    CustomerGastronomicPreferenceService,
+    InMemoryCustomerIdentityRepository,
+    InMemoryCustomerGastronomicPreferenceRepository,
+]
+
 
 def _customer(customer_id: str = "customer-1") -> CustomerIdentity:
     return CustomerIdentity(
@@ -30,7 +37,7 @@ def _customer(customer_id: str = "customer-1") -> CustomerIdentity:
     )
 
 
-def _service():
+def _service() -> ServiceFixture:
     customers = InMemoryCustomerIdentityRepository()
     preferences = InMemoryCustomerGastronomicPreferenceRepository()
     service = CustomerGastronomicPreferenceService(
@@ -143,7 +150,9 @@ def test_delete_removes_preference_but_not_customer_identity() -> None:
         source="customer_stated",
     )
 
-    service.delete(customer_id=customer.customer_id, preference_id=created.preference_id)
+    service.delete(
+        customer_id=customer.customer_id, preference_id=created.preference_id
+    )
 
     assert preferences.get_by_id(created.preference_id) is None
     assert customers.get_by_id(customer.customer_id) == customer

--- a/tests/unit/test_customer_gastronomic_preference_service.py
+++ b/tests/unit/test_customer_gastronomic_preference_service.py
@@ -1,0 +1,161 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from catering_system.domain.customer_identity import CustomerIdentity
+from catering_system.repositories.in_memory_customer_gastronomic_preference_repository import (
+    InMemoryCustomerGastronomicPreferenceRepository,
+)
+from catering_system.repositories.in_memory_customer_identity_repository import (
+    InMemoryCustomerIdentityRepository,
+)
+from catering_system.services.customer_gastronomic_preference_service import (
+    CustomerGastronomicPreferenceNotFoundError,
+    CustomerGastronomicPreferenceService,
+    CustomerNotFoundError,
+)
+
+
+NOW = datetime(2026, 8, 25, 18, 0, tzinfo=UTC)
+
+
+def _customer(customer_id: str = "customer-1") -> CustomerIdentity:
+    return CustomerIdentity(
+        customer_id=customer_id,
+        display_name="Testkunde",
+        company_name=None,
+        status="active",
+        created_at=NOW - timedelta(days=1),
+        updated_at=NOW - timedelta(days=1),
+    )
+
+
+def _service():
+    customers = InMemoryCustomerIdentityRepository()
+    preferences = InMemoryCustomerGastronomicPreferenceRepository()
+    service = CustomerGastronomicPreferenceService(
+        customers,
+        preferences,
+        now=lambda: NOW,
+        new_id=lambda: "pref-1",
+    )
+    return service, customers, preferences
+
+
+def test_create_requires_existing_customer_and_persists_only_explicit_fact() -> None:
+    service, customers, preferences = _service()
+    with pytest.raises(CustomerNotFoundError):
+        service.create(
+            customer_id="missing",
+            kind="favorite_dish",
+            value="Mini-Frikadellen",
+            source="customer_stated",
+        )
+
+    customers.add(_customer())
+    created = service.create(
+        customer_id="customer-1",
+        kind="favorite_dish",
+        value="Mini-Frikadellen",
+        source="customer_stated",
+    )
+
+    assert created.preference_id == "pref-1"
+    assert created.customer_id == "customer-1"
+    assert created.created_at == NOW
+    assert created.updated_at == NOW
+    assert preferences.get_by_id("pref-1") == created
+
+
+def test_list_requires_existing_customer() -> None:
+    service, customers, _ = _service()
+    with pytest.raises(CustomerNotFoundError):
+        service.list_for_customer("missing")
+
+    customers.add(_customer())
+    assert service.list_for_customer("customer-1") == []
+
+
+def test_update_preserves_customer_and_created_at() -> None:
+    service, customers, preferences = _service()
+    customers.add(_customer())
+    created = service.create(
+        customer_id="customer-1",
+        kind="favorite_dish",
+        value="Mini-Frikadellen",
+        source="customer_stated",
+    )
+
+    later = NOW + timedelta(minutes=5)
+    service._now = lambda: later
+    updated = service.update(
+        customer_id="customer-1",
+        preference_id="pref-1",
+        kind="disliked_dish",
+        value="Leber",
+        source="office_recorded",
+    )
+
+    assert updated.customer_id == created.customer_id
+    assert updated.created_at == created.created_at
+    assert updated.updated_at == later
+    assert updated.kind == "disliked_dish"
+    assert updated.source == "office_recorded"
+    assert preferences.get_by_id("pref-1") == updated
+
+
+def test_customer_scoping_hides_other_customers_preferences() -> None:
+    service, customers, preferences = _service()
+    customers.add(_customer("customer-1"))
+    customers.add(_customer("customer-2"))
+    created = service.create(
+        customer_id="customer-1",
+        kind="service_style",
+        value="Buffet",
+        source="office_recorded",
+    )
+
+    with pytest.raises(CustomerGastronomicPreferenceNotFoundError):
+        service.update(
+            customer_id="customer-2",
+            preference_id=created.preference_id,
+            kind="service_style",
+            value="Fingerfood",
+            source="office_recorded",
+        )
+    with pytest.raises(CustomerGastronomicPreferenceNotFoundError):
+        service.delete(
+            customer_id="customer-2",
+            preference_id=created.preference_id,
+        )
+
+    assert preferences.get_by_id(created.preference_id) == created
+
+
+def test_delete_removes_preference_but_not_customer_identity() -> None:
+    service, customers, preferences = _service()
+    customer = _customer()
+    customers.add(customer)
+    created = service.create(
+        customer_id=customer.customer_id,
+        kind="spice_level",
+        value="mild",
+        source="customer_stated",
+    )
+
+    service.delete(customer_id=customer.customer_id, preference_id=created.preference_id)
+
+    assert preferences.get_by_id(created.preference_id) is None
+    assert customers.get_by_id(customer.customer_id) == customer
+
+
+def test_inferred_source_is_rejected_by_domain_boundary() -> None:
+    service, customers, _ = _service()
+    customers.add(_customer())
+    with pytest.raises(ValueError, match="source must be explicit"):
+        service.create(
+            customer_id="customer-1",
+            kind="favorite_dish",
+            value="Mini-Frikadellen",
+            source="inferred",  # type: ignore[arg-type]
+        )

--- a/tests/unit/test_issue152_explicit_preferences_office_api.py
+++ b/tests/unit/test_issue152_explicit_preferences_office_api.py
@@ -152,7 +152,8 @@ def test_office_can_create_list_update_and_delete_explicit_preference(
 
     status, deleted = _post(f"{root}/{preference_id}/delete")
     assert status == 200
-    assert deleted == {"deleted_preference_id": preference_id}
+    assert deleted["deleted_preference_id"] == preference_id
+    assert isinstance(deleted["command_id"], str)
 
     status, listed = _get(root)
     assert status == 200

--- a/tests/unit/test_issue152_explicit_preferences_office_api.py
+++ b/tests/unit/test_issue152_explicit_preferences_office_api.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from catering_system.domain.customer_identity import CustomerIdentity
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+
 from catering_system.repositories.sqlite_customer_identity_repository import (
     SQLiteCustomerIdentityRepository,
 )
@@ -48,6 +50,7 @@ def _start_api_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
             _TOKEN,
             "127.0.0.1",
             0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
         )
         ready.put(server)
         server.serve_forever()

--- a/tests/unit/test_issue152_explicit_preferences_office_api.py
+++ b/tests/unit/test_issue152_explicit_preferences_office_api.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, datetime
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.customer_identity import CustomerIdentity
+from catering_system.repositories.sqlite_customer_identity_repository import (
+    SQLiteCustomerIdentityRepository,
+)
+
+_TOKEN = "test-office-api-token"
+_AUTH = {"Authorization": f"Bearer {_TOKEN}"}
+_NOW = datetime(2026, 8, 25, 18, 0, tzinfo=UTC)
+
+
+def _seed_customer(db: Path, customer_id: str = "customer-1") -> None:
+    repo = SQLiteCustomerIdentityRepository(db)
+    repo.add(
+        CustomerIdentity(
+            customer_id=customer_id,
+            display_name="Testkunde",
+            company_name=None,
+            status="active",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    repo.close()
+
+
+def _start_api_server(db: Path) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.office_api import create_office_api_server
+
+        server = create_office_api_server(
+            str(db),
+            _TOKEN,
+            "127.0.0.1",
+            0,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+@pytest.fixture()
+def preference_api(tmp_path: Path):
+    db = tmp_path / "core.db"
+    _seed_customer(db)
+    _seed_customer(db, "customer-2")
+    server, thread, base = _start_api_server(db)
+    try:
+        yield base
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert thread.is_alive() is False
+
+
+def _get(url: str) -> tuple[int, dict[str, object]]:
+    req = urllib.request.Request(url, headers=_AUTH)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def _post(
+    url: str,
+    *,
+    args: dict[str, object] | None = None,
+) -> tuple[int, dict[str, object]]:
+    body = json.dumps(
+        {
+            "command_id": str(uuid.uuid4()),
+            "expect": {},
+            "args": args or {},
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={**_AUTH, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}")
+
+
+def test_office_can_create_list_update_and_delete_explicit_preference(
+    preference_api: str,
+) -> None:
+    base = preference_api
+    root = f"{base}/office/v1/customers/customer-1/gastronomic-preferences"
+
+    status, created = _post(
+        f"{root}/create",
+        args={
+            "kind": "favorite_dish",
+            "value": "Mini-Frikadellen",
+            "source": "customer_stated",
+        },
+    )
+    assert status == 201
+    preference = created["preference"]
+    assert isinstance(preference, dict)
+    preference_id = preference["preference_id"]
+    assert preference["customer_id"] == "customer-1"
+    assert preference["source"] == "customer_stated"
+
+    status, listed = _get(root)
+    assert status == 200
+    assert listed["customer_id"] == "customer-1"
+    assert listed["preferences"] == [preference]
+
+    status, updated = _post(
+        f"{root}/{preference_id}/update",
+        args={
+            "kind": "disliked_dish",
+            "value": "Leber",
+            "source": "office_recorded",
+        },
+    )
+    assert status == 200
+    updated_preference = updated["preference"]
+    assert isinstance(updated_preference, dict)
+    assert updated_preference["preference_id"] == preference_id
+    assert updated_preference["customer_id"] == "customer-1"
+    assert updated_preference["created_at"] == preference["created_at"]
+    assert updated_preference["source"] == "office_recorded"
+
+    status, deleted = _post(f"{root}/{preference_id}/delete")
+    assert status == 200
+    assert deleted == {"deleted_preference_id": preference_id}
+
+    status, listed = _get(root)
+    assert status == 200
+    assert listed["preferences"] == []
+
+
+def test_missing_customer_is_404_for_read_and_create(preference_api: str) -> None:
+    base = preference_api
+    root = f"{base}/office/v1/customers/missing/gastronomic-preferences"
+
+    status, body = _get(root)
+    assert status == 404
+    assert body == {"error": "customer_not_found"}
+
+    status, body = _post(
+        f"{root}/create",
+        args={
+            "kind": "favorite_dish",
+            "value": "Mini-Frikadellen",
+            "source": "customer_stated",
+        },
+    )
+    assert status == 404
+    assert body == {"error": "customer_not_found"}
+
+
+def test_inferred_source_is_rejected_and_cross_customer_access_is_hidden(
+    preference_api: str,
+) -> None:
+    base = preference_api
+    root = f"{base}/office/v1/customers/customer-1/gastronomic-preferences"
+
+    status, body = _post(
+        f"{root}/create",
+        args={
+            "kind": "favorite_dish",
+            "value": "Mini-Frikadellen",
+            "source": "inferred",
+        },
+    )
+    assert status == 422
+    assert body == {"error": "invalid_gastronomic_preference"}
+
+    status, created = _post(
+        f"{root}/create",
+        args={
+            "kind": "service_style",
+            "value": "Buffet",
+            "source": "office_recorded",
+        },
+    )
+    assert status == 201
+    preference = created["preference"]
+    assert isinstance(preference, dict)
+    preference_id = preference["preference_id"]
+
+    other_root = f"{base}/office/v1/customers/customer-2/gastronomic-preferences"
+    status, body = _post(
+        f"{other_root}/{preference_id}/update",
+        args={
+            "kind": "service_style",
+            "value": "Fingerfood",
+            "source": "office_recorded",
+        },
+    )
+    assert status == 404
+    assert body == {"error": "gastronomic_preference_not_found"}


### PR DESCRIPTION
## Summary

Expose the existing explicit customer gastronomic preference model through the Office API without introducing any inferred-preference behavior.

- add customer-scoped GET list endpoint
- add idempotent Office command endpoints for create/update/delete
- validate customer existence through `CustomerIdentity`
- preserve `created_at` on update
- reject unsupported/inferred sources through the existing domain validators
- hide cross-customer preference access as `gastronomic_preference_not_found`
- add focused service and HTTP API coverage

## Validation

Normal PR CI #938 passed on head `245aa37c57bf4ba6625ab571dd050968643583f2`, including lock check, Ruff, mypy, full Python coverage, PDF/systemd verification, and JavaScript tests.

This is the explicit-preference service/API/Office slice only. Order-history projection and inferred recommendation hints remain separate follow-up work.

Refs #152