### PR TITLE
Add payment escalation audit trail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff src/catering_system/services/payment_reminder_service.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff \
-            src/catering_system/domain/order_payment_reminder.py \
-            src/catering_system/ui/remote_core_client.py \
-            tests/unit/test_payment_reminder.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff \
+            src/catering_system/domain/order_payment_reminder.py \
+            src/catering_system/ui/remote_core_client.py \
+            tests/unit/test_payment_reminder.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff src/catering_system/services/payment_reminder_service.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/domain/order_payment_reminder.py
+++ b/src/catering_system/domain/order_payment_reminder.py
@@ -395,9 +395,7 @@ def derive_payment_reminder(
     elif reminder.mahnung_sent_at is None:
         mahnung_due = _local_date(reminder.payment_reminder_sent_at) + timedelta(days=7)
         next_step = (
-            "Mahnung senden"
-            if today >= mahnung_due
-            else "Zahlungseingang prüfen"
+            "Mahnung senden" if today >= mahnung_due else "Zahlungseingang prüfen"
         )
         next_due = mahnung_due
     else:

--- a/src/catering_system/domain/order_payment_reminder.py
+++ b/src/catering_system/domain/order_payment_reminder.py
@@ -394,7 +394,11 @@ def derive_payment_reminder(
         next_due = reminder_due if today > canonical_due else canonical_due
     elif reminder.mahnung_sent_at is None:
         mahnung_due = _local_date(reminder.payment_reminder_sent_at) + timedelta(days=7)
-        next_step = "Mahnung senden" if today >= mahnung_due else "Zahlungseingang prüfen"
+        next_step = (
+            "Mahnung senden"
+            if today >= mahnung_due
+            else "Zahlungseingang prüfen"
+        )
         next_due = mahnung_due
     else:
         manual_due = _local_date(reminder.mahnung_sent_at) + timedelta(days=7)

--- a/src/catering_system/domain/order_payment_reminder.py
+++ b/src/catering_system/domain/order_payment_reminder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Literal
+from zoneinfo import ZoneInfo
 
 PaymentMethod = Literal["VORKASSE", "RECHNUNG", "BAR_VOR_ORT"]
 PAYMENT_METHODS: tuple[PaymentMethod, ...] = (
@@ -17,6 +18,7 @@ PAYMENT_METHOD_LABELS: dict[PaymentMethod, str] = {
     "RECHNUNG": "Rechnung",
     "BAR_VOR_ORT": "Bar vor Ort",
 }
+_BERLIN = ZoneInfo("Europe/Berlin")
 
 
 def validate_payment_method(value: str) -> PaymentMethod:
@@ -43,6 +45,18 @@ class OrderPaymentReminder:
     cash_received: bool = False
     quittung_printed: bool = False
     updated_at: datetime | None = None
+    invoice_created_at: datetime | None = None
+    invoice_created_by: str | None = None
+    invoice_sent_recorded_at: datetime | None = None
+    invoice_sent_recorded_by: str | None = None
+    payment_reminder_sent_at: datetime | None = None
+    payment_reminder_sent_by: str | None = None
+    mahnung_sent_at: datetime | None = None
+    mahnung_sent_by: str | None = None
+    quittung_printed_at: datetime | None = None
+    quittung_printed_by: str | None = None
+    paid_recorded_at: datetime | None = None
+    paid_recorded_by: str | None = None
 
 
 @dataclass(frozen=True)
@@ -61,6 +75,33 @@ class PaymentReminderView:
     payment_state_label: str
     next_step: str | None
     updated_at: datetime | None
+    next_step_due_on: date | None = None
+    invoice_created_at: datetime | None = None
+    invoice_created_by: str | None = None
+    invoice_sent_recorded_at: datetime | None = None
+    invoice_sent_recorded_by: str | None = None
+    payment_reminder_sent_at: datetime | None = None
+    payment_reminder_sent_by: str | None = None
+    mahnung_sent_at: datetime | None = None
+    mahnung_sent_by: str | None = None
+    quittung_printed_at: datetime | None = None
+    quittung_printed_by: str | None = None
+    paid_recorded_at: datetime | None = None
+    paid_recorded_by: str | None = None
+
+
+def _validate_audit_pair(
+    timestamp: datetime | None,
+    actor: str | None,
+    *,
+    name: str,
+) -> None:
+    if (timestamp is None) != (actor is None):
+        raise ValueError(f"{name} audit requires timestamp and actor together")
+    if timestamp is not None and timestamp.utcoffset() is None:
+        raise ValueError(f"{name} audit timestamp must be timezone-aware")
+    if actor is not None and (not actor.strip() or len(actor) > 200):
+        raise ValueError(f"{name} audit actor must be non-empty and at most 200 chars")
 
 
 def validate_payment_reminder(reminder: OrderPaymentReminder) -> None:
@@ -72,19 +113,55 @@ def validate_payment_reminder(reminder: OrderPaymentReminder) -> None:
     if number is not None and (not number.strip() or len(number) > 200):
         raise ValueError("invoice number must be non-empty and at most 200 chars")
 
+    audit_pairs = (
+        ("invoice created", reminder.invoice_created_at, reminder.invoice_created_by),
+        (
+            "invoice sent",
+            reminder.invoice_sent_recorded_at,
+            reminder.invoice_sent_recorded_by,
+        ),
+        (
+            "payment reminder",
+            reminder.payment_reminder_sent_at,
+            reminder.payment_reminder_sent_by,
+        ),
+        ("Mahnung", reminder.mahnung_sent_at, reminder.mahnung_sent_by),
+        (
+            "Quittung printed",
+            reminder.quittung_printed_at,
+            reminder.quittung_printed_by,
+        ),
+        ("payment recorded", reminder.paid_recorded_at, reminder.paid_recorded_by),
+    )
+    for name, timestamp, actor in audit_pairs:
+        _validate_audit_pair(timestamp, actor, name=name)
+
+    if reminder.invoice_created_at is not None and not reminder.invoice_created:
+        raise ValueError("invoice creation audit requires invoice_created")
+    if reminder.invoice_sent_recorded_at is not None and reminder.sent_on is None:
+        raise ValueError("invoice sent audit requires sent_on")
+    if reminder.paid_recorded_at is not None and reminder.paid_on is None:
+        raise ValueError("payment audit requires paid_on")
+
     if reminder.payment_method == "BAR_VOR_ORT":
         if (
             reminder.invoice_created
             or number is not None
             or reminder.sent_on is not None
             or reminder.due_on is not None
+            or reminder.invoice_created_at is not None
+            or reminder.invoice_sent_recorded_at is not None
+            or reminder.payment_reminder_sent_at is not None
+            or reminder.mahnung_sent_at is not None
         ):
             raise ValueError("cash payment cannot carry invoice reminder facts")
         if reminder.cash_received != (reminder.paid_on is not None):
             raise ValueError("cash receipt and paid date must be recorded together")
+        if reminder.quittung_printed_at is not None and not reminder.quittung_printed:
+            raise ValueError("Quittung audit requires printed readiness")
         return
 
-    if reminder.quittung_printed:
+    if reminder.quittung_printed or reminder.quittung_printed_at is not None:
         raise ValueError("invoice payment cannot carry quittung readiness facts")
     if reminder.cash_received:
         raise ValueError("invoice payment cannot be marked as cash received")
@@ -93,11 +170,22 @@ def validate_payment_reminder(reminder: OrderPaymentReminder) -> None:
         or reminder.sent_on is not None
         or reminder.due_on is not None
         or reminder.paid_on is not None
+        or reminder.invoice_created_at is not None
+        or reminder.invoice_sent_recorded_at is not None
+        or reminder.payment_reminder_sent_at is not None
+        or reminder.mahnung_sent_at is not None
     )
     if not reminder.invoice_created and invoice_facts:
         raise ValueError("invoice facts require invoice_created")
     if reminder.invoice_created and number is None:
         raise ValueError("invoice number is required after invoice creation")
+    if reminder.payment_reminder_sent_at is not None and reminder.sent_on is None:
+        raise ValueError("payment reminder audit requires sent invoice")
+    if reminder.mahnung_sent_at is not None:
+        if reminder.payment_method != "RECHNUNG":
+            raise ValueError("Mahnung is only valid for Rechnung")
+        if reminder.payment_reminder_sent_at is None:
+            raise ValueError("Mahnung requires a recorded payment reminder")
 
 
 def has_downstream_payment_facts(reminder: OrderPaymentReminder) -> bool:
@@ -109,6 +197,56 @@ def has_downstream_payment_facts(reminder: OrderPaymentReminder) -> bool:
         or reminder.paid_on
         or reminder.cash_received
         or reminder.quittung_printed
+        or reminder.invoice_created_at
+        or reminder.invoice_sent_recorded_at
+        or reminder.payment_reminder_sent_at
+        or reminder.mahnung_sent_at
+        or reminder.quittung_printed_at
+        or reminder.paid_recorded_at
+    )
+
+
+def _local_date(value: datetime) -> date:
+    return value.astimezone(_BERLIN).date()
+
+
+def _view(
+    reminder: OrderPaymentReminder,
+    *,
+    due_on: date | None,
+    invoice_state_label: str | None,
+    payment_state_label: str,
+    next_step: str | None,
+    next_step_due_on: date | None,
+) -> PaymentReminderView:
+    return PaymentReminderView(
+        order_id=reminder.order_id,
+        payment_method=reminder.payment_method,
+        payment_method_label=PAYMENT_METHOD_LABELS[reminder.payment_method],
+        invoice_created=reminder.invoice_created,
+        invoice_number=reminder.invoice_number,
+        sent_on=reminder.sent_on,
+        due_on=due_on,
+        paid_on=reminder.paid_on,
+        cash_received=reminder.cash_received,
+        quittung_printed=reminder.quittung_printed,
+        invoice_state_label=invoice_state_label,
+        payment_state_label=payment_state_label,
+        next_step=next_step,
+        updated_at=reminder.updated_at,
+        next_step_due_on=next_step_due_on,
+        invoice_created_at=reminder.invoice_created_at,
+        invoice_created_by=reminder.invoice_created_by,
+        invoice_sent_recorded_at=reminder.invoice_sent_recorded_at,
+        invoice_sent_recorded_by=reminder.invoice_sent_recorded_by,
+        payment_reminder_sent_at=reminder.payment_reminder_sent_at,
+        payment_reminder_sent_by=reminder.payment_reminder_sent_by,
+        mahnung_sent_at=reminder.mahnung_sent_at,
+        mahnung_sent_by=reminder.mahnung_sent_by,
+        quittung_printed_at=reminder.quittung_printed_at,
+        quittung_printed_by=reminder.quittung_printed_by,
+        paid_recorded_at=reminder.paid_recorded_at,
+        paid_recorded_by=reminder.paid_recorded_by,
     )
 
 
@@ -141,28 +279,28 @@ def derive_payment_reminder(
     method = reminder.payment_method
     if method == "BAR_VOR_ORT":
         if not reminder.quittung_printed:
-            state, next_step = "Offen", "Quittung vorbereiten/drucken"
+            state, next_step, next_due = (
+                "Offen",
+                "Quittung vorbereiten/drucken",
+                None,
+            )
         elif reminder.cash_received:
-            state, next_step = "Bezahlt", None
+            state, next_step, next_due = "Bezahlt", None, None
         elif today > event_date:
-            state, next_step = "Offen", "Barzahlung klären"
+            state, next_step, next_due = "Offen", "Barzahlung klären", event_date
         else:
-            state, next_step = "Offen", "Barzahlung vor Ort abwarten"
-        return PaymentReminderView(
-            order_id=reminder.order_id,
-            payment_method=method,
-            payment_method_label=PAYMENT_METHOD_LABELS[method],
-            invoice_created=False,
-            invoice_number=None,
-            sent_on=None,
+            state, next_step, next_due = (
+                "Offen",
+                "Barzahlung vor Ort abwarten",
+                event_date,
+            )
+        return _view(
+            reminder,
             due_on=None,
-            paid_on=reminder.paid_on,
-            cash_received=reminder.cash_received,
-            quittung_printed=reminder.quittung_printed,
             invoice_state_label=None,
             payment_state_label=state,
             next_step=next_step,
-            updated_at=reminder.updated_at,
+            next_step_due_on=next_due,
         )
 
     canonical_due = (
@@ -176,43 +314,102 @@ def derive_payment_reminder(
     )
     invoice_label = "Erstellt" if reminder.invoice_created else "Noch nicht erstellt"
     if not reminder.invoice_created:
-        state = "Offen"
-        next_step = (
-            "Rechnung erstellen/senden"
-            if method == "VORKASSE"
-            else "Rechnung in der Buchhaltung erstellen"
+        return _view(
+            reminder,
+            due_on=canonical_due,
+            invoice_state_label=invoice_label,
+            payment_state_label="Offen",
+            next_step=(
+                "Rechnung erstellen/senden"
+                if method == "VORKASSE"
+                else "Rechnung in der Buchhaltung erstellen"
+            ),
+            next_step_due_on=None,
         )
-    elif reminder.paid_on is not None:
-        state, next_step = "Bezahlt", None
-    elif reminder.sent_on is None or canonical_due is None:
-        state, next_step = "Offen", "Rechnungsdaten vervollständigen"
-    elif canonical_due < today:
-        if method == "VORKASSE" and today <= event_date:
-            state, next_step = "Sofort fällig", "Zahlungseingang dringend prüfen"
-        else:
-            days = (today - canonical_due).days
-            duration = "1 Tag" if days == 1 else f"{days} Tagen"
-            state, next_step = f"Überfällig seit {duration}", "Zahlung überfällig"
+    if reminder.paid_on is not None:
+        return _view(
+            reminder,
+            due_on=canonical_due,
+            invoice_state_label=invoice_label,
+            payment_state_label="Bezahlt",
+            next_step=None,
+            next_step_due_on=None,
+        )
+    if reminder.sent_on is None or canonical_due is None:
+        return _view(
+            reminder,
+            due_on=canonical_due,
+            invoice_state_label=invoice_label,
+            payment_state_label="Offen",
+            next_step="Rechnungsdaten vervollständigen",
+            next_step_due_on=None,
+        )
+
+    if canonical_due < today:
+        days = (today - canonical_due).days
+        duration = "1 Tag" if days == 1 else f"{days} Tagen"
+        state = (
+            "Sofort fällig"
+            if method == "VORKASSE" and today <= event_date
+            else f"Überfällig seit {duration}"
+        )
     elif canonical_due == today:
-        state, next_step = "Heute fällig", "Zahlungseingang prüfen"
+        state = "Heute fällig"
     elif method == "RECHNUNG" and (canonical_due - today).days in {7, 3}:
-        days = (canonical_due - today).days
-        state, next_step = f"Fällig in {days} Tagen", "Zahlungseingang prüfen"
+        state = f"Fällig in {(canonical_due - today).days} Tagen"
     else:
-        state, next_step = "Offen", "Zahlungseingang prüfen"
-    return PaymentReminderView(
-        order_id=reminder.order_id,
-        payment_method=method,
-        payment_method_label=PAYMENT_METHOD_LABELS[method],
-        invoice_created=reminder.invoice_created,
-        invoice_number=reminder.invoice_number,
-        sent_on=reminder.sent_on,
+        state = "Offen"
+
+    if method == "VORKASSE":
+        reminder_due = event_date - timedelta(days=6)
+        urgent_due = event_date - timedelta(days=3)
+        if today >= urgent_due:
+            next_step = "Dringende manuelle Entscheidung erforderlich"
+            next_due = urgent_due
+        elif today >= reminder_due and reminder.payment_reminder_sent_at is None:
+            next_step = "Zahlungserinnerung senden"
+            next_due = reminder_due
+        elif today >= reminder_due:
+            next_step = "Zahlungseingang prüfen"
+            next_due = urgent_due
+        else:
+            next_step = "Zahlungseingang prüfen"
+            next_due = canonical_due
+        return _view(
+            reminder,
+            due_on=canonical_due,
+            invoice_state_label=invoice_label,
+            payment_state_label=state,
+            next_step=next_step,
+            next_step_due_on=next_due,
+        )
+
+    reminder_due = canonical_due + timedelta(days=1)
+    if reminder.payment_reminder_sent_at is None:
+        next_step = (
+            "Zahlungserinnerung senden"
+            if today >= reminder_due
+            else "Zahlungseingang prüfen"
+        )
+        next_due = reminder_due if today > canonical_due else canonical_due
+    elif reminder.mahnung_sent_at is None:
+        mahnung_due = _local_date(reminder.payment_reminder_sent_at) + timedelta(days=7)
+        next_step = "Mahnung senden" if today >= mahnung_due else "Zahlungseingang prüfen"
+        next_due = mahnung_due
+    else:
+        manual_due = _local_date(reminder.mahnung_sent_at) + timedelta(days=7)
+        next_step = (
+            "Manuelle Entscheidung erforderlich"
+            if today >= manual_due
+            else "Zahlungseingang prüfen"
+        )
+        next_due = manual_due
+
+    return _view(
+        reminder,
         due_on=canonical_due,
-        paid_on=reminder.paid_on,
-        cash_received=False,
-        quittung_printed=False,
         invoice_state_label=invoice_label,
         payment_state_label=state,
         next_step=next_step,
-        updated_at=reminder.updated_at,
+        next_step_due_on=next_due,
     )

--- a/src/catering_system/repositories/sqlite_payment_reminder_repository.py
+++ b/src/catering_system/repositories/sqlite_payment_reminder_repository.py
@@ -56,10 +56,69 @@ def _migration_2_add_quittung_printed(connection: sqlite3.Connection) -> None:
         )
 
 
+def _migration_3_add_audit_facts(connection: sqlite3.Connection) -> None:
+    columns = {
+        row[1]
+        for row in connection.execute("PRAGMA table_info(order_payment_reminders)")
+    }
+    for column in (
+        "invoice_created_at",
+        "invoice_created_by",
+        "invoice_sent_recorded_at",
+        "invoice_sent_recorded_by",
+        "payment_reminder_sent_at",
+        "payment_reminder_sent_by",
+        "mahnung_sent_at",
+        "mahnung_sent_by",
+        "quittung_printed_at",
+        "quittung_printed_by",
+        "paid_recorded_at",
+        "paid_recorded_by",
+    ):
+        if column not in columns:
+            connection.execute(
+                f"ALTER TABLE order_payment_reminders ADD COLUMN {column} TEXT"
+            )
+
+
 _MIGRATIONS = (
     (1, "create_order_payment_reminders", _migration_1_create_table),
     (2, "add_quittung_printed", _migration_2_add_quittung_printed),
+    (3, "add_payment_audit_facts", _migration_3_add_audit_facts),
 )
+
+_SELECT_COLUMNS = """
+    order_id,
+    payment_method,
+    invoice_created,
+    invoice_number,
+    sent_on,
+    due_on,
+    paid_on,
+    cash_received,
+    updated_at,
+    quittung_printed,
+    invoice_created_at,
+    invoice_created_by,
+    invoice_sent_recorded_at,
+    invoice_sent_recorded_by,
+    payment_reminder_sent_at,
+    payment_reminder_sent_by,
+    mahnung_sent_at,
+    mahnung_sent_by,
+    quittung_printed_at,
+    quittung_printed_by,
+    paid_recorded_at,
+    paid_recorded_by
+"""
+
+
+def _date(value: str | None) -> date | None:
+    return date.fromisoformat(value) if value is not None else None
+
+
+def _datetime(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value is not None else None
 
 
 class SQLitePaymentReminderRepository:
@@ -90,7 +149,8 @@ class SQLitePaymentReminderRepository:
 
     def get(self, order_id: str) -> OrderPaymentReminder | None:
         row = self._conn.execute(
-            "SELECT * FROM order_payment_reminders WHERE order_id = ?", (order_id,)
+            f"SELECT {_SELECT_COLUMNS} FROM order_payment_reminders WHERE order_id = ?",
+            (order_id,),
         ).fetchone()
         if row is None:
             return None
@@ -99,12 +159,24 @@ class SQLitePaymentReminderRepository:
             payment_method=validate_payment_method(row[1]),
             invoice_created=bool(row[2]),
             invoice_number=row[3],
-            sent_on=date.fromisoformat(row[4]) if row[4] is not None else None,
-            due_on=date.fromisoformat(row[5]) if row[5] is not None else None,
-            paid_on=date.fromisoformat(row[6]) if row[6] is not None else None,
+            sent_on=_date(row[4]),
+            due_on=_date(row[5]),
+            paid_on=_date(row[6]),
             cash_received=bool(row[7]),
+            updated_at=_datetime(row[8]),
             quittung_printed=bool(row[9]),
-            updated_at=datetime.fromisoformat(row[8]),
+            invoice_created_at=_datetime(row[10]),
+            invoice_created_by=row[11],
+            invoice_sent_recorded_at=_datetime(row[12]),
+            invoice_sent_recorded_by=row[13],
+            payment_reminder_sent_at=_datetime(row[14]),
+            payment_reminder_sent_by=row[15],
+            mahnung_sent_at=_datetime(row[16]),
+            mahnung_sent_by=row[17],
+            quittung_printed_at=_datetime(row[18]),
+            quittung_printed_by=row[19],
+            paid_recorded_at=_datetime(row[20]),
+            paid_recorded_by=row[21],
         )
 
     def save(self, reminder: OrderPaymentReminder) -> None:
@@ -117,8 +189,30 @@ class SQLitePaymentReminderRepository:
             reminder.due_on.isoformat() if reminder.due_on else None,
             reminder.paid_on.isoformat() if reminder.paid_on else None,
             int(reminder.cash_received),
-            int(reminder.quittung_printed),
             reminder.updated_at.isoformat() if reminder.updated_at else None,
+            int(reminder.quittung_printed),
+            reminder.invoice_created_at.isoformat()
+            if reminder.invoice_created_at
+            else None,
+            reminder.invoice_created_by,
+            reminder.invoice_sent_recorded_at.isoformat()
+            if reminder.invoice_sent_recorded_at
+            else None,
+            reminder.invoice_sent_recorded_by,
+            reminder.payment_reminder_sent_at.isoformat()
+            if reminder.payment_reminder_sent_at
+            else None,
+            reminder.payment_reminder_sent_by,
+            reminder.mahnung_sent_at.isoformat() if reminder.mahnung_sent_at else None,
+            reminder.mahnung_sent_by,
+            reminder.quittung_printed_at.isoformat()
+            if reminder.quittung_printed_at
+            else None,
+            reminder.quittung_printed_by,
+            reminder.paid_recorded_at.isoformat()
+            if reminder.paid_recorded_at
+            else None,
+            reminder.paid_recorded_by,
         )
         with self._write_scope():
             self._conn.execute(
@@ -132,9 +226,24 @@ class SQLitePaymentReminderRepository:
                     due_on,
                     paid_on,
                     cash_received,
+                    updated_at,
                     quittung_printed,
-                    updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    invoice_created_at,
+                    invoice_created_by,
+                    invoice_sent_recorded_at,
+                    invoice_sent_recorded_by,
+                    payment_reminder_sent_at,
+                    payment_reminder_sent_by,
+                    mahnung_sent_at,
+                    mahnung_sent_by,
+                    quittung_printed_at,
+                    quittung_printed_by,
+                    paid_recorded_at,
+                    paid_recorded_by
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
                 ON CONFLICT(order_id) DO UPDATE SET
                     payment_method = excluded.payment_method,
                     invoice_created = excluded.invoice_created,
@@ -143,8 +252,20 @@ class SQLitePaymentReminderRepository:
                     due_on = excluded.due_on,
                     paid_on = excluded.paid_on,
                     cash_received = excluded.cash_received,
+                    updated_at = excluded.updated_at,
                     quittung_printed = excluded.quittung_printed,
-                    updated_at = excluded.updated_at
+                    invoice_created_at = excluded.invoice_created_at,
+                    invoice_created_by = excluded.invoice_created_by,
+                    invoice_sent_recorded_at = excluded.invoice_sent_recorded_at,
+                    invoice_sent_recorded_by = excluded.invoice_sent_recorded_by,
+                    payment_reminder_sent_at = excluded.payment_reminder_sent_at,
+                    payment_reminder_sent_by = excluded.payment_reminder_sent_by,
+                    mahnung_sent_at = excluded.mahnung_sent_at,
+                    mahnung_sent_by = excluded.mahnung_sent_by,
+                    quittung_printed_at = excluded.quittung_printed_at,
+                    quittung_printed_by = excluded.quittung_printed_by,
+                    paid_recorded_at = excluded.paid_recorded_at,
+                    paid_recorded_by = excluded.paid_recorded_by
                 """,
                 values,
             )

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -95,7 +95,10 @@ class PaymentReminderService:
     ) -> None:
         if current.invoice_created and not incoming.invoice_created:
             raise ValueError("invoice creation cannot be cleared silently")
-        if current.invoice_number is not None and incoming.invoice_number != current.invoice_number:
+        if (
+            current.invoice_number is not None
+            and incoming.invoice_number != current.invoice_number
+        ):
             raise ValueError("invoice number cannot be changed silently")
         if current.sent_on is not None and incoming.sent_on != current.sent_on:
             raise ValueError("invoice sent date cannot be changed silently")

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -21,6 +21,8 @@ from catering_system.repositories.payment_reminder_repository import (
 )
 
 _BERLIN = ZoneInfo("Europe/Berlin")
+
+
 class PaymentReminderService:
     def __init__(
         self,

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -21,22 +21,6 @@ from catering_system.repositories.payment_reminder_repository import (
 )
 
 _BERLIN = ZoneInfo("Europe/Berlin")
-_AUDIT_FIELDS = (
-    "invoice_created_at",
-    "invoice_created_by",
-    "invoice_sent_recorded_at",
-    "invoice_sent_recorded_by",
-    "payment_reminder_sent_at",
-    "payment_reminder_sent_by",
-    "mahnung_sent_at",
-    "mahnung_sent_by",
-    "quittung_printed_at",
-    "quittung_printed_by",
-    "paid_recorded_at",
-    "paid_recorded_by",
-)
-
-
 class PaymentReminderService:
     def __init__(
         self,
@@ -128,7 +112,18 @@ class PaymentReminderService:
         reminder = replace(
             reminder,
             due_on=None,
-            **{field: None for field in _AUDIT_FIELDS},
+            invoice_created_at=None,
+            invoice_created_by=None,
+            invoice_sent_recorded_at=None,
+            invoice_sent_recorded_by=None,
+            payment_reminder_sent_at=None,
+            payment_reminder_sent_by=None,
+            mahnung_sent_at=None,
+            mahnung_sent_by=None,
+            quittung_printed_at=None,
+            quittung_printed_by=None,
+            paid_recorded_at=None,
+            paid_recorded_by=None,
         )
         current = self._reminders.get(reminder.order_id)
         if current is not None:
@@ -140,7 +135,18 @@ class PaymentReminderService:
             self._reject_silent_fact_rewrite(current, reminder)
             reminder = replace(
                 reminder,
-                **{field: getattr(current, field) for field in _AUDIT_FIELDS},
+                invoice_created_at=current.invoice_created_at,
+                invoice_created_by=current.invoice_created_by,
+                invoice_sent_recorded_at=current.invoice_sent_recorded_at,
+                invoice_sent_recorded_by=current.invoice_sent_recorded_by,
+                payment_reminder_sent_at=current.payment_reminder_sent_at,
+                payment_reminder_sent_by=current.payment_reminder_sent_by,
+                mahnung_sent_at=current.mahnung_sent_at,
+                mahnung_sent_by=current.mahnung_sent_by,
+                quittung_printed_at=current.quittung_printed_at,
+                quittung_printed_by=current.quittung_printed_by,
+                paid_recorded_at=current.paid_recorded_at,
+                paid_recorded_by=current.paid_recorded_by,
             )
 
         actor = self._actor(actor_reference)

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Callable
+from zoneinfo import ZoneInfo
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
@@ -17,6 +18,22 @@ from catering_system.domain.order_payment_reminder import (
 from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.payment_reminder_repository import (
     PaymentReminderRepository,
+)
+
+_BERLIN = ZoneInfo("Europe/Berlin")
+_AUDIT_FIELDS = (
+    "invoice_created_at",
+    "invoice_created_by",
+    "invoice_sent_recorded_at",
+    "invoice_sent_recorded_by",
+    "payment_reminder_sent_at",
+    "payment_reminder_sent_by",
+    "mahnung_sent_at",
+    "mahnung_sent_by",
+    "quittung_printed_at",
+    "quittung_printed_by",
+    "paid_recorded_at",
+    "paid_recorded_by",
 )
 
 
@@ -34,7 +51,7 @@ class PaymentReminderService:
         self._now = now or (lambda: datetime.now(UTC))
         self._today = today or date.today
 
-    def view(self, order_id: str) -> PaymentReminderView:
+    def _event_date(self, order_id: str) -> date:
         order = self._orders.get_order(order_id)
         if order is None:
             raise KeyError(order_id)
@@ -49,36 +66,164 @@ class PaymentReminderService:
         )
         if version is None:
             raise ValueError("order has no event date")
+        return version.event_date
+
+    def view(self, order_id: str) -> PaymentReminderView:
+        event_date = self._event_date(order_id)
         view = derive_payment_reminder(
             self._reminders.get(order_id),
-            event_date=version.event_date,
+            event_date=event_date,
             today=self._today(),
         )
         return replace(view, order_id=order_id)
 
-    def save(self, reminder: OrderPaymentReminder) -> PaymentReminderView:
+    @staticmethod
+    def _actor(value: str) -> str:
+        actor = value.strip()
+        if not actor or len(actor) > 200:
+            raise ValueError("actor_reference must be non-empty and at most 200 chars")
+        return actor
+
+    @staticmethod
+    def _local_date(value: datetime) -> date:
+        return value.astimezone(_BERLIN).date()
+
+    @staticmethod
+    def _reject_silent_fact_rewrite(
+        current: OrderPaymentReminder,
+        incoming: OrderPaymentReminder,
+    ) -> None:
+        if current.invoice_created and not incoming.invoice_created:
+            raise ValueError("invoice creation cannot be cleared silently")
+        if current.invoice_number is not None and incoming.invoice_number != current.invoice_number:
+            raise ValueError("invoice number cannot be changed silently")
+        if current.sent_on is not None and incoming.sent_on != current.sent_on:
+            raise ValueError("invoice sent date cannot be changed silently")
+        if current.paid_on is not None and incoming.paid_on != current.paid_on:
+            raise ValueError("payment completion cannot be changed silently")
+        if current.cash_received and not incoming.cash_received:
+            raise ValueError("cash receipt cannot be cleared silently")
+        if current.quittung_printed and not incoming.quittung_printed:
+            raise ValueError("Quittung readiness cannot be cleared silently")
+
+    def save(
+        self,
+        reminder: OrderPaymentReminder,
+        *,
+        actor_reference: str = "office-panel",
+        mark_payment_reminder_sent: bool = False,
+        mark_mahnung_sent: bool = False,
+    ) -> PaymentReminderView:
         order = self._orders.get_order(reminder.order_id)
         if order is None:
             raise KeyError(reminder.order_id)
         if order.cancelled_at is not None:
             raise ValueError("cancelled order cannot update payment reminders")
-        # Payment deadlines are system-derived; never trust or persist an
-        # operator-entered due date from an older client.
-        reminder = replace(reminder, due_on=None)
-        validate_payment_reminder(reminder)
+
+        # Deadlines and audit stamps are Core truth. Older clients may still
+        # submit due_on; callers are never allowed to forge actor/time evidence.
+        reminder = replace(
+            reminder,
+            due_on=None,
+            **{field: None for field in _AUDIT_FIELDS},
+        )
         current = self._reminders.get(reminder.order_id)
-        if (
-            current is not None
-            and current.payment_method != reminder.payment_method
-            and has_downstream_payment_facts(current)
-        ):
-            raise ValueError("payment method cannot change after payment facts")
+        if current is not None:
+            if (
+                current.payment_method != reminder.payment_method
+                and has_downstream_payment_facts(current)
+            ):
+                raise ValueError("payment method cannot change after payment facts")
+            self._reject_silent_fact_rewrite(current, reminder)
+            reminder = replace(
+                reminder,
+                **{field: getattr(current, field) for field in _AUDIT_FIELDS},
+            )
+
+        actor = self._actor(actor_reference)
+        now = self._now()
+        if now.utcoffset() is None:
+            raise ValueError("audit clock must return timezone-aware datetime")
+
+        was_invoice_created = current.invoice_created if current is not None else False
+        was_sent = current.sent_on if current is not None else None
+        was_paid = current.paid_on if current is not None else None
+        was_quittung = current.quittung_printed if current is not None else False
+
+        if reminder.invoice_created and not was_invoice_created:
+            reminder = replace(
+                reminder,
+                invoice_created_at=now,
+                invoice_created_by=actor,
+            )
+        if reminder.sent_on is not None and was_sent is None:
+            reminder = replace(
+                reminder,
+                invoice_sent_recorded_at=now,
+                invoice_sent_recorded_by=actor,
+            )
+        if reminder.paid_on is not None and was_paid is None:
+            reminder = replace(
+                reminder,
+                paid_recorded_at=now,
+                paid_recorded_by=actor,
+            )
+        if reminder.quittung_printed and not was_quittung:
+            reminder = replace(
+                reminder,
+                quittung_printed_at=now,
+                quittung_printed_by=actor,
+            )
+
+        event_date = self._event_date(reminder.order_id)
+        today = self._today()
+        if mark_payment_reminder_sent and reminder.payment_reminder_sent_at is None:
+            if (
+                reminder.payment_method == "BAR_VOR_ORT"
+                or not reminder.invoice_created
+                or reminder.sent_on is None
+                or reminder.paid_on is not None
+            ):
+                raise ValueError("payment reminder cannot be recorded in current state")
+            reminder_due = (
+                event_date - timedelta(days=6)
+                if reminder.payment_method == "VORKASSE"
+                else reminder.sent_on + timedelta(days=15)
+            )
+            if today < reminder_due:
+                raise ValueError("payment reminder is not due yet")
+            reminder = replace(
+                reminder,
+                payment_reminder_sent_at=now,
+                payment_reminder_sent_by=actor,
+            )
+
+        if mark_mahnung_sent and reminder.mahnung_sent_at is None:
+            if (
+                reminder.payment_method != "RECHNUNG"
+                or reminder.paid_on is not None
+                or reminder.payment_reminder_sent_at is None
+            ):
+                raise ValueError("Mahnung cannot be recorded in current state")
+            mahnung_due = self._local_date(
+                reminder.payment_reminder_sent_at
+            ) + timedelta(days=7)
+            if today < mahnung_due:
+                raise ValueError("Mahnung is not due yet")
+            reminder = replace(
+                reminder,
+                mahnung_sent_at=now,
+                mahnung_sent_by=actor,
+            )
+
+        validate_payment_reminder(reminder)
         comparable = replace(
-            reminder, updated_at=current.updated_at if current else None
+            reminder,
+            updated_at=current.updated_at if current else None,
         )
         if current is not None and comparable == current:
             return self.view(reminder.order_id)
-        self._reminders.save(replace(reminder, updated_at=self._now()))
+        self._reminders.save(replace(reminder, updated_at=now))
         return self.view(reminder.order_id)
 
     def seed_from_conversion(self, order_id: str, payment_method: str) -> None:

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -169,7 +169,7 @@ class TaskProjectionService:
                 continue
             if payment.next_step is None:
                 continue
-            due_at = payment.due_on
+            due_at = payment.next_step_due_on
             overdue = due_at is not None and due_at < operating_today
             tasks.append(
                 (

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -3190,6 +3190,9 @@ class OfficeApi:
         if expected_at != actual_at:
             raise ApiError(409, "stale_state")
         try:
+            actor_reference = (
+                _v_optional_str(args.get("actor_reference"), 200) or CLIENT_ID
+            )
             view = self.payment_reminder_service.save(
                 OrderPaymentReminder(
                     order_id=order.order_id,
@@ -3203,7 +3206,12 @@ class OfficeApi:
                     paid_on=_v_optional_date(args["paid_on"]),
                     cash_received=_v_bool(args["cash_received"]),
                     quittung_printed=_v_bool(args.get("quittung_printed", False)),
-                )
+                ),
+                actor_reference=actor_reference,
+                mark_payment_reminder_sent=_v_bool(
+                    args.get("payment_reminder_sent", False)
+                ),
+                mark_mahnung_sent=_v_bool(args.get("mahnung_sent", False)),
             )
         except ValueError as exc:
             raise ApiError(422, "invalid_payment_reminder") from exc
@@ -3475,7 +3483,14 @@ _PAYMENT_REMINDER_ARGS = _ArgKeys(
             "cash_received",
         }
     ),
-    optional=frozenset({"quittung_printed"}),
+    optional=frozenset(
+        {
+            "quittung_printed",
+            "payment_reminder_sent",
+            "mahnung_sent",
+            "actor_reference",
+        }
+    ),
 )
 _CONFIRMATION_DOCUMENT_ARGS = _ArgKeys(required=frozenset({"created_by"}))
 _CONFIRMATION_DOCUMENT_SEND_ARGS = _ArgKeys(

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -836,6 +836,9 @@ def customer_document_preview_shape(preview: object) -> dict[str, object]:
 
 
 def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
+    def dt(value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
     return {
         "order_id": view.order_id,
         "payment_method": view.payment_method,
@@ -850,7 +853,22 @@ def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
         "invoice_state_label": view.invoice_state_label,
         "payment_state_label": view.payment_state_label,
         "next_step": view.next_step,
-        "updated_at": view.updated_at.isoformat() if view.updated_at else None,
+        "next_step_due_on": (
+            view.next_step_due_on.isoformat() if view.next_step_due_on else None
+        ),
+        "invoice_created_at": dt(view.invoice_created_at),
+        "invoice_created_by": view.invoice_created_by,
+        "invoice_sent_recorded_at": dt(view.invoice_sent_recorded_at),
+        "invoice_sent_recorded_by": view.invoice_sent_recorded_by,
+        "payment_reminder_sent_at": dt(view.payment_reminder_sent_at),
+        "payment_reminder_sent_by": view.payment_reminder_sent_by,
+        "mahnung_sent_at": dt(view.mahnung_sent_at),
+        "mahnung_sent_by": view.mahnung_sent_by,
+        "quittung_printed_at": dt(view.quittung_printed_at),
+        "quittung_printed_by": view.quittung_printed_by,
+        "paid_recorded_at": dt(view.paid_recorded_at),
+        "paid_recorded_by": view.paid_recorded_by,
+        "updated_at": dt(view.updated_at),
     }
 
 

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -4131,9 +4131,37 @@ class OfficePanel:
             f"<p><strong>Zahlungsstatus:</strong> {_e(payment.payment_state_label)}</p>"
         )
         if payment.next_step:
+            next_step_text = payment.next_step
+            if payment.next_step_due_on is not None:
+                next_step_text += f" · {payment.next_step_due_on.isoformat()}"
             payment_rows.append(
-                f"<p><strong>Nächster Schritt:</strong> {_e(payment.next_step)}</p>"
+                f"<p><strong>Nächster Schritt:</strong> {_e(next_step_text)}</p>"
             )
+        for label, timestamp, actor in (
+            ("Rechnung erstellt", payment.invoice_created_at, payment.invoice_created_by),
+            (
+                "Rechnungsversand erfasst",
+                payment.invoice_sent_recorded_at,
+                payment.invoice_sent_recorded_by,
+            ),
+            (
+                "Zahlungserinnerung",
+                payment.payment_reminder_sent_at,
+                payment.payment_reminder_sent_by,
+            ),
+            ("Mahnung", payment.mahnung_sent_at, payment.mahnung_sent_by),
+            (
+                "Quittung gedruckt",
+                payment.quittung_printed_at,
+                payment.quittung_printed_by,
+            ),
+            ("Zahlung erfasst", payment.paid_recorded_at, payment.paid_recorded_by),
+        ):
+            if timestamp is not None:
+                payment_rows.append(
+                    f"<p><strong>{_e(label)}:</strong> "
+                    f"{_e(timestamp.isoformat())} · {_e(actor or 'unbekannt')}</p>"
+                )
         payment_form = ""
         if not cancelled and context.can("orders.payment.reminder"):
             options = ['<option value="">Bitte wählen</option>']
@@ -4158,6 +4186,8 @@ class OfficePanel:
 <p><label>Bezahlt am</label><input type="date" name="paid_on" value="{payment.paid_on.isoformat() if payment.paid_on else ""}"></p>
 <p><label><input type="checkbox" name="quittung_printed" value="1"{" checked" if payment.quittung_printed else ""}> Quittung gedruckt</label></p>
 <p><label><input type="checkbox" name="cash_received" value="1"{" checked" if payment.cash_received else ""}> Barzahlung erhalten</label></p>
+<p><label><input type="checkbox" name="payment_reminder_sent" value="1"{" checked" if payment.payment_reminder_sent_at else ""}> Zahlungserinnerung gesendet</label></p>
+<p><label><input type="checkbox" name="mahnung_sent" value="1"{" checked" if payment.mahnung_sent_at else ""}> Mahnung gesendet</label></p>
 <p><button type="submit">Zahlungshinweis speichern</button></p>
 </fieldset></form>"""
         header = '<p class="cancelled">STORNIERT</p>' if cancelled else ""
@@ -4348,7 +4378,13 @@ class OfficePanel:
             context=context,
         )
 
-    def save_payment_reminder(self, order_id: str, form: dict[str, str]) -> None:
+    def save_payment_reminder(
+        self,
+        order_id: str,
+        form: dict[str, str],
+        *,
+        actor_reference: str = "office-panel",
+    ) -> None:
         def optional_date(name: str) -> date | None:
             raw = form.get(name, "").strip()
             return date.fromisoformat(raw) if raw else None
@@ -4366,7 +4402,12 @@ class OfficePanel:
         )
 
         def work() -> None:
-            self.payment_reminder_service.save(reminder)
+            self.payment_reminder_service.save(
+                reminder,
+                actor_reference=actor_reference,
+                mark_payment_reminder_sent=form.get("payment_reminder_sent") == "1",
+                mark_mahnung_sent=form.get("mahnung_sent") == "1",
+            )
 
         if self._remote is not None:
             work()
@@ -4374,6 +4415,7 @@ class OfficePanel:
             self._command_executor.run(work)
         else:
             work()
+
 
     def send_confirmation_test(self, order_id: str, form: dict[str, str]) -> None:
         order = self._orders.get_order(order_id)

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -4138,7 +4138,11 @@ class OfficePanel:
                 f"<p><strong>Nächster Schritt:</strong> {_e(next_step_text)}</p>"
             )
         for label, timestamp, actor in (
-            ("Rechnung erstellt", payment.invoice_created_at, payment.invoice_created_by),
+            (
+                "Rechnung erstellt",
+                payment.invoice_created_at,
+                payment.invoice_created_by,
+            ),
             (
                 "Rechnungsversand erfasst",
                 payment.invoice_sent_recorded_at,
@@ -4415,7 +4419,6 @@ class OfficePanel:
             self._command_executor.run(work)
         else:
             work()
-
 
     def send_confirmation_test(self, order_id: str, form: dict[str, str]) -> None:
         order = self._orders.get_order(order_id)

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -2671,7 +2671,11 @@ def make_office_panel_handler(
             elif action == "payment-reminder":
                 auth = self._request_auth
                 actor_reference = "office-panel"
-                if auth is not None and auth.kind == "employee" and auth.employee is not None:
+                if (
+                    auth is not None
+                    and auth.kind == "employee"
+                    and auth.employee is not None
+                ):
                     account = auth.employee.account
                     actor_reference = f"{account.display_name} [{account.id}]"
                 panel.save_payment_reminder(

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -2669,7 +2669,16 @@ def make_office_panel_handler(
                 self._delete_order(order_id)
                 return
             elif action == "payment-reminder":
-                panel.save_payment_reminder(order_id, self._form())
+                auth = self._request_auth
+                actor_reference = "office-panel"
+                if auth is not None and auth.kind == "employee" and auth.employee is not None:
+                    account = auth.employee.account
+                    actor_reference = f"{account.display_name} [{account.id}]"
+                panel.save_payment_reminder(
+                    order_id,
+                    self._form(),
+                    actor_reference=actor_reference,
+                )
             elif action == "confirmation-document":
                 panel.prepare_confirmation_document(order_id, self._form())
             elif action == "pause":

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -899,7 +899,10 @@ def _payment_card(
         facts.append(("Rechnung", payment.invoice_state_label))
     if payment.payment_method == "BAR_VOR_ORT":
         facts.append(
-            ("Quittung", "Gedruckt" if payment.quittung_printed else "Noch nicht gedruckt")
+            (
+                "Quittung",
+                "Gedruckt" if payment.quittung_printed else "Noch nicht gedruckt",
+            )
         )
     if payment.invoice_number:
         facts.append(("Rechnungsnummer", payment.invoice_number))

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -838,6 +838,26 @@ def _payment_form(
             f'<option value="{method}"{selected}>'
             f"{_e(PAYMENT_METHOD_LABELS[method])}</option>"
         )
+    quittung = ""
+    if payment.payment_method == "BAR_VOR_ORT":
+        quittung = (
+            f'<p><label><input type="checkbox" name="quittung_printed" value="1"'
+            f"{' checked' if payment.quittung_printed else ''}> "
+            "Quittung gedruckt</label></p>"
+        )
+    escalation = ""
+    if payment.payment_method != "BAR_VOR_ORT":
+        escalation += (
+            f'<p><label><input type="checkbox" name="payment_reminder_sent" value="1"'
+            f"{' checked' if payment.payment_reminder_sent_at else ''}> "
+            "Zahlungserinnerung gesendet</label></p>"
+        )
+    if payment.payment_method == "RECHNUNG":
+        escalation += (
+            f'<p><label><input type="checkbox" name="mahnung_sent" value="1"'
+            f"{' checked' if payment.mahnung_sent_at else ''}> "
+            "Mahnung gesendet</label></p>"
+        )
     return (
         '<details class="order-payment-edit"><summary>Zahlungsdaten bearbeiten</summary>'
         f'<form method="post" action="/order/{_e(order.order_id)}/payment-reminder">'
@@ -851,14 +871,15 @@ def _payment_form(
         f'maxlength="200" value="{_e(payment.invoice_number or "")}"></p>'
         f'<p><label>Versendet am</label><input type="date" name="sent_on" '
         f'value="{_e(payment.sent_on.isoformat() if payment.sent_on else "")}"></p>'
-        f'<p><label>Fällig am</label><input type="date" name="due_on" '
-        f'value="{_e(payment.due_on.isoformat() if payment.due_on else "")}"></p>'
+        "<p>Fälligkeit wird automatisch berechnet.</p>"
         f'<p><label>Bezahlt am</label><input type="date" name="paid_on" '
         f'value="{_e(payment.paid_on.isoformat() if payment.paid_on else "")}"></p>'
-        f'<p><label><input type="checkbox" name="cash_received" value="1"'
+        + quittung
+        + f'<p><label><input type="checkbox" name="cash_received" value="1"'
         f"{' checked' if payment.cash_received else ''}> "
         "Barzahlung erhalten</label></p>"
-        '<p><button type="submit">Zahlungshinweis speichern</button></p>'
+        + escalation
+        + '<p><button type="submit">Zahlungshinweis speichern</button></p>'
         "</fieldset></form></details>"
     )
 
@@ -876,11 +897,50 @@ def _payment_card(
     ]
     if payment.invoice_state_label is not None:
         facts.append(("Rechnung", payment.invoice_state_label))
+    if payment.payment_method == "BAR_VOR_ORT":
+        facts.append(
+            ("Quittung", "Gedruckt" if payment.quittung_printed else "Noch nicht gedruckt")
+        )
     if payment.invoice_number:
         facts.append(("Rechnungsnummer", payment.invoice_number))
+    if payment.sent_on is not None:
+        facts.append(("Versendet am", payment.sent_on.strftime("%d.%m.%Y")))
     if payment.due_on is not None:
         facts.append(("Fällig am", payment.due_on.strftime("%d.%m.%Y")))
+    if payment.paid_on is not None:
+        facts.append(("Bezahlt am", payment.paid_on.strftime("%d.%m.%Y")))
+
+    for label, timestamp, actor in (
+        ("Rechnung erstellt", payment.invoice_created_at, payment.invoice_created_by),
+        (
+            "Rechnungsversand erfasst",
+            payment.invoice_sent_recorded_at,
+            payment.invoice_sent_recorded_by,
+        ),
+        (
+            "Zahlungserinnerung",
+            payment.payment_reminder_sent_at,
+            payment.payment_reminder_sent_by,
+        ),
+        ("Mahnung", payment.mahnung_sent_at, payment.mahnung_sent_by),
+        (
+            "Quittung gedruckt",
+            payment.quittung_printed_at,
+            payment.quittung_printed_by,
+        ),
+        ("Zahlung erfasst", payment.paid_recorded_at, payment.paid_recorded_by),
+    ):
+        if timestamp is not None:
+            facts.append(
+                (
+                    label,
+                    f"{timestamp.strftime('%d.%m.%Y · %H:%M')} · {actor or 'unbekannt'}",
+                )
+            )
+
     next_step = payment.next_step or "Keine offene Zahlungsaufgabe."
+    if payment.next_step_due_on is not None and payment.next_step is not None:
+        next_step += f" · {payment.next_step_due_on.strftime('%d.%m.%Y')}"
     return (
         '<section class="order-card order-content-card order-payment-card">'
         '<div class="order-section-kicker">Separater Bereich</div>'

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1110,13 +1110,9 @@ def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
         ),
         invoice_created_at=_optional_datetime(data["invoice_created_at"]),
         invoice_created_by=_optional_str(data["invoice_created_by"]),
-        invoice_sent_recorded_at=_optional_datetime(
-            data["invoice_sent_recorded_at"]
-        ),
+        invoice_sent_recorded_at=_optional_datetime(data["invoice_sent_recorded_at"]),
         invoice_sent_recorded_by=_optional_str(data["invoice_sent_recorded_by"]),
-        payment_reminder_sent_at=_optional_datetime(
-            data["payment_reminder_sent_at"]
-        ),
+        payment_reminder_sent_at=_optional_datetime(data["payment_reminder_sent_at"]),
         payment_reminder_sent_by=_optional_str(data["payment_reminder_sent_by"]),
         mahnung_sent_at=_optional_datetime(data["mahnung_sent_at"]),
         mahnung_sent_by=_optional_str(data["mahnung_sent_by"]),

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1056,6 +1056,19 @@ _PAYMENT_REMINDER_KEYS = frozenset(
         "invoice_state_label",
         "payment_state_label",
         "next_step",
+        "next_step_due_on",
+        "invoice_created_at",
+        "invoice_created_by",
+        "invoice_sent_recorded_at",
+        "invoice_sent_recorded_by",
+        "payment_reminder_sent_at",
+        "payment_reminder_sent_by",
+        "mahnung_sent_at",
+        "mahnung_sent_by",
+        "quittung_printed_at",
+        "quittung_printed_by",
+        "paid_recorded_at",
+        "paid_recorded_by",
         "updated_at",
     }
 )
@@ -1090,6 +1103,27 @@ def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
         updated_at=(
             None if data["updated_at"] is None else _datetime(data["updated_at"])
         ),
+        next_step_due_on=(
+            None
+            if data["next_step_due_on"] is None
+            else _date(data["next_step_due_on"])
+        ),
+        invoice_created_at=_optional_datetime(data["invoice_created_at"]),
+        invoice_created_by=_optional_str(data["invoice_created_by"]),
+        invoice_sent_recorded_at=_optional_datetime(
+            data["invoice_sent_recorded_at"]
+        ),
+        invoice_sent_recorded_by=_optional_str(data["invoice_sent_recorded_by"]),
+        payment_reminder_sent_at=_optional_datetime(
+            data["payment_reminder_sent_at"]
+        ),
+        payment_reminder_sent_by=_optional_str(data["payment_reminder_sent_by"]),
+        mahnung_sent_at=_optional_datetime(data["mahnung_sent_at"]),
+        mahnung_sent_by=_optional_str(data["mahnung_sent_by"]),
+        quittung_printed_at=_optional_datetime(data["quittung_printed_at"]),
+        quittung_printed_by=_optional_str(data["quittung_printed_by"]),
+        paid_recorded_at=_optional_datetime(data["paid_recorded_at"]),
+        paid_recorded_by=_optional_str(data["paid_recorded_by"]),
     )
 
 
@@ -3897,7 +3931,14 @@ class _RemotePaymentReminderService:
     def view(self, order_id: str) -> PaymentReminderView:
         return self._client.payment_reminder_view(order_id)
 
-    def save(self, reminder: OrderPaymentReminder) -> PaymentReminderView:
+    def save(
+        self,
+        reminder: OrderPaymentReminder,
+        *,
+        actor_reference: str = "office-panel",
+        mark_payment_reminder_sent: bool = False,
+        mark_mahnung_sent: bool = False,
+    ) -> PaymentReminderView:
         expected_at = self._client.form_value("_expect_payment_reminder_updated_at")
         current = self.view(reminder.order_id)
         result = self._client.command(
@@ -3911,6 +3952,9 @@ class _RemotePaymentReminderService:
                 "paid_on": reminder.paid_on.isoformat() if reminder.paid_on else None,
                 "cash_received": reminder.cash_received,
                 "quittung_printed": reminder.quittung_printed,
+                "payment_reminder_sent": mark_payment_reminder_sent,
+                "mahnung_sent": mark_mahnung_sent,
+                "actor_reference": actor_reference,
             },
             {
                 "updated_at": (

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2069,7 +2069,7 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
 
     assert "order-payment-card" in body
     assert "<h2>Zahlung</h2>" in body
-    assert "Zahlung überfällig" in body
+    assert "Zahlungserinnerung senden" in body
     assert "Reminder-Status" in body
     assert "RE-UI4-1" in body
     assert f'action="/order/{order_id}/payment-reminder"' in body

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -88,13 +88,15 @@ def test_vorkasse_progression_and_overdue_are_purely_derived() -> None:
     )
     assert urgent.due_on == date(2026, 7, 25)
     assert urgent.payment_state_label == "Sofort fällig"
-    assert urgent.next_step == "Zahlungseingang dringend prüfen"
+    assert urgent.next_step == "Zahlungserinnerung senden"
+    assert urgent.next_step_due_on == date(2026, 7, 26)
 
     overdue = derive_payment_reminder(
         complete, event_date=date(2026, 8, 1), today=date(2026, 8, 2)
     )
     assert overdue.payment_state_label == "Überfällig seit 8 Tagen"
-    assert overdue.next_step == "Zahlung überfällig"
+    assert overdue.next_step == "Dringende manuelle Entscheidung erforderlich"
+    assert overdue.next_step_due_on == date(2026, 7, 29)
 
     paid = derive_payment_reminder(
         replace(complete, paid_on=date(2026, 7, 27)),
@@ -143,6 +145,136 @@ def test_rechnung_due_date_and_stages_are_system_derived() -> None:
         sent, event_date=date(2026, 8, 1), today=date(2026, 7, 30)
     )
     assert overdue.payment_state_label == "Überfällig seit 1 Tag"
+    assert overdue.next_step == "Zahlungserinnerung senden"
+    assert overdue.next_step_due_on == date(2026, 7, 30)
+
+
+
+def test_vorkasse_recorded_reminder_advances_to_manual_decision_boundary() -> None:
+    reminder = OrderPaymentReminder(
+        order_id="order",
+        payment_method="VORKASSE",
+        invoice_created=True,
+        invoice_number="RE-V-1",
+        sent_on=date(2026, 7, 20),
+        payment_reminder_sent_at=datetime(2026, 7, 26, 8, 0, tzinfo=UTC),
+        payment_reminder_sent_by="Alice",
+    )
+
+    waiting = derive_payment_reminder(
+        reminder,
+        event_date=date(2026, 8, 1),
+        today=date(2026, 7, 27),
+    )
+    assert waiting.next_step == "Zahlungseingang prüfen"
+    assert waiting.next_step_due_on == date(2026, 7, 29)
+
+    urgent = derive_payment_reminder(
+        reminder,
+        event_date=date(2026, 8, 1),
+        today=date(2026, 7, 29),
+    )
+    assert urgent.next_step == "Dringende manuelle Entscheidung erforderlich"
+    assert urgent.next_step_due_on == date(2026, 7, 29)
+
+
+def test_rechnung_escalation_audit_is_idempotent_and_drives_mahnung() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    invoice = OrderPaymentReminder(
+        order_id=order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-AUDIT-1",
+        sent_on=date(2026, 7, 15),
+    )
+    reminder_now = datetime(2026, 7, 30, 8, 0, tzinfo=UTC)
+    reminder_service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: reminder_now,
+        today=lambda: date(2026, 7, 30),
+    )
+
+    reminder_service.save(
+        invoice,
+        actor_reference="Alice",
+        mark_payment_reminder_sent=True,
+    )
+    stored = reminders.get(order_id)
+    assert stored is not None
+    assert stored.invoice_created_at == reminder_now
+    assert stored.invoice_created_by == "Alice"
+    assert stored.invoice_sent_recorded_at == reminder_now
+    assert stored.invoice_sent_recorded_by == "Alice"
+    assert stored.payment_reminder_sent_at == reminder_now
+    assert stored.payment_reminder_sent_by == "Alice"
+
+    reminder_service.save(
+        invoice,
+        actor_reference="Bob",
+        mark_payment_reminder_sent=True,
+    )
+    replayed = reminders.get(order_id)
+    assert replayed == stored
+
+    mahnung_now = datetime(2026, 8, 6, 9, 0, tzinfo=UTC)
+    mahnung_service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: mahnung_now,
+        today=lambda: date(2026, 8, 6),
+    )
+    before_mahnung = mahnung_service.view(order_id)
+    assert before_mahnung.next_step == "Mahnung senden"
+    assert before_mahnung.next_step_due_on == date(2026, 8, 6)
+
+    mahnung_service.save(
+        invoice,
+        actor_reference="Bob",
+        mark_mahnung_sent=True,
+    )
+    after = reminders.get(order_id)
+    assert after is not None
+    assert after.mahnung_sent_at == mahnung_now
+    assert after.mahnung_sent_by == "Bob"
+
+    manual_service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: datetime(2026, 8, 13, 9, 0, tzinfo=UTC),
+        today=lambda: date(2026, 8, 13),
+    )
+    manual = manual_service.view(order_id)
+    assert manual.next_step == "Manuelle Entscheidung erforderlich"
+    assert manual.next_step_due_on == date(2026, 8, 13)
+
+
+def test_quittung_print_audit_is_stamped_once() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    printed_at = datetime(2026, 7, 15, 10, 0, tzinfo=UTC)
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: printed_at,
+        today=lambda: date(2026, 7, 15),
+    )
+    row = OrderPaymentReminder(
+        order_id=order_id,
+        payment_method="BAR_VOR_ORT",
+        quittung_printed=True,
+    )
+
+    service.save(row, actor_reference="Alice")
+    first = reminders.get(order_id)
+    assert first is not None
+    assert first.quittung_printed_at == printed_at
+    assert first.quittung_printed_by == "Alice"
+
+    service.save(row, actor_reference="Bob")
+    assert reminders.get(order_id) == first
+
 
 
 def test_cash_quittung_is_required_before_collection_wait_state() -> None:

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -275,7 +275,6 @@ def test_quittung_print_audit_is_stamped_once() -> None:
     assert reminders.get(order_id) == first
 
 
-
 def test_cash_quittung_is_required_before_collection_wait_state() -> None:
     reminder = OrderPaymentReminder(order_id="order", payment_method="BAR_VOR_ORT")
     before_print = derive_payment_reminder(

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -149,7 +149,6 @@ def test_rechnung_due_date_and_stages_are_system_derived() -> None:
     assert overdue.next_step_due_on == date(2026, 7, 30)
 
 
-
 def test_vorkasse_recorded_reminder_advances_to_manual_decision_boundary() -> None:
     reminder = OrderPaymentReminder(
         order_id="order",

--- a/tests/unit/test_payment_reminder_sqlite.py
+++ b/tests/unit/test_payment_reminder_sqlite.py
@@ -65,10 +65,21 @@ def test_sqlite_round_trip_and_owner_constraint(tmp_path: Path) -> None:
         sent_on=date(2026, 7, 15),
         due_on=date(2026, 7, 22),
         updated_at=datetime(2026, 7, 15, tzinfo=UTC),
+        invoice_created_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        invoice_created_by="Alice",
+        invoice_sent_recorded_at=datetime(2026, 7, 15, 8, 5, tzinfo=UTC),
+        invoice_sent_recorded_by="Alice",
+        payment_reminder_sent_at=datetime(2026, 7, 30, 9, 0, tzinfo=UTC),
+        payment_reminder_sent_by="Bob",
+        mahnung_sent_at=datetime(2026, 8, 6, 9, 0, tzinfo=UTC),
+        mahnung_sent_by="Bob",
     )
 
     reminders.save(row)
 
+    assert reminders.get(order.order_id) == row
+    reminders.close()
+    reminders = SQLitePaymentReminderRepository(db)
     assert reminders.get(order.order_id) == row
     orphan = OrderPaymentReminder(
         order_id="99999999-9999-4999-8999-999999999999",

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -330,7 +330,8 @@ def test_payment_task_emitted_with_overdue_urgency() -> None:
     payment_row = next(row for row in rows if row.category == "payment")
     assert payment_row.task_id == f"order:{order.order_id}:payment"
     assert payment_row.urgency == "overdue"
-    assert payment_row.due_at == date(2026, 6, 15)
+    assert payment_row.title == "Zahlungserinnerung senden"
+    assert payment_row.due_at == date(2026, 6, 16)
 
 
 def test_sort_overdue_payment_before_verify() -> None:


### PR DESCRIPTION
## Issue

Continues #201.

## What this slice does

- derives the Vorkasse escalation chain at event -6 and event -3
- derives Rechnung reminder at due +1, Mahnung 7 days after the recorded reminder, and manual decision 7 days after the recorded Mahnung
- separates payment due date from the due date of the next Office action
- records immutable actor/time audit facts for:
  - invoice created
  - invoice send date recorded
  - payment reminder sent
  - Mahnung sent
  - Quittung printed
  - payment completion recorded
- persists audit facts in SQLite and exposes them in the Office API/order detail
- keeps repeated reminder/Mahnung actions idempotent
- rejects early reminder/Mahnung recording and silent clearing of recorded facts
- removes the stale editable Fällig-am field from the V2 Order payment form
- binds Office audit actor to the authenticated employee snapshot where available

## Boundaries

- no amount or ledger
- no partial payments
- no accounting integration
- no PDF/invoice/receipt generation
- no automatic email/reminder/Mahnung sending
- no Courier handoff (#202/#13)
- payment-method change reason/history and correction/cancellation workflow remain follow-up slices of #201
