### PR TITLE
Issue #152: derive explainable history-based recommendation hints

### DIFF
--- a/src/catering_system/domain/customer_recommendation_hint.py
+++ b/src/catering_system/domain/customer_recommendation_hint.py
@@ -1,0 +1,28 @@
+"""Explainable soft recommendation hints derived from factual customer history.
+
+Hints are projections, not customer facts. They must never be persisted as explicit
+preferences or treated as hard constraints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+
+CustomerRecommendationHintKind = Literal[
+    "frequently_ordered",
+    "recently_ordered",
+]
+
+
+@dataclass(frozen=True)
+class CustomerRecommendationHint:
+    kind: CustomerRecommendationHintKind
+    catalog_item_id: str
+    display_name: str
+    order_count: int
+    last_ordered_on: date
+    source_order_ids: tuple[str, ...]
+    explanation: str
+    score_delta: int

--- a/src/catering_system/services/customer_recommendation_hint_service.py
+++ b/src/catering_system/services/customer_recommendation_hint_service.py
@@ -1,0 +1,98 @@
+"""Derive explainable, non-blocking recommendation hints from customer history."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from typing import Protocol
+
+from catering_system.domain.customer_order_history import CustomerOrderHistoryEntry
+from catering_system.domain.customer_recommendation_hint import CustomerRecommendationHint
+
+
+class CustomerOrderHistoryReader(Protocol):
+    def list_for_customer(self, customer_id: str) -> list[CustomerOrderHistoryEntry]: ...
+
+
+class CustomerRecommendationHintService:
+    """Build deterministic hints without persisting inference or rewriting history."""
+
+    FREQUENT_MIN_ORDERS = 2
+    RECENT_WINDOW_DAYS = 90
+
+    def __init__(self, history: CustomerOrderHistoryReader) -> None:
+        self._history = history
+
+    def list_for_customer(
+        self, customer_id: str, *, as_of: date
+    ) -> list[CustomerRecommendationHint]:
+        orders = [
+            entry
+            for entry in self._history.list_for_customer(customer_id)
+            if entry.cancelled_at is None
+        ]
+        by_item: dict[str, list[tuple[CustomerOrderHistoryEntry, str]]] = defaultdict(list)
+        for entry in orders:
+            seen_in_order: set[str] = set()
+            for dish in entry.dishes:
+                item_id = dish.catalog_item_id
+                if item_id is None or item_id in seen_in_order:
+                    continue
+                seen_in_order.add(item_id)
+                by_item[item_id].append((entry, dish.name))
+
+        hints: list[CustomerRecommendationHint] = []
+        for item_id, occurrences in by_item.items():
+            occurrences.sort(
+                key=lambda item: (
+                    item[0].event_date,
+                    item[0].order_created_at,
+                    item[0].order_id,
+                ),
+                reverse=True,
+            )
+            latest_entry, latest_name = occurrences[0]
+            source_order_ids = tuple(entry.order_id for entry, _ in occurrences)
+            order_count = len(occurrences)
+
+            if order_count >= self.FREQUENT_MIN_ORDERS:
+                hints.append(
+                    CustomerRecommendationHint(
+                        kind="frequently_ordered",
+                        catalog_item_id=item_id,
+                        display_name=latest_name,
+                        order_count=order_count,
+                        last_ordered_on=latest_entry.event_date,
+                        source_order_ids=source_order_ids,
+                        explanation=(
+                            f"In {order_count} previous orders; positive soft signal only."
+                        ),
+                        score_delta=2,
+                    )
+                )
+
+            age_days = (as_of - latest_entry.event_date).days
+            if 0 <= age_days <= self.RECENT_WINDOW_DAYS:
+                hints.append(
+                    CustomerRecommendationHint(
+                        kind="recently_ordered",
+                        catalog_item_id=item_id,
+                        display_name=latest_name,
+                        order_count=order_count,
+                        last_ordered_on=latest_entry.event_date,
+                        source_order_ids=source_order_ids,
+                        explanation=(
+                            f"Last ordered {age_days} day(s) ago; repetition penalty is advisory."
+                        ),
+                        score_delta=-3,
+                    )
+                )
+
+        return sorted(
+            hints,
+            key=lambda hint: (
+                hint.catalog_item_id,
+                hint.kind,
+                hint.last_ordered_on,
+            ),
+        )

--- a/src/catering_system/services/customer_recommendation_hint_service.py
+++ b/src/catering_system/services/customer_recommendation_hint_service.py
@@ -31,7 +31,9 @@ class CustomerRecommendationHintService:
             for entry in self._history.list_for_customer(customer_id)
             if entry.cancelled_at is None
         ]
-        by_item: dict[str, list[tuple[CustomerOrderHistoryEntry, str]]] = defaultdict(list)
+        by_item: dict[str, list[tuple[CustomerOrderHistoryEntry, str]]] = (
+            defaultdict(list)
+        )
         for entry in orders:
             seen_in_order: set[str] = set()
             for dish in entry.dishes:

--- a/src/catering_system/services/customer_recommendation_hint_service.py
+++ b/src/catering_system/services/customer_recommendation_hint_service.py
@@ -7,11 +7,15 @@ from datetime import date
 from typing import Protocol
 
 from catering_system.domain.customer_order_history import CustomerOrderHistoryEntry
-from catering_system.domain.customer_recommendation_hint import CustomerRecommendationHint
+from catering_system.domain.customer_recommendation_hint import (
+    CustomerRecommendationHint,
+)
 
 
 class CustomerOrderHistoryReader(Protocol):
-    def list_for_customer(self, customer_id: str) -> list[CustomerOrderHistoryEntry]: ...
+    def list_for_customer(
+        self, customer_id: str
+    ) -> list[CustomerOrderHistoryEntry]: ...
 
 
 class CustomerRecommendationHintService:
@@ -31,8 +35,8 @@ class CustomerRecommendationHintService:
             for entry in self._history.list_for_customer(customer_id)
             if entry.cancelled_at is None
         ]
-        by_item: dict[str, list[tuple[CustomerOrderHistoryEntry, str]]] = (
-            defaultdict(list)
+        by_item: dict[str, list[tuple[CustomerOrderHistoryEntry, str]]] = defaultdict(
+            list
         )
         for entry in orders:
             seen_in_order: set[str] = set()

--- a/tests/unit/test_customer_recommendation_hint_service.py
+++ b/tests/unit/test_customer_recommendation_hint_service.py
@@ -1,0 +1,142 @@
+from datetime import UTC, date, datetime
+
+from catering_system.domain.customer_order_history import (
+    CustomerOrderHistoryDish,
+    CustomerOrderHistoryEntry,
+)
+from catering_system.services.customer_recommendation_hint_service import (
+    CustomerRecommendationHintService,
+)
+
+
+def _entry(
+    order_id: str,
+    event_date: date,
+    *dishes: tuple[str, str],
+    cancelled: bool = False,
+) -> CustomerOrderHistoryEntry:
+    return CustomerOrderHistoryEntry(
+        order_id=order_id,
+        source_inquiry_id=f"inquiry-{order_id}",
+        order_version_id=f"version-{order_id}",
+        event_date=event_date,
+        guest_count=20,
+        fulfillment_mode="DELIVERY",
+        accepted_offer_id=f"offer-{order_id}",
+        accepted_offer_version_id=f"offer-version-{order_id}",
+        accepted_variant_id=f"variant-{order_id}",
+        accepted_variant_label="Standard",
+        dishes=tuple(
+            CustomerOrderHistoryDish(
+                position_id=f"{order_id}-{item_id}",
+                name=name,
+                kind="catalog",
+                catalog_item_id=item_id,
+                gross_total_cents=1000,
+            )
+            for item_id, name in dishes
+        ),
+        gross_total_cents=1000 * len(dishes),
+        order_created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        cancelled_at=(datetime(2026, 1, 2, tzinfo=UTC) if cancelled else None),
+    )
+
+
+class _History:
+    def __init__(self, entries: list[CustomerOrderHistoryEntry]) -> None:
+        self.entries = entries
+        self.customer_ids: list[str] = []
+
+    def list_for_customer(self, customer_id: str) -> list[CustomerOrderHistoryEntry]:
+        self.customer_ids.append(customer_id)
+        return self.entries
+
+
+def test_repeated_item_produces_explainable_positive_and_recent_soft_signals() -> None:
+    history = _History(
+        [
+            _entry("order-2", date(2026, 8, 1), ("dish-1", "Mini-Burger")),
+            _entry("order-1", date(2026, 5, 1), ("dish-1", "Mini-Burger")),
+        ]
+    )
+    service = CustomerRecommendationHintService(history)
+
+    hints = service.list_for_customer("customer-1", as_of=date(2026, 8, 25))
+
+    assert history.customer_ids == ["customer-1"]
+    assert [(hint.kind, hint.score_delta) for hint in hints] == [
+        ("frequently_ordered", 2),
+        ("recently_ordered", -3),
+    ]
+    assert all(hint.catalog_item_id == "dish-1" for hint in hints)
+    assert all(hint.order_count == 2 for hint in hints)
+    assert all(hint.source_order_ids == ("order-2", "order-1") for hint in hints)
+    assert "soft signal only" in hints[0].explanation
+    assert "advisory" in hints[1].explanation
+
+
+def test_single_old_item_has_no_hint() -> None:
+    service = CustomerRecommendationHintService(
+        _History([_entry("order-1", date(2026, 1, 1), ("dish-1", "Suppe"))])
+    )
+
+    assert service.list_for_customer("customer-1", as_of=date(2026, 8, 25)) == []
+
+
+def test_cancelled_orders_do_not_become_taste_evidence() -> None:
+    service = CustomerRecommendationHintService(
+        _History(
+            [
+                _entry(
+                    "order-cancelled",
+                    date(2026, 8, 20),
+                    ("dish-1", "Suppe"),
+                    cancelled=True,
+                )
+            ]
+        )
+    )
+
+    assert service.list_for_customer("customer-1", as_of=date(2026, 8, 25)) == []
+
+
+def test_custom_positions_without_catalog_identity_are_not_inferred() -> None:
+    entry = _entry("order-1", date(2026, 8, 20))
+    entry = CustomerOrderHistoryEntry(
+        **{
+            **entry.__dict__,
+            "dishes": (
+                CustomerOrderHistoryDish(
+                    position_id="custom-1",
+                    name="Spezialplatte",
+                    kind="custom",
+                    catalog_item_id=None,
+                    gross_total_cents=1000,
+                ),
+            ),
+        }
+    )
+    service = CustomerRecommendationHintService(_History([entry]))
+
+    assert service.list_for_customer("customer-1", as_of=date(2026, 8, 25)) == []
+
+
+def test_same_catalog_item_is_counted_once_per_order() -> None:
+    service = CustomerRecommendationHintService(
+        _History(
+            [
+                _entry(
+                    "order-1",
+                    date(2026, 8, 20),
+                    ("dish-1", "Mini-Burger"),
+                    ("dish-1", "Mini-Burger"),
+                )
+            ]
+        )
+    )
+
+    hints = service.list_for_customer("customer-1", as_of=date(2026, 8, 25))
+
+    assert len(hints) == 1
+    assert hints[0].kind == "recently_ordered"
+    assert hints[0].order_count == 1


### PR DESCRIPTION
## Summary

Add the first history-derived hint layer for repeat-customer recommendations.

- derive hints only from factual customer order history
- emit a positive soft signal for repeatedly ordered catalog dishes
- emit an advisory recent-repetition penalty for recently ordered catalog dishes
- keep the two signals independently explainable, even when they coexist
- ignore cancelled orders
- avoid inference for custom positions without a stable catalog identity
- persist nothing and do not write inferred data into explicit gastronomic preferences

## Scope boundary

This slice deliberately does not block recommendations and does not yet wire the score deltas into configurator ranking. Explicit preferences and current inquiry requirements remain separate inputs; integration into the existing recommendation path follows after this read-model is validated.

Refs #152