### PR TITLE
Add audited payment completion corrections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff \
-            src/catering_system/ui/remote_core_client.py \
-            tests/unit/test_office_api.py \
-            tests/unit/test_remote_core_client_reads.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff \
+            src/catering_system/ui/remote_core_client.py \
+            tests/unit/test_office_api.py \
+            tests/unit/test_remote_core_client_reads.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/domain/order_payment_reminder.py
+++ b/src/catering_system/domain/order_payment_reminder.py
@@ -60,6 +60,18 @@ class OrderPaymentReminder:
 
 
 @dataclass(frozen=True)
+class PaymentCompletionCorrection:
+    """Append-only correction of a previously recorded payment completion."""
+
+    correction_id: str
+    order_id: str
+    reason: str
+    actor_reference: str
+    corrected_at: datetime
+    previous_reminder: OrderPaymentReminder
+
+
+@dataclass(frozen=True)
 class PaymentMethodChange:
     """Append-only audit event for an explicit payment-method switch."""
 
@@ -104,6 +116,7 @@ class PaymentReminderView:
     paid_recorded_at: datetime | None = None
     paid_recorded_by: str | None = None
     method_changes: tuple[PaymentMethodChange, ...] = ()
+    payment_corrections: tuple[PaymentCompletionCorrection, ...] = ()
 
 
 def _validate_audit_pair(

--- a/src/catering_system/repositories/in_memory_payment_reminder_repository.py
+++ b/src/catering_system/repositories/in_memory_payment_reminder_repository.py
@@ -11,6 +11,7 @@ class InMemoryPaymentReminderRepository:
     def __init__(self) -> None:
         self._rows: dict[str, OrderPaymentReminder] = {}
         self._method_changes: dict[str, list[PaymentMethodChange]] = {}
+        self._payment_corrections: dict[str, list[PaymentCompletionCorrection]] = {}
 
     def get(self, order_id: str) -> OrderPaymentReminder | None:
         return self._rows.get(order_id)
@@ -28,3 +29,24 @@ class InMemoryPaymentReminderRepository:
     ) -> None:
         self._rows[reminder.order_id] = reminder
         self._method_changes.setdefault(reminder.order_id, []).append(change)
+
+    def list_payment_corrections(
+        self, order_id: str
+    ) -> tuple[PaymentCompletionCorrection, ...]:
+        return tuple(reversed(self._payment_corrections.get(order_id, [])))
+
+    def save_payment_correction(
+        self,
+        reminder: OrderPaymentReminder,
+        correction: PaymentCompletionCorrection,
+    ) -> None:
+        for rows in self._payment_corrections.values():
+            for existing in rows:
+                if existing.correction_id != correction.correction_id:
+                    continue
+                if existing == correction:
+                    self._rows[reminder.order_id] = reminder
+                    return
+                raise ValueError("payment correction id conflict")
+        self._rows[reminder.order_id] = reminder
+        self._payment_corrections.setdefault(reminder.order_id, []).append(correction)

--- a/src/catering_system/repositories/in_memory_payment_reminder_repository.py
+++ b/src/catering_system/repositories/in_memory_payment_reminder_repository.py
@@ -2,6 +2,7 @@
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethodChange,
 )
 

--- a/src/catering_system/repositories/payment_reminder_repository.py
+++ b/src/catering_system/repositories/payment_reminder_repository.py
@@ -6,6 +6,7 @@ from typing import Protocol
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethodChange,
 )
 
@@ -21,4 +22,14 @@ class PaymentReminderRepository(Protocol):
         self,
         reminder: OrderPaymentReminder,
         change: PaymentMethodChange,
+    ) -> None: ...
+
+    def list_payment_corrections(
+        self, order_id: str
+    ) -> tuple[PaymentCompletionCorrection, ...]: ...
+
+    def save_payment_correction(
+        self,
+        reminder: OrderPaymentReminder,
+        correction: PaymentCompletionCorrection,
     ) -> None: ...

--- a/src/catering_system/repositories/sqlite_payment_reminder_repository.py
+++ b/src/catering_system/repositories/sqlite_payment_reminder_repository.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethodChange,
     validate_payment_method,
 )
@@ -113,11 +114,45 @@ def _migration_4_add_payment_method_history(connection: sqlite3.Connection) -> N
     )
 
 
+def _migration_5_add_payment_completion_corrections(
+    connection: sqlite3.Connection,
+) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS order_payment_completion_corrections (
+            correction_id TEXT PRIMARY KEY,
+            order_id TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            actor_reference TEXT NOT NULL,
+            corrected_at TEXT NOT NULL,
+            previous_reminder_json TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """CREATE TRIGGER IF NOT EXISTS trg_payment_correction_owner_insert
+        BEFORE INSERT ON order_payment_completion_corrections
+        WHEN NOT EXISTS (SELECT 1 FROM orders WHERE order_id = NEW.order_id)
+        BEGIN SELECT RAISE(ABORT, 'payment correction owner does not exist'); END"""
+    )
+    connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_payment_corrections_order_corrected
+        ON order_payment_completion_corrections(order_id, corrected_at DESC)
+        """
+    )
+
+
 _MIGRATIONS = (
     (1, "create_order_payment_reminders", _migration_1_create_table),
     (2, "add_quittung_printed", _migration_2_add_quittung_printed),
     (3, "add_payment_audit_facts", _migration_3_add_audit_facts),
     (4, "add_payment_method_history", _migration_4_add_payment_method_history),
+    (
+        5,
+        "add_payment_completion_corrections",
+        _migration_5_add_payment_completion_corrections,
+    ),
 )
 
 _SELECT_COLUMNS = """
@@ -325,6 +360,41 @@ class SQLitePaymentReminderRepository:
             )
         return tuple(result)
 
+    def list_payment_corrections(
+        self, order_id: str
+    ) -> tuple[PaymentCompletionCorrection, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT
+                correction_id,
+                order_id,
+                reason,
+                actor_reference,
+                corrected_at,
+                previous_reminder_json
+            FROM order_payment_completion_corrections
+            WHERE order_id = ?
+            ORDER BY corrected_at DESC, correction_id DESC
+            """,
+            (order_id,),
+        ).fetchall()
+        result: list[PaymentCompletionCorrection] = []
+        for row in rows:
+            raw = json.loads(row[5])
+            if not isinstance(raw, dict):
+                raise ValueError("invalid payment correction history payload")
+            result.append(
+                PaymentCompletionCorrection(
+                    correction_id=row[0],
+                    order_id=row[1],
+                    reason=row[2],
+                    actor_reference=row[3],
+                    corrected_at=datetime.fromisoformat(row[4]),
+                    previous_reminder=_reminder_from_payload(raw),
+                )
+            )
+        return tuple(result)
+
     def _upsert(self, reminder: OrderPaymentReminder) -> None:
         values = (
             reminder.order_id,
@@ -453,6 +523,59 @@ class SQLitePaymentReminderRepository:
                         ensure_ascii=False,
                         sort_keys=True,
                     ),
+                ),
+            )
+            self._upsert(reminder)
+
+    def save_payment_correction(
+        self,
+        reminder: OrderPaymentReminder,
+        correction: PaymentCompletionCorrection,
+    ) -> None:
+        with self._write_scope():
+            existing = self._conn.execute(
+                """
+                SELECT order_id, reason, actor_reference, corrected_at,
+                       previous_reminder_json
+                FROM order_payment_completion_corrections
+                WHERE correction_id = ?
+                """,
+                (correction.correction_id,),
+            ).fetchone()
+            payload = json.dumps(
+                _reminder_payload(correction.previous_reminder),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            if existing is not None:
+                if existing != (
+                    correction.order_id,
+                    correction.reason,
+                    correction.actor_reference,
+                    correction.corrected_at.isoformat(),
+                    payload,
+                ):
+                    raise ValueError("payment correction id conflict")
+                self._upsert(reminder)
+                return
+            self._conn.execute(
+                """
+                INSERT INTO order_payment_completion_corrections (
+                    correction_id,
+                    order_id,
+                    reason,
+                    actor_reference,
+                    corrected_at,
+                    previous_reminder_json
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    correction.correction_id,
+                    correction.order_id,
+                    correction.reason,
+                    correction.actor_reference,
+                    correction.corrected_at.isoformat(),
+                    payload,
                 ),
             )
             self._upsert(reminder)

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethodChange,
     PaymentReminderView,
     derive_payment_reminder,
@@ -70,6 +71,7 @@ class PaymentReminderService:
             view,
             order_id=order_id,
             method_changes=self._reminders.list_method_changes(order_id),
+            payment_corrections=self._reminders.list_payment_corrections(order_id),
         )
         if order.cancelled_at is not None:
             if reminder is not None and (
@@ -303,6 +305,64 @@ class PaymentReminderService:
             return self.view(reminder.order_id)
         self._reminders.save(replace(reminder, updated_at=now))
         return self.view(reminder.order_id)
+
+    def correct_payment_completion(
+        self,
+        order_id: str,
+        *,
+        correction_id: str,
+        reason: str,
+        actor_reference: str,
+    ) -> PaymentReminderView:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise KeyError(order_id)
+
+        clean_id = correction_id.strip()
+        if not clean_id or len(clean_id) > 200:
+            raise ValueError("payment correction id is required")
+        clean_reason = reason.strip()
+        if not clean_reason or len(clean_reason) > 500:
+            raise ValueError(
+                "payment correction reason must be non-empty and at most 500 chars"
+            )
+        actor = self._actor(actor_reference)
+
+        for existing in self._reminders.list_payment_corrections(order_id):
+            if existing.correction_id != clean_id:
+                continue
+            if existing.reason != clean_reason or existing.actor_reference != actor:
+                raise ValueError("payment correction id conflict")
+            return self.view(order_id)
+
+        current = self._reminders.get(order_id)
+        if current is None:
+            raise ValueError("payment completion is not recorded")
+        if current.paid_on is None and not current.cash_received:
+            raise ValueError("payment completion is not recorded")
+
+        now = self._now()
+        if now.utcoffset() is None:
+            raise ValueError("audit clock must return timezone-aware datetime")
+        correction = PaymentCompletionCorrection(
+            correction_id=clean_id,
+            order_id=order_id,
+            reason=clean_reason,
+            actor_reference=actor,
+            corrected_at=now,
+            previous_reminder=current,
+        )
+        replacement = replace(
+            current,
+            paid_on=None,
+            cash_received=False,
+            paid_recorded_at=None,
+            paid_recorded_by=None,
+            updated_at=now,
+        )
+        validate_payment_reminder(replacement)
+        self._reminders.save_payment_correction(replacement, correction)
+        return self.view(order_id)
 
     def change_payment_method(
         self,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -3261,6 +3261,47 @@ class OfficeApi:
             "updated_at": view.updated_at.isoformat(),
         }
 
+    def cmd_payment_completion_correction(
+        self, path_ids: dict[str, str], args: dict[str, object], expect: dict
+    ) -> tuple[int, dict[str, object]]:
+        order = self._require_order(path_ids["id"])
+        current = self.payment_reminders.get(order.order_id)
+        expected_at = expect["updated_at"]
+        if expected_at is not None and not isinstance(expected_at, str):
+            raise _invalid()
+        actual_at = (
+            current.updated_at.isoformat()
+            if current is not None and current.updated_at is not None
+            else None
+        )
+        if expected_at != actual_at:
+            raise ApiError(409, "stale_state")
+        command_id = self._active_command_id
+        if command_id is None:
+            raise ApiError(500, "internal")
+        try:
+            actor_reference = (
+                _v_optional_str(args.get("actor_reference"), 200) or CLIENT_ID
+            )
+            view = self.payment_reminder_service.correct_payment_completion(
+                order.order_id,
+                correction_id=command_id,
+                reason=_v_str(args["reason"], 500),
+                actor_reference=actor_reference,
+            )
+        except ValueError as exc:
+            if str(exc) in {
+                "payment completion is not recorded",
+                "payment correction id conflict",
+            }:
+                raise ApiError(409, "payment_correction_conflict") from exc
+            raise ApiError(422, "invalid_payment_correction") from exc
+        assert view.updated_at is not None
+        return 200, {
+            "order_id": order.order_id,
+            "updated_at": view.updated_at.isoformat(),
+        }
+
     def cmd_confirmation_document(
         self, path_ids: dict[str, str], args: dict[str, object], expect: dict
     ) -> tuple[int, dict[str, object]]:
@@ -3536,6 +3577,10 @@ _PAYMENT_METHOD_CHANGE_ARGS = _ArgKeys(
     required=frozenset({"new_payment_method", "reason"}),
     optional=frozenset({"actor_reference"}),
 )
+_PAYMENT_CORRECTION_ARGS = _ArgKeys(
+    required=frozenset({"reason"}),
+    optional=frozenset({"actor_reference"}),
+)
 _CONFIRMATION_DOCUMENT_ARGS = _ArgKeys(required=frozenset({"created_by"}))
 _CONFIRMATION_DOCUMENT_SEND_ARGS = _ArgKeys(
     required=frozenset({"document_snapshot_id", "requested_by"})
@@ -3685,6 +3730,11 @@ _COMMANDS: dict[str, _CommandSpec] = {
     "payment-method": _CommandSpec(
         "cmd_payment_method_change",
         _PAYMENT_METHOD_CHANGE_ARGS,
+        {"updated_at"},
+    ),
+    "payment-correction": _CommandSpec(
+        "cmd_payment_completion_correction",
+        _PAYMENT_CORRECTION_ARGS,
         {"updated_at"},
     ),
     "confirmation-document": _CommandSpec(
@@ -4083,6 +4133,11 @@ _ROUTES: tuple[tuple[re.Pattern[str], str, dict[str, str]], ...] = (
         re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/payment-method$"),
         "/office/v1/orders/{id}/payment-method",
         {"POST": "payment-method"},
+    ),
+    (
+        re.compile(r"^/office/v1/orders/(?P<id>[^/]+)/payment-correction$"),
+        "/office/v1/orders/{id}/payment-correction",
+        {"POST": "payment-correction"},
     ),
     (
         re.compile(

--- a/src/catering_system/ui/office_api_views.py
+++ b/src/catering_system/ui/office_api_views.py
@@ -920,6 +920,18 @@ def payment_reminder_shape(view: PaymentReminderView) -> dict[str, object]:
             }
             for change in view.method_changes
         ],
+        "payment_corrections": [
+            {
+                "correction_id": correction.correction_id,
+                "reason": correction.reason,
+                "actor_reference": correction.actor_reference,
+                "corrected_at": correction.corrected_at.isoformat(),
+                "previous_reminder": _payment_reminder_fact_shape(
+                    correction.previous_reminder
+                ),
+            }
+            for correction in view.payment_corrections
+        ],
     }
 
 

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3963,14 +3963,21 @@ class OfficePanel:
                         else ""
                     ),
                     payment_correction_command_fields=(
-                        self._command_fields(
-                            {
-                                "payment_reminder_updated_at": (
-                                    payment.updated_at.isoformat()
-                                    if payment.updated_at
-                                    else ""
-                                )
-                            }
+                        (
+                            self._command_fields(
+                                {
+                                    "payment_reminder_updated_at": (
+                                        payment.updated_at.isoformat()
+                                        if payment.updated_at
+                                        else ""
+                                    )
+                                }
+                            )
+                            if self._remote is not None
+                            else (
+                                '<input type="hidden" name="_correction_id" '
+                                f'value="{_e(str(uuid4()))}">'
+                            )
                         )
                         if not cancelled and context.can("orders.payment.reminder")
                         else ""
@@ -4483,7 +4490,11 @@ class OfficePanel:
         reason = form.get("reason", "").strip()
         if not reason:
             raise ValueError("Grund für die Korrektur ist erforderlich.")
-        correction_id = form.get("_command_id", "").strip() or str(uuid4())
+        correction_id = (
+            form.get("_command_id", "").strip()
+            or form.get("_correction_id", "").strip()
+            or str(uuid4())
+        )
 
         def work() -> None:
             self.payment_reminder_service.correct_payment_completion(

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -3962,6 +3962,19 @@ class OfficePanel:
                         if not cancelled and context.can("orders.payment.reminder")
                         else ""
                     ),
+                    payment_correction_command_fields=(
+                        self._command_fields(
+                            {
+                                "payment_reminder_updated_at": (
+                                    payment.updated_at.isoformat()
+                                    if payment.updated_at
+                                    else ""
+                                )
+                            }
+                        )
+                        if not cancelled and context.can("orders.payment.reminder")
+                        else ""
+                    ),
                     confirmation_command_fields=(
                         self._command_fields(
                             {
@@ -4449,6 +4462,33 @@ class OfficePanel:
             self.payment_reminder_service.change_payment_method(
                 order_id,
                 new_payment_method=new_payment_method,
+                reason=reason,
+                actor_reference=actor_reference,
+            )
+
+        if self._remote is not None:
+            work()
+        elif self._command_executor is not None:
+            self._command_executor.run(work)
+        else:
+            work()
+
+    def correct_payment_completion(
+        self,
+        order_id: str,
+        form: dict[str, str],
+        *,
+        actor_reference: str = "office-panel",
+    ) -> None:
+        reason = form.get("reason", "").strip()
+        if not reason:
+            raise ValueError("Grund für die Korrektur ist erforderlich.")
+        correction_id = form.get("_command_id", "").strip() or str(uuid4())
+
+        def work() -> None:
+            self.payment_reminder_service.correct_payment_completion(
+                order_id,
+                correction_id=correction_id,
                 reason=reason,
                 actor_reference=actor_reference,
             )

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -2698,6 +2698,21 @@ def make_office_panel_handler(
                     self._form(),
                     actor_reference=actor_reference,
                 )
+            elif action == "payment-correction":
+                auth = self._request_auth
+                actor_reference = "office-panel"
+                if (
+                    auth is not None
+                    and auth.kind == "employee"
+                    and auth.employee is not None
+                ):
+                    account = auth.employee.account
+                    actor_reference = f"{account.display_name} [{account.id}]"
+                panel.correct_payment_completion(
+                    order_id,
+                    self._form(),
+                    actor_reference=actor_reference,
+                )
             elif action == "confirmation-document":
                 panel.prepare_confirmation_document(order_id, self._form())
             elif action == "pause":

--- a/src/catering_system/ui/office_panel_order_detail.py
+++ b/src/catering_system/ui/office_panel_order_detail.py
@@ -168,6 +168,7 @@ class OrderDetailFormFields:
     version_command_fields: str
     payment_command_fields: str
     payment_method_command_fields: str = ""
+    payment_correction_command_fields: str = ""
     confirmation_command_fields: str = ""
     print_confirm_button_labels: Mapping[str, str] = field(default_factory=dict)
     print_status_messages: Mapping[str, str] = field(default_factory=dict)
@@ -936,6 +937,59 @@ def _payment_method_change_form(
     )
 
 
+def _payment_correction_form(
+    order: Order,
+    payment: PaymentReminderView,
+    forms: OrderDetailFormFields,
+    *,
+    context: OfficePageContext,
+) -> str:
+    if (
+        order.cancelled_at is not None
+        or not context.can("orders.payment.reminder")
+        or (payment.paid_on is None and not payment.cash_received)
+    ):
+        return ""
+    return (
+        '<details class="order-payment-correction">'
+        "<summary>Zahlungsstatus korrigieren</summary>"
+        f'<form method="post" action="/order/{_e(order.order_id)}/payment-correction">'
+        f"{forms.csrf_input}{forms.payment_correction_command_fields}<fieldset>"
+        "<p>Die bisherige Zahlungsbestätigung bleibt in der Historie erhalten.</p>"
+        "<p><label>Grund*</label>"
+        '<textarea name="reason" maxlength="500" required></textarea></p>'
+        '<p><button type="submit">Zahlungsstatus korrigieren</button></p>'
+        "</fieldset></form></details>"
+    )
+
+
+def _payment_correction_history(payment: PaymentReminderView) -> str:
+    if not payment.payment_corrections:
+        return ""
+    rows: list[str] = []
+    for correction in payment.payment_corrections:
+        previous = correction.previous_reminder
+        previous_paid = (
+            previous.paid_on.strftime("%d.%m.%Y")
+            if previous.paid_on is not None
+            else "Barzahlung erfasst"
+        )
+        rows.append(
+            "<li>"
+            f"<strong>Zahlungsbestätigung korrigiert</strong>"
+            f" · {_e(correction.corrected_at.strftime('%d.%m.%Y · %H:%M'))}"
+            f" · {_e(correction.actor_reference)}"
+            f"<br>Vorher: {_e(previous_paid)}"
+            f"<br>Grund: {_e(correction.reason)}"
+            "</li>"
+        )
+    return (
+        '<details class="order-payment-correction-history">'
+        f"<summary>Zahlungskorrekturen ({len(rows)})</summary>"
+        f"<ul>{''.join(rows)}</ul></details>"
+    )
+
+
 def _payment_method_history(payment: PaymentReminderView) -> str:
     if not payment.method_changes:
         return ""
@@ -1043,7 +1097,9 @@ def _payment_card(
         f"<strong>{_e(next_step)}</strong></div>"
         + _payment_form(order, payment, forms, context=context)
         + _payment_method_change_form(order, payment, forms, context=context)
+        + _payment_correction_form(order, payment, forms, context=context)
         + _payment_method_history(payment)
+        + _payment_correction_history(payment)
         + "</section>"
     )
 

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -1184,9 +1184,7 @@ def _payment_method_change(value: object, order_id: str) -> PaymentMethodChange:
     )
 
 
-def _payment_correction(
-    value: object, order_id: str
-) -> PaymentCompletionCorrection:
+def _payment_correction(value: object, order_id: str) -> PaymentCompletionCorrection:
     data = _dict(value)
     _exact(data, _PAYMENT_CORRECTION_KEYS)
     return PaymentCompletionCorrection(

--- a/src/catering_system/ui/remote_core_client.py
+++ b/src/catering_system/ui/remote_core_client.py
@@ -86,6 +86,7 @@ from catering_system.domain.order_operational_context import (
 from catering_system.domain.order_payment_reminder import (
     PAYMENT_METHODS,
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethod,
     PaymentMethodChange,
     PaymentReminderView,
@@ -285,6 +286,8 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "order_already_paused",
             "order_not_paused",
             "already_exists",
+            "payment_method_change_conflict",
+            "payment_correction_conflict",
         }
     ),
     413: frozenset({"body_too_large"}),
@@ -298,6 +301,8 @@ _ERROR_CODES_BY_STATUS: dict[int, frozenset[str]] = {
             "kitchen_print_not_confirmed",
             "version_not_owned",
             "invalid_payment_reminder",
+            "invalid_payment_method_change",
+            "invalid_payment_correction",
             "conversion_blocked",
             "accepted_offer_required",
             "offer_blocks_conversion",
@@ -1072,6 +1077,18 @@ _PAYMENT_REMINDER_KEYS = frozenset(
         "paid_recorded_by",
         "updated_at",
         "method_changes",
+        "payment_corrections",
+    }
+)
+
+
+_PAYMENT_CORRECTION_KEYS = frozenset(
+    {
+        "correction_id",
+        "reason",
+        "actor_reference",
+        "corrected_at",
+        "previous_reminder",
     }
 )
 
@@ -1167,6 +1184,21 @@ def _payment_method_change(value: object, order_id: str) -> PaymentMethodChange:
     )
 
 
+def _payment_correction(
+    value: object, order_id: str
+) -> PaymentCompletionCorrection:
+    data = _dict(value)
+    _exact(data, _PAYMENT_CORRECTION_KEYS)
+    return PaymentCompletionCorrection(
+        correction_id=_uuid4(data["correction_id"]),
+        order_id=order_id,
+        reason=_str(data["reason"]),
+        actor_reference=_str(data["actor_reference"]),
+        corrected_at=_datetime(data["corrected_at"]),
+        previous_reminder=_payment_fact_reminder(data["previous_reminder"], order_id),
+    )
+
+
 def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
     data = _dict(value)
     _exact(data, _PAYMENT_REMINDER_KEYS)
@@ -1216,6 +1248,10 @@ def _payment_reminder(value: object, order_id: str) -> PaymentReminderView:
         method_changes=tuple(
             _payment_method_change(item, order_id)
             for item in _list(data["method_changes"])
+        ),
+        payment_corrections=tuple(
+            _payment_correction(item, order_id)
+            for item in _list(data["payment_corrections"])
         ),
     )
 
@@ -4052,6 +4088,40 @@ class _RemotePaymentReminderService:
             },
             expected={200},
             result_keys={"order_id", "updated_at"},
+        )
+        if _uuid4(result["order_id"]) != order_id:
+            _bad_response()
+        self._client._order_details.pop(order_id, None)
+        return self.view(order_id)
+
+    def correct_payment_completion(
+        self,
+        order_id: str,
+        *,
+        correction_id: str,
+        reason: str,
+        actor_reference: str,
+    ) -> PaymentReminderView:
+        current = self.view(order_id)
+        expected_at = self._client.form_value("_expect_payment_reminder_updated_at")
+        result = self._client.command(
+            f"/office/v1/orders/{quote(order_id, safe='')}/payment-correction",
+            {
+                "reason": reason,
+                "actor_reference": actor_reference,
+            },
+            {
+                "updated_at": (
+                    expected_at
+                    if expected_at
+                    else (
+                        current.updated_at.isoformat() if current.updated_at else None
+                    )
+                )
+            },
+            expected={200},
+            result_keys={"order_id", "updated_at"},
+            command_id=correction_id,
         )
         if _uuid4(result["order_id"]) != order_id:
             _bad_response()

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -1460,6 +1460,77 @@ def test_payment_method_change_requires_reason_and_preserves_history(api) -> Non
     assert (status, conflict["error"]) == (409, "payment_method_change_conflict")
 
 
+def test_payment_completion_correction_requires_reason_and_preserves_history(api) -> None:
+    base, ids, _db = api
+    order_id = ids["order_unprinted"]
+    detail_url = f"{base}/office/v1/orders/{order_id}"
+    reminder_url = f"{detail_url}/payment-reminder"
+    correction_url = f"{detail_url}/payment-correction"
+
+    status, paid, _h = _post(
+        reminder_url,
+        args={
+            "payment_method": "RECHNUNG",
+            "invoice_created": True,
+            "invoice_number": "RE-CORR-API-1",
+            "sent_on": "2026-07-01",
+            "due_on": None,
+            "paid_on": "2026-07-15",
+            "cash_received": False,
+            "actor_reference": "Alice",
+        },
+        expect={"updated_at": None},
+    )
+    assert status == 200
+
+    status, invalid, _h = _post(
+        correction_url,
+        args={"reason": "", "actor_reference": "Bob"},
+        expect={"updated_at": paid["updated_at"]},
+    )
+    assert (status, invalid["error"]) == (422, "invalid_payment_correction")
+
+    command_id = str(uuid.uuid4())
+    args = {
+        "reason": "Zahlung irrtümlich als eingegangen markiert",
+        "actor_reference": "Bob",
+    }
+    status, corrected, _h = _post(
+        correction_url,
+        args=args,
+        expect={"updated_at": paid["updated_at"]},
+        command_id=command_id,
+    )
+    assert status == 200
+    status, replay, _h = _post(
+        correction_url,
+        args=args,
+        expect={"updated_at": paid["updated_at"]},
+        command_id=command_id,
+    )
+    assert (status, replay) == (200, corrected)
+
+    status, detail, _h = _get(detail_url)
+    assert status == 200
+    payment = detail["payment_reminder"]
+    assert payment["paid_on"] is None
+    assert payment["paid_recorded_at"] is None
+    assert len(payment["payment_corrections"]) == 1
+    history = payment["payment_corrections"][0]
+    assert history["correction_id"] == command_id
+    assert history["reason"] == "Zahlung irrtümlich als eingegangen markiert"
+    assert history["actor_reference"] == "Bob"
+    assert history["previous_reminder"]["paid_on"] == "2026-07-15"
+    assert history["previous_reminder"]["paid_recorded_by"] == "Alice"
+
+    status, conflict, _h = _post(
+        correction_url,
+        args={"reason": "Noch einmal", "actor_reference": "Bob"},
+        expect={"updated_at": corrected["updated_at"]},
+    )
+    assert (status, conflict["error"]) == (409, "payment_correction_conflict")
+
+
 def test_payment_reminder_rejects_cancelled_order_and_contradictory_facts(api) -> None:
     base, ids, _db = api
     base_args = {

--- a/tests/unit/test_office_api.py
+++ b/tests/unit/test_office_api.py
@@ -1460,7 +1460,9 @@ def test_payment_method_change_requires_reason_and_preserves_history(api) -> Non
     assert (status, conflict["error"]) == (409, "payment_method_change_conflict")
 
 
-def test_payment_completion_correction_requires_reason_and_preserves_history(api) -> None:
+def test_payment_completion_correction_requires_reason_and_preserves_history(
+    api,
+) -> None:
     base, ids, _db = api
     order_id = ids["order_unprinted"]
     detail_url = f"{base}/office/v1/orders/{order_id}"

--- a/tests/unit/test_office_panel.py
+++ b/tests/unit/test_office_panel.py
@@ -2111,6 +2111,40 @@ def test_v2_order_detail_keeps_payment_separate_and_cancelled_read_only(
         assert f'action="/order/{order_id}/{action}"' not in cancelled
 
 
+def test_v2_order_detail_payment_correction_keeps_visible_history(
+    premium_panel: str,
+) -> None:
+    inquiry_id = _create_inquiry(premium_panel)
+    _set_fulfillment_mode(premium_panel, inquiry_id, "PICKUP")
+    order_id = _convert(premium_panel, inquiry_id)
+
+    _post(
+        f"{premium_panel}/order/{order_id}/payment-reminder",
+        {
+            "payment_method": "RECHNUNG",
+            "invoice_created": "1",
+            "invoice_number": "RE-UI-CORR-1",
+            "sent_on": "2026-07-01",
+            "paid_on": "2026-07-15",
+        },
+    )
+    _status, paid = _get(f"{premium_panel}/order/{order_id}")
+    assert "Zahlungsstatus korrigieren" in paid
+    assert f'action="/order/{order_id}/payment-correction"' in paid
+
+    _post(
+        f"{premium_panel}/order/{order_id}/payment-correction",
+        {"reason": "Zahlung war eine Fehleingabe"},
+    )
+    _status, corrected = _get(f"{premium_panel}/order/{order_id}")
+
+    assert "Zahlungskorrekturen (1)" in corrected
+    assert "Zahlungsbestätigung korrigiert" in corrected
+    assert "Zahlung war eine Fehleingabe" in corrected
+    assert "15.07.2026" in corrected
+    assert "Zahlungsstatus korrigieren" not in corrected
+
+
 def test_v2_order_detail_escapes_hostile_facts_and_hides_technical_values(
     premium_panel: str,
 ) -> None:

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -8,6 +8,7 @@ import pytest
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     derive_payment_reminder,
     validate_payment_reminder,
 )
@@ -623,6 +624,99 @@ def test_cash_payment_completion_correction_restores_open_cash_state() -> None:
     assert corrected.cash_received is False
     assert corrected.quittung_printed is True
     assert corrected.payment_corrections[0].previous_reminder.cash_received is True
+
+
+def test_payment_completion_correction_rejects_invalid_command_metadata() -> None:
+    orders, reminders, _service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        now=lambda: _NOW.replace(tzinfo=None),
+        today=lambda: date(2026, 7, 15),
+    )
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-META-1",
+            sent_on=date(2026, 7, 1),
+            paid_on=date(2026, 7, 15),
+            paid_recorded_at=_NOW,
+            paid_recorded_by="Alice",
+            updated_at=_NOW,
+        )
+    )
+
+    with pytest.raises(ValueError, match="id is required"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id=" ",
+            reason="Fehleingabe",
+            actor_reference="Bob",
+        )
+    with pytest.raises(ValueError, match="reason"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id="meta-1",
+            reason=" ",
+            actor_reference="Bob",
+        )
+    with pytest.raises(ValueError, match="actor_reference"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id="meta-2",
+            reason="Fehleingabe",
+            actor_reference=" ",
+        )
+    with pytest.raises(ValueError, match="timezone-aware"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id="meta-3",
+            reason="Fehleingabe",
+            actor_reference="Bob",
+        )
+
+
+def test_in_memory_payment_correction_repository_replay_and_conflict() -> None:
+    reminders = InMemoryPaymentReminderRepository()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    previous = OrderPaymentReminder(
+        order_id=order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-MEM-1",
+        sent_on=date(2026, 7, 1),
+        paid_on=date(2026, 7, 15),
+        paid_recorded_at=_NOW,
+        paid_recorded_by="Alice",
+        updated_at=_NOW,
+    )
+    current = replace(
+        previous,
+        paid_on=None,
+        paid_recorded_at=None,
+        paid_recorded_by=None,
+    )
+    correction = PaymentCompletionCorrection(
+        correction_id="mem-correction-1",
+        order_id=order_id,
+        reason="Fehleingabe",
+        actor_reference="Bob",
+        corrected_at=_NOW,
+        previous_reminder=previous,
+    )
+
+    reminders.save_payment_correction(current, correction)
+    reminders.save_payment_correction(current, correction)
+
+    assert reminders.get(order_id) == current
+    assert reminders.list_payment_corrections(order_id) == (correction,)
+
+    conflicting = replace(correction, reason="Anderer Grund")
+    with pytest.raises(ValueError, match="id conflict"):
+        reminders.save_payment_correction(current, conflicting)
 
 
 def test_invoice_recorded_before_order_revision_requires_correction() -> None:

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -503,6 +503,128 @@ def test_payment_method_change_after_payment_is_forbidden() -> None:
         )
 
 
+def test_payment_completion_correction_preserves_invoice_payment_audit() -> None:
+    _orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-CORRECT-1",
+            sent_on=date(2026, 7, 1),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    before = reminders.get(order_id)
+    assert before is not None
+    assert before.paid_recorded_at == _NOW
+    assert before.paid_recorded_by == "Alice"
+
+    corrected = service.correct_payment_completion(
+        order_id,
+        correction_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        reason="Zahlung versehentlich als eingegangen markiert",
+        actor_reference="Bob",
+    )
+
+    assert corrected.paid_on is None
+    assert corrected.cash_received is False
+    assert corrected.paid_recorded_at is None
+    assert corrected.payment_state_label != "Bezahlt"
+    assert len(corrected.payment_corrections) == 1
+    event = corrected.payment_corrections[0]
+    assert event.reason == "Zahlung versehentlich als eingegangen markiert"
+    assert event.actor_reference == "Bob"
+    assert event.corrected_at == _NOW
+    assert event.previous_reminder.paid_on == date(2026, 7, 15)
+    assert event.previous_reminder.paid_recorded_at == _NOW
+    assert event.previous_reminder.paid_recorded_by == "Alice"
+
+
+def test_payment_completion_correction_is_idempotent_by_correction_id() -> None:
+    _orders, _reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            invoice_created=True,
+            invoice_number="RE-CORRECT-2",
+            sent_on=date(2026, 7, 1),
+            paid_on=date(2026, 7, 15),
+        ),
+        actor_reference="Alice",
+    )
+    correction_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+    first = service.correct_payment_completion(
+        order_id,
+        correction_id=correction_id,
+        reason="Fehleingabe",
+        actor_reference="Bob",
+    )
+    replay = service.correct_payment_completion(
+        order_id,
+        correction_id=correction_id,
+        reason="Fehleingabe",
+        actor_reference="Bob",
+    )
+
+    assert replay == first
+    assert len(replay.payment_corrections) == 1
+
+    with pytest.raises(ValueError, match="id conflict"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id=correction_id,
+            reason="Anderer Grund",
+            actor_reference="Bob",
+        )
+
+
+def test_payment_completion_correction_requires_recorded_payment() -> None:
+    _orders, _reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(OrderPaymentReminder(order_id=order_id, payment_method="RECHNUNG"))
+
+    with pytest.raises(ValueError, match="not recorded"):
+        service.correct_payment_completion(
+            order_id,
+            correction_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            reason="Fehleingabe",
+            actor_reference="Alice",
+        )
+
+
+def test_cash_payment_completion_correction_restores_open_cash_state() -> None:
+    _orders, _reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="BAR_VOR_ORT",
+            quittung_printed=True,
+            paid_on=date(2026, 7, 15),
+            cash_received=True,
+        ),
+        actor_reference="Alice",
+    )
+
+    corrected = service.correct_payment_completion(
+        order_id,
+        correction_id="dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        reason="Barzahlung doch nicht erhalten",
+        actor_reference="Bob",
+    )
+
+    assert corrected.paid_on is None
+    assert corrected.cash_received is False
+    assert corrected.quittung_printed is True
+    assert corrected.payment_corrections[0].previous_reminder.cash_received is True
+
+
 def test_invoice_recorded_before_order_revision_requires_correction() -> None:
     orders, reminders, _service = _world()
     order_id = "11111111-1111-4111-8111-111111111111"

--- a/tests/unit/test_payment_reminder_sqlite.py
+++ b/tests/unit/test_payment_reminder_sqlite.py
@@ -155,6 +155,66 @@ def test_payment_completion_correction_survives_restart(tmp_path: Path) -> None:
     reminders.close()
 
 
+def test_sqlite_payment_correction_replay_and_conflict(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders = SQLiteOrderRepository(db)
+    order, version = _order("11111111-1111-4111-8111-111111111111")
+    orders.save_order_with_initial_version(order, version)
+    orders.close()
+
+    reminders = SQLitePaymentReminderRepository(db)
+    previous = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-CORRECTION-REPLAY",
+        sent_on=date(2026, 7, 1),
+        paid_on=date(2026, 7, 15),
+        updated_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        paid_recorded_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        paid_recorded_by="Alice",
+    )
+    current = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-CORRECTION-REPLAY",
+        sent_on=date(2026, 7, 1),
+        updated_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+    )
+    correction = PaymentCompletionCorrection(
+        correction_id="ffffffff-ffff-4fff-8fff-ffffffffffff",
+        order_id=order.order_id,
+        reason="Fehleingabe",
+        actor_reference="Bob",
+        corrected_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+        previous_reminder=previous,
+    )
+
+    reminders.save(previous)
+    reminders.save_payment_correction(current, correction)
+    reminders.save_payment_correction(current, correction)
+
+    assert reminders.get(order.order_id) == current
+    assert reminders.list_payment_corrections(order.order_id) == (correction,)
+
+    conflicting = PaymentCompletionCorrection(
+        correction_id=correction.correction_id,
+        order_id=order.order_id,
+        reason="Anderer Grund",
+        actor_reference="Bob",
+        corrected_at=correction.corrected_at,
+        previous_reminder=previous,
+    )
+    try:
+        reminders.save_payment_correction(current, conflicting)
+    except ValueError as exc:
+        assert str(exc) == "payment correction id conflict"
+    else:
+        raise AssertionError("payment correction id conflict was accepted")
+    reminders.close()
+
+
 def test_sqlite_round_trip_and_owner_constraint(tmp_path: Path) -> None:
     db = tmp_path / "core.db"
     orders = SQLiteOrderRepository(db)

--- a/tests/unit/test_payment_reminder_sqlite.py
+++ b/tests/unit/test_payment_reminder_sqlite.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_payment_reminder import (
     OrderPaymentReminder,
+    PaymentCompletionCorrection,
     PaymentMethodChange,
 )
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
@@ -97,6 +98,60 @@ def test_payment_method_history_survives_restart(tmp_path: Path) -> None:
     reminders = SQLitePaymentReminderRepository(db)
     assert reminders.get(order.order_id) == current
     assert reminders.list_method_changes(order.order_id) == (change,)
+    reminders.close()
+
+
+def test_payment_completion_correction_survives_restart(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    orders = SQLiteOrderRepository(db)
+    order, version = _order("11111111-1111-4111-8111-111111111111")
+    orders.save_order_with_initial_version(order, version)
+    orders.close()
+
+    reminders = SQLitePaymentReminderRepository(db)
+    previous = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-CORRECTION-1",
+        sent_on=date(2026, 7, 1),
+        paid_on=date(2026, 7, 15),
+        updated_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        invoice_created_at=datetime(2026, 7, 1, 8, 0, tzinfo=UTC),
+        invoice_created_by="Alice",
+        invoice_sent_recorded_at=datetime(2026, 7, 1, 8, 5, tzinfo=UTC),
+        invoice_sent_recorded_by="Alice",
+        paid_recorded_at=datetime(2026, 7, 15, 8, 0, tzinfo=UTC),
+        paid_recorded_by="Alice",
+    )
+    current = OrderPaymentReminder(
+        order_id=order.order_id,
+        payment_method="RECHNUNG",
+        invoice_created=True,
+        invoice_number="RE-CORRECTION-1",
+        sent_on=date(2026, 7, 1),
+        updated_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+        invoice_created_at=previous.invoice_created_at,
+        invoice_created_by="Alice",
+        invoice_sent_recorded_at=previous.invoice_sent_recorded_at,
+        invoice_sent_recorded_by="Alice",
+    )
+    correction = PaymentCompletionCorrection(
+        correction_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        order_id=order.order_id,
+        reason="Fehleingabe",
+        actor_reference="Bob",
+        corrected_at=datetime(2026, 7, 16, 9, 0, tzinfo=UTC),
+        previous_reminder=previous,
+    )
+
+    reminders.save(previous)
+    reminders.save_payment_correction(current, correction)
+    reminders.close()
+
+    reminders = SQLitePaymentReminderRepository(db)
+    assert reminders.get(order.order_id) == current
+    assert reminders.list_payment_corrections(order.order_id) == (correction,)
     reminders.close()
 
 

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -830,7 +830,7 @@ def test_list_tasks_accepts_valid_payload() -> None:
 
 
 def test_list_calendar_accepts_valid_payload() -> None:
-    
+
     entity_id = str(uuid.uuid4())
     inquiry_id = str(uuid.uuid4())
     payload = {

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -105,6 +105,7 @@ def _valid_queue_body() -> dict[str, object]:
 def test_payment_reminder_parser_accepts_method_change_history() -> None:
     order_id = str(uuid.uuid4())
     change_id = str(uuid.uuid4())
+    correction_id = str(uuid.uuid4())
     previous = {
         "payment_method": "RECHNUNG",
         "invoice_created": True,
@@ -167,6 +168,20 @@ def test_payment_reminder_parser_accepts_method_change_history() -> None:
                 "previous_reminder": previous,
             }
         ],
+        "payment_corrections": [
+            {
+                "correction_id": correction_id,
+                "reason": "Fehleingabe",
+                "actor_reference": "Clara",
+                "corrected_at": "2026-07-17T09:00:00+00:00",
+                "previous_reminder": {
+                    **previous,
+                    "paid_on": "2026-07-16",
+                    "paid_recorded_at": "2026-07-16T08:00:00+00:00",
+                    "paid_recorded_by": "Alice",
+                },
+            }
+        ],
     }
 
     parsed = remote_core_client._payment_reminder(payload, order_id)
@@ -181,6 +196,13 @@ def test_payment_reminder_parser_accepts_method_change_history() -> None:
     assert change.reason == "Kunde zahlt bar"
     assert change.previous_reminder.invoice_number == "RE-HIST-1"
     assert change.previous_reminder.invoice_created_by == "Alice"
+    assert len(parsed.payment_corrections) == 1
+    correction = parsed.payment_corrections[0]
+    assert correction.correction_id == correction_id
+    assert correction.reason == "Fehleingabe"
+    assert correction.actor_reference == "Clara"
+    assert correction.previous_reminder.paid_on == date(2026, 7, 16)
+    assert correction.previous_reminder.paid_recorded_by == "Alice"
 
 
 def test_queue_view_accepts_valid_payload() -> None:

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -201,7 +201,8 @@ def test_payment_reminder_parser_accepts_method_change_history() -> None:
     assert correction.correction_id == correction_id
     assert correction.reason == "Fehleingabe"
     assert correction.actor_reference == "Clara"
-    assert correction.previous_reminder.paid_on == date(2026, 7, 16)
+    assert correction.previous_reminder.paid_on is not None
+    assert correction.previous_reminder.paid_on.isoformat() == "2026-07-16"
     assert correction.previous_reminder.paid_recorded_by == "Alice"
 
 
@@ -828,8 +829,7 @@ def test_list_tasks_accepts_valid_payload() -> None:
 
 
 def test_list_calendar_accepts_valid_payload() -> None:
-    from datetime import date
-
+    
     entity_id = str(uuid.uuid4())
     inquiry_id = str(uuid.uuid4())
     payload = {

--- a/tests/unit/test_remote_core_client_reads.py
+++ b/tests/unit/test_remote_core_client_reads.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 import uuid
+from datetime import date
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import cast
 


### PR DESCRIPTION
## Issue

Continues #201.

## What this slice does

- adds an explicit payment-completion correction command
- requires a non-empty correction reason
- preserves the previous paid snapshot append-only, including paid_on, paid_recorded_at/by and cash custody fact
- clears only the current payment-completion projection after the correction
- keeps invoice/Quittung/reminder facts intact
- supports Rechnung and BAR corrections
- uses correction/command identity for replay-safe idempotency and explicit conflicts
- persists correction history in SQLite across restart
- exposes correction history through Office API and remote client
- adds a dedicated Office form and visible correction history
- keeps ordinary payment save unable to silently clear a recorded payment

## Boundaries

- no amount/difference calculation
- no refund execution
- no partial payment
- no automatic customer communication
- no accounting integration
- final Rechnung-after-fulfilment timing is a separate #201 slice
- no Courier integration
