### PR TITLE
Add audited payment method changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff \
+            src/catering_system/repositories/sqlite_payment_reminder_repository.py \
+            src/catering_system/ui/office_panel.py \
+            src/catering_system/ui/office_panel_order_detail.py \
+            tests/unit/test_task_projection.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff \
-            src/catering_system/repositories/sqlite_payment_reminder_repository.py \
-            src/catering_system/ui/office_panel.py \
-            src/catering_system/ui/office_panel_order_detail.py \
-            tests/unit/test_task_projection.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/domain/order_payment_reminder.py
+++ b/src/catering_system/domain/order_payment_reminder.py
@@ -60,6 +60,21 @@ class OrderPaymentReminder:
 
 
 @dataclass(frozen=True)
+class PaymentMethodChange:
+    """Append-only audit event for an explicit payment-method switch."""
+
+    change_id: str
+    order_id: str
+    from_method: PaymentMethod
+    to_method: PaymentMethod
+    reason: str
+    actor_reference: str
+    changed_at: datetime
+    retired_task_title: str | None
+    previous_reminder: OrderPaymentReminder
+
+
+@dataclass(frozen=True)
 class PaymentReminderView:
     order_id: str
     payment_method: PaymentMethod | None
@@ -88,6 +103,7 @@ class PaymentReminderView:
     quittung_printed_by: str | None = None
     paid_recorded_at: datetime | None = None
     paid_recorded_by: str | None = None
+    method_changes: tuple[PaymentMethodChange, ...] = ()
 
 
 def _validate_audit_pair(

--- a/src/catering_system/repositories/in_memory_payment_reminder_repository.py
+++ b/src/catering_system/repositories/in_memory_payment_reminder_repository.py
@@ -1,14 +1,29 @@
 """In-memory payment reminder adapter."""
 
-from catering_system.domain.order_payment_reminder import OrderPaymentReminder
+from catering_system.domain.order_payment_reminder import (
+    OrderPaymentReminder,
+    PaymentMethodChange,
+)
 
 
 class InMemoryPaymentReminderRepository:
     def __init__(self) -> None:
         self._rows: dict[str, OrderPaymentReminder] = {}
+        self._method_changes: dict[str, list[PaymentMethodChange]] = {}
 
     def get(self, order_id: str) -> OrderPaymentReminder | None:
         return self._rows.get(order_id)
 
     def save(self, reminder: OrderPaymentReminder) -> None:
         self._rows[reminder.order_id] = reminder
+
+    def list_method_changes(self, order_id: str) -> tuple[PaymentMethodChange, ...]:
+        return tuple(reversed(self._method_changes.get(order_id, [])))
+
+    def save_method_change(
+        self,
+        reminder: OrderPaymentReminder,
+        change: PaymentMethodChange,
+    ) -> None:
+        self._rows[reminder.order_id] = reminder
+        self._method_changes.setdefault(reminder.order_id, []).append(change)

--- a/src/catering_system/repositories/payment_reminder_repository.py
+++ b/src/catering_system/repositories/payment_reminder_repository.py
@@ -4,10 +4,21 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from catering_system.domain.order_payment_reminder import OrderPaymentReminder
+from catering_system.domain.order_payment_reminder import (
+    OrderPaymentReminder,
+    PaymentMethodChange,
+)
 
 
 class PaymentReminderRepository(Protocol):
     def get(self, order_id: str) -> OrderPaymentReminder | None: ...
 
     def save(self, reminder: OrderPaymentReminder) -> None: ...
+
+    def list_method_changes(self, order_id: str) -> tuple[PaymentMethodChange, ...]: ...
+
+    def save_method_change(
+        self,
+        reminder: OrderPaymentReminder,
+        change: PaymentMethodChange,
+    ) -> None: ...

--- a/src/catering_system/repositories/sqlite_payment_reminder_repository.py
+++ b/src/catering_system/repositories/sqlite_payment_reminder_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from contextlib import nullcontext
 from datetime import date, datetime
@@ -9,6 +10,7 @@ from pathlib import Path
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentMethodChange,
     validate_payment_method,
 )
 from catering_system.repositories.sqlite_migrations import apply_migrations
@@ -81,10 +83,41 @@ def _migration_3_add_audit_facts(connection: sqlite3.Connection) -> None:
             )
 
 
+def _migration_4_add_payment_method_history(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS order_payment_method_changes (
+            change_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            from_method TEXT NOT NULL,
+            to_method TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            actor_reference TEXT NOT NULL,
+            changed_at TEXT NOT NULL,
+            retired_task_title TEXT,
+            previous_reminder_json TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """CREATE TRIGGER IF NOT EXISTS trg_payment_method_change_owner_insert
+        BEFORE INSERT ON order_payment_method_changes
+        WHEN NOT EXISTS (SELECT 1 FROM orders WHERE order_id = NEW.order_id)
+        BEGIN SELECT RAISE(ABORT, 'payment method change owner does not exist'); END"""
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_payment_method_changes_order_changed
+        ON order_payment_method_changes(order_id, changed_at DESC)
+        """
+    )
+
+
 _MIGRATIONS = (
     (1, "create_order_payment_reminders", _migration_1_create_table),
     (2, "add_quittung_printed", _migration_2_add_quittung_printed),
     (3, "add_payment_audit_facts", _migration_3_add_audit_facts),
+    (4, "add_payment_method_history", _migration_4_add_payment_method_history),
 )
 
 _SELECT_COLUMNS = """
@@ -119,6 +152,84 @@ def _date(value: str | None) -> date | None:
 
 def _datetime(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value) if value is not None else None
+
+
+def _optional_text(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _reminder_payload(reminder: OrderPaymentReminder) -> dict[str, object]:
+    def d(value: date | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    def dt(value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    return {
+        "order_id": reminder.order_id,
+        "payment_method": reminder.payment_method,
+        "invoice_created": reminder.invoice_created,
+        "invoice_number": reminder.invoice_number,
+        "sent_on": d(reminder.sent_on),
+        "due_on": d(reminder.due_on),
+        "paid_on": d(reminder.paid_on),
+        "cash_received": reminder.cash_received,
+        "quittung_printed": reminder.quittung_printed,
+        "updated_at": dt(reminder.updated_at),
+        "invoice_created_at": dt(reminder.invoice_created_at),
+        "invoice_created_by": reminder.invoice_created_by,
+        "invoice_sent_recorded_at": dt(reminder.invoice_sent_recorded_at),
+        "invoice_sent_recorded_by": reminder.invoice_sent_recorded_by,
+        "payment_reminder_sent_at": dt(reminder.payment_reminder_sent_at),
+        "payment_reminder_sent_by": reminder.payment_reminder_sent_by,
+        "mahnung_sent_at": dt(reminder.mahnung_sent_at),
+        "mahnung_sent_by": reminder.mahnung_sent_by,
+        "quittung_printed_at": dt(reminder.quittung_printed_at),
+        "quittung_printed_by": reminder.quittung_printed_by,
+        "paid_recorded_at": dt(reminder.paid_recorded_at),
+        "paid_recorded_by": reminder.paid_recorded_by,
+    }
+
+
+def _reminder_from_payload(payload: dict[str, object]) -> OrderPaymentReminder:
+    return OrderPaymentReminder(
+        order_id=str(payload["order_id"]),
+        payment_method=validate_payment_method(str(payload["payment_method"])),
+        invoice_created=bool(payload["invoice_created"]),
+        invoice_number=_optional_text(payload.get("invoice_number")),
+        sent_on=_date(_optional_text(payload.get("sent_on"))),
+        due_on=_date(_optional_text(payload.get("due_on"))),
+        paid_on=_date(_optional_text(payload.get("paid_on"))),
+        cash_received=bool(payload["cash_received"]),
+        quittung_printed=bool(payload["quittung_printed"]),
+        updated_at=_datetime(_optional_text(payload.get("updated_at"))),
+        invoice_created_at=_datetime(
+            _optional_text(payload.get("invoice_created_at"))
+        ),
+        invoice_created_by=_optional_text(payload.get("invoice_created_by")),
+        invoice_sent_recorded_at=_datetime(
+            _optional_text(payload.get("invoice_sent_recorded_at"))
+        ),
+        invoice_sent_recorded_by=_optional_text(
+            payload.get("invoice_sent_recorded_by")
+        ),
+        payment_reminder_sent_at=_datetime(
+            _optional_text(payload.get("payment_reminder_sent_at"))
+        ),
+        payment_reminder_sent_by=_optional_text(
+            payload.get("payment_reminder_sent_by")
+        ),
+        mahnung_sent_at=_datetime(_optional_text(payload.get("mahnung_sent_at"))),
+        mahnung_sent_by=_optional_text(payload.get("mahnung_sent_by")),
+        quittung_printed_at=_datetime(
+            _optional_text(payload.get("quittung_printed_at"))
+        ),
+        quittung_printed_by=_optional_text(payload.get("quittung_printed_by")),
+        paid_recorded_at=_datetime(
+            _optional_text(payload.get("paid_recorded_at"))
+        ),
+        paid_recorded_by=_optional_text(payload.get("paid_recorded_by")),
+    )
 
 
 class SQLitePaymentReminderRepository:
@@ -179,7 +290,46 @@ class SQLitePaymentReminderRepository:
             paid_recorded_by=row[21],
         )
 
-    def save(self, reminder: OrderPaymentReminder) -> None:
+    def list_method_changes(self, order_id: str) -> tuple[PaymentMethodChange, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT
+                change_id,
+                order_id,
+                from_method,
+                to_method,
+                reason,
+                actor_reference,
+                changed_at,
+                retired_task_title,
+                previous_reminder_json
+            FROM order_payment_method_changes
+            WHERE order_id = ?
+            ORDER BY changed_at DESC, change_id DESC
+            """,
+            (order_id,),
+        ).fetchall()
+        result: list[PaymentMethodChange] = []
+        for row in rows:
+            raw = json.loads(row[8])
+            if not isinstance(raw, dict):
+                raise ValueError("invalid payment method history payload")
+            result.append(
+                PaymentMethodChange(
+                    change_id=row[0],
+                    order_id=row[1],
+                    from_method=validate_payment_method(row[2]),
+                    to_method=validate_payment_method(row[3]),
+                    reason=row[4],
+                    actor_reference=row[5],
+                    changed_at=datetime.fromisoformat(row[6]),
+                    retired_task_title=row[7],
+                    previous_reminder=_reminder_from_payload(raw),
+                )
+            )
+        return tuple(result)
+
+    def _upsert(self, reminder: OrderPaymentReminder) -> None:
         values = (
             reminder.order_id,
             reminder.payment_method,
@@ -214,58 +364,99 @@ class SQLitePaymentReminderRepository:
             else None,
             reminder.paid_recorded_by,
         )
+        self._conn.execute(
+            """
+            INSERT INTO order_payment_reminders (
+                order_id,
+                payment_method,
+                invoice_created,
+                invoice_number,
+                sent_on,
+                due_on,
+                paid_on,
+                cash_received,
+                updated_at,
+                quittung_printed,
+                invoice_created_at,
+                invoice_created_by,
+                invoice_sent_recorded_at,
+                invoice_sent_recorded_by,
+                payment_reminder_sent_at,
+                payment_reminder_sent_by,
+                mahnung_sent_at,
+                mahnung_sent_by,
+                quittung_printed_at,
+                quittung_printed_by,
+                paid_recorded_at,
+                paid_recorded_by
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            ON CONFLICT(order_id) DO UPDATE SET
+                payment_method = excluded.payment_method,
+                invoice_created = excluded.invoice_created,
+                invoice_number = excluded.invoice_number,
+                sent_on = excluded.sent_on,
+                due_on = excluded.due_on,
+                paid_on = excluded.paid_on,
+                cash_received = excluded.cash_received,
+                updated_at = excluded.updated_at,
+                quittung_printed = excluded.quittung_printed,
+                invoice_created_at = excluded.invoice_created_at,
+                invoice_created_by = excluded.invoice_created_by,
+                invoice_sent_recorded_at = excluded.invoice_sent_recorded_at,
+                invoice_sent_recorded_by = excluded.invoice_sent_recorded_by,
+                payment_reminder_sent_at = excluded.payment_reminder_sent_at,
+                payment_reminder_sent_by = excluded.payment_reminder_sent_by,
+                mahnung_sent_at = excluded.mahnung_sent_at,
+                mahnung_sent_by = excluded.mahnung_sent_by,
+                quittung_printed_at = excluded.quittung_printed_at,
+                quittung_printed_by = excluded.quittung_printed_by,
+                paid_recorded_at = excluded.paid_recorded_at,
+                paid_recorded_by = excluded.paid_recorded_by
+            """,
+            values,
+        )
+
+    def save(self, reminder: OrderPaymentReminder) -> None:
+        with self._write_scope():
+            self._upsert(reminder)
+
+    def save_method_change(
+        self,
+        reminder: OrderPaymentReminder,
+        change: PaymentMethodChange,
+    ) -> None:
         with self._write_scope():
             self._conn.execute(
                 """
-                INSERT INTO order_payment_reminders (
+                INSERT INTO order_payment_method_changes (
+                    change_id,
                     order_id,
-                    payment_method,
-                    invoice_created,
-                    invoice_number,
-                    sent_on,
-                    due_on,
-                    paid_on,
-                    cash_received,
-                    updated_at,
-                    quittung_printed,
-                    invoice_created_at,
-                    invoice_created_by,
-                    invoice_sent_recorded_at,
-                    invoice_sent_recorded_by,
-                    payment_reminder_sent_at,
-                    payment_reminder_sent_by,
-                    mahnung_sent_at,
-                    mahnung_sent_by,
-                    quittung_printed_at,
-                    quittung_printed_by,
-                    paid_recorded_at,
-                    paid_recorded_by
-                ) VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-                )
-                ON CONFLICT(order_id) DO UPDATE SET
-                    payment_method = excluded.payment_method,
-                    invoice_created = excluded.invoice_created,
-                    invoice_number = excluded.invoice_number,
-                    sent_on = excluded.sent_on,
-                    due_on = excluded.due_on,
-                    paid_on = excluded.paid_on,
-                    cash_received = excluded.cash_received,
-                    updated_at = excluded.updated_at,
-                    quittung_printed = excluded.quittung_printed,
-                    invoice_created_at = excluded.invoice_created_at,
-                    invoice_created_by = excluded.invoice_created_by,
-                    invoice_sent_recorded_at = excluded.invoice_sent_recorded_at,
-                    invoice_sent_recorded_by = excluded.invoice_sent_recorded_by,
-                    payment_reminder_sent_at = excluded.payment_reminder_sent_at,
-                    payment_reminder_sent_by = excluded.payment_reminder_sent_by,
-                    mahnung_sent_at = excluded.mahnung_sent_at,
-                    mahnung_sent_by = excluded.mahnung_sent_by,
-                    quittung_printed_at = excluded.quittung_printed_at,
-                    quittung_printed_by = excluded.quittung_printed_by,
-                    paid_recorded_at = excluded.paid_recorded_at,
-                    paid_recorded_by = excluded.paid_recorded_by
+                    from_method,
+                    to_method,
+                    reason,
+                    actor_reference,
+                    changed_at,
+                    retired_task_title,
+                    previous_reminder_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                values,
+                (
+                    change.change_id,
+                    change.order_id,
+                    change.from_method,
+                    change.to_method,
+                    change.reason,
+                    change.actor_reference,
+                    change.changed_at.isoformat(),
+                    change.retired_task_title,
+                    json.dumps(
+                        _reminder_payload(change.previous_reminder),
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                ),
             )
+            self._upsert(reminder)

--- a/src/catering_system/repositories/sqlite_payment_reminder_repository.py
+++ b/src/catering_system/repositories/sqlite_payment_reminder_repository.py
@@ -203,9 +203,7 @@ def _reminder_from_payload(payload: dict[str, object]) -> OrderPaymentReminder:
         cash_received=bool(payload["cash_received"]),
         quittung_printed=bool(payload["quittung_printed"]),
         updated_at=_datetime(_optional_text(payload.get("updated_at"))),
-        invoice_created_at=_datetime(
-            _optional_text(payload.get("invoice_created_at"))
-        ),
+        invoice_created_at=_datetime(_optional_text(payload.get("invoice_created_at"))),
         invoice_created_by=_optional_text(payload.get("invoice_created_by")),
         invoice_sent_recorded_at=_datetime(
             _optional_text(payload.get("invoice_sent_recorded_at"))
@@ -225,9 +223,7 @@ def _reminder_from_payload(payload: dict[str, object]) -> OrderPaymentReminder:
             _optional_text(payload.get("quittung_printed_at"))
         ),
         quittung_printed_by=_optional_text(payload.get("quittung_printed_by")),
-        paid_recorded_at=_datetime(
-            _optional_text(payload.get("paid_recorded_at"))
-        ),
+        paid_recorded_at=_datetime(_optional_text(payload.get("paid_recorded_at"))),
         paid_recorded_by=_optional_text(payload.get("paid_recorded_by")),
     )
 

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -239,6 +239,68 @@ class PaymentReminderService:
         self._reminders.save(replace(reminder, updated_at=now))
         return self.view(reminder.order_id)
 
+    def change_payment_method(
+        self,
+        order_id: str,
+        *,
+        new_payment_method: str,
+        reason: str,
+        actor_reference: str,
+    ) -> PaymentReminderView:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise KeyError(order_id)
+        if order.cancelled_at is not None:
+            raise ValueError("cancelled order cannot change payment method")
+        current = self._reminders.get(order_id)
+        if current is None:
+            raise ValueError("current payment method is missing")
+
+        new_method = validate_payment_method(new_payment_method)
+        if new_method == current.payment_method:
+            raise ValueError("new payment method must differ")
+
+        clean_reason = reason.strip()
+        if not clean_reason or len(clean_reason) > 500:
+            raise ValueError(
+                "payment method change reason must be non-empty and at most 500 chars"
+            )
+        actor = self._actor(actor_reference)
+        if (
+            current.paid_on is not None
+            or current.cash_received
+            or current.paid_recorded_at is not None
+        ):
+            raise ValueError("payment method cannot change after payment")
+
+        now = self._now()
+        if now.utcoffset() is None:
+            raise ValueError("audit clock must return timezone-aware datetime")
+        previous_view = derive_payment_reminder(
+            current,
+            event_date=self._event_date(order_id),
+            today=self._today(),
+        )
+        change = PaymentMethodChange(
+            change_id=str(uuid4()),
+            order_id=order_id,
+            from_method=current.payment_method,
+            to_method=new_method,
+            reason=clean_reason,
+            actor_reference=actor,
+            changed_at=now,
+            retired_task_title=previous_view.next_step,
+            previous_reminder=current,
+        )
+        replacement = OrderPaymentReminder(
+            order_id=order_id,
+            payment_method=new_method,
+            updated_at=now,
+        )
+        validate_payment_reminder(replacement)
+        self._reminders.save_method_change(replacement, change)
+        return self.view(order_id)
+
     def seed_from_conversion(self, order_id: str, payment_method: str) -> None:
         """Persist the explicit conversion choice, with conflict-safe replay."""
         method = validate_payment_method(payment_method)

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
 from typing import Callable
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentMethodChange,
     PaymentReminderView,
     derive_payment_reminder,
-    has_downstream_payment_facts,
     validate_payment_method,
     validate_payment_reminder,
 )
@@ -61,7 +62,11 @@ class PaymentReminderService:
             event_date=event_date,
             today=self._today(),
         )
-        return replace(view, order_id=order_id)
+        return replace(
+            view,
+            order_id=order_id,
+            method_changes=self._reminders.list_method_changes(order_id),
+        )
 
     @staticmethod
     def _actor(value: str) -> str:
@@ -129,11 +134,8 @@ class PaymentReminderService:
         )
         current = self._reminders.get(reminder.order_id)
         if current is not None:
-            if (
-                current.payment_method != reminder.payment_method
-                and has_downstream_payment_facts(current)
-            ):
-                raise ValueError("payment method cannot change after payment facts")
+            if current.payment_method != reminder.payment_method:
+                raise ValueError("payment method change requires explicit command")
             self._reject_silent_fact_rewrite(current, reminder)
             reminder = replace(
                 reminder,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -3221,6 +3221,46 @@ class OfficeApi:
             "updated_at": view.updated_at.isoformat(),
         }
 
+    def cmd_payment_method_change(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        order = self._require_active_order(path_ids["id"])
+        current = self.payment_reminders.get(order.order_id)
+        expected_at = expect["updated_at"]
+        if expected_at is not None and not isinstance(expected_at, str):
+            raise _invalid()
+        actual_at = (
+            current.updated_at.isoformat()
+            if current is not None and current.updated_at is not None
+            else None
+        )
+        if expected_at != actual_at:
+            raise ApiError(409, "stale_state")
+        try:
+            actor_reference = (
+                _v_optional_str(args.get("actor_reference"), 200) or CLIENT_ID
+            )
+            view = self.payment_reminder_service.change_payment_method(
+                order.order_id,
+                new_payment_method=_v_enum(
+                    args["new_payment_method"], validate_payment_method
+                ),
+                reason=_v_str(args["reason"], 500),
+                actor_reference=actor_reference,
+            )
+        except ValueError as exc:
+            if str(exc) in {
+                "payment method cannot change after payment",
+                "new payment method must differ",
+            }:
+                raise ApiError(409, "payment_method_change_conflict") from exc
+            raise ApiError(422, "invalid_payment_method_change") from exc
+        assert view.updated_at is not None
+        return 200, {
+            "order_id": order.order_id,
+            "updated_at": view.updated_at.isoformat(),
+        }
+
     def cmd_confirmation_document(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
     ) -> tuple[int, dict[str, object]]:
@@ -3492,6 +3532,10 @@ _PAYMENT_REMINDER_ARGS = _ArgKeys(
         }
     ),
 )
+_PAYMENT_METHOD_CHANGE_ARGS = _ArgKeys(
+    required=frozenset({"new_payment_method", "reason"}),
+    optional=frozenset({"actor_reference"}),
+)
 _CONFIRMATION_DOCUMENT_ARGS = _ArgKeys(required=frozenset({"created_by"}))
 _CONFIRMATION_DOCUMENT_SEND_ARGS = _ArgKeys(
     required=frozenset({"document_snapshot_id", "requested_by"})
@@ -3637,6 +3681,11 @@ _COMMANDS: dict[str, _CommandSpec] = {
     "delete-order": _CommandSpec("cmd_delete_order", _ORDER_DELETE_ARGS, set()),
     "payment-reminder": _CommandSpec(
         "cmd_payment_reminder", _PAYMENT_REMINDER_ARGS, {"updated_at"}
+    ),
+    "payment-method": _CommandSpec(
+        "cmd_payment_method_change",
+        _PAYMENT_METHOD_CHANGE_ARGS,
+        {"updated_at"},
     ),
     "confirmation-document": _CommandSpec(
         "cmd_confirmation_document",
@@ -4029,6 +4078,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/payment-reminder$"),
         "/office/v1/orders/{id}/payment-reminder",
         {"POST": "payment-reminder"},
+    ),
+    (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/payment-method$"),
+        "/office/v1/orders/{id}/payment-method",
+        {"POST": "payment-method"},
     ),
     (
         re.compile(

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -59,7 +59,10 @@ from catering_system.domain.order_operational_pause import (
     OrderOperationalPauseEvent,
     derive_operational_pause_projection,
 )
-from catering_system.domain.order_payment_reminder import PaymentReminderView
+from catering_system.domain.order_payment_reminder import (
+    OrderPaymentReminder,
+    PaymentReminderView,
+)
 from catering_system.domain.ready_to_send import ReadyToSendEvaluation
 from catering_system.domain.task_projection import TaskProjection
 from catering_system.domain.wochenuebersicht import Wochenuebersicht
@@ -835,6 +838,39 @@ def customer_document_preview_shape(preview: object) -> dict[str, object]:
     }
 
 
+def _payment_reminder_fact_shape(
+    reminder: OrderPaymentReminder,
+) -> dict[str, object]:
+    def d(value: date | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    def dt(value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None
+
+    return {
+        "payment_method": reminder.payment_method,
+        "invoice_created": reminder.invoice_created,
+        "invoice_number": reminder.invoice_number,
+        "sent_on": d(reminder.sent_on),
+        "paid_on": d(reminder.paid_on),
+        "cash_received": reminder.cash_received,
+        "quittung_printed": reminder.quittung_printed,
+        "updated_at": dt(reminder.updated_at),
+        "invoice_created_at": dt(reminder.invoice_created_at),
+        "invoice_created_by": reminder.invoice_created_by,
+        "invoice_sent_recorded_at": dt(reminder.invoice_sent_recorded_at),
+        "invoice_sent_recorded_by": reminder.invoice_sent_recorded_by,
+        "payment_reminder_sent_at": dt(reminder.payment_reminder_sent_at),
+        "payment_reminder_sent_by": reminder.payment_reminder_sent_by,
+        "mahnung_sent_at": dt(reminder.mahnung_sent_at),
+        "mahnung_sent_by": reminder.mahnung_sent_by,
+        "quittung_printed_at": dt(reminder.quittung_printed_at),
+        "quittung_printed_by": reminder.quittung_printed_by,
+        "paid_recorded_at": dt(reminder.paid_recorded_at),
+        "paid_recorded_by": reminder.paid_recorded_by,
+    }
+
+
 def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
     def dt(value: datetime | None) -> str | None:
         return value.isoformat() if value is not None else None
@@ -869,6 +905,21 @@ def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
         "paid_recorded_at": dt(view.paid_recorded_at),
         "paid_recorded_by": view.paid_recorded_by,
         "updated_at": dt(view.updated_at),
+        "method_changes": [
+            {
+                "change_id": change.change_id,
+                "from_method": change.from_method,
+                "to_method": change.to_method,
+                "reason": change.reason,
+                "actor_reference": change.actor_reference,
+                "changed_at": change.changed_at.isoformat(),
+                "retired_task_title": change.retired_task_title,
+                "previous_reminder": _payment_reminder_fact_shape(
+                    change.previous_reminder
+                ),
+            }
+            for change in view.method_changes
+        ],
     }
 
 

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -4440,9 +4440,7 @@ class OfficePanel:
         *,
         actor_reference: str = "office-panel",
     ) -> None:
-        new_payment_method = validate_payment_method(
-            form.get("new_payment_method", "")
-        )
+        new_payment_method = validate_payment_method(form.get("new_payment_method", ""))
         reason = form.get("reason", "").strip()
         if not reason:
             raise ValueError("Grund für die Änderung ist erforderlich.")

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3949,6 +3949,19 @@ class OfficePanel:
                         if not cancelled and context.can("orders.payment.reminder")
                         else ""
                     ),
+                    payment_method_command_fields=(
+                        self._command_fields(
+                            {
+                                "payment_reminder_updated_at": (
+                                    payment.updated_at.isoformat()
+                                    if payment.updated_at
+                                    else ""
+                                )
+                            }
+                        )
+                        if not cancelled and context.can("orders.payment.reminder")
+                        else ""
+                    ),
                     confirmation_command_fields=(
                         self._command_fields(
                             {
@@ -4411,6 +4424,35 @@ class OfficePanel:
                 actor_reference=actor_reference,
                 mark_payment_reminder_sent=form.get("payment_reminder_sent") == "1",
                 mark_mahnung_sent=form.get("mahnung_sent") == "1",
+            )
+
+        if self._remote is not None:
+            work()
+        elif self._command_executor is not None:
+            self._command_executor.run(work)
+        else:
+            work()
+
+    def change_payment_method(
+        self,
+        order_id: str,
+        form: dict[str, str],
+        *,
+        actor_reference: str = "office-panel",
+    ) -> None:
+        new_payment_method = validate_payment_method(
+            form.get("new_payment_method", "")
+        )
+        reason = form.get("reason", "").strip()
+        if not reason:
+            raise ValueError("Grund für die Änderung ist erforderlich.")
+
+        def work() -> None:
+            self.payment_reminder_service.change_payment_method(
+                order_id,
+                new_payment_method=new_payment_method,
+                reason=reason,
+                actor_reference=actor_reference,
             )
 
         if self._remote is not None:

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -2683,6 +2683,21 @@ def make_office_panel_handler(
                     self._form(),
                     actor_reference=actor_reference,
                 )
+            elif action == "payment-method":
+                auth = self._request_auth
+                actor_reference = "office-panel"
+                if (
+                    auth is not None
+                    and auth.kind == "employee"
+                    and auth.employee is not None
+                ):
+                    account = auth.employee.account
+                    actor_reference = f"{account.display_name} [{account.id}]"
+                panel.change_payment_method(
+                    order_id,
+                    self._form(),
+                    actor_reference=actor_reference,
+                )
             elif action == "confirmation-document":
                 panel.prepare_confirmation_document(order_id, self._form())
             elif action == "pause":

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -832,13 +832,25 @@ def _payment_form(
         return ""
     if not context.can("orders.payment.reminder"):
         return ""
-    options = ['<option value="">Bitte wählen</option>']
-    for method in PAYMENT_METHODS:
-        selected = " selected" if payment.payment_method == method else ""
-        options.append(
-            f'<option value="{method}"{selected}>'
-            f"{_e(PAYMENT_METHOD_LABELS[method])}</option>"
+
+    if payment.payment_method is None:
+        options = ['<option value="">Bitte wählen</option>']
+        for method in PAYMENT_METHODS:
+            options.append(
+                f'<option value="{method}">{_e(PAYMENT_METHOD_LABELS[method])}</option>'
+            )
+        method_field = (
+            '<p><label>Zahlungsart*</label>'
+            '<select name="payment_method" required>'
+            f"{''.join(options)}</select></p>"
         )
+    else:
+        method_field = (
+            f"<p><strong>Zahlungsart:</strong> {_e(payment.payment_method_label)}</p>"
+            f'<input type="hidden" name="payment_method" '
+            f'value="{_e(payment.payment_method)}">'
+        )
+
     quittung = ""
     if payment.payment_method == "BAR_VOR_ORT":
         quittung = (
@@ -863,9 +875,8 @@ def _payment_form(
         '<details class="order-payment-edit"><summary>Zahlungsdaten bearbeiten</summary>'
         f'<form method="post" action="/order/{_e(order.order_id)}/payment-reminder">'
         f"{forms.csrf_input}{forms.payment_command_fields}<fieldset>"
-        '<p><label>Zahlungsart*</label><select name="payment_method" required>'
-        f"{''.join(options)}</select></p>"
-        f'<p><label><input type="checkbox" name="invoice_created" value="1"'
+        + method_field
+        + f'<p><label><input type="checkbox" name="invoice_created" value="1"'
         f"{' checked' if payment.invoice_created else ''}> "
         "Rechnung in der Buchhaltung erstellt</label></p>"
         f'<p><label>Rechnungsnummer</label><input name="invoice_number" '
@@ -882,6 +893,79 @@ def _payment_form(
         + escalation
         + '<p><button type="submit">Zahlungshinweis speichern</button></p>'
         "</fieldset></form></details>"
+    )
+
+
+def _payment_method_change_form(
+    order: Order,
+    payment: PaymentReminderView,
+    forms: OrderDetailFormFields,
+    *,
+    context: OfficePageContext,
+) -> str:
+    if (
+        order.cancelled_at is not None
+        or not context.can("orders.payment.reminder")
+        or payment.payment_method is None
+        or payment.paid_on is not None
+        or payment.cash_received
+    ):
+        return ""
+    options = ['<option value="">Neue Zahlungsart wählen</option>']
+    for method in PAYMENT_METHODS:
+        if method == payment.payment_method:
+            continue
+        options.append(
+            f'<option value="{method}">{_e(PAYMENT_METHOD_LABELS[method])}</option>'
+        )
+    return (
+        '<details class="order-payment-method-change">'
+        "<summary>Zahlungsart ändern</summary>"
+        f'<form method="post" action="/order/{_e(order.order_id)}/payment-method">'
+        f"{forms.csrf_input}{forms.payment_method_command_fields}<fieldset>"
+        '<p><label>Neue Zahlungsart*</label>'
+        '<select name="new_payment_method" required>'
+        f"{''.join(options)}</select></p>"
+        '<p><label>Grund*</label>'
+        '<textarea name="reason" maxlength="500" required></textarea></p>'
+        '<p class="order-context-note">'
+        "Die bisherige Zahlungsart und ihre Dokument-/Reminder-Fakten "
+        "bleiben in der Historie erhalten.</p>"
+        '<p><button type="submit">Zahlungsart ändern</button></p>'
+        "</fieldset></form></details>"
+    )
+
+
+def _payment_method_history(payment: PaymentReminderView) -> str:
+    if not payment.method_changes:
+        return ""
+    rows: list[str] = []
+    for change in payment.method_changes:
+        previous = change.previous_reminder
+        old_facts: list[str] = []
+        if previous.invoice_number:
+            old_facts.append(f"Rechnung {previous.invoice_number}")
+        if previous.sent_on is not None:
+            old_facts.append(f"versendet {previous.sent_on.strftime('%d.%m.%Y')}")
+        if previous.quittung_printed:
+            old_facts.append("Quittung gedruckt")
+        if change.retired_task_title:
+            old_facts.append(f"Aufgabe beendet: {change.retired_task_title}")
+        details = " · ".join(old_facts) if old_facts else "Keine Dokumentfakten"
+        rows.append(
+            "<li>"
+            f"<strong>{_e(PAYMENT_METHOD_LABELS[change.from_method])} → "
+            f"{_e(PAYMENT_METHOD_LABELS[change.to_method])}</strong>"
+            f" · {_e(change.changed_at.strftime('%d.%m.%Y · %H:%M'))}"
+            f" · {_e(change.actor_reference)}"
+            f"<br>Grund: {_e(change.reason)}"
+            f"<br>{_e(details)}"
+            "</li>"
+        )
+    return (
+        '<details class="order-payment-method-history">'
+        f"<summary>Zahlungsarten-Historie ({len(rows)})</summary>"
+        f"<ul>{''.join(rows)}</ul></details>"
     )
 
 
@@ -958,6 +1042,8 @@ def _payment_card(
         '<div class="order-payment-next"><span>Nächste Zahlungsaufgabe</span>'
         f"<strong>{_e(next_step)}</strong></div>"
         + _payment_form(order, payment, forms, context=context)
+        + _payment_method_change_form(order, payment, forms, context=context)
+        + _payment_method_history(payment)
         + "</section>"
     )
 

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -167,6 +167,7 @@ class OrderDetailFormFields:
     cancel_command_fields: str
     version_command_fields: str
     payment_command_fields: str
+    payment_method_command_fields: str = ""
     confirmation_command_fields: str = ""
     print_confirm_button_labels: Mapping[str, str] = field(default_factory=dict)
     print_status_messages: Mapping[str, str] = field(default_factory=dict)

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -840,7 +840,7 @@ def _payment_form(
                 f'<option value="{method}">{_e(PAYMENT_METHOD_LABELS[method])}</option>'
             )
         method_field = (
-            '<p><label>Zahlungsart*</label>'
+            "<p><label>Zahlungsart*</label>"
             '<select name="payment_method" required>'
             f"{''.join(options)}</select></p>"
         )
@@ -923,10 +923,10 @@ def _payment_method_change_form(
         "<summary>Zahlungsart ändern</summary>"
         f'<form method="post" action="/order/{_e(order.order_id)}/payment-method">'
         f"{forms.csrf_input}{forms.payment_method_command_fields}<fieldset>"
-        '<p><label>Neue Zahlungsart*</label>'
+        "<p><label>Neue Zahlungsart*</label>"
         '<select name="new_payment_method" required>'
         f"{''.join(options)}</select></p>"
-        '<p><label>Grund*</label>'
+        "<p><label>Grund*</label>"
         '<textarea name="reason" maxlength="500" required></textarea></p>'
         '<p class="order-context-note">'
         "Die bisherige Zahlungsart und ihre Dokument-/Reminder-Fakten "

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -87,6 +87,7 @@ from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHODS,
     OrderPaymentReminder,
     PaymentMethod,
+    PaymentMethodChange,
     PaymentReminderView,
     validate_payment_method,
 )
@@ -1070,8 +1071,100 @@ _PAYMENT_REMINDER_KEYS = frozenset(
         "paid_recorded_at",
         "paid_recorded_by",
         "updated_at",
+        "method_changes",
     }
 )
+
+
+_PAYMENT_METHOD_CHANGE_KEYS = frozenset(
+    {
+        "change_id",
+        "from_method",
+        "to_method",
+        "reason",
+        "actor_reference",
+        "changed_at",
+        "retired_task_title",
+        "previous_reminder",
+    }
+)
+_PAYMENT_FACT_KEYS = frozenset(
+    {
+        "payment_method",
+        "invoice_created",
+        "invoice_number",
+        "sent_on",
+        "paid_on",
+        "cash_received",
+        "quittung_printed",
+        "updated_at",
+        "invoice_created_at",
+        "invoice_created_by",
+        "invoice_sent_recorded_at",
+        "invoice_sent_recorded_by",
+        "payment_reminder_sent_at",
+        "payment_reminder_sent_by",
+        "mahnung_sent_at",
+        "mahnung_sent_by",
+        "quittung_printed_at",
+        "quittung_printed_by",
+        "paid_recorded_at",
+        "paid_recorded_by",
+    }
+)
+
+
+def _payment_fact_reminder(value: object, order_id: str) -> OrderPaymentReminder:
+    data = _dict(value)
+    _exact(data, _PAYMENT_FACT_KEYS)
+    try:
+        method = validate_payment_method(_str(data["payment_method"]))
+    except ValueError:
+        _bad_response()
+    return OrderPaymentReminder(
+        order_id=order_id,
+        payment_method=method,
+        invoice_created=_bool(data["invoice_created"]),
+        invoice_number=_optional_str(data["invoice_number"]),
+        sent_on=None if data["sent_on"] is None else _date(data["sent_on"]),
+        paid_on=None if data["paid_on"] is None else _date(data["paid_on"]),
+        cash_received=_bool(data["cash_received"]),
+        quittung_printed=_bool(data["quittung_printed"]),
+        updated_at=_optional_datetime(data["updated_at"]),
+        invoice_created_at=_optional_datetime(data["invoice_created_at"]),
+        invoice_created_by=_optional_str(data["invoice_created_by"]),
+        invoice_sent_recorded_at=_optional_datetime(data["invoice_sent_recorded_at"]),
+        invoice_sent_recorded_by=_optional_str(data["invoice_sent_recorded_by"]),
+        payment_reminder_sent_at=_optional_datetime(data["payment_reminder_sent_at"]),
+        payment_reminder_sent_by=_optional_str(data["payment_reminder_sent_by"]),
+        mahnung_sent_at=_optional_datetime(data["mahnung_sent_at"]),
+        mahnung_sent_by=_optional_str(data["mahnung_sent_by"]),
+        quittung_printed_at=_optional_datetime(data["quittung_printed_at"]),
+        quittung_printed_by=_optional_str(data["quittung_printed_by"]),
+        paid_recorded_at=_optional_datetime(data["paid_recorded_at"]),
+        paid_recorded_by=_optional_str(data["paid_recorded_by"]),
+    )
+
+
+def _payment_method_change(value: object, order_id: str) -> PaymentMethodChange:
+    data = _dict(value)
+    _exact(data, _PAYMENT_METHOD_CHANGE_KEYS)
+    try:
+        from_method = validate_payment_method(_str(data["from_method"]))
+        to_method = validate_payment_method(_str(data["to_method"]))
+    except ValueError:
+        _bad_response()
+    return PaymentMethodChange(
+        change_id=_uuid4(data["change_id"]),
+        order_id=order_id,
+        from_method=from_method,
+        to_method=to_method,
+        reason=_str(data["reason"]),
+        actor_reference=_str(data["actor_reference"]),
+        changed_at=_datetime(data["changed_at"]),
+        retired_task_title=_optional_str(data["retired_task_title"]),
+        previous_reminder=_payment_fact_reminder(data["previous_reminder"], order_id),
+    )
 
 
 def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
@@ -1120,6 +1213,10 @@ def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
         quittung_printed_by=_optional_str(data["quittung_printed_by"]),
         paid_recorded_at=_optional_datetime(data["paid_recorded_at"]),
         paid_recorded_by=_optional_str(data["paid_recorded_by"]),
+        method_changes=tuple(
+            _payment_method_change(item, order_id)
+            for item in _list(data["method_changes"])
+        ),
     )
 
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -4024,6 +4024,40 @@ class _RemotePaymentReminderService:
     def view(self, order_id: str) -> PaymentReminderView:
         return self._client.payment_reminder_view(order_id)
 
+    def change_payment_method(
+        self,
+        order_id: str,
+        *,
+        new_payment_method: str,
+        reason: str,
+        actor_reference: str,
+    ) -> PaymentReminderView:
+        current = self.view(order_id)
+        expected_at = self._client.form_value("_expect_payment_reminder_updated_at")
+        result = self._client.command(
+            f"/office/v1/orders/{quote(order_id, safe='')}/payment-method",
+            {
+                "new_payment_method": new_payment_method,
+                "reason": reason,
+                "actor_reference": actor_reference,
+            },
+            {
+                "updated_at": (
+                    expected_at
+                    if expected_at
+                    else (
+                        current.updated_at.isoformat() if current.updated_at else None
+                    )
+                )
+            },
+            expected={200},
+            result_keys={"order_id", "updated_at"},
+        )
+        if _uuid4(result["order_id"]) != order_id:
+            _bad_response()
+        self._client._order_details.pop(order_id, None)
+        return self.view(order_id)
+
     def save(
         self,
         reminder: OrderPaymentReminder,

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -1387,6 +1387,79 @@ def test_payment_reminder_read_write_replay_and_stale_gate(api) -> None:
     assert (status, body["error"]) == (409, "stale_state")
 
 
+def test_payment_method_change_requires_reason_and_preserves_history(api) -> None:
+    base, ids, _db = api
+    order_id = ids["order_unprinted"]
+    detail_url = f"{base}/office/v1/orders/{order_id}"
+    reminder_url = f"{detail_url}/payment-reminder"
+    change_url = f"{detail_url}/payment-method"
+
+    status, created, _h = _post(
+        reminder_url,
+        args={
+            "payment_method": "RECHNUNG",
+            "invoice_created": True,
+            "invoice_number": "RE-METHOD-1",
+            "sent_on": "2026-07-15",
+            "due_on": None,
+            "paid_on": None,
+            "cash_received": False,
+            "actor_reference": "Alice",
+        },
+        expect={"updated_at": None},
+    )
+    assert status == 200
+
+    status, invalid, _h = _post(
+        change_url,
+        args={
+            "new_payment_method": "BAR_VOR_ORT",
+            "reason": "",
+            "actor_reference": "Bob",
+        },
+        expect={"updated_at": created["updated_at"]},
+    )
+    assert (status, invalid["error"]) == (422, "invalid_payment_method_change")
+
+    status, changed, _h = _post(
+        change_url,
+        args={
+            "new_payment_method": "BAR_VOR_ORT",
+            "reason": "Kunde zahlt bei Abholung bar",
+            "actor_reference": "Bob",
+        },
+        expect={"updated_at": created["updated_at"]},
+    )
+    assert status == 200
+
+    status, detail, _h = _get(detail_url)
+    assert status == 200
+    payment = detail["payment_reminder"]
+    assert payment["payment_method"] == "BAR_VOR_ORT"
+    assert payment["invoice_created"] is False
+    assert payment["invoice_number"] is None
+    assert payment["next_step"] == "Quittung vorbereiten/drucken"
+    assert len(payment["method_changes"]) == 1
+    history = payment["method_changes"][0]
+    assert history["from_method"] == "RECHNUNG"
+    assert history["to_method"] == "BAR_VOR_ORT"
+    assert history["reason"] == "Kunde zahlt bei Abholung bar"
+    assert history["actor_reference"] == "Bob"
+    assert history["previous_reminder"]["invoice_number"] == "RE-METHOD-1"
+    assert history["retired_task_title"] is not None
+
+    status, conflict, _h = _post(
+        change_url,
+        args={
+            "new_payment_method": "BAR_VOR_ORT",
+            "reason": "Replay without original command id",
+            "actor_reference": "Bob",
+        },
+        expect={"updated_at": changed["updated_at"]},
+    )
+    assert (status, conflict["error"]) == (409, "payment_method_change_conflict")
+
+
 def test_payment_reminder_rejects_cancelled_order_and_contradictory_facts(api) -> None:
     base, ids, _db = api
     base_args = {

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2073,7 +2073,24 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
     assert "Reminder-Status" in body
     assert "RE-UI4-1" in body
     assert f'action="/order/{order_id}/payment-reminder"' in body
+    assert f'action="/order/{order_id}/payment-method"' in body
+    assert "Zahlungsart ändern" in body
     assert "Küchenzettel für den aktuellen Stand drucken" in body
+
+    _post(
+        f"{premium_panel}/order/{order_id}/payment-method",
+        {
+            "new_payment_method": "BAR_VOR_ORT",
+            "reason": "Kunde zahlt bei Abholung bar",
+        },
+    )
+    _status, changed = _get(f"{premium_panel}/order/{order_id}")
+    assert "Bar vor Ort" in changed
+    assert "Quittung vorbereiten/drucken" in changed
+    assert "Zahlungsarten-Historie (1)" in changed
+    assert "Rechnung → Bar vor Ort" in changed
+    assert "Kunde zahlt bei Abholung bar" in changed
+    assert "RE-UI4-1" in changed
 
     _post(f"{premium_panel}/order/{order_id}/cancel", {})
     _status, cancelled = _get(f"{premium_panel}/order/{order_id}")
@@ -2089,6 +2106,7 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
         "cancel",
         "version",
         "payment-reminder",
+        "payment-method",
     ):
         assert f'action="/order/{order_id}/{action}"' not in cancelled
 

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -370,7 +370,81 @@ def test_service_discards_legacy_manual_due_date() -> None:
     assert service.view(order_id).due_on == date(2026, 7, 29)
 
 
-def test_payment_method_cannot_change_after_downstream_facts() -> None:
+def test_direct_save_cannot_silently_change_payment_method() -> None:
+    _orders, _reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(OrderPaymentReminder(order_id=order_id, payment_method="RECHNUNG"))
+
+    with pytest.raises(ValueError, match="explicit command"):
+        service.save(
+            OrderPaymentReminder(order_id=order_id, payment_method="BAR_VOR_ORT")
+        )
+
+
+def test_explicit_payment_method_change_archives_facts_and_resets_workflow() -> None:
+    _orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-OLD-1",
+            sent_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+
+    changed = service.change_payment_method(
+        order_id,
+        new_payment_method="BAR_VOR_ORT",
+        reason="Kunde zahlt bei Abholung bar",
+        actor_reference="Bob",
+    )
+
+    assert changed.payment_method == "BAR_VOR_ORT"
+    assert changed.invoice_created is False
+    assert changed.invoice_number is None
+    assert changed.sent_on is None
+    assert changed.quittung_printed is False
+    assert changed.next_step == "Quittung vorbereiten/drucken"
+    assert len(changed.method_changes) == 1
+
+    event = changed.method_changes[0]
+    assert event.from_method == "RECHNUNG"
+    assert event.to_method == "BAR_VOR_ORT"
+    assert event.reason == "Kunde zahlt bei Abholung bar"
+    assert event.actor_reference == "Bob"
+    assert event.changed_at == _NOW
+    assert event.retired_task_title == "Zahlungseingang prüfen"
+    assert event.previous_reminder.invoice_number == "RE-OLD-1"
+    assert event.previous_reminder.invoice_created_by == "Alice"
+    assert reminders.get(order_id) is not None
+    assert reminders.get(order_id).payment_method == "BAR_VOR_ORT"
+
+
+def test_payment_method_change_requires_reason_and_different_method() -> None:
+    _orders, _reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(OrderPaymentReminder(order_id=order_id, payment_method="VORKASSE"))
+
+    with pytest.raises(ValueError, match="reason"):
+        service.change_payment_method(
+            order_id,
+            new_payment_method="RECHNUNG",
+            reason=" ",
+            actor_reference="Alice",
+        )
+    with pytest.raises(ValueError, match="must differ"):
+        service.change_payment_method(
+            order_id,
+            new_payment_method="VORKASSE",
+            reason="Korrektur",
+            actor_reference="Alice",
+        )
+
+
+def test_payment_method_change_after_payment_is_forbidden() -> None:
     _orders, _reminders, service = _world()
     order_id = "11111111-1111-4111-8111-111111111111"
     service.save(
@@ -378,13 +452,19 @@ def test_payment_method_cannot_change_after_downstream_facts() -> None:
             order_id=order_id,
             payment_method="RECHNUNG",
             invoice_created=True,
-            invoice_number="RE-1",
-        )
+            invoice_number="RE-PAID-1",
+            sent_on=date(2026, 7, 1),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
     )
 
-    with pytest.raises(ValueError, match="cannot change"):
-        service.save(
-            OrderPaymentReminder(order_id=order_id, payment_method="BAR_VOR_ORT")
+    with pytest.raises(ValueError, match="after payment"):
+        service.change_payment_method(
+            order_id,
+            new_payment_method="BAR_VOR_ORT",
+            reason="Zu spät bemerkt",
+            actor_reference="Bob",
         )
 
 

--- a/tests/unit/test_payment_reminder_sqlite.py
+++ b/tests/unit/test_payment_reminder_sqlite.py
@@ -5,7 +5,10 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 
 from catering_system.domain.order import Order, OrderVersion
-from catering_system.domain.order_payment_reminder import OrderPaymentReminder
+from catering_system.domain.order_payment_reminder import (
+    OrderPaymentReminder,
+    PaymentMethodChange,
+)
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
 from catering_system.repositories.sqlite_payment_reminder_repository import (
     SQLitePaymentReminderRepository,
@@ -47,6 +50,53 @@ def test_additive_migration_keeps_existing_order_without_financial_data(
     reminders = SQLitePaymentReminderRepository(db)
 
     assert reminders.get(order.order_id) is None
+    reminders.close()
+
+
+def test_payment_method_history_survives_restart(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders = SQLiteOrderRepository(db)
+    order, version = _order("11111111-1111-4111-8111-111111111111")
+    orders.save_order_with_initial_version(order, version)
+    orders.close()
+
+    reminders = SQLitePaymentReminderRepository(db)
+    previous = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-HISTORY-1",
+        sent_on=date(2026, 7, 15),
+        updated_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        invoice_created_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        invoice_created_by="Alice",
+        invoice_sent_recorded_at=datetime(2026, 7, 15, 8, 5, tzinfo=UTC),
+        invoice_sent_recorded_by="Alice",
+    )
+    current = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="BAR_VOR_ORT",
+        updated_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+    )
+    change = PaymentMethodChange(
+        change_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        order_id=order.order_id,
+        from_method="RECHNUNG",
+        to_method="BAR_VOR_ORT",
+        reason="Kunde zahlt bar",
+        actor_reference="Bob",
+        changed_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+        retired_task_title="Zahlungseingang prüfen",
+        previous_reminder=previous,
+    )
+
+    reminders.save(previous)
+    reminders.save_method_change(current, change)
+    reminders.close()
+
+    reminders = SQLitePaymentReminderRepository(db)
+    assert reminders.get(order.order_id) == current
+    assert reminders.list_method_changes(order.order_id) == (change,)
     reminders.close()
 
 

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import pytest
 
+import catering_system.ui.remote_core_client as remote_core_client
 from catering_system.ui.remote_core_client import RemoteCoreClient, RemoteCoreError
 
 _TOKEN = "test-remote-token"
@@ -99,6 +100,87 @@ def _valid_queue_body() -> dict[str, object]:
             }
         ],
     }
+
+
+def test_payment_reminder_parser_accepts_method_change_history() -> None:
+    order_id = str(uuid.uuid4())
+    change_id = str(uuid.uuid4())
+    previous = {
+        "payment_method": "RECHNUNG",
+        "invoice_created": True,
+        "invoice_number": "RE-HIST-1",
+        "sent_on": "2026-07-15",
+        "paid_on": None,
+        "cash_received": False,
+        "quittung_printed": False,
+        "updated_at": "2026-07-15T08:00:00+00:00",
+        "invoice_created_at": "2026-07-15T08:00:00+00:00",
+        "invoice_created_by": "Alice",
+        "invoice_sent_recorded_at": "2026-07-15T08:05:00+00:00",
+        "invoice_sent_recorded_by": "Alice",
+        "payment_reminder_sent_at": None,
+        "payment_reminder_sent_by": None,
+        "mahnung_sent_at": None,
+        "mahnung_sent_by": None,
+        "quittung_printed_at": None,
+        "quittung_printed_by": None,
+        "paid_recorded_at": None,
+        "paid_recorded_by": None,
+    }
+    payload = {
+        "order_id": order_id,
+        "payment_method": "BAR_VOR_ORT",
+        "payment_method_label": "Bar vor Ort",
+        "invoice_created": False,
+        "invoice_number": None,
+        "sent_on": None,
+        "due_on": None,
+        "paid_on": None,
+        "cash_received": False,
+        "quittung_printed": False,
+        "invoice_state_label": None,
+        "payment_state_label": "Offen",
+        "next_step": "Quittung vorbereiten/drucken",
+        "next_step_due_on": None,
+        "invoice_created_at": None,
+        "invoice_created_by": None,
+        "invoice_sent_recorded_at": None,
+        "invoice_sent_recorded_by": None,
+        "payment_reminder_sent_at": None,
+        "payment_reminder_sent_by": None,
+        "mahnung_sent_at": None,
+        "mahnung_sent_by": None,
+        "quittung_printed_at": None,
+        "quittung_printed_by": None,
+        "paid_recorded_at": None,
+        "paid_recorded_by": None,
+        "updated_at": "2026-07-16T09:00:00+00:00",
+        "method_changes": [
+            {
+                "change_id": change_id,
+                "from_method": "RECHNUNG",
+                "to_method": "BAR_VOR_ORT",
+                "reason": "Kunde zahlt bar",
+                "actor_reference": "Bob",
+                "changed_at": "2026-07-16T09:00:00+00:00",
+                "retired_task_title": "Zahlungseingang prüfen",
+                "previous_reminder": previous,
+            }
+        ],
+    }
+
+    parsed = remote_core_client._payment_reminder(payload, order_id)
+
+    assert parsed.payment_method == "BAR_VOR_ORT"
+    assert parsed.next_step == "Quittung vorbereiten/drucken"
+    assert len(parsed.method_changes) == 1
+    change = parsed.method_changes[0]
+    assert change.change_id == change_id
+    assert change.from_method == "RECHNUNG"
+    assert change.to_method == "BAR_VOR_ORT"
+    assert change.reason == "Kunde zahlt bar"
+    assert change.previous_reminder.invoice_number == "RE-HIST-1"
+    assert change.previous_reminder.invoice_created_by == "Alice"
 
 
 def test_queue_view_accepts_valid_payload() -> None:

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -334,6 +334,55 @@ def test_payment_task_emitted_with_overdue_urgency() -> None:
     assert payment_row.due_at == date(2026, 6, 16)
 
 
+def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    inquiry = _save_inquiry(inquiries, event_date=date(2026, 8, 1))
+    order, _version = seed_order(orders, inquiry)
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+            updated_at=_NOW,
+        )
+    )
+    payment = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: _NOW,
+        today=lambda: _TODAY,
+    )
+    before = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+    assert any(
+        row.title == "Rechnung in der Buchhaltung erstellen" for row in before
+    )
+
+    payment.change_payment_method(
+        order.order_id,
+        new_payment_method="BAR_VOR_ORT",
+        reason="Barzahlung vereinbart",
+        actor_reference="Alice",
+    )
+
+    after = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+    payment_row = next(row for row in after if row.category == "payment")
+    assert payment_row.title == "Quittung vorbereiten/drucken"
+    assert not any(
+        row.title == "Rechnung in der Buchhaltung erstellen" for row in after
+    )
+    history = payment.view(order.order_id).method_changes
+    assert history[0].retired_task_title == "Rechnung in der Buchhaltung erstellen"
+
+
 def test_sort_overdue_payment_before_verify() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -358,9 +358,7 @@ def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
         orders=orders,
         payment_reminders=reminders,
     ).list_tasks()
-    assert any(
-        row.title == "Rechnung in der Buchhaltung erstellen" for row in before
-    )
+    assert any(row.title == "Rechnung in der Buchhaltung erstellen" for row in before)
 
     payment.change_payment_method(
         order.order_id,


### PR DESCRIPTION
## Issue

Continues #201.

## What this slice does

- adds an explicit payment-method change command instead of allowing silent mutation through the payment facts form
- requires a non-empty reason for every change
- forbids direct method changes after payment completion
- allows method changes before payment even when invoice/receipt reminder facts already exist
- archives the previous payment workflow as append-only history before resetting the current workflow
- keeps the retired previous payment task title in the change history
- derives the new method's Office task immediately after the change
- persists method-change history in SQLite across restart
- exposes history through the Office API and remote client
- shows a dedicated Office form for changing the method and a visible payment-method history
- keeps current payment facts editing separate from payment-method switching

## Boundaries

- no amount/ledger
- no partial payment
- no automatic customer communication
- no accounting integration
- no payment-completion correction yet
- no Order-change document correction/cancellation slice yet
- no Courier integration (#202/#13)
