### PR TITLE
Schedule final Rechnung after fulfilment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff src/catering_system/services/payment_reminder_service.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff src/catering_system/services/payment_reminder_service.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -56,6 +56,41 @@ class PaymentReminderService:
             raise ValueError("order has no event date")
         return version.event_date
 
+    def _fulfilment_date(self, order_id: str) -> date:
+        order = self._orders.get_order(order_id)
+        if order is None:
+            raise KeyError(order_id)
+        versions = self._orders.list_order_versions(order_id)
+        version = None
+        for preferred_id in (
+            order.effective_order_version_id,
+            order.candidate_order_version_id,
+        ):
+            if preferred_id is None:
+                continue
+            version = next(
+                (
+                    item
+                    for item in versions
+                    if item.order_version_id == preferred_id
+                ),
+                None,
+            )
+            if version is not None:
+                break
+        if version is None:
+            version = max(versions, key=lambda item: item.version_number, default=None)
+        if version is None:
+            raise ValueError("order has no fulfilment date")
+        return version.delivery_date_local or version.event_date
+
+    @staticmethod
+    def _next_working_day(day: date) -> date:
+        candidate = day + timedelta(days=1)
+        while candidate.weekday() >= 5:
+            candidate += timedelta(days=1)
+        return candidate
+
     def view(self, order_id: str) -> PaymentReminderView:
         order = self._orders.get_order(order_id)
         if order is None:
@@ -92,6 +127,15 @@ class PaymentReminderService:
 
         if reminder is None:
             return view
+        if reminder.payment_method == "RECHNUNG" and not reminder.invoice_created:
+            fulfilment_date = self._fulfilment_date(order_id)
+            if self._today() <= fulfilment_date:
+                return replace(view, next_step=None, next_step_due_on=None)
+            return replace(
+                view,
+                next_step="Rechnung in der Buchhaltung erstellen",
+                next_step_due_on=self._next_working_day(fulfilment_date),
+            )
         revisions = [
             version.created_at
             for version in self._orders.list_order_versions(order_id)
@@ -401,11 +445,7 @@ class PaymentReminderService:
         now = self._now()
         if now.utcoffset() is None:
             raise ValueError("audit clock must return timezone-aware datetime")
-        previous_view = derive_payment_reminder(
-            current,
-            event_date=self._event_date(order_id),
-            today=self._today(),
-        )
+        previous_view = self.view(order_id)
         change = PaymentMethodChange(
             change_id=str(uuid4()),
             order_id=order_id,

--- a/src/catering_system/services/payment_reminder_service.py
+++ b/src/catering_system/services/payment_reminder_service.py
@@ -69,11 +69,7 @@ class PaymentReminderService:
             if preferred_id is None:
                 continue
             version = next(
-                (
-                    item
-                    for item in versions
-                    if item.order_version_id == preferred_id
-                ),
+                (item for item in versions if item.order_version_id == preferred_id),
                 None,
             )
             if version is not None:

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -504,6 +504,116 @@ def test_payment_method_change_after_payment_is_forbidden() -> None:
         )
 
 
+def test_rechnung_invoice_task_starts_only_after_fulfilment_date() -> None:
+    _orders, reminders, service = _world()
+    order_id = "11111111-1111-4111-8111-111111111111"
+    service.save(OrderPaymentReminder(order_id=order_id, payment_method="RECHNUNG"))
+
+    before = service.view(order_id)
+    assert before.next_step is None
+    assert before.next_step_due_on is None
+
+    after_service = PaymentReminderService(
+        reminders,
+        _orders,
+        now=lambda: datetime(2026, 7, 21, 8, 0, tzinfo=UTC),
+        today=lambda: date(2026, 7, 21),
+    )
+    after = after_service.view(order_id)
+    assert after.next_step == "Rechnung in der Buchhaltung erstellen"
+    assert after.next_step_due_on == date(2026, 7, 21)
+
+
+def test_rechnung_invoice_due_skips_weekend() -> None:
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    order_id = "12121212-1212-4121-8121-121212121212"
+    created = datetime(2026, 7, 10, 8, 0, tzinfo=UTC)
+    order = Order(
+        order_id=order_id,
+        source_inquiry_id="22222222-2222-4222-8222-222222222222",
+        created_at=created,
+        updated_at=created,
+    )
+    version = OrderVersion(
+        order_version_id="34343434-3434-4343-8343-343434343434",
+        order_id=order_id,
+        version_number=1,
+        created_at=created,
+        event_date=date(2026, 7, 17),
+        time_window_text="abends",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+    )
+    orders.save_order_with_initial_version(order, version)
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            updated_at=created,
+        )
+    )
+    service = PaymentReminderService(
+        reminders,
+        orders,
+        today=lambda: date(2026, 7, 18),
+    )
+
+    view = service.view(order_id)
+
+    assert view.next_step == "Rechnung in der Buchhaltung erstellen"
+    assert view.next_step_due_on == date(2026, 7, 20)
+
+
+def test_rechnung_uses_delivery_date_when_it_is_later_than_event_date() -> None:
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    order_id = "56565656-5656-4565-8565-565656565656"
+    created = datetime(2026, 7, 10, 8, 0, tzinfo=UTC)
+    order = Order(
+        order_id=order_id,
+        source_inquiry_id="22222222-2222-4222-8222-222222222222",
+        created_at=created,
+        updated_at=created,
+    )
+    version = OrderVersion(
+        order_version_id="78787878-7878-4787-8787-787878787878",
+        order_id=order_id,
+        version_number=1,
+        created_at=created,
+        event_date=date(2026, 7, 20),
+        time_window_text="abends",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+        delivery_date_local=date(2026, 7, 22),
+    )
+    orders.save_order_with_initial_version(order, version)
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order_id,
+            payment_method="RECHNUNG",
+            updated_at=created,
+        )
+    )
+
+    before = PaymentReminderService(
+        reminders,
+        orders,
+        today=lambda: date(2026, 7, 21),
+    ).view(order_id)
+    assert before.next_step is None
+
+    after = PaymentReminderService(
+        reminders,
+        orders,
+        today=lambda: date(2026, 7, 23),
+    ).view(order_id)
+    assert after.next_step == "Rechnung in der Buchhaltung erstellen"
+    assert after.next_step_due_on == date(2026, 7, 23)
+
+
 def test_payment_completion_correction_preserves_invoice_payment_audit() -> None:
     _orders, reminders, service = _world()
     order_id = "11111111-1111-4111-8111-111111111111"

--- a/tests/unit/test_payment_reminder.py
+++ b/tests/unit/test_payment_reminder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
 
 import pytest
 
@@ -588,6 +588,8 @@ def test_rechnung_uses_delivery_date_when_it_is_later_than_event_date() -> None:
         guest_count_estimate=20,
         planning_mode="caterer_suggestion",
         delivery_date_local=date(2026, 7, 22),
+        delivery_window_start_local=time(17, 0),
+        delivery_window_end_local=time(19, 0),
     )
     orders.save_order_with_initial_version(order, version)
     reminders.save(

--- a/tests/unit/test_task_projection.py
+++ b/tests/unit/test_task_projection.py
@@ -336,6 +336,32 @@ def test_payment_task_emitted_with_overdue_urgency() -> None:
     assert payment_row.due_at == date(2026, 6, 16)
 
 
+def test_rechnung_task_is_projected_only_after_fulfilment() -> None:
+    inquiries = InMemoryInquiryRepository()
+    orders = InMemoryOrderRepository()
+    reminders = InMemoryPaymentReminderRepository()
+    inquiry = _save_inquiry(inquiries, event_date=date(2026, 7, 14))
+    order, _version = seed_order(orders, inquiry)
+    reminders.save(
+        OrderPaymentReminder(
+            order_id=order.order_id,
+            payment_method="RECHNUNG",
+            updated_at=_NOW,
+        )
+    )
+
+    rows = _service(
+        inquiries=inquiries,
+        orders=orders,
+        payment_reminders=reminders,
+    ).list_tasks()
+
+    payment_row = next(row for row in rows if row.category == "payment")
+    assert payment_row.title == "Rechnung in der Buchhaltung erstellen"
+    assert payment_row.due_at == date(2026, 7, 15)
+    assert payment_row.urgency == "normal"
+
+
 def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
     inquiries = InMemoryInquiryRepository()
     orders = InMemoryOrderRepository()
@@ -360,7 +386,7 @@ def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
         orders=orders,
         payment_reminders=reminders,
     ).list_tasks()
-    assert any(row.title == "Rechnung in der Buchhaltung erstellen" for row in before)
+    assert not any(row.category == "payment" for row in before)
 
     payment.change_payment_method(
         order.order_id,
@@ -380,7 +406,7 @@ def test_payment_method_change_retires_old_task_and_projects_new_one() -> None:
         row.title == "Rechnung in der Buchhaltung erstellen" for row in after
     )
     history = payment.view(order.order_id).method_changes
-    assert history[0].retired_task_title == "Rechnung in der Buchhaltung erstellen"
+    assert history[0].retired_task_title is None
 
 
 def test_order_revision_projects_invoice_correction_task() -> None:


### PR DESCRIPTION
## Issue

Completes the remaining Rechnung timing slice of #201.

## What this slice does

- suppresses the final `RECHNUNG` invoice-creation task before the fulfilment date
- starts `Rechnung in der Buchhaltung erstellen` only after fulfilment
- makes that Office task due on the next Monday-Friday working day
- uses `delivery_date_local` as the fulfilment date when present, otherwise the Order event date
- keeps an overdue invoice-creation task visible until the external invoice fact is recorded
- keeps payment escalation after invoice send unchanged: payment due remains sent_on + 14 calendar days
- archives only the payment task actually visible to Office when the payment method is changed

## Truth boundary

Core has no separate fulfilled_at/completed event today. This slice therefore uses the resolved service date as the narrow deterministic fulfilment boundary and does not invent a delivery/completion fact.

## Boundaries

- no invoice generation
- no automatic send
- no accounting integration
- no holiday-calendar dependency; Office working day is Monday-Friday
- no Courier integration
