### PR TITLE
Expose unresolved delivery context during accepted Offer conversion

### DIFF
--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -2774,12 +2774,14 @@ class OfficeApi:
                 raise ApiError(422, "version_not_owned") from exc
             if "accepted variant does not belong" in message:
                 raise ApiError(422, "invalid_variant") from exc
-            if "conversion blocked" in message:
-                raise ApiError(422, "conversion_blocked") from exc
+            if "inquiry delivery context unresolved" in message:
+                raise ApiError(422, "delivery_context_unresolved") from exc
             if "inquiry conversion blocked" in message:
                 raise ApiError(422, "verification_gate_blocked") from exc
             if "contact information incomplete" in message:
                 raise ApiError(422, "contact_information_incomplete") from exc
+            if "conversion blocked" in message:
+                raise ApiError(422, "conversion_blocked") from exc
             raise ApiError(422, "conversion_blocked") from exc
         except sqlite3.IntegrityError:
             offer_check = self.offers.get(offer_id)

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -178,6 +178,10 @@ _INQUIRY_COMMAND_ERROR_LABELS: dict[str, str] = {
     "conversion_blocked": (
         "Das angenommene Angebot kann derzeit nicht in einen Auftrag umgewandelt werden."
     ),
+    "delivery_context_unresolved": (
+        "Die Lieferdaten sind unvollständig. Bitte Lieferart und die vollständige "
+        "wirksame Lieferadresse einschließlich Land in der Anfrage ergänzen."
+    ),
     "already_converted": "Für diese Anfrage existiert bereits ein Auftrag.",
     "accepted_offer_required": (
         "Auftrag nur aus angenommenem Angebot — "

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3893,6 +3893,49 @@ def test_convert_accepted_happy_path_and_replay(api) -> None:
     orders.close()
 
 
+def test_convert_accepted_reports_unresolved_delivery_context(api) -> None:
+    base, _ids, db = api
+    offer_id, version_id, acceptance_id, variant_id = _prepare_send_accept(api)
+
+    conn = sqlite3.connect(db)
+    inquiry_id = conn.execute(
+        "SELECT source_inquiry_id FROM offers WHERE offer_id = ?",
+        (offer_id,),
+    ).fetchone()[0]
+    conn.execute(
+        """
+        UPDATE inquiries
+        SET fulfillment_mode = 'DELIVERY',
+            snapshot_delivery_address_mode = 'SEPARATE',
+            snapshot_delivery_address_json = ?
+        WHERE inquiry_id = ?
+        """,
+        (
+            json.dumps(
+                {
+                    "street": "Auf dem Königslande 4",
+                    "postal_code": "22041",
+                    "city": "Hamburg",
+                    "country": None,
+                }
+            ),
+            inquiry_id,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    status, body, _h = _post(
+        _convert_accepted_url(base, offer_id, version_id),
+        args={
+            "accepted_variant_id": variant_id,
+            "acceptance_id": acceptance_id,
+        },
+    )
+
+    assert (status, body["error"]) == (422, "delivery_context_unresolved")
+
+
 def test_convert_accepted_rejects_prepared(api) -> None:
     base, _ids, _db = api
     offer_id, version_id = _prepare_offer(api)

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -53,7 +53,10 @@ from catering_system.ui.office_panel import (
     OfficePanel,
     create_office_panel_server,
 )
-from catering_system.ui.office_panel_http import csrf_token_for_password
+from catering_system.ui.office_panel_http import (
+    csrf_token_for_password,
+    office_command_error_message,
+)
 from catering_system.ui.office_panel_order_detail import (
     ConfirmationLivePreviewView,
     OrderDetailFormFields,
@@ -63,6 +66,14 @@ from catering_system.ui.office_panel_shell import OFFICE_PANEL_STYLE
 from catering_system.ui.office_panel_tasks_list import SUBJECT_PICKER_SCRIPT_CSP_SOURCE
 from catering_system.ui.office_panel_views import OfficePageContext, _page
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
+
+
+
+def test_delivery_context_conversion_error_is_actionable() -> None:
+    message = office_command_error_message("delivery_context_unresolved")
+    assert "Lieferdaten sind unvollständig" in message
+    assert "Land" in message
+
 from tests.helpers.office_panel_context import legacy_office_context
 from tests.helpers.order_seed import seed_order
 

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -75,6 +75,7 @@ def test_delivery_context_conversion_error_is_actionable() -> None:
     assert "Lieferdaten sind unvollständig" in message
     assert "Land" in message
 
+
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()
 _CSRF_TOKEN = csrf_token_for_password(_PASSWORD)

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -66,16 +66,14 @@ from catering_system.ui.office_panel_shell import OFFICE_PANEL_STYLE
 from catering_system.ui.office_panel_tasks_list import SUBJECT_PICKER_SCRIPT_CSP_SOURCE
 from catering_system.ui.office_panel_views import OfficePageContext, _page
 from tests.helpers.commercial_snapshot_seed import seed_commercial_snapshot
-
+from tests.helpers.office_panel_context import legacy_office_context
+from tests.helpers.order_seed import seed_order
 
 
 def test_delivery_context_conversion_error_is_actionable() -> None:
     message = office_command_error_message("delivery_context_unresolved")
     assert "Lieferdaten sind unvollständig" in message
     assert "Land" in message
-
-from tests.helpers.office_panel_context import legacy_office_context
-from tests.helpers.order_seed import seed_order
 
 _PASSWORD = "test-pw"
 _AUTH = "Basic " + base64.b64encode(f"office:{_PASSWORD}".encode()).decode()


### PR DESCRIPTION
Closes #199.

Production E2E reached an Accepted Offer but conversion to Order failed with the generic `conversion_blocked` page. The persisted Inquiry had `fulfillment_mode=DELIVERY`, `delivery_address_mode=SEPARATE`, and an effective delivery address whose `country` was null, which the defensive conversion gate rejects.

Changes:
- map `inquiry delivery context unresolved` to stable `delivery_context_unresolved` at the Office API boundary;
- check the specific inquiry conversion errors before the generic `conversion blocked` branch;
- show an actionable German Office message that points to incomplete delivery data including country;
- add API and presentation regressions.

The source-side prevention is handled separately in fingerfood-app #52, which now blocks incomplete effective delivery addresses before Offer prepare.