### PR TITLE
Fix Safari hidden-state handling in manual task subject search

### DIFF
--- a/infra/office-panel/manual_task_subject_picker.test.mjs
+++ b/infra/office-panel/manual_task_subject_picker.test.mjs
@@ -11,6 +11,14 @@ const source = readFileSync(
   "utf8",
 );
 
+const shellSource = readFileSync(
+  new URL(
+    "../../src/catering_system/ui/office_panel_shell.py",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
 const marker = '_SUBJECT_PICKER_SCRIPT = r"""';
 const start = source.indexOf(marker);
 assert.notEqual(start, -1, "subject picker script marker must exist");
@@ -224,4 +232,11 @@ test("Ohne Bezug clears selection and collapses the picker", () => {
   assert.equal(fixture.summarySelection.textContent, "Ohne Bezug");
   assert.equal(fixture.results.hidden, true);
   assert.equal(fixture.picker.open, false);
+});
+
+test("hidden picker rows remain hidden under author display rules", () => {
+  assert.match(
+    shellSource,
+    /\.task-subject-result\[hidden\][\s\S]*display:\s*none\s*!important;/,
+  );
 });

--- a/src/catering_system/ui/office_panel_shell.py
+++ b/src/catering_system/ui/office_panel_shell.py
@@ -439,6 +439,11 @@ button.office-account-link:hover {
   margin-top: 10px;
   overflow: auto;
 }
+.task-subject-results[hidden],
+.task-subject-result[hidden],
+.task-subject-empty[hidden] {
+  display: none !important;
+}
 .office-content .task-subject-result {
   display: grid;
   grid-template-columns: 76px minmax(0, 1fr);


### PR DESCRIPTION
Closes #190.

Production Safari showed all subject rows even after the picker JavaScript set non-matches to hidden.

This adds an explicit scoped hidden-state CSS rule for the subject picker so author display:grid rules cannot override hidden elements.

No backend/API/database changes.