### PR TITLE
Expose manual tasks in Aufgaben UI (#182)

### DIFF
--- a/src/catering_system/repositories/sqlite_manual_task_repository.py
+++ b/src/catering_system/repositories/sqlite_manual_task_repository.py
@@ -72,6 +72,41 @@ def _migration_1_create_manual_tasks(connection: sqlite3.Connection) -> None:
 _MIGRATIONS = ((1, "create_manual_tasks", _migration_1_create_manual_tasks),)
 
 
+def _apply_migrations_in_current_transaction(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            component TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            applied_at TEXT NOT NULL,
+            PRIMARY KEY (component, version)
+        )
+        """
+    )
+    existing = {
+        row[0]: row[1]
+        for row in connection.execute(
+            "SELECT version, name FROM schema_migrations WHERE component = ?",
+            ("manual_tasks",),
+        ).fetchall()
+    }
+    for version, name, apply in _MIGRATIONS:
+        if version in existing:
+            if existing[version] != name:
+                raise RuntimeError(
+                    "manual_tasks migration "
+                    f"{version} name mismatch: database={existing[version]!r}, code={name!r}"
+                )
+            continue
+        apply(connection)
+        connection.execute(
+            "INSERT INTO schema_migrations (component, version, name, applied_at) "
+            "VALUES (?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            ("manual_tasks", version, name),
+        )
+
+
 class SQLiteManualTaskRepository:
     def __init__(self, db_path: str | Path) -> None:
         self._conn = sqlite3.connect(str(db_path))
@@ -89,7 +124,10 @@ class SQLiteManualTaskRepository:
         repo = cls.__new__(cls)
         repo._conn = connection
         repo._manage_transactions = False
-        apply_migrations(connection, "manual_tasks", _MIGRATIONS)
+        if connection.in_transaction:
+            _apply_migrations_in_current_transaction(connection)
+        else:
+            apply_migrations(connection, "manual_tasks", _MIGRATIONS)
         return repo
 
     def _write_scope(self):

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -13,11 +13,12 @@ import os
 import re
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import quote, urlencode
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 from catering_system.domain.catalog import (
     ALLERGEN_CODES,
@@ -51,6 +52,7 @@ from catering_system.domain.inquiry_contact_completeness import (
     derive_inquiry_contact_completeness,
     missing_contact_fields,
 )
+from catering_system.domain.manual_task import ManualTask
 from catering_system.domain.offer import (
     ACCEPTANCE_CHANNELS,
     SENT_CHANNELS,
@@ -159,6 +161,7 @@ from catering_system.services.email_intake_projection_service import (
 )
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.services.kitchen_print_service import KitchenPrintService
+from catering_system.services.manual_task_service import ManualTaskService
 from catering_system.services.offer_document_snapshot_service import (
     OfferDocumentSnapshotService,
 )
@@ -269,6 +272,7 @@ _KITCHEN_PRINT_REJECTION_MESSAGES = {
     "invalid_printer_configuration": "Drucker ist nicht korrekt eingerichtet.",
     "order_cancelled": "Der Auftrag wurde storniert.",
 }
+_BERLIN = ZoneInfo("Europe/Berlin")
 
 __all__ = [
     "CALL_VERIFICATION_STATUS_LABELS",
@@ -477,6 +481,7 @@ class OfficePanel:
         offer_document_repo: OfferDocumentSnapshotRepository | None = None,
         offer_pdf_static_content: OfferPdfStaticContent | None = None,
         kitchen_print_job_repo: KitchenPrintJobRepository | None = None,
+        manual_task_service: ManualTaskService | None = None,
         ui_version: str = "legacy",
     ) -> None:
         if ui_version not in {"legacy", "v2"}:
@@ -587,6 +592,7 @@ class OfficePanel:
             self.kitchen_print_service = None
             self._pause_repository = None
         self._remote = remote
+        self._manual_task_service = manual_task_service
         self._command_executor = command_executor
         self._ui_version = ui_version
         # Pure-read derivations: safe to run over the remote client's repo-
@@ -909,13 +915,155 @@ class OfficePanel:
     def _task_list_rows(self) -> list[dict[str, object]]:
         if self._remote is not None:
             body = self._remote.list_tasks()
-            return cast(list[dict[str, object]], body["tasks"])
-        return api_views.task_list_view(self._task_projection_service().list_tasks())
+            rows = cast(list[dict[str, object]], body["tasks"])
+        else:
+            rows = api_views.task_list_view(
+                self._task_projection_service().list_tasks()
+            )
+        return [self._system_task_row(row) for row in rows]
+
+    def _system_task_row(self, row: dict[str, object]) -> dict[str, object]:
+        return {
+            **row,
+            "kind": "system",
+            "type_label": "System",
+            "assigned_to": "–",
+        }
+
+    def _manual_tasks(self, *, employee_session_token: str | None) -> list[ManualTask]:
+        if self._remote is not None:
+            if not employee_session_token:
+                return []
+            return self._remote.list_manual_tasks(
+                employee_session_token=employee_session_token
+            )
+        if self._manual_task_service is None:
+            return []
+        return self._manual_task_service.list_open_tasks()
+
+    def _manual_task_rows(
+        self,
+        *,
+        context: OfficePageContext,
+        employee_session_token: str | None,
+        assignee_names: dict[str, str],
+        can_complete: bool,
+    ) -> list[dict[str, object]]:
+        rows: list[dict[str, object]] = []
+        for task in self._manual_tasks(employee_session_token=employee_session_token):
+            assigned_to = "–"
+            if task.assigned_to_employee_id is not None:
+                assigned_to = assignee_names.get(
+                    task.assigned_to_employee_id, task.assigned_to_employee_id
+                )
+            rows.append(
+                {
+                    "kind": "manual",
+                    "type_label": "Manuell",
+                    "urgency": "normal",
+                    "title": task.title,
+                    "subtitle": task.description or "–",
+                    "due_at": task.due_at,
+                    "assigned_to": assigned_to,
+                    "task_id": task.task_id,
+                    "can_complete": can_complete,
+                    "complete_form_fields": _csrf_input(context)
+                    + self._command_fields(),
+                }
+            )
+        return rows
 
     def render_aufgaben(
-        self, *, context: OfficePageContext = _EMPTY_PAGE_CONTEXT
+        self,
+        *,
+        context: OfficePageContext = _EMPTY_PAGE_CONTEXT,
+        employee_session_token: str | None = None,
+        assignee_options: list[dict[str, str]] | None = None,
     ) -> str:
-        return render_aufgaben_list(self._task_list_rows(), context=context)
+        assignee_options = assignee_options or []
+        assignee_names = {
+            option["id"]: option["display_name"] for option in assignee_options
+        }
+        rows = [
+            *self._manual_task_rows(
+                context=context,
+                employee_session_token=employee_session_token,
+                assignee_names=assignee_names,
+                can_complete=context.can("tasks.complete")
+                and bool(context.employee_account_id),
+            ),
+            *self._task_list_rows(),
+        ]
+        return render_aufgaben_list(
+            rows,
+            context=context,
+            assignee_options=assignee_options,
+            can_create_manual_task=context.can("tasks.create")
+            and bool(context.employee_account_id),
+            can_assign_manual_task=context.can("tasks.assign"),
+            create_form_fields=_csrf_input(context) + self._command_fields(),
+        )
+
+    @staticmethod
+    def _manual_task_due_at_from_form(form: dict[str, str]) -> datetime | None:
+        raw = form.get("due_date", "").strip()
+        if not raw:
+            return None
+        selected = date.fromisoformat(raw)
+        berlin_start = datetime.combine(selected, time.min, tzinfo=_BERLIN)
+        return berlin_start.astimezone(UTC)
+
+    def create_manual_task(
+        self,
+        form: dict[str, str],
+        *,
+        created_by_employee_id: str,
+        employee_session_token: str | None = None,
+    ) -> ManualTask:
+        assigned_to_employee_id: str | None = form.get(
+            "assigned_to_employee_id", ""
+        ).strip()
+        if not assigned_to_employee_id:
+            assigned_to_employee_id = None
+        due_at = self._manual_task_due_at_from_form(form)
+        if self._remote is not None:
+            if not employee_session_token:
+                raise ValueError("employee session is required")
+            return self._remote.create_manual_task(
+                employee_session_token=employee_session_token,
+                title=form.get("title", ""),
+                description=form.get("description", ""),
+                due_at=due_at,
+                assigned_to_employee_id=assigned_to_employee_id,
+                command_id=form.get("_command_id") or None,
+            )
+        if self._manual_task_service is None:
+            raise ValueError("manual tasks are not available")
+        return self._manual_task_service.create_task(
+            title=form.get("title", ""),
+            description=form.get("description", ""),
+            due_at=due_at,
+            created_by_employee_id=created_by_employee_id,
+            assigned_to_employee_id=assigned_to_employee_id,
+        )
+
+    def complete_manual_task(
+        self,
+        task_id: str,
+        *,
+        employee_session_token: str | None = None,
+    ) -> ManualTask:
+        if self._remote is not None:
+            if not employee_session_token:
+                raise ValueError("employee session is required")
+            return self._remote.complete_manual_task(
+                task_id,
+                employee_session_token=employee_session_token,
+                command_id=self._remote.form_value("_command_id"),
+            )
+        if self._manual_task_service is None:
+            raise ValueError("manual tasks are not available")
+        return self._manual_task_service.complete_task(task_id)
 
     def _calendar_list_rows(self) -> list[dict[str, object]]:
         operating_today = api_views.berlin_today()

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -62,6 +62,9 @@ from catering_system.repositories.payment_reminder_repository import (
 from catering_system.repositories.sqlite_configurator_handoff_repository import (
     SQLiteConfiguratorHandoffRepository,
 )
+from catering_system.repositories.sqlite_manual_task_repository import (
+    SQLiteManualTaskRepository,
+)
 from catering_system.services.buffet_cards_service import BuffetCardsService
 from catering_system.services.configurator_handoff_service import (
     ConfiguratorHandoffService,
@@ -75,6 +78,7 @@ from catering_system.services.employee_auth_service import (
     EmployeeAuthService,
     LastActiveSuperadminError,
 )
+from catering_system.services.manual_task_service import ManualTaskService
 from catering_system.services.order_confirmation_document_preview import (
     build_preview,
     render_preview_html,
@@ -113,6 +117,7 @@ from catering_system.ui.office_panel_authz import (
     BusinessAccessDenied,
     DynamicCatalogUpdateAuth,
     authorize_catalog_update,
+    can_access,
     require_all_business_permissions,
     require_all_business_permissions_post,
     require_any_business_permissions,
@@ -430,6 +435,26 @@ def make_office_panel_handler(
     local_confirmation_document_repo = (
         confirmation_document_repo or InMemoryOrderConfirmationDocumentRepository()
     )
+    manual_task_service: ManualTaskService | None = None
+    if (
+        remote is None
+        and validated_auth_mode in {"migration", "employee"}
+        and auth_service is not None
+    ):
+        repository = getattr(auth_service.repository, "_conn", None)
+        if isinstance(repository, sqlite3.Connection):
+            manual_task_repository = SQLiteManualTaskRepository.from_connection(
+                repository
+            )
+
+            def _employee_exists(employee_id: str) -> bool:
+                account = auth_service.repository.get_account_by_id(employee_id)
+                return account is not None and account.is_active
+
+            manual_task_service = ManualTaskService(
+                manual_task_repository,
+                employee_exists=_employee_exists,
+            )
     panel = OfficePanel(
         inquiry_repo,
         order_repo,
@@ -450,6 +475,7 @@ def make_office_panel_handler(
         offer_document_repo=offer_document_repo,
         offer_pdf_static_content=offer_pdf_static_content,
         kitchen_print_job_repo=kitchen_print_job_repo,
+        manual_task_service=manual_task_service,
         ui_version=ui_version,
     )
     expected = "Basic " + base64.b64encode(f"office:{password}".encode()).decode()
@@ -684,6 +710,40 @@ def make_office_panel_handler(
                 raise SettingsUsersAccessDenied()
             return auth.employee
 
+        def _employee_session_token(self) -> str | None:
+            return session_token_from_headers(self.headers)
+
+        def _manual_task_employee_or_forbidden(
+            self, auth: OfficePanelRequestAuth | None
+        ) -> AuthenticatedEmployee | None:
+            if (
+                auth is None
+                or auth.kind != "employee"
+                or auth.employee is None
+                or auth.legacy_shared_access
+                or not auth.employee.application_access_allowed
+            ):
+                self._business_forbidden(active_section="tasks")
+                return None
+            return auth.employee
+
+        def _manual_task_assignee_options(
+            self, auth: OfficePanelRequestAuth | None
+        ) -> list[dict[str, str]]:
+            if (
+                auth_service is None
+                or auth is None
+                or auth.kind != "employee"
+                or auth.employee is None
+                or not can_access(auth, "tasks.assign")
+            ):
+                return []
+            return [
+                {"id": account.id, "display_name": account.display_name}
+                for account in auth_service.repository.list_accounts()
+                if account.is_active
+            ]
+
         def _forbidden_page_context(
             self, auth: OfficePanelRequestAuth | None = None
         ) -> OfficePageContext:
@@ -840,6 +900,10 @@ def make_office_panel_handler(
                 return ("chat.send",)
             if len(parts) == 3 and parts[0] == "chat" and parts[2] == "read":
                 return ("chat.view",)
+            if parts == ["aufgaben", "new"]:
+                return ("tasks.create",)
+            if len(parts) == 3 and parts[0] == "aufgaben" and parts[2] == "complete":
+                return ("tasks.complete",)
             if parts == ["gerichte", "new"]:
                 return ("catalog.edit", "prices.edit")
             if len(parts) == 3 and parts[0] == "gerichte":
@@ -1279,11 +1343,17 @@ def make_office_panel_handler(
                 )
             elif parts == ["aufgaben"]:
                 if not self._require_business_permission_get(
-                    auth, "queue.view", active_section="tasks"
+                    auth, "tasks.view", active_section="tasks"
                 ):
                     return
                 context = self._page_context()
-                self._html(panel.render_aufgaben(context=context))
+                self._html(
+                    panel.render_aufgaben(
+                        context=context,
+                        employee_session_token=self._employee_session_token(),
+                        assignee_options=self._manual_task_assignee_options(auth),
+                    )
+                )
             elif parts == ["kalender"]:
                 if not self._require_business_permission_get(
                     auth, "calendar.view", active_section="calendar"
@@ -1898,6 +1968,10 @@ def make_office_panel_handler(
                 self._send_chat_message(auth, unquote(parts[1]))
             elif len(parts) == 3 and parts[0] == "chat" and parts[2] == "read":
                 self._mark_chat_read(auth, unquote(parts[1]))
+            elif parts == ["aufgaben", "new"]:
+                self._aufgaben_create(auth)
+            elif len(parts) == 3 and parts[0] == "aufgaben" and parts[2] == "complete":
+                self._aufgaben_complete(auth, unquote(parts[1]))
             elif parts == ["gerichte", "new"]:
                 self._create_catalog_dish()
             elif len(parts) == 3 and parts[0] == "gerichte" and parts[2] == "update":
@@ -2039,6 +2113,35 @@ def make_office_panel_handler(
                 command_id=form.get("_command_id") or None,
             )
             self._redirect(f"/chat/{quote(thread_id, safe='')}")
+
+        def _aufgaben_create(self, auth: OfficePanelRequestAuth | None) -> None:
+            employee = self._manual_task_employee_or_forbidden(auth)
+            if employee is None:
+                return
+            form = self._form()
+            assigned_to = form.get("assigned_to_employee_id", "").strip()
+            if assigned_to and not self._require_business_permission_post(
+                auth, "tasks.assign", active_section="tasks"
+            ):
+                return
+            panel.create_manual_task(
+                form,
+                created_by_employee_id=employee.account.id,
+                employee_session_token=self._employee_session_token(),
+            )
+            self._redirect("/aufgaben")
+
+        def _aufgaben_complete(
+            self, auth: OfficePanelRequestAuth | None, task_id: str
+        ) -> None:
+            employee = self._manual_task_employee_or_forbidden(auth)
+            if employee is None:
+                return
+            panel.complete_manual_task(
+                task_id,
+                employee_session_token=self._employee_session_token(),
+            )
+            self._redirect("/aufgaben")
 
         def _settings_users_create(self, auth: OfficePanelRequestAuth | None) -> None:
             actor = self._settings_users_actor_or_forbidden(auth)

--- a/src/catering_system/ui/office_panel_tasks_list.py
+++ b/src/catering_system/ui/office_panel_tasks_list.py
@@ -1,8 +1,8 @@
-"""Aufgaben list presentation — read-only system task projection rows (5D-1a)."""
+"""Aufgaben list presentation — manual and read-only system office tasks."""
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 from catering_system.ui.office_panel_views import (
@@ -22,6 +22,8 @@ def _format_due(raw: object | None) -> str:
             value = date.fromisoformat(raw)
         except ValueError:
             return raw
+    elif isinstance(raw, datetime):
+        value = raw.astimezone(_BERLIN).date()
     elif isinstance(raw, date):
         value = raw
     else:
@@ -39,26 +41,77 @@ def render_aufgaben_list(
     rows: list[dict[str, object]],
     *,
     context: OfficePageContext,
+    assignee_options: list[dict[str, str]] | None = None,
+    can_create_manual_task: bool = False,
+    can_assign_manual_task: bool = False,
+    create_form_fields: str = "",
 ) -> str:
+    create_form = ""
+    if can_create_manual_task:
+        assignee_field = ""
+        if can_assign_manual_task:
+            options = ['<option value="">Nicht zugewiesen</option>']
+            for option in assignee_options or []:
+                options.append(
+                    f'<option value="{_e(option["id"])}">'
+                    f"{_e(option['display_name'])}</option>"
+                )
+            assignee_field = (
+                '<p><label for="assigned_to_employee_id">Zuweisen an</label><br>'
+                '<select id="assigned_to_employee_id" name="assigned_to_employee_id">'
+                + "".join(options)
+                + "</select></p>"
+            )
+        create_form = (
+            "<section><h2>Neue Aufgabe</h2>"
+            '<form method="post" action="/aufgaben/new">'
+            f"{create_form_fields}"
+            '<p><label for="manual_task_title">Titel</label><br>'
+            '<input id="manual_task_title" name="title" required maxlength="200"></p>'
+            '<p><label for="manual_task_description">Beschreibung</label><br>'
+            '<textarea id="manual_task_description" name="description" '
+            'maxlength="4000"></textarea></p>'
+            '<p><label for="manual_task_due_date">Fällig</label><br>'
+            '<input id="manual_task_due_date" name="due_date" type="date"></p>'
+            f"{assignee_field}"
+            '<p><button type="submit">Aufgabe anlegen</button></p>'
+            "</form></section>"
+        )
     table_rows = []
     for row in rows:
-        href = str(row["action_href"])
+        action = ""
+        if row["kind"] == "manual":
+            if row.get("can_complete"):
+                action = (
+                    f'<form method="post" action="/aufgaben/{_e(row["task_id"])}/complete">'
+                    f"{row.get('complete_form_fields', '')}"
+                    '<button type="submit">Erledigt</button></form>'
+                )
+            else:
+                action = "–"
+        else:
+            href = str(row["action_href"])
+            action = f'<a href="{_e(href)}">{_e(str(row["action_label"]))}</a>'
         table_rows.append(
             "<tr>"
+            f"<td>{_e(str(row['type_label']))}</td>"
             f"<td>{_e(_urgency_label(row['urgency']))}</td>"
             f"<td>{_e(str(row['title']))}</td>"
             f"<td>{_e(str(row['subtitle']))}</td>"
             f"<td>{_e(_format_due(row.get('due_at')))}</td>"
-            f'<td><a href="{_e(href)}">{_e(str(row["action_label"]))}</a></td>'
+            f"<td>{_e(str(row.get('assigned_to', '–')))}</td>"
+            f"<td>{action}</td>"
             "</tr>"
         )
     body = (
-        '<p class="subtitle">Abgeleitete Büro-Aufgaben aus Anfragen, Aufträgen '
-        "und Zahlungserinnerungen.</p>"
-        "<table><tr><th>Dringlichkeit</th><th>Aufgabe</th><th>Bezug</th>"
-        "<th>Fällig</th><th></th></tr>"
+        '<p class="subtitle">Manuelle Aufgaben und abgeleitete Büro-Aufgaben '
+        "aus Anfragen, Aufträgen und Zahlungserinnerungen.</p>"
+        + create_form
+        + "<h2>Offene Aufgaben</h2>"
+        + "<table><tr><th>Typ</th><th>Dringlichkeit</th><th>Aufgabe</th>"
+        "<th>Beschreibung/Bezug</th><th>Fällig</th><th>Zugewiesen</th><th>Aktion</th></tr>"
         + "".join(
-            table_rows or ['<tr><td colspan="5">Keine offenen Aufgaben.</td></tr>']
+            table_rows or ['<tr><td colspan="7">Keine offenen Aufgaben.</td></tr>']
         )
         + "</table>"
         + '<p><a href="/">← Zurück zur Arbeitszentrale</a></p>'

--- a/src/catering_system/ui/office_panel_views.py
+++ b/src/catering_system/ui/office_panel_views.py
@@ -213,7 +213,7 @@ def _page(
                 badge=context.chat_unread_count,
             )
         )
-    if _nav_visible(context, "queue.view"):
+    if _nav_visible(context, "tasks.view"):
         vertrieb.append(
             _nav_link("/aufgaben", "Aufgaben", "doc", "tasks", active_section)
         )

--- a/tests/unit/test_office_panel_auth_2d1.py
+++ b/tests/unit/test_office_panel_auth_2d1.py
@@ -676,7 +676,7 @@ def test_allowed_anfragen_still_fetches_rueckruf_count_for_badge(
     count_mock.assert_called_once()
 
 
-def test_aufgaben_hidden_without_queue_view(employee_panel: PanelHarness) -> None:
+def test_aufgaben_hidden_without_tasks_view(employee_panel: PanelHarness) -> None:
     super_jar = _ready_superadmin(employee_panel)
     _create_employee(
         employee_panel,
@@ -692,7 +692,7 @@ def test_aufgaben_hidden_without_queue_view(employee_panel: PanelHarness) -> Non
     assert 'href="/aufgaben"' not in body
 
 
-def test_aufgaben_visible_with_queue_view_without_inquiries_view(
+def test_aufgaben_visible_with_tasks_view_without_inquiries_view(
     employee_panel: PanelHarness,
 ) -> None:
     super_jar = _ready_superadmin(employee_panel)
@@ -702,16 +702,16 @@ def test_aufgaben_visible_with_queue_view_without_inquiries_view(
         username="queue.only.tasks",
         password="ReaderTemp1!",
         role="USER",
-        permissions=frozenset({"queue.view"}),
+        permissions=frozenset({"tasks.view"}),
     )
     jar = _login(employee_panel, username="queue.only.tasks", password="ReaderTemp1!")
-    status, _url, body, _headers = _request(employee_panel.base, "/", jar=jar)
+    status, _url, body, _headers = _request(employee_panel.base, "/aufgaben", jar=jar)
     assert status == 200
     assert 'href="/aufgaben"' in body
     assert 'href="/anfragen"' not in body
 
 
-def test_aufgaben_direct_url_requires_queue_view(
+def test_aufgaben_direct_url_requires_tasks_view(
     employee_panel: PanelHarness,
 ) -> None:
     super_jar = _ready_superadmin(employee_panel)

--- a/tests/unit/test_office_panel_manual_tasks_ui.py
+++ b/tests/unit/test_office_panel_manual_tasks_ui.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import http.cookiejar
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from catering_system.domain.manual_task import ManualTask
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.ui.office_panel import OfficePanel
+from catering_system.ui.office_panel_views import OfficePageContext
+from tests.unit.test_office_panel_auth_2d1 import (
+    PanelHarness,
+    _create_employee,
+    _create_panel,
+    _csrf,
+    _login,
+    _ready_superadmin,
+    _request,
+    _shutdown,
+)
+
+
+@pytest.fixture()
+def employee_panel(tmp_path: Path):
+    panel = _create_panel(tmp_path, auth_mode="employee")
+    yield panel
+    _shutdown(panel)
+
+
+def _login_employee(
+    panel: PanelHarness,
+    super_jar: http.cookiejar.CookieJar,
+    *,
+    username: str,
+    permissions: frozenset[str],
+) -> http.cookiejar.CookieJar:
+    _create_employee(
+        panel,
+        super_jar,
+        username=username,
+        password="TaskTemp1!",
+        role="USER",
+        permissions=permissions,
+    )
+    return _login(panel, username=username, password="TaskTemp1!")
+
+
+def test_aufgaben_requires_tasks_view_not_queue_view(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    task_reader = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.reader",
+        permissions=frozenset({"tasks.view"}),
+    )
+    queue_reader = _login_employee(
+        employee_panel,
+        super_jar,
+        username="queue.reader",
+        permissions=frozenset({"queue.view"}),
+    )
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=task_reader
+    )
+    assert status == 200
+    assert "Aufgaben" in body
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=queue_reader
+    )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+
+
+def test_manual_tasks_render_created_data_escaped(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    jar = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.creator",
+        permissions=frozenset({"tasks.view", "tasks.create", "tasks.complete"}),
+    )
+
+    status, _url, _body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(jar),
+            "title": "<script>alert(1)</script>",
+            "description": "Rechnung vorbereiten",
+            "due_date": "2026-08-27",
+        },
+        jar=jar,
+    )
+    assert status == 303
+
+    status, _url, body, _headers = _request(employee_panel.base, "/aufgaben", jar=jar)
+    assert status == 200
+    assert "Manuell" in body
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+    assert "<script>alert(1)</script>" not in body
+    assert "Rechnung vorbereiten" in body
+    assert "27.08.2026" in body
+    assert 'action="/aufgaben/inquiry:' not in body
+
+
+def test_create_permission_controls_form_and_post(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    viewer = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.no.create",
+        permissions=frozenset({"tasks.view"}),
+    )
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=viewer
+    )
+    assert status == 200
+    assert "Aufgabe anlegen" not in body
+
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={"_csrf_token": _csrf(viewer), "title": "Nicht erlaubt"},
+        jar=viewer,
+    )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+
+
+def test_assignment_requires_tasks_assign_server_side(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    assignee_id = _create_employee(
+        employee_panel,
+        super_jar,
+        username="task.assignee",
+        password="TaskTemp1!",
+        role="USER",
+        permissions=frozenset({"tasks.view"}),
+    )
+    assigner = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.assigner",
+        permissions=frozenset({"tasks.view", "tasks.create", "tasks.assign"}),
+    )
+    creator = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.no.assign",
+        permissions=frozenset({"tasks.view", "tasks.create"}),
+    )
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=assigner
+    )
+    assert status == 200
+    assert 'name="assigned_to_employee_id"' in body
+    assert "task.assignee" in body
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=creator
+    )
+    assert status == 200
+    assert 'name="assigned_to_employee_id"' not in body
+
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(creator),
+            "title": "Forged assignment",
+            "assigned_to_employee_id": assignee_id,
+        },
+        jar=creator,
+    )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+
+    status, _url, _body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={
+            "_csrf_token": _csrf(assigner),
+            "title": "Mit Zuweisung",
+            "assigned_to_employee_id": assignee_id,
+        },
+        jar=assigner,
+    )
+    assert status == 303
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=assigner
+    )
+    assert status == 200
+    assert "Mit Zuweisung" in body
+    assert "task.assignee" in body
+
+
+def test_complete_permission_controls_button_and_post(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    completer = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.completer",
+        permissions=frozenset({"tasks.view", "tasks.create", "tasks.complete"}),
+    )
+    viewer = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.no.complete",
+        permissions=frozenset({"tasks.view"}),
+    )
+    status, _url, _body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={"_csrf_token": _csrf(completer), "title": "Abschliessen"},
+        jar=completer,
+    )
+    assert status == 303
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=viewer
+    )
+    assert status == 200
+    assert "Abschliessen" in body
+    assert "Erledigt" not in body
+
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=completer
+    )
+    assert status == 200
+    assert "Erledigt" in body
+    task_match = re.search(r'action="/aufgaben/([0-9a-f-]{36})/complete"', body)
+    assert task_match is not None
+    task_id = task_match.group(1)
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        f"/aufgaben/{task_id}/complete",
+        method="POST",
+        data={"_csrf_token": _csrf(viewer)},
+        jar=viewer,
+    )
+    assert status == 403
+    assert "Ihre Berechtigung reicht" in body
+
+    status, _url, _body, _headers = _request(
+        employee_panel.base,
+        f"/aufgaben/{task_id}/complete",
+        method="POST",
+        data={"_csrf_token": _csrf(completer)},
+        jar=completer,
+    )
+    assert status == 303
+    status, _url, body, _headers = _request(
+        employee_panel.base, "/aufgaben", jar=completer
+    )
+    assert status == 200
+    assert "Abschliessen" not in body
+
+
+def test_create_requires_valid_csrf_and_does_not_mutate_on_failure(
+    employee_panel: PanelHarness,
+) -> None:
+    super_jar = _ready_superadmin(employee_panel)
+    jar = _login_employee(
+        employee_panel,
+        super_jar,
+        username="task.csrf",
+        permissions=frozenset({"tasks.view", "tasks.create"}),
+    )
+
+    status, _url, body, _headers = _request(
+        employee_panel.base,
+        "/aufgaben/new",
+        method="POST",
+        data={"title": "No CSRF"},
+        jar=jar,
+    )
+    assert status == 403
+    assert "CSRF" in body
+
+    status, _url, body, _headers = _request(employee_panel.base, "/aufgaben", jar=jar)
+    assert status == 200
+    assert "No CSRF" not in body
+
+
+class _RemoteStub:
+    def __init__(self) -> None:
+        self.inquiry_service = object()
+        self.order_service = object()
+        self.core = object()
+        self.payment_reminder_service = object()
+        self.confirmation_document_service = object()
+        self.confirmation_outbound_service = object()
+        self.catalog_dish_write_service = object()
+        self.seen_tokens: list[str] = []
+        self.created_token: str | None = None
+        self.completed_token: str | None = None
+        self._form: dict[str, str] = {}
+
+    def begin_request(self, form=None) -> None:
+        self._form = dict(form or {})
+
+    def new_page_command_id(self) -> str:
+        return "44444444-4444-4444-8444-444444444444"
+
+    def form_value(self, key: str) -> str | None:
+        return self._form.get(key)
+
+    def list_tasks(self) -> dict[str, object]:
+        return {
+            "tasks": [
+                {
+                    "task_id": "inquiry:abc:verify",
+                    "category": "verify",
+                    "title": "System Aufgabe",
+                    "subtitle": "aus Projektion",
+                    "entity_type": "inquiry",
+                    "entity_id": "abc",
+                    "action_label": "Anfrage öffnen",
+                    "action_href": "/inquiry/abc",
+                    "due_at": None,
+                    "urgency": "normal",
+                    "opened_at": "2026-08-01T08:00:00+00:00",
+                }
+            ]
+        }
+
+    def list_manual_tasks(self, *, employee_session_token: str, **_kwargs):
+        self.seen_tokens.append(employee_session_token)
+        return [
+            ManualTask(
+                task_id="11111111-1111-4111-8111-111111111111",
+                title="Remote Aufgabe",
+                description="",
+                due_at=None,
+                created_at=datetime(2026, 8, 1, 8, 0, tzinfo=UTC),
+                completed_at=None,
+                created_by_employee_id="22222222-2222-4222-8222-222222222222",
+                assigned_to_employee_id=None,
+                subject_type="NONE",
+                subject_id=None,
+            )
+        ]
+
+    def create_manual_task(self, *, employee_session_token: str, **_kwargs):
+        self.created_token = employee_session_token
+        return self.list_manual_tasks(employee_session_token=employee_session_token)[0]
+
+    def complete_manual_task(
+        self, _task_id: str, *, employee_session_token: str, **_kwargs
+    ):
+        self.completed_token = employee_session_token
+        return self.list_manual_tasks(employee_session_token=employee_session_token)[0]
+
+
+def test_remote_manual_tasks_use_employee_session_token() -> None:
+    remote = _RemoteStub()
+    panel = OfficePanel(
+        InMemoryInquiryRepository(),
+        InMemoryOrderRepository(),
+        remote=remote,  # type: ignore[arg-type]
+    )
+    context = OfficePageContext(
+        csrf_token="csrf-token",
+        employee_account_id="22222222-2222-4222-8222-222222222222",
+        employee_effective_permissions=frozenset(
+            {"tasks.view", "tasks.create", "tasks.complete"}
+        ),
+    )
+
+    html = panel.render_aufgaben(
+        context=context, employee_session_token="employee-session-token"
+    )
+    assert "Remote Aufgabe" in html
+    assert "System Aufgabe" in html
+    assert "Manuell" in html
+    assert "System" in html
+    assert 'href="/inquiry/abc"' in html
+    assert 'action="/aufgaben/inquiry:abc:verify/complete"' not in html
+    assert remote.seen_tokens == ["employee-session-token"]
+
+    panel.begin_request({"_command_id": "cmd-1"})
+    panel.create_manual_task(
+        {"title": "Remote neu", "_command_id": "cmd-1"},
+        created_by_employee_id=context.employee_account_id,
+        employee_session_token="employee-session-token",
+    )
+    assert remote.created_token == "employee-session-token"
+
+    panel.begin_request({"_command_id": "cmd-2"})
+    panel.complete_manual_task(
+        "11111111-1111-4111-8111-111111111111",
+        employee_session_token="employee-session-token",
+    )
+    assert remote.completed_token == "employee-session-token"


### PR DESCRIPTION
## Summary
- show persisted manual tasks together with existing system-derived advisory tasks on `/aufgaben`
- add manual task creation with optional description/date and assignment gated by `tasks.assign`
- add completion for open manual tasks gated by `tasks.complete`; system rows remain read-only
- require `tasks.view` for the page and preserve CSRF/authentication/idempotency boundaries
- use the existing `ManualTaskService` in direct mode and authenticated `RemoteCoreClient` manual-task methods in remote mode

## Verification
- focused UI/API: `14 passed`
- full Python suite: `3075 passed`
- coverage: `90.2%`
- `uv run ruff check src tests infra`: passed
- `uv run ruff format --check src tests infra`: passed
- `uv run mypy src/catering_system`: passed
- lock, PDF runtime alignment, and both Node suites: passed
- clean scope: 1 commit, 7 files

Closes #182