### PR TITLE
Derive payment correction and cancellation tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff tests/unit/test_payment_reminder.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff tests/unit/test_payment_reminder.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -122,15 +122,10 @@ class PaymentReminderService:
                 )
             return view
 
-        invoice_audit = [
-            timestamp
-            for timestamp in (
-                reminder.invoice_created_at,
-                reminder.invoice_sent_recorded_at,
-            )
-            if timestamp is not None
-        ]
-        if invoice_audit and latest_revision_at > max(invoice_audit):
+        invoice_recorded_at = (
+            reminder.invoice_created_at or reminder.invoice_sent_recorded_at
+        )
+        if invoice_recorded_at is not None and latest_revision_at > invoice_recorded_at:
             return replace(
                 view,
                 next_step="Rechnungskorrektur erforderlich",

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -56,17 +56,87 @@ class PaymentReminderService:
         return version.event_date
 
     def view(self, order_id: str) -> PaymentReminderView:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise KeyError(order_id)
+        reminder = self._reminders.get(order_id)
         event_date = self._event_date(order_id)
         view = derive_payment_reminder(
-            self._reminders.get(order_id),
+            reminder,
             event_date=event_date,
             today=self._today(),
         )
-        return replace(
+        view = replace(
             view,
             order_id=order_id,
             method_changes=self._reminders.list_method_changes(order_id),
         )
+        if order.cancelled_at is not None:
+            if reminder is not None and (
+                reminder.paid_on is not None or reminder.cash_received
+            ):
+                return replace(
+                    view,
+                    payment_state_label="Bezahlt · Auftrag storniert",
+                    next_step="Rückzahlung prüfen",
+                    next_step_due_on=self._local_date(order.cancelled_at),
+                )
+            return replace(
+                view,
+                payment_state_label="Entfallen · Auftrag storniert",
+                next_step=None,
+                next_step_due_on=None,
+            )
+
+        if reminder is None:
+            return view
+        revisions = [
+            version.created_at
+            for version in self._orders.list_order_versions(order_id)
+            if version.parent_order_version_id is not None
+        ]
+        if not revisions:
+            return view
+        latest_revision_at = max(revisions)
+        revision_due = self._local_date(latest_revision_at)
+
+        if (
+            reminder.paid_recorded_at is not None
+            and latest_revision_at > reminder.paid_recorded_at
+        ):
+            return replace(
+                view,
+                next_step="Zahlung nach Auftragsänderung prüfen",
+                next_step_due_on=revision_due,
+            )
+
+        if reminder.payment_method == "BAR_VOR_ORT":
+            if (
+                reminder.quittung_printed_at is not None
+                and latest_revision_at > reminder.quittung_printed_at
+            ):
+                return replace(
+                    view,
+                    next_step="Quittung neu erstellen und drucken",
+                    next_step_due_on=revision_due,
+                )
+            return view
+
+        invoice_audit = [
+            timestamp
+            for timestamp in (
+                reminder.invoice_created_at,
+                reminder.invoice_sent_recorded_at,
+            )
+            if timestamp is not None
+        ]
+        if invoice_audit and latest_revision_at > max(invoice_audit):
+            return replace(
+                view,
+                next_step="Rechnungskorrektur erforderlich",
+                next_step_due_on=revision_due,
+            )
+        return view
 
     @staticmethod
     def _actor(value: str) -> str:

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -133,36 +133,37 @@ class TaskProjectionService:
                 )
 
         for order in orders:
-            if order.cancelled_at is not None:
-                continue
             versions = self._orders.list_order_versions(order.order_id)
-            next_action = resolve_next_action(order, versions)
             linked_inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
             subtitle = _order_subtitle(linked_inquiry, order, versions)
             event_date = _order_event_date(order, versions)
-            if next_action is not None:
-                version_id = next_action["order_version_id"]
-                if next_action["action"] == "print-confirm":
-                    tasks.append(
-                        (
-                            TaskProjection(
-                                task_id=(
-                                    f"order:{order.order_id}:print-confirm:{version_id}"
+
+            if order.cancelled_at is None:
+                next_action = resolve_next_action(order, versions)
+                if next_action is not None:
+                    version_id = next_action["order_version_id"]
+                    if next_action["action"] == "print-confirm":
+                        tasks.append(
+                            (
+                                TaskProjection(
+                                    task_id=(
+                                        f"order:{order.order_id}:print-confirm:{version_id}"
+                                    ),
+                                    category="order_print",
+                                    title="Druck bestätigen",
+                                    subtitle=subtitle,
+                                    entity_type="order",
+                                    entity_id=order.order_id,
+                                    action_label="Auftrag öffnen",
+                                    action_href=f"/order/{order.order_id}",
+                                    due_at=None,
+                                    urgency="normal",
+                                    opened_at=order.created_at,
                                 ),
-                                category="order_print",
-                                title="Druck bestätigen",
-                                subtitle=subtitle,
-                                entity_type="order",
-                                entity_id=order.order_id,
-                                action_label="Auftrag öffnen",
-                                action_href=f"/order/{order.order_id}",
-                                due_at=None,
-                                urgency="normal",
-                                opened_at=order.created_at,
-                            ),
-                            event_date,
+                                event_date,
+                            )
                         )
-                    )
+
             try:
                 payment = self._payment_reminders.view(order.order_id)
             except (KeyError, ValueError):

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -534,6 +534,18 @@ def test_invoice_recorded_before_order_revision_requires_correction() -> None:
     assert view.next_step_due_on == revision.created_at.date()
     assert view.invoice_number == "RE-CORR-1"
 
+    current = orders.get_order(order_id)
+    assert current is not None
+    orders.update_order(
+        replace(
+            current,
+            effective_order_version_id=revision.order_version_id,
+            candidate_order_version_id=None,
+            updated_at=revision.created_at,
+        )
+    )
+    assert service.view(order_id).next_step == "Rechnungskorrektur erforderlich"
+
 
 def test_quittung_recorded_before_order_revision_requires_reprint() -> None:
     orders, reminders, _service = _world()

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -636,9 +636,7 @@ def test_legacy_document_without_audit_does_not_guess_revision_ordering() -> Non
 def test_cancelled_unpaid_payment_tasks_are_derived_as_entfallen() -> None:
     orders, reminders, service = _world()
     order_id = "11111111-1111-4111-8111-111111111111"
-    service.save(
-        OrderPaymentReminder(order_id=order_id, payment_method="VORKASSE")
-    )
+    service.save(OrderPaymentReminder(order_id=order_id, payment_method="VORKASSE"))
     current = orders.get_order(order_id)
     assert current is not None
     cancelled_at = datetime(2026, 7, 16, 11, 0, tzinfo=UTC)

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -54,6 +54,41 @@ def _world() -> tuple[
     return orders, reminders, service
 
 
+def _append_revision(
+    orders: InMemoryOrderRepository,
+    *,
+    created_at: datetime,
+) -> OrderVersion:
+    order_id = "11111111-1111-4111-8111-111111111111"
+    current = orders.get_order(order_id)
+    assert current is not None
+    source = orders.list_order_versions(order_id)[0]
+    revision = OrderVersion(
+        order_version_id="44444444-4444-4444-8444-444444444444",
+        order_id=order_id,
+        version_number=2,
+        created_at=created_at,
+        event_date=date(2026, 7, 21),
+        time_window_text="abends",
+        location_text="Hamburg",
+        guest_count_estimate=25,
+        planning_mode="caterer_suggestion",
+        parent_order_version_id=source.order_version_id,
+        created_by="Office",
+        change_reason="Kunde hat den Auftrag geändert",
+        changed_fields=("event_date", "guest_count_estimate"),
+    )
+    orders.append_order_version(
+        replace(
+            current,
+            candidate_order_version_id=revision.order_version_id,
+            updated_at=created_at,
+        ),
+        revision,
+    )
+    return revision
+
+
 def test_legacy_order_without_reminder_derives_selection_task() -> None:
     _orders, _reminders, service = _world()
 
@@ -466,6 +501,180 @@ def test_payment_method_change_after_payment_is_forbidden() -> None:
             reason="Zu spät bemerkt",
             actor_reference="Bob",
         )
+
+
+def test_invoice_recorded_before_order_revision_requires_correction() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    invoice_at = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: invoice_at,
+        today=lambda: date(2026, 7, 16),
+    )
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-CORR-1",
+            sent_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    revision = _append_revision(
+        orders,
+        created_at=datetime(2026, 7, 16, 10, 0, tzinfo=UTC),
+    )
+
+    view = service.view(order_id)
+
+    assert view.next_step == "Rechnungskorrektur erforderlich"
+    assert view.next_step_due_on == revision.created_at.date()
+    assert view.invoice_number == "RE-CORR-1"
+
+
+def test_quittung_recorded_before_order_revision_requires_reprint() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    printed_at = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: printed_at,
+        today=lambda: date(2026, 7, 16),
+    )
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="BAR_VOR_ORT",
+            quittung_printed=True,
+        ),
+        actor_reference="Alice",
+    )
+    revision = _append_revision(
+        orders,
+        created_at=datetime(2026, 7, 16, 10, 0, tzinfo=UTC),
+    )
+
+    view = service.view(order_id)
+
+    assert view.next_step == "Quittung neu erstellen und drucken"
+    assert view.next_step_due_on == revision.created_at.date()
+    assert view.quittung_printed is True
+
+
+def test_paid_order_revision_requires_payment_review_without_difference() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    paid_at = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: paid_at,
+        today=lambda: date(2026, 7, 16),
+    )
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-PAID-CORR-1",
+            sent_on=date(2026, 7, 10),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    revision = _append_revision(
+        orders,
+        created_at=datetime(2026, 7, 16, 10, 0, tzinfo=UTC),
+    )
+
+    view = service.view(order_id)
+
+    assert view.next_step == "Zahlung nach Auftragsänderung prüfen"
+    assert view.next_step_due_on == revision.created_at.date()
+    assert view.payment_state_label == "Bezahlt"
+
+
+def test_legacy_document_without_audit_does_not_guess_revision_ordering() -> None:
+    orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-LEGACY",
+            sent_on=date(2026, 7, 15),
+            updated_at=_NOW,
+        )
+    )
+    _append_revision(
+        orders,
+        created_at=datetime(2026, 7, 16, 10, 0, tzinfo=UTC),
+    )
+
+    view = service.view(order_id)
+
+    assert view.next_step != "Rechnungskorrektur erforderlich"
+
+
+def test_cancelled_unpaid_payment_tasks_are_derived_as_entfallen() -> None:
+    orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(
+        OrderPaymentReminder(order_id=order_id, payment_method="VORKASSE")
+    )
+    current = orders.get_order(order_id)
+    assert current is not None
+    cancelled_at = datetime(2026, 7, 16, 11, 0, tzinfo=UTC)
+    orders.update_order(
+        replace(current, cancelled_at=cancelled_at, updated_at=cancelled_at)
+    )
+
+    view = service.view(order_id)
+
+    assert view.payment_state_label == "Entfallen · Auftrag storniert"
+    assert view.next_step is None
+    assert view.next_step_due_on is None
+
+
+def test_cancelled_paid_order_requires_refund_review() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    paid_at = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: paid_at,
+        today=lambda: date(2026, 7, 16),
+    )
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-REFUND-1",
+            sent_on=date(2026, 7, 10),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    current = orders.get_order(order_id)
+    assert current is not None
+    cancelled_at = datetime(2026, 7, 16, 11, 0, tzinfo=UTC)
+    orders.update_order(
+        replace(current, cancelled_at=cancelled_at, updated_at=cancelled_at)
+    )
+
+    view = service.view(order_id)
+
+    assert view.payment_state_label == "Bezahlt · Auftrag storniert"
+    assert view.next_step == "Rückzahlung prüfen"
+    assert view.next_step_due_on == date(2026, 7, 16)
+    assert view.paid_on == date(2026, 7, 15)
 
 
 def test_cancelled_order_cannot_update_reminder() -> None:

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from tests.helpers.order_seed import seed_order
 
 from datetime import UTC, date, datetime, timedelta
@@ -379,6 +381,145 @@ def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
     )
     history = payment.view(order.order_id).method_changes
     assert history[0].retired_task_title == "Rechnung in der Buchhaltung erstellen"
+
+
+def test_order_revision_projects_invoice_correction_task() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    inquiry = _save_inquiry(inquiries, event_date=date(2026, 8, 1))
+    order, version = seed_order(orders, inquiry)
+    payment = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: _NOW,
+        today=lambda: _TODAY,
+    )
+    payment.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-CORR-TASK-1",
+            sent_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    revision_at = _NOW + timedelta(days=1)
+    revision = replace(
+        version,
+        order_version_id="99999999-9999-4999-8999-999999999991",
+        version_number=2,
+        created_at=revision_at,
+        parent_order_version_id=version.order_version_id,
+        created_by="Office",
+        change_reason="Gästezahl geändert",
+        changed_fields=("guest_count_estimate",),
+        guest_count_estimate=(version.guest_count_estimate or 0) + 5,
+    )
+    current = orders.get_order(order.order_id)
+    assert current is not None
+    orders.append_order_version(
+        replace(
+            current,
+            candidate_order_version_id=revision.order_version_id,
+            updated_at=revision_at,
+        ),
+        revision,
+    )
+
+    rows = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+
+    payment_row = next(row for row in rows if row.category == "payment")
+    assert payment_row.title == "Rechnungskorrektur erforderlich"
+    assert payment_row.due_at == revision_at.date()
+
+
+def test_cancelled_unpaid_order_retires_payment_task() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    inquiry = _save_inquiry(inquiries, event_date=date(2026, 8, 1))
+    order, _version = seed_order(orders, inquiry)
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="VORKASSE",
+            updated_at=_NOW,
+        )
+    )
+    current = orders.get_order(order.order_id)
+    assert current is not None
+    orders.update_order(
+        replace(
+            current,
+            cancelled_at=_NOW + timedelta(days=1),
+            updated_at=_NOW + timedelta(days=1),
+        )
+    )
+
+    rows = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+
+    assert not any(
+        row.category == "payment" and row.entity_id == order.order_id for row in rows
+    )
+
+
+def test_cancelled_paid_order_projects_refund_review_task() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    inquiry = _save_inquiry(inquiries, event_date=date(2026, 8, 1))
+    order, _version = seed_order(orders, inquiry)
+    payment = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: _NOW,
+        today=lambda: _TODAY,
+    )
+    payment.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-REFUND-TASK-1",
+            sent_on=date(2026, 7, 1),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    current = orders.get_order(order.order_id)
+    assert current is not None
+    cancelled_at = _NOW + timedelta(days=1)
+    orders.update_order(
+        replace(
+            current,
+            cancelled_at=cancelled_at,
+            updated_at=cancelled_at,
+        )
+    )
+
+    rows = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+
+    payment_row = next(
+        row
+        for row in rows
+        if row.category == "payment" and row.entity_id == order.order_id
+    )
+    assert payment_row.title == "Rückzahlung prüfen"
+    assert payment_row.due_at == cancelled_at.date()
 
 
 def test_sort_overdue_payment_before_verify() -> None:


### PR DESCRIPTION
## Issue

Continues #201.

## What this slice does

- derives `Rechnungskorrektur erforderlich` when an Order revision was created after the recorded invoice creation
- derives `Quittung neu erstellen und drucken` when an Order revision was created after Quittung readiness was recorded
- derives `Zahlung nach Auftragsänderung prüfen` when an already-recorded payment predates a later Order revision
- keeps those correction tasks active even after the revised OrderVersion becomes effective
- does not guess chronology for legacy document facts that lack audit timestamps
- retires unpaid cancelled payment workflows as `Entfallen · Auftrag storniert`
- derives `Rückzahlung prüfen` for cancelled Orders already marked paid
- keeps cancelled operational print tasks suppressed while allowing the refund-review payment task to remain in the Office task projection
- preserves all existing invoice/Quittung/payment facts; no amount or difference calculation is introduced

## Boundaries

- no refund calculation or execution
- no amount/difference calculation
- no invoice/receipt generation
- no automatic customer communication
- no silent payment correction
- explicit payment-completion correction with mandatory reason/history remains a separate #201 slice
- no Courier integration
