### PR TITLE
Require explicit payment method during Offer conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,12 +75,14 @@ here. Historical fine-grained execution notes remain in `WORKLOG.md`.
   changed, and the slice is not deployed.
 - Added a local, undeployed payment-reminder block to Order detail. Confirmed
   Orders without reminder data truthfully show `Zahlungsart auswählen`; the
-  office can record `Vorkasse`, `Rechnung` or `Bar vor Ort`, external invoice
-  reference/dates, payment date or cash receipt. Deadlines and the next German
-  reminder are purely derived. The additive SQLite data, direct mode and the
-  idempotent remote command remain separate from OrderVersion, kitchen print,
-  `wirksam`, `READY_TO_SEND` and kiosk state. No invoice document, accounting,
-  banking or automatic payment matching was added.
+  office must explicitly choose `Vorkasse`, `Rechnung` or `Bar vor Ort` while
+  converting an accepted Offer, and can then record external invoice
+  reference/dates, payment date or cash receipt. Replays preserve the original
+  conversion choice and reject a conflicting one. Deadlines and the next
+  German reminder are purely derived. The additive SQLite data, direct mode
+  and the idempotent remote command remain separate from OrderVersion, kitchen
+  print, `wirksam`, `READY_TO_SEND` and kiosk state. No invoice document,
+  accounting, banking or automatic payment matching was added.
 
 - Corrected the operational status after the office-workflow proof: the
   staging form now exercises an already-connected office queue, the Lenovo

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -79,10 +79,15 @@ class PaymentReminderService:
         return self.view(reminder.order_id)
 
     def seed_from_conversion(self, order_id: str, payment_method: str) -> None:
-        """Insert a minimal payment reminder when absent after offer conversion."""
-        if self._reminders.get(order_id) is not None:
-            return
+        """Persist the explicit conversion choice, with conflict-safe replay."""
         method = validate_payment_method(payment_method)
+        current = self._reminders.get(order_id)
+        if current is not None:
+            if current.payment_method != method:
+                raise ValueError(
+                    "payment method conflicts with existing conversion selection"
+                )
+            return
         reminder = OrderPaymentReminder(order_id=order_id, payment_method=method)
         validate_payment_reminder(reminder)
         self._reminders.save(replace(reminder, updated_at=self._now()))

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -2751,6 +2751,7 @@ class OfficeApi:
         offer_version_id = path_ids["version_id"]
         accepted_variant_id = _v_uuid(args["accepted_variant_id"])
         acceptance_id = _v_uuid(args["acceptance_id"])
+        payment_method = _v_enum(args["payment_method"], validate_payment_method)
         existing = self.offers.get(offer_id)
         if existing is None:
             raise ApiError(404, "not_found")
@@ -2814,13 +2815,15 @@ class OfficeApi:
                 raise ApiError(409, "already_converted") from None
             else:
                 raise
-        offer_version = next(
-            item for item in offer.versions if item.offer_version_id == offer_version_id
-        )
-        self.payment_reminder_service.seed_from_conversion(
-            order.order_id,
-            offer_version.payment_method,
-        )
+        try:
+            self.payment_reminder_service.seed_from_conversion(
+                order.order_id,
+                payment_method,
+            )
+        except ValueError as exc:
+            if "conflicts with existing conversion selection" in str(exc):
+                raise ApiError(409, "payment_method_conflict") from exc
+            raise
         self.inquiry_service.update_inquiry(
             offer.source_inquiry_id,
             crm_stage=ACTIVE_ORDER_CRM_STAGE,
@@ -3455,7 +3458,7 @@ _RECORD_WITHDRAWAL_ARGS = _ArgKeys(
     optional=frozenset({"reason"}),
 )
 _CONVERT_ACCEPTED_ARGS = _ArgKeys(
-    required=frozenset({"accepted_variant_id", "acceptance_id"})
+    required=frozenset({"accepted_variant_id", "acceptance_id", "payment_method"})
 )
 _VERSION_ID_ARGS = _ArgKeys(required=frozenset({"order_version_id"}))
 _ORDER_DELETE_ARGS = _ArgKeys(required=frozenset({"confirmation_name"}))

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -1758,6 +1758,7 @@ class OfficePanel:
         offer_version_id = str(detail["offer_version_id"])
         accepted_variant_id = form.get("accepted_variant_id", "").strip()
         acceptance_id = form.get("acceptance_id", "").strip()
+        payment_method = validate_payment_method(form.get("payment_method", ""))
         if not accepted_variant_id or not acceptance_id:
             raise ValueError("conversion blocked")
 
@@ -1769,20 +1770,15 @@ class OfficePanel:
                 self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
-            converted, order, order_version = offer_service.convert_accepted_offer(
+            _converted, order, order_version = offer_service.convert_accepted_offer(
                 offer_id,
                 offer_version_id,
                 accepted_variant_id,
                 acceptance_id,
             )
-            commercial_version = next(
-                item
-                for item in converted.versions
-                if item.offer_version_id == offer_version_id
-            )
             self.payment_reminder_service.seed_from_conversion(
                 order.order_id,
-                commercial_version.payment_method,
+                payment_method,
             )
             self.inquiry_service.update_inquiry(
                 str(detail["inquiry_id"]),
@@ -1796,6 +1792,7 @@ class OfficePanel:
                 offer_version_id,
                 accepted_variant_id=accepted_variant_id,
                 acceptance_id=acceptance_id,
+                payment_method=payment_method,
             )
             order = self._orders.get_order(order_id)
             order_version = self._orders.get_order_version(order_version_id)
@@ -3525,6 +3522,11 @@ class OfficePanel:
                 and context.can("offers.view")
                 and context.can("orders.version.create")
             ):
+                payment_options = "".join(
+                    f'<option value="{_e(method)}">'
+                    f"{_e(PAYMENT_METHOD_LABELS[method])}</option>"
+                    for method in PAYMENT_METHODS
+                )
                 convert += (
                     f'<form class="inline" method="post" '
                     f'action="/inquiry/{_e(inquiry_id)}/convert-accepted" '
@@ -3532,6 +3534,9 @@ class OfficePanel:
                     "'Dieses angenommene Angebot wird jetzt in einen Auftrag umgewandelt.'"
                     ');">'
                     f"{_csrf_input(context)}{self._command_fields()}"
+                    '<label>Zahlungsart* <select name="payment_method" required>'
+                    '<option value="" selected disabled>Bitte wählen</option>'
+                    f"{payment_options}</select></label> "
                     "<button>Angenommenes Angebot in Auftrag überführen</button>"
                     "</form>"
                 )
@@ -3671,9 +3676,10 @@ class OfficePanel:
         return work()
 
     def convert_accepted_offer_for_inquiry(
-        self, inquiry_id: str
+        self, inquiry_id: str, form: dict[str, str]
     ) -> tuple[Order, OrderVersion]:
         """Run the accepted-offer conversion through the existing Core command path."""
+        payment_method = validate_payment_method(form.get("payment_method", ""))
 
         def work() -> tuple[Order, OrderVersion]:
             inquiry = self._inquiries.get_by_id(inquiry_id)
@@ -3700,6 +3706,10 @@ class OfficePanel:
                         None,
                     )
                     if order is not None and order_version is not None:
+                        self.payment_reminder_service.seed_from_conversion(
+                            order.order_id,
+                            payment_method,
+                        )
                         return order, order_version
                 raise ValueError("accepted offer conversion gate is not satisfied")
             assert state.offer is not None
@@ -3716,20 +3726,15 @@ class OfficePanel:
                 self._commercial_snapshots,
                 today=api_views.berlin_today,
             )
-            converted, order, order_version = offer_service.convert_accepted_offer(
+            _converted, order, order_version = offer_service.convert_accepted_offer(
                 projection.offer_id,
                 projection.offer_version_id,
                 projection.accepted_variant_id,
                 projection.acceptance_id,
             )
-            commercial_version = next(
-                item
-                for item in converted.versions
-                if item.offer_version_id == projection.offer_version_id
-            )
             self.payment_reminder_service.seed_from_conversion(
                 order.order_id,
-                commercial_version.payment_method,
+                payment_method,
             )
             self.inquiry_service.update_inquiry(
                 inquiry_id,
@@ -3776,6 +3781,7 @@ class OfficePanel:
                 projection.offer_version_id,
                 accepted_variant_id=projection.accepted_variant_id,
                 acceptance_id=projection.acceptance_id,
+                payment_method=payment_method,
             )
             order = self._orders.get_order(order_id)
             order_version = self._orders.get_order_version(order_version_id)

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -2557,7 +2557,7 @@ def make_office_panel_handler(
                 self._redirect(f"/order/{order.order_id}")
             elif action == "convert-accepted":
                 order, _initial_version = panel.convert_accepted_offer_for_inquiry(
-                    inquiry_id
+                    inquiry_id, self._form()
                 )
                 self._redirect(f"/order/{order.order_id}")
             else:

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -197,8 +197,7 @@ def _primary_action(
         if not (context.can("offers.view") and context.can("orders.version.create")):
             return ""
         payment_options = "".join(
-            f'<option value="{_e(method)}">'
-            f"{_e(PAYMENT_METHOD_LABELS[method])}</option>"
+            f'<option value="{_e(method)}">{_e(PAYMENT_METHOD_LABELS[method])}</option>'
             for method in PAYMENT_METHODS
         )
         return (

--- a/src/catering_system/ui/office_panel_inquiry_detail.py
+++ b/src/catering_system/ui/office_panel_inquiry_detail.py
@@ -19,6 +19,10 @@ from catering_system.domain.inquiry_contact_completeness import (
     missing_contact_fields,
 )
 from catering_system.domain.order import Order
+from catering_system.domain.order_payment_reminder import (
+    PAYMENT_METHOD_LABELS,
+    PAYMENT_METHODS,
+)
 from catering_system.ui.office_panel_views import OfficePageContext
 
 _SOURCE_LABELS = {
@@ -192,6 +196,11 @@ def _primary_action(
     elif inquiry_shows_convert_accepted_button(state):
         if not (context.can("offers.view") and context.can("orders.version.create")):
             return ""
+        payment_options = "".join(
+            f'<option value="{_e(method)}">'
+            f"{_e(PAYMENT_METHOD_LABELS[method])}</option>"
+            for method in PAYMENT_METHODS
+        )
         return (
             '<section class="inquiry-next-step">'
             '<div class="inquiry-eyebrow">Nächster Schritt</div>'
@@ -202,6 +211,9 @@ def _primary_action(
             "'Dieses angenommene Angebot wird jetzt in einen Auftrag umgewandelt.'"
             ');">'
             f"{forms.csrf_input}{forms.primary_command_fields}"
+            '<label>Zahlungsart* <select name="payment_method" required>'
+            '<option value="" selected disabled>Bitte wählen</option>'
+            f"{payment_options}</select></label>"
             '<button class="inquiry-button" type="submit">'
             "Angenommenes Angebot in Auftrag überführen"
             "</button></form></section>"

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import cast
+from typing import TypeVar, cast
 from zoneinfo import ZoneInfo
 
 from catering_system.domain.offer import ACCEPTANCE_CHANNELS, SENT_CHANNELS
@@ -39,6 +39,7 @@ _ACCEPTANCE_CHANNEL_LABELS = {
     "in_person": "Persönlich",
     "other": "Sonstiges",
 }
+_OptionValue = TypeVar("_OptionValue", bound=str)
 
 _OFFER_DETAIL_STYLE = """
 <style>
@@ -513,8 +514,8 @@ def _budget_block(surface: dict[str, object]) -> str:
 
 
 def _select_options(
-    values: tuple[str, ...],
-    labels: Mapping[str, str],
+    values: tuple[_OptionValue, ...],
+    labels: Mapping[_OptionValue, str],
     *,
     selected: str | None = None,
 ) -> str:

--- a/src/catering_system/ui/office_panel_offer_detail.py
+++ b/src/catering_system/ui/office_panel_offer_detail.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
 from typing import cast
 from zoneinfo import ZoneInfo
 
 from catering_system.domain.offer import ACCEPTANCE_CHANNELS, SENT_CHANNELS
+from catering_system.domain.order_payment_reminder import (
+    PAYMENT_METHOD_LABELS,
+    PAYMENT_METHODS,
+)
 from catering_system.ui.office_api_views import offer_state_label
 from catering_system.ui.office_panel_views import (
     OfficePageContext,
@@ -509,7 +514,7 @@ def _budget_block(surface: dict[str, object]) -> str:
 
 def _select_options(
     values: tuple[str, ...],
-    labels: dict[str, str],
+    labels: Mapping[str, str],
     *,
     selected: str | None = None,
 ) -> str:
@@ -698,6 +703,7 @@ def _convert_form(
 ) -> str:
     if not (context.can("offers.view") and context.can("orders.version.create")):
         return ""
+    payment_options = _select_options(PAYMENT_METHODS, PAYMENT_METHOD_LABELS)
     return (
         '<section class="offer-action-section">'
         "<p>Das angenommene Angebot wird in einen Auftrag überführt.</p>"
@@ -710,6 +716,9 @@ def _convert_form(
         f'<input type="hidden" name="accepted_variant_id" '
         f'value="{_e(accepted_variant_id)}">'
         f'<input type="hidden" name="acceptance_id" value="{_e(acceptance_id)}">'
+        '<label>Zahlungsart*<select name="payment_method" required>'
+        '<option value="" selected disabled>Bitte wählen</option>'
+        f"{payment_options}</select></label>"
         '<button class="offer-primary-button" type="submit">'
         "In Auftrag umwandeln</button>"
         "</form></section>"

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1635,6 +1635,7 @@ class RemoteCoreClient:
         *,
         accepted_variant_id: str,
         acceptance_id: str,
+        payment_method: str,
     ) -> tuple[str, str]:
         result = self.command(
             f"/office/v1/offers/{quote(offer_id, safe='')}/versions/"
@@ -1642,6 +1643,7 @@ class RemoteCoreClient:
             {
                 "accepted_variant_id": accepted_variant_id,
                 "acceptance_id": acceptance_id,
+                "payment_method": payment_method,
             },
             {},
             expected={201, 200},

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -3856,7 +3856,11 @@ def test_convert_accepted_happy_path_and_replay(api) -> None:
     base, _ids, db = api
     offer_id, version_id, acceptance_id, variant_id = _prepare_send_accept(api)
     url = _convert_accepted_url(base, offer_id, version_id)
-    args = {"accepted_variant_id": variant_id, "acceptance_id": acceptance_id}
+    args = {
+        "accepted_variant_id": variant_id,
+        "acceptance_id": acceptance_id,
+        "payment_method": "VORKASSE",
+    }
     command_id = str(uuid.uuid4())
 
     status, body, _h = _post(url, args=args, command_id=command_id)
@@ -3872,6 +3876,17 @@ def test_convert_accepted_happy_path_and_replay(api) -> None:
     }
     assert body["offer_id"] == offer_id
     assert body["offer_version_id"] == version_id
+    conn = sqlite3.connect(db)
+    try:
+        stored_method = conn.execute(
+            "SELECT payment_method FROM order_payment_reminders WHERE order_id = ?",
+            (body["order_id"],),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    # The operator's explicit conversion choice is operational truth; the
+    # accepted offer in this fixture carries RECHNUNG as immutable evidence.
+    assert stored_method == "VORKASSE"
 
     status2, body2, _h = _post(url, args=args, command_id=command_id)
     assert (status2, body2) == (status, body)
@@ -3879,6 +3894,12 @@ def test_convert_accepted_happy_path_and_replay(api) -> None:
     status3, body3, _h = _post(url, args=args)
     assert status3 == 200
     assert body3["order_id"] == body["order_id"]
+
+    status4, body4, _h = _post(
+        url,
+        args={**args, "payment_method": "RECHNUNG"},
+    )
+    assert (status4, body4["error"]) == (409, "payment_method_conflict")
 
     offers = SQLiteOfferRepository(db)
     orders = SQLiteOrderRepository(db)
@@ -3891,6 +3912,35 @@ def test_convert_accepted_happy_path_and_replay(api) -> None:
     assert versions[0].location_text == "Hamburg"
     offers.close()
     orders.close()
+
+
+def test_convert_accepted_requires_explicit_payment_method(api) -> None:
+    base, _ids, db = api
+    offer_id, version_id, acceptance_id, variant_id = _prepare_send_accept(api)
+
+    status, body, _h = _post(
+        _convert_accepted_url(base, offer_id, version_id),
+        args={
+            "accepted_variant_id": variant_id,
+            "acceptance_id": acceptance_id,
+        },
+    )
+
+    assert (status, body["error"]) == (400, "invalid_request")
+    conn = sqlite3.connect(db)
+    try:
+        inquiry_id = conn.execute(
+            "SELECT source_inquiry_id FROM offers WHERE offer_id = ?", (offer_id,)
+        ).fetchone()[0]
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM orders WHERE source_inquiry_id = ?",
+                (inquiry_id,),
+            ).fetchone()[0]
+            == 0
+        )
+    finally:
+        conn.close()
 
 
 def test_convert_accepted_reports_unresolved_delivery_context(api) -> None:
@@ -3930,6 +3980,7 @@ def test_convert_accepted_reports_unresolved_delivery_context(api) -> None:
         args={
             "accepted_variant_id": variant_id,
             "acceptance_id": acceptance_id,
+            "payment_method": "RECHNUNG",
         },
     )
 
@@ -3944,6 +3995,7 @@ def test_convert_accepted_rejects_prepared(api) -> None:
         args={
             "accepted_variant_id": _VARIANT_ID,
             "acceptance_id": str(uuid.uuid4()),
+            "payment_method": "RECHNUNG",
         },
     )
     assert (status, body["error"]) == (422, "conversion_blocked")
@@ -3958,6 +4010,7 @@ def test_convert_accepted_rejects_wrong_variant_or_acceptance(api) -> None:
         args={
             "accepted_variant_id": "55555555-5555-4555-8555-555555555551",
             "acceptance_id": acceptance_id,
+            "payment_method": "RECHNUNG",
         },
     )
     assert (status, body["error"]) == (422, "invalid_variant")
@@ -3966,6 +4019,7 @@ def test_convert_accepted_rejects_wrong_variant_or_acceptance(api) -> None:
         args={
             "accepted_variant_id": variant_id,
             "acceptance_id": "66666666-6666-4666-8666-666666666666",
+            "payment_method": "RECHNUNG",
         },
     )
     assert (status, body["error"]) == (422, "conversion_blocked")
@@ -3997,6 +4051,7 @@ def test_convert_accepted_linked_order_without_link_blocks(api) -> None:
         args={
             "accepted_variant_id": accepted["accepted_variant_id"],
             "acceptance_id": accepted["acceptance_id"],
+            "payment_method": "RECHNUNG",
         },
     )
     assert (status, body["error"]) == (409, "already_converted")
@@ -4018,7 +4073,11 @@ def test_convert_accepted_storno_replay_same_order(api) -> None:
     base, _ids, db = api
     offer_id, version_id, acceptance_id, variant_id = _prepare_send_accept(api)
     url = _convert_accepted_url(base, offer_id, version_id)
-    args = {"accepted_variant_id": variant_id, "acceptance_id": acceptance_id}
+    args = {
+        "accepted_variant_id": variant_id,
+        "acceptance_id": acceptance_id,
+        "payment_method": "BAR_VOR_ORT",
+    }
     status, body, _h = _post(url, args=args)
     assert status == 201
     order_id = body["order_id"]
@@ -4054,6 +4113,7 @@ def test_convert_accepted_failure_leaves_no_conversion_or_ledger(api) -> None:
         args={
             "accepted_variant_id": variant_id,
             "acceptance_id": "00000000-0000-4000-8000-000000000099",
+            "payment_method": "RECHNUNG",
         },
         command_id=command_id,
     )
@@ -4857,6 +4917,7 @@ def _make_effective_offer_order(
         args={
             "accepted_variant_id": accept_body["accepted_variant_id"],
             "acceptance_id": accept_body["acceptance_id"],
+            "payment_method": "RECHNUNG",
         },
     )
     assert convert_status in (200, 201)

--- a/tests/unit/test_office_panel_convert_accepted.py
+++ b/tests/unit/test_office_panel_convert_accepted.py
@@ -339,6 +339,7 @@ def _post_convert_accepted(panel_url: str, inquiry_id: str) -> tuple[int, str, s
         block = form.group(0)
         if "_command_id" in block:
             fields["_command_id"] = _extract_hidden(block, "_command_id")
+        fields["payment_method"] = "BAR_VOR_ORT"
     return _post(f"{panel_url}/inquiry/{inquiry_id}/convert-accepted", fields)
 
 
@@ -389,6 +390,10 @@ def test_accepted_offer_button_creates_order_and_disappears(direct_world) -> Non
     assert (
         "Dieses angenommene Angebot wird jetzt in einen Auftrag umgewandelt." in detail
     )
+    assert 'name="payment_method" required' in detail
+    assert "Vorkasse" in detail
+    assert "Rechnung" in detail
+    assert "Bar vor Ort" in detail
 
     status, final_url, _body = _post_convert_accepted(panel_url, inquiry_id)
     assert status == 200
@@ -417,7 +422,11 @@ def test_converted_storno_shows_open_link_not_create_button(direct_world) -> Non
 
     status, body = _api_post(
         f"{api_url}/office/v1/offers/{offer.offer_id}/versions/{version_id}/convert-accepted",
-        args={"accepted_variant_id": variant_id, "acceptance_id": acceptance_id},
+        args={
+            "accepted_variant_id": variant_id,
+            "acceptance_id": acceptance_id,
+            "payment_method": "RECHNUNG",
+        },
     )
     assert status == 201
     order_id = body["order_id"]
@@ -448,7 +457,7 @@ def test_convert_accepted_replay_does_not_create_second_order(direct_world) -> N
 
     status, final_url, _body = _post(
         f"{panel_url}/inquiry/{inquiry_id}/convert-accepted",
-        {},
+        {"payment_method": "BAR_VOR_ORT"},
     )
     assert status == 200
     assert "/order/" in final_url

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -618,6 +618,8 @@ def test_accepted_shows_convert_form_only(direct_world) -> None:
     _status, html = _get(f"{panel_url}/offer/{offer_id}")
     assert "In Auftrag umwandeln" in html
     assert "/offer/" in html and "/convert" in html
+    assert 'name="payment_method" required' in html
+    assert '<option value="" selected disabled>Bitte wählen</option>' in html
     assert "Als gesendet markieren" not in html
     assert "Annahme erfassen" not in html
 
@@ -635,6 +637,7 @@ def test_converted_shows_order_link_without_actions(direct_world) -> None:
         args={
             "accepted_variant_id": offer.acceptance_evidence.accepted_variant_id,
             "acceptance_id": offer.acceptance_evidence.acceptance_id,
+            "payment_method": "RECHNUNG",
         },
     )
     offers.close()
@@ -823,6 +826,7 @@ def test_convert_redirects_to_created_order(direct_world) -> None:
     fields = _offer_form_fields(html, "/convert")
     fields["accepted_variant_id"] = _extract_hidden(html, "accepted_variant_id")
     fields["acceptance_id"] = _extract_hidden(html, "acceptance_id")
+    fields["payment_method"] = "VORKASSE"
     status, final_url, _body = _post(f"{panel_url}/offer/{offer_id}/convert", fields)
     assert status == 200
     assert "/order/" in final_url
@@ -849,6 +853,7 @@ def test_inquiry_convert_accepted_still_works(direct_world) -> None:
     _status, detail = _get(f"{panel_url}/inquiry/{inquiry_id}")
     assert "Angenommenes Angebot in Auftrag überführen" in detail
     fields = _offer_form_fields(detail, "convert-accepted")
+    fields["payment_method"] = "RECHNUNG"
     status, final_url, _body = _post(
         f"{panel_url}/inquiry/{inquiry_id}/convert-accepted",
         fields,

--- a/tests/unit/test_office_panel_remote.py
+++ b/tests/unit/test_office_panel_remote.py
@@ -1251,6 +1251,7 @@ def test_full_write_flow_through_remote_panel(remote_world) -> None:
             "_command_id": _extract_hidden(
                 convert_accepted_form.group(0), "_command_id"
             ),
+            "payment_method": "BAR_VOR_ORT",
         },
     )
     assert status == 200
@@ -1726,6 +1727,7 @@ def test_idempotent_retry_same_command_id_and_preconditions(remote_world) -> Non
         {
             "_csrf_token": _CSRF_TOKEN,
             "_command_id": _extract_hidden(convert_accepted_form, "_command_id"),
+            "payment_method": "RECHNUNG",
         },
     )
     assert status == 200

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -164,6 +164,22 @@ def test_save_is_idempotent_and_does_not_modify_operational_order() -> None:
     assert orders.get_order(reminder.order_id) == order_before
 
 
+def test_conversion_seed_is_idempotent_and_rejects_a_different_choice() -> None:
+    _orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+
+    service.seed_from_conversion(order_id, "VORKASSE")
+    service.seed_from_conversion(order_id, "VORKASSE")
+
+    stored = reminders.get(order_id)
+    assert stored is not None
+    assert stored.payment_method == "VORKASSE"
+    assert stored.updated_at == _NOW
+    with pytest.raises(ValueError, match="conflicts with existing"):
+        service.seed_from_conversion(order_id, "RECHNUNG")
+    assert reminders.get(order_id) == stored
+
+
 def test_payment_method_cannot_change_after_downstream_facts() -> None:
     _orders, _reminders, service = _world()
     order_id = "11111111-1111-4111-8111-111111111111"


### PR DESCRIPTION
Part of #201.

## What changes

- require the office to choose Vorkasse, Rechnung, or Bar vor Ort when converting an accepted Offer
- pass the selected method through direct and remote Office Panel paths into the existing payment reminder record
- keep repeat conversion idempotent for the same method and return `409 payment_method_conflict` for a different method
- preserve the accepted Offer payment terms as immutable evidence; the explicit office choice becomes operational Order payment truth
- add API, panel, remote-mode, and service regression coverage

## Boundaries

This does not create invoices, amounts, accounting records, bank matching, or Courier cash handoff behavior.

## Verification

- `python -m compileall -q src tests infra`
- payment seed smoke scenario
- `node --test infra/staging-form/app.test.cjs`
- `node --test infra/cloudflare_worker/sanitize.test.mjs`
- `node --test infra/office-panel/manual_task_subject_picker.test.mjs`

The complete Python lint/type/test/coverage gate runs in GitHub Actions because the local environment has no cached dev dependencies.