### PR TITLE
Carry fulfillment and addresses in Configurator handoff

### DIFF
--- a/src/catering_system/ui/office_panel_offer_prefill.py
+++ b/src/catering_system/ui/office_panel_offer_prefill.py
@@ -43,6 +43,28 @@ def _contact_prefill_value(
     return _clip(structured_value) or _clip(labelled_fallback)
 
 
+def _address_prefill(address: object | None) -> dict[str, str]:
+    if address is None:
+        return {"street": "", "postalCode": "", "city": "", "country": ""}
+    return {
+        "street": _clip(getattr(address, "street", None)),
+        "postalCode": _clip(getattr(address, "postal_code", None)),
+        "city": _clip(getattr(address, "city", None)),
+        "country": _clip(getattr(address, "country", None)),
+    }
+
+
+def _formatted_address(address: object | None) -> str:
+    if address is None:
+        return ""
+    street = _clip(getattr(address, "street", None))
+    postal_code = _clip(getattr(address, "postal_code", None))
+    city = _clip(getattr(address, "city", None))
+    country = _clip(getattr(address, "country", None))
+    locality = " ".join(part for part in (postal_code, city) if part)
+    return ", ".join(part for part in (street, locality, country) if part)
+
+
 def offer_prefill_payload(inquiry: Inquiry) -> dict[str, object]:
     """Build proposal-phase copy only; this performs no Core write."""
     labelled, remaining = labelled_intake_context(inquiry.intake_message)
@@ -92,8 +114,22 @@ def offer_prefill_payload(inquiry: Inquiry) -> dict[str, object]:
                 "eventDate": inquiry.event_date.isoformat(),
                 "eventTime": _clip(inquiry.time_window_text),
                 "location": _clip(inquiry.location_text),
-                "billingAddress": "",
+                "billingAddress": _formatted_address(
+                    customer.invoice_address if customer is not None else None
+                ),
                 "remarks": remarks,
+            },
+            "fulfillmentPrefill": {
+                "fulfillmentMode": inquiry.fulfillment_mode,
+                "deliveryAddressMode": (
+                    customer.delivery_address_mode if customer is not None else "UNKNOWN"
+                ),
+                "invoiceAddress": _address_prefill(
+                    customer.invoice_address if customer is not None else None
+                ),
+                "deliveryAddress": _address_prefill(
+                    customer.delivery_address if customer is not None else None
+                ),
             },
         },
     }

--- a/src/catering_system/ui/office_panel_offer_prefill.py
+++ b/src/catering_system/ui/office_panel_offer_prefill.py
@@ -122,7 +122,9 @@ def offer_prefill_payload(inquiry: Inquiry) -> dict[str, object]:
             "fulfillmentPrefill": {
                 "fulfillmentMode": inquiry.fulfillment_mode,
                 "deliveryAddressMode": (
-                    customer.delivery_address_mode if customer is not None else "UNKNOWN"
+                    customer.delivery_address_mode
+                    if customer is not None
+                    else "UNKNOWN"
                 ),
                 "invoiceAddress": _address_prefill(
                     customer.invoice_address if customer is not None else None

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1303,7 +1303,11 @@ def _validate_offer_prefill(value: object) -> None:
         _bad_response()
     _uuid4(payload["inquiry_id"])
     transfer = _dict(payload["transfer"])
-    _exact(transfer, {"planning", "orderContextPrefill"})
+    transfer_keys = set(transfer)
+    required_transfer_keys = {"planning", "orderContextPrefill"}
+    allowed_transfer_keys = required_transfer_keys | {"fulfillmentPrefill"}
+    if not required_transfer_keys <= transfer_keys <= allowed_transfer_keys:
+        _bad_response()
     planning = _dict(transfer["planning"])
     _exact(
         planning,
@@ -1343,6 +1347,30 @@ def _validate_offer_prefill(value: object) -> None:
     for item in context.values():
         _str(item)
     _date(context["eventDate"])
+
+    if "fulfillmentPrefill" in transfer:
+        fulfillment = _dict(transfer["fulfillmentPrefill"])
+        _exact(
+            fulfillment,
+            {
+                "fulfillmentMode",
+                "deliveryAddressMode",
+                "invoiceAddress",
+                "deliveryAddress",
+            },
+        )
+        validate_fulfillment_mode(_str(fulfillment["fulfillmentMode"]))
+        if _str(fulfillment["deliveryAddressMode"]) not in {
+            "UNKNOWN",
+            "SAME_AS_INVOICE",
+            "SEPARATE",
+        }:
+            _bad_response()
+        for address_key in ("invoiceAddress", "deliveryAddress"):
+            address = _dict(fulfillment[address_key])
+            _exact(address, {"street", "postalCode", "city", "country"})
+            for item in address.values():
+                _str(item)
 
 
 class RemoteCoreClient:

--- a/tests/unit/test_office_panel_offer_prefill.py
+++ b/tests/unit/test_office_panel_offer_prefill.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from catering_system.domain.configurator_handoff import ConfiguratorHandoffRecord
+from catering_system.domain.customer_document_projection import CustomerAddress
 from catering_system.domain.inquiry import (
     Inquiry,
     InquiryOfferProjection,
@@ -190,6 +191,75 @@ def test_fragment_maps_structured_customer_snapshot_and_all_event_fields() -> No
             "Zusätzlicher Anfragekontext\n\n"
             "Zusammenfassung: Website-Anfrage — 42 Personen, 2026-10-03"
         ),
+    }
+
+
+def test_fulfillment_and_structured_addresses_are_carried_into_handoff() -> None:
+    inquiry = replace(
+        _inquiry(),
+        fulfillment_mode="DELIVERY",
+        customer_snapshot=InquiryCustomerSnapshot(
+            company_name="Muster GmbH",
+            contact_name="Max Muster",
+            email="max@example.test",
+            phone="+49 40 12345",
+            invoice_address=CustomerAddress(
+                street="Rechnungsweg 7",
+                postal_code="22549",
+                city="Hamburg",
+                country="DE",
+            ),
+            delivery_address=CustomerAddress(
+                street="Festplatz 3",
+                postal_code="22765",
+                city="Hamburg",
+                country="DE",
+            ),
+            delivery_address_mode="SEPARATE",
+        ),
+    )
+
+    transfer = offer_prefill_payload(inquiry)["transfer"]
+
+    assert transfer["orderContextPrefill"]["billingAddress"] == (
+        "Rechnungsweg 7, 22549 Hamburg, DE"
+    )
+    assert transfer["fulfillmentPrefill"] == {
+        "fulfillmentMode": "DELIVERY",
+        "deliveryAddressMode": "SEPARATE",
+        "invoiceAddress": {
+            "street": "Rechnungsweg 7",
+            "postalCode": "22549",
+            "city": "Hamburg",
+            "country": "DE",
+        },
+        "deliveryAddress": {
+            "street": "Festplatz 3",
+            "postalCode": "22765",
+            "city": "Hamburg",
+            "country": "DE",
+        },
+    }
+
+
+def test_unknown_fulfillment_is_explicit_without_inventing_addresses() -> None:
+    transfer = offer_prefill_payload(_inquiry())["transfer"]
+
+    assert transfer["fulfillmentPrefill"] == {
+        "fulfillmentMode": "UNKNOWN",
+        "deliveryAddressMode": "UNKNOWN",
+        "invoiceAddress": {
+            "street": "",
+            "postalCode": "",
+            "city": "",
+            "country": "",
+        },
+        "deliveryAddress": {
+            "street": "",
+            "postalCode": "",
+            "city": "",
+            "country": "",
+        },
     }
 
 


### PR DESCRIPTION
Closes #197.

Production E2E showed that the Office already held fulfillment and customer addresses, but the Configurator asked the operator to enter them again.

Changes:
- include `fulfillmentPrefill` in the existing inquiry transfer;
- carry fulfillment mode, delivery-address mode, invoice address and separate delivery address;
- populate legacy `billingAddress` from the structured invoice address when available;
- keep UNKNOWN/blank explicit when Core has no fact;
- add focused regressions.