### PR TITLE
Freeze Courier cash handoff contract V1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff \
-            tests/helpers/courier_cash_handoff_contract.py \
-            tests/unit/test_issue202_courier_cash_handoff_contract.py
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff \
+            tests/helpers/courier_cash_handoff_contract.py \
+            tests/unit/test_issue202_courier_cash_handoff_contract.py
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/docs/api/kiosk-order-feed.md
+++ b/docs/api/kiosk-order-feed.md
@@ -1,8 +1,11 @@
 # Kiosk order feed API
 
 The kitchen kiosk exposes one read-only JSON route so the separate courier
-app (Tourenplanung) can list the released orders of a given date. The courier
-app talks only to the kiosk; Core keeps exactly one reader.
+app (Tourenplanung) can list the released orders of a given date. Planning
+reads continue to go only through Kiosk. Issue #202 deliberately introduces a
+separate exception for authenticated cash **writes**: the Courier backend will
+write directly to a dedicated Core machine endpoint. Kiosk itself remains
+strictly read-only and is not a write relay.
 
 The original route/selection contract is frozen in
 [KIOSK_ORDER_FEED_PACK_V1](../archive/packs/KIOSK_ORDER_FEED_PACK_V1.md).
@@ -10,6 +13,24 @@ Issue #171 evolves the order payload with the explicit planning-only extension
 [KIOSK_ORDER_FEED_RETURN_LOGISTICS_V2](../proposals/KIOSK_ORDER_FEED_RETURN_LOGISTICS_V2.md).
 Issue #175 adds canonical local planning timing in
 [KIOSK_ORDER_FEED_LOGISTICS_TIMING_V3](../proposals/KIOSK_ORDER_FEED_LOGISTICS_TIMING_V3.md).
+
+Issue #202 freezes the next additive BAR execution projection plus the separate
+authenticated Courier -> Core write contract in
+[COURIER_CASH_HANDOFF_CONTRACT_V1](../contracts/courier-cash-handoff-v1/README.md).
+The current runtime does **not** project `cash_handoff` yet. Until the rollout
+slice is deployed, its absence explicitly means that Courier must hide all BAR
+execution actions rather than infer payment or Quittung state.
+
+When rolled out, each order gains an additive `cash_handoff` field:
+
+- absent: producer has not enabled contract V1;
+- `null`: contract enabled, current Order does not require BAR execution;
+- object: frozen V1 object with `bar_required=true`,
+  `quittung_status`, immutable effective `order_version_id` and opaque
+  `cash_execution_context_id`.
+
+No amount, price, billing data, invoice/Quittung contents or PDF crosses that
+extension. The write route belongs to Core, not this Kiosk server.
 
 ## Route
 
@@ -92,9 +113,13 @@ count.
 without deliveries. Ordering remains deterministic: `(time_window_text,
 order_id)`.
 
-No version numbers, planning mode, or direct customer identity/contact fields
-are exposed. The payload is still sensitive operational data (event addresses,
-dates, time windows): keep it out of logs, chats, and screenshots.
+The current V3 runtime exposes no version numbers, planning mode, or direct
+customer identity/contact fields. The #202 rollout adds only the immutable
+`order_version_id` inside the narrow `cash_handoff` object because stale
+execution must be rejected explicitly; it does not expose the human numeric
+version or any additional customer data. The payload remains sensitive
+operational data (event addresses, dates, time windows): keep it out of logs,
+chats, and screenshots.
 
 ## Selection semantics
 

--- a/docs/contracts/courier-cash-handoff-v1/README.md
+++ b/docs/contracts/courier-cash-handoff-v1/README.md
@@ -1,0 +1,217 @@
+# COURIER_CASH_HANDOFF_CONTRACT_V1
+
+Status: **FROZEN** for Core issue #202.
+
+Contract version: `courier-cash-handoff-v1`
+
+This pack freezes the smallest cross-repository contract for BAR execution
+between Silberlöffel Core/Kiosk and Courier App. It deliberately does not
+implement the complete Courier UI or accounting. The implementation consumer
+is `courier-app#13`.
+
+## 1. Topology decision
+
+The previous Kiosk order-feed decision said Courier App never talks to Core
+directly. Issue #202 revisits that rule only for machine writes.
+
+1. Planning/read direction stays Courier -> private Kiosk
+   `GET /api/order-feed`.
+2. Cash execution writes go from the Courier backend directly to Core:
+   `POST /machine/v1/courier/cash-events`.
+3. **Kiosk remains strictly read-only.** It is not a write relay and stores no
+   Courier execution state.
+4. Core remains source of truth for payment workflow/audit. Courier owns
+   assignment UI and its immutable `assignment_id`.
+
+Routing writes through Kiosk was rejected because it would destroy the Kiosk's
+strongest safety property: no write surface.
+
+## 2. Kiosk -> Courier projection
+
+The existing order-feed gets one additive order field `cash_handoff`.
+
+- field absent: producer has not rolled out this contract; hide cash actions;
+- field present as `null`: contract available, Order is not BAR;
+- field present as object: BAR execution context exists.
+
+The object is frozen by `order-feed-cash-handoff.schema.json`:
+
+```json
+{
+  "contract_version": "courier-cash-handoff-v1",
+  "bar_required": true,
+  "quittung_status": "PRINTED_CURRENT",
+  "order_version_id": "11111111-1111-4111-8111-111111111111",
+  "cash_execution_context_id": "22222222-2222-4222-8222-222222222222"
+}
+```
+
+`PRINTED_CURRENT` means the external Quittung readiness fact belongs to the
+current BAR/effective-OrderVersion context. A later effective Order revision,
+payment-method change, Quittung reprint or privileged correction makes the old
+context stale.
+
+`cash_execution_context_id` is an opaque immutable UUID minted by Core for
+one execution-relevant BAR context. It changes when payment method,
+effective OrderVersion or Quittung readiness/currentness changes. It does not
+change merely because custody advances through the same context.
+
+Courier must not enable customer cash completion while
+`quittung_status=NOT_READY`.
+
+No amount, billing, invoice contents, document/PDF, price or accounting data
+crosses this projection.
+
+## 3. Courier -> Core command
+
+```http
+POST /machine/v1/courier/cash-events
+Authorization: Bearer <dedicated service token>
+Content-Type: application/json
+```
+
+No query parameters. Request exact field set is frozen in
+`cash-event-command.schema.json`.
+
+Every event carries contract version, idempotency key, Order identity,
+Courier-owned assignment identity, effective OrderVersion identity,
+cash execution context identity, actor identity/role and occurred-at time.
+
+`occurred_at` is audit provenance. Server `recorded_at`, transaction order
+and state preconditions decide current Core truth. A client timestamp never
+wins a race.
+
+## 4. Frozen event types
+
+### BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER
+Actor `DRIVER`. READY -> `DRIVER_CUSTODY`. **Not final payment.**
+
+### BAR_NOT_RECEIVED
+Actor `DRIVER` or `CHEF`. Exactly one reason:
+`CUSTOMER_NOT_FOUND`, `CUSTOMER_COULD_NOT_PAY`,
+`AMOUNT_NOT_ACCEPTABLE`, `OTHER`.
+
+`OTHER` requires a non-empty note. Other reasons require `note=null`.
+The reason code `AMOUNT_NOT_ACCEPTABLE` carries no numeric amount.
+
+Result `NOT_RECEIVED`; Core stays unpaid and projects urgent
+`Barzahlung klären`.
+
+### BAR_HANDED_TO_CHEF
+Actor `DRIVER`. `DRIVER_CUSTODY` ->
+`AWAITING_CHEF_CONFIRMATION`. Still not final payment.
+
+### BAR_RECEIVED_FROM_DRIVER_BY_CHEF
+Actor `CHEF`. `AWAITING_CHEF_CONFIRMATION` -> `FINAL_PAID`.
+This distinct chef confirmation is required for delivery cash.
+
+### BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER
+Actor `CHEF`, pickup/direct chef path only.
+READY -> `FINAL_PAID` without driver custody.
+
+### BAR_HANDOFF_CORRECTION
+Actor `CHEF` or `OFFICE`. Requires
+`correction_of_idempotency_key` and mandatory `correction_reason`.
+Original event remains immutable/auditable. Current cash state becomes
+`MANUAL_REVIEW_REQUIRED`. If the corrected event established final payment,
+Core also uses the existing #201 audited payment-completion correction.
+Drivers cannot correct/delete events.
+
+Machine transition source: `transition-table.json`.
+
+## 5. Authentication
+
+Dedicated Core service token, separate from Courier user/phone tokens and the
+Kiosk pickup-signal token.
+
+Implementation requirements:
+
+- token from mode-0600 service environment file;
+- constant-time bearer comparison;
+- route returns 404 when no server-side token is configured;
+- once configured, missing/malformed/wrong bearer always returns the same
+  `401 {"error":"unauthorized"}`;
+- authenticate before body/schema validation;
+- token never accepted in URL/query/body;
+- Authorization and request bodies never logged;
+- `Cache-Control: no-store` and `X-Content-Type-Options: nosniff`.
+
+LAN/Tailscale is defence in depth, not authentication.
+
+## 6. Replay, ordering and concurrency
+
+- exact version `courier-cash-handoff-v1`;
+- exact JSON field sets, unknown fields rejected;
+- maximum request body 16 KiB;
+- globally unique `idempotency_key`;
+- first accepted command stores request fingerprint and exact success response;
+- identical replay returns the **same persisted success response**;
+- same key with different canonical request -> 409
+  `{"error":"idempotency_conflict"}`;
+- stale OrderVersion -> 409 `{"error":"stale_order_revision"}`;
+- stale cash context -> 409 `{"error":"stale_cash_context"}`;
+- out-of-order state -> 409 `{"error":"invalid_transition"}`;
+- concurrent commands are serialized transactionally; first valid transition
+  wins and every loser is re-evaluated against resulting state.
+
+Stale revision/context conflicts before mutation.
+
+## 7. Responses
+
+Frozen by `cash-event-response.schema.json`.
+
+Success contains only contract version, immutable Core event id, idempotency
+key, Order id, resulting cash state and server recorded-at.
+
+Error codes:
+- 401 `unauthorized`
+- 400 `invalid_request`
+- 400 `unsupported_contract_version`
+- 409 `idempotency_conflict`
+- 409 `stale_order_revision`
+- 409 `stale_cash_context`
+- 409 `invalid_transition`
+- 503 `core_unavailable`
+
+Error bodies do not echo request fields.
+
+## 8. Failure behaviour
+
+Kiosk unavailable: unavailable feed is not an empty day. No cash context is
+invented and no cash action is enabled.
+
+Core write unavailable/timeout: Courier must **not** display the event as saved
+and must not advance authoritative local cash state. Physical reality may
+already have happened, so UI stays explicitly unsaved/retryable and retries
+use the same idempotency key.
+
+Courier unavailable: Core keeps current truth and invents no Courier event.
+
+## 9. Rollout and compatibility
+
+1. Merge/freeze this contract pack.
+2. Implement Core journal/state machine/machine endpoint dormant until token.
+3. Deploy Courier support that tolerates absent `cash_handoff` and hides cash
+   actions when absent/unsupported.
+4. Add Kiosk `cash_handoff` projection. Existing Courier parser reads named
+   fields and ignores unknown top-level order keys, so old Courier remains
+   compatible.
+5. Configure Core write token/URL.
+6. Enable Courier cash UI from `courier-app#13`.
+
+Rollback before step 6 is safe: absent context disables actions. Unknown/stale
+context is never guessed current.
+
+## 10. Non-goals
+
+No amount/paid-amount, cents, price, ledger, balance/difference, partial
+payment, invoice/receipt/PDF transport/generation, accounting API, automatic
+customer communication, customer billing expansion, Kiosk write relay, or
+complete Office/Courier UI.
+
+## 11. Shared assets
+
+Both repositories must test the same semantics from this directory:
+schemas, transition table and `fixtures.json`. Courier may vendor the fixture
+pack verbatim in its implementation PR. Any semantic change requires a new
+contract version.

--- a/docs/contracts/courier-cash-handoff-v1/cash-event-command.schema.json
+++ b/docs/contracts/courier-cash-handoff-v1/cash-event-command.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silberloeffel.local/contracts/courier-cash-handoff-v1/cash-event-command.schema.json",
+  "title": "Courier cash event command V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "idempotency_key",
+    "event_type",
+    "order_id",
+    "assignment_id",
+    "order_version_id",
+    "cash_execution_context_id",
+    "actor_id",
+    "actor_role",
+    "occurred_at",
+    "not_received_reason",
+    "note",
+    "correction_reason",
+    "correction_of_idempotency_key"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "courier-cash-handoff-v1"
+    },
+    "idempotency_key": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "event_type": {
+      "enum": [
+        "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+        "BAR_NOT_RECEIVED",
+        "BAR_HANDED_TO_CHEF",
+        "BAR_RECEIVED_FROM_DRIVER_BY_CHEF",
+        "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+        "BAR_HANDOFF_CORRECTION"
+      ]
+    },
+    "order_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "assignment_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "order_version_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "cash_execution_context_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "actor_role": {
+      "enum": [
+        "DRIVER",
+        "CHEF",
+        "OFFICE"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "not_received_reason": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        null,
+        "CUSTOMER_NOT_FOUND",
+        "CUSTOMER_COULD_NOT_PAY",
+        "AMOUNT_NOT_ACCEPTABLE",
+        "OTHER"
+      ]
+    },
+    "note": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "correction_reason": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "correction_of_idempotency_key": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uuid"
+    }
+  }
+}

--- a/docs/contracts/courier-cash-handoff-v1/cash-event-response.schema.json
+++ b/docs/contracts/courier-cash-handoff-v1/cash-event-response.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silberloeffel.local/contracts/courier-cash-handoff-v1/cash-event-response.schema.json",
+  "title": "Courier cash event response V1",
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_version",
+        "event_id",
+        "idempotency_key",
+        "order_id",
+        "cash_state",
+        "recorded_at"
+      ],
+      "properties": {
+        "contract_version": {
+          "const": "courier-cash-handoff-v1"
+        },
+        "event_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "idempotency_key": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "order_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "cash_state": {
+          "enum": [
+            "READY_FOR_CUSTOMER_HANDOFF",
+            "DRIVER_CUSTODY",
+            "AWAITING_CHEF_CONFIRMATION",
+            "FINAL_PAID",
+            "NOT_RECEIVED",
+            "MANUAL_REVIEW_REQUIRED"
+          ]
+        },
+        "recorded_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "error"
+      ],
+      "properties": {
+        "error": {
+          "enum": [
+            "unauthorized",
+            "invalid_request",
+            "unsupported_contract_version",
+            "idempotency_conflict",
+            "stale_order_revision",
+            "stale_cash_context",
+            "invalid_transition",
+            "core_unavailable"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/contracts/courier-cash-handoff-v1/fixtures.json
+++ b/docs/contracts/courier-cash-handoff-v1/fixtures.json
@@ -1,0 +1,136 @@
+{
+  "contract_version": "courier-cash-handoff-v1",
+  "projection": {
+    "bar_ready": {
+      "contract_version": "courier-cash-handoff-v1",
+      "bar_required": true,
+      "quittung_status": "PRINTED_CURRENT",
+      "order_version_id": "11111111-1111-4111-8111-111111111111",
+      "cash_execution_context_id": "22222222-2222-4222-8222-222222222222"
+    },
+    "bar_not_ready": {
+      "contract_version": "courier-cash-handoff-v1",
+      "bar_required": true,
+      "quittung_status": "NOT_READY",
+      "order_version_id": "11111111-1111-4111-8111-111111111111",
+      "cash_execution_context_id": "33333333-3333-4333-8333-333333333333"
+    }
+  },
+  "commands": {
+    "driver_received": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000001",
+      "event_type": "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "assignment_id": "60000000-0000-4000-8000-000000000001",
+      "order_version_id": "70000000-0000-4000-8000-000000000001",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+      "actor_id": "driver-17",
+      "actor_role": "DRIVER",
+      "occurred_at": "2026-08-31T09:00:00+00:00",
+      "not_received_reason": null,
+      "note": null,
+      "correction_reason": null,
+      "correction_of_idempotency_key": null
+    },
+    "not_received_other": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000002",
+      "event_type": "BAR_NOT_RECEIVED",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "assignment_id": "60000000-0000-4000-8000-000000000001",
+      "order_version_id": "70000000-0000-4000-8000-000000000001",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+      "actor_id": "driver-17",
+      "actor_role": "DRIVER",
+      "occurred_at": "2026-08-31T09:05:00+00:00",
+      "not_received_reason": "OTHER",
+      "note": "Kunde verweist an Büro",
+      "correction_reason": null,
+      "correction_of_idempotency_key": null
+    },
+    "driver_handoff": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000003",
+      "event_type": "BAR_HANDED_TO_CHEF",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "assignment_id": "60000000-0000-4000-8000-000000000001",
+      "order_version_id": "70000000-0000-4000-8000-000000000001",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+      "actor_id": "driver-17",
+      "actor_role": "DRIVER",
+      "occurred_at": "2026-08-31T11:00:00+00:00",
+      "not_received_reason": null,
+      "note": null,
+      "correction_reason": null,
+      "correction_of_idempotency_key": null
+    },
+    "chef_confirm": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000004",
+      "event_type": "BAR_RECEIVED_FROM_DRIVER_BY_CHEF",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "assignment_id": "60000000-0000-4000-8000-000000000001",
+      "order_version_id": "70000000-0000-4000-8000-000000000001",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+      "actor_id": "chef-2",
+      "actor_role": "CHEF",
+      "occurred_at": "2026-08-31T11:02:00+00:00",
+      "not_received_reason": null,
+      "note": null,
+      "correction_reason": null,
+      "correction_of_idempotency_key": null
+    },
+    "pickup_chef": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000005",
+      "event_type": "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+      "order_id": "50000000-0000-4000-8000-000000000002",
+      "assignment_id": "60000000-0000-4000-8000-000000000002",
+      "order_version_id": "70000000-0000-4000-8000-000000000002",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000002",
+      "actor_id": "chef-2",
+      "actor_role": "CHEF",
+      "occurred_at": "2026-08-31T12:00:00+00:00",
+      "not_received_reason": null,
+      "note": null,
+      "correction_reason": null,
+      "correction_of_idempotency_key": null
+    },
+    "correction": {
+      "contract_version": "courier-cash-handoff-v1",
+      "idempotency_key": "40000000-0000-4000-8000-000000000006",
+      "event_type": "BAR_HANDOFF_CORRECTION",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "assignment_id": "60000000-0000-4000-8000-000000000001",
+      "order_version_id": "70000000-0000-4000-8000-000000000001",
+      "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+      "actor_id": "chef-2",
+      "actor_role": "CHEF",
+      "occurred_at": "2026-08-31T11:10:00+00:00",
+      "not_received_reason": null,
+      "note": null,
+      "correction_reason": "Falsche Übergabe bestätigt",
+      "correction_of_idempotency_key": "40000000-0000-4000-8000-000000000004"
+    }
+  },
+  "responses": {
+    "driver_custody": {
+      "contract_version": "courier-cash-handoff-v1",
+      "event_id": "90000000-0000-4000-8000-000000000001",
+      "idempotency_key": "40000000-0000-4000-8000-000000000001",
+      "order_id": "50000000-0000-4000-8000-000000000001",
+      "cash_state": "DRIVER_CUSTODY",
+      "recorded_at": "2026-08-31T09:00:01+00:00"
+    },
+    "stale_context": {
+      "error": "stale_cash_context"
+    },
+    "unauthorized": {
+      "error": "unauthorized"
+    },
+    "unavailable": {
+      "error": "core_unavailable"
+    }
+  }
+}

--- a/docs/contracts/courier-cash-handoff-v1/order-feed-cash-handoff.schema.json
+++ b/docs/contracts/courier-cash-handoff-v1/order-feed-cash-handoff.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://silberloeffel.local/contracts/courier-cash-handoff-v1/order-feed-cash-handoff.schema.json",
+  "title": "Courier cash handoff order-feed projection V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "bar_required",
+    "quittung_status",
+    "order_version_id",
+    "cash_execution_context_id"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "courier-cash-handoff-v1"
+    },
+    "bar_required": {
+      "const": true
+    },
+    "quittung_status": {
+      "enum": [
+        "PRINTED_CURRENT",
+        "NOT_READY"
+      ]
+    },
+    "order_version_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "cash_execution_context_id": {
+      "type": "string",
+      "format": "uuid"
+    }
+  }
+}

--- a/docs/contracts/courier-cash-handoff-v1/transition-table.json
+++ b/docs/contracts/courier-cash-handoff-v1/transition-table.json
@@ -1,0 +1,82 @@
+{
+  "contract_version": "courier-cash-handoff-v1",
+  "transitions": [
+    {
+      "from_states": [
+        "READY_FOR_CUSTOMER_HANDOFF"
+      ],
+      "event_type": "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+      "actor_roles": [
+        "DRIVER"
+      ],
+      "to_state": "DRIVER_CUSTODY",
+      "final_payment": false,
+      "office_task": null
+    },
+    {
+      "from_states": [
+        "READY_FOR_CUSTOMER_HANDOFF"
+      ],
+      "event_type": "BAR_NOT_RECEIVED",
+      "actor_roles": [
+        "DRIVER",
+        "CHEF"
+      ],
+      "to_state": "NOT_RECEIVED",
+      "final_payment": false,
+      "office_task": "Barzahlung klären"
+    },
+    {
+      "from_states": [
+        "DRIVER_CUSTODY"
+      ],
+      "event_type": "BAR_HANDED_TO_CHEF",
+      "actor_roles": [
+        "DRIVER"
+      ],
+      "to_state": "AWAITING_CHEF_CONFIRMATION",
+      "final_payment": false,
+      "office_task": null
+    },
+    {
+      "from_states": [
+        "AWAITING_CHEF_CONFIRMATION"
+      ],
+      "event_type": "BAR_RECEIVED_FROM_DRIVER_BY_CHEF",
+      "actor_roles": [
+        "CHEF"
+      ],
+      "to_state": "FINAL_PAID",
+      "final_payment": true,
+      "office_task": null
+    },
+    {
+      "from_states": [
+        "READY_FOR_CUSTOMER_HANDOFF"
+      ],
+      "event_type": "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+      "actor_roles": [
+        "CHEF"
+      ],
+      "to_state": "FINAL_PAID",
+      "final_payment": true,
+      "office_task": null
+    },
+    {
+      "from_states": [
+        "DRIVER_CUSTODY",
+        "AWAITING_CHEF_CONFIRMATION",
+        "FINAL_PAID",
+        "NOT_RECEIVED"
+      ],
+      "event_type": "BAR_HANDOFF_CORRECTION",
+      "actor_roles": [
+        "CHEF",
+        "OFFICE"
+      ],
+      "to_state": "MANUAL_REVIEW_REQUIRED",
+      "final_payment": false,
+      "office_task": "Barzahlung klären"
+    }
+  ]
+}

--- a/tests/helpers/courier_cash_handoff_contract.py
+++ b/tests/helpers/courier_cash_handoff_contract.py
@@ -1,0 +1,225 @@
+"""Stdlib-only validators for frozen Core/Courier cash contract V1."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+CONTRACT_VERSION = "courier-cash-handoff-v1"
+EVENT_TYPES = frozenset(
+    {
+        "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+        "BAR_NOT_RECEIVED",
+        "BAR_HANDED_TO_CHEF",
+        "BAR_RECEIVED_FROM_DRIVER_BY_CHEF",
+        "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+        "BAR_HANDOFF_CORRECTION",
+    }
+)
+NOT_RECEIVED_REASONS = frozenset(
+    {
+        "CUSTOMER_NOT_FOUND",
+        "CUSTOMER_COULD_NOT_PAY",
+        "AMOUNT_NOT_ACCEPTABLE",
+        "OTHER",
+    }
+)
+ACTOR_ROLES = frozenset({"DRIVER", "CHEF", "OFFICE"})
+PROJECTION_KEYS = frozenset(
+    {
+        "contract_version",
+        "bar_required",
+        "quittung_status",
+        "order_version_id",
+        "cash_execution_context_id",
+    }
+)
+COMMAND_KEYS = frozenset(
+    {
+        "contract_version",
+        "idempotency_key",
+        "event_type",
+        "order_id",
+        "assignment_id",
+        "order_version_id",
+        "cash_execution_context_id",
+        "actor_id",
+        "actor_role",
+        "occurred_at",
+        "not_received_reason",
+        "note",
+        "correction_reason",
+        "correction_of_idempotency_key",
+    }
+)
+SUCCESS_KEYS = frozenset(
+    {
+        "contract_version",
+        "event_id",
+        "idempotency_key",
+        "order_id",
+        "cash_state",
+        "recorded_at",
+    }
+)
+CASH_STATES = frozenset(
+    {
+        "READY_FOR_CUSTOMER_HANDOFF",
+        "DRIVER_CUSTODY",
+        "AWAITING_CHEF_CONFIRMATION",
+        "FINAL_PAID",
+        "NOT_RECEIVED",
+        "MANUAL_REVIEW_REQUIRED",
+    }
+)
+ERRORS = frozenset(
+    {
+        "unauthorized",
+        "invalid_request",
+        "unsupported_contract_version",
+        "idempotency_conflict",
+        "stale_order_revision",
+        "stale_cash_context",
+        "invalid_transition",
+        "core_unavailable",
+    }
+)
+_EVENT_ROLES = {
+    "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER": frozenset({"DRIVER"}),
+    "BAR_NOT_RECEIVED": frozenset({"DRIVER", "CHEF"}),
+    "BAR_HANDED_TO_CHEF": frozenset({"DRIVER"}),
+    "BAR_RECEIVED_FROM_DRIVER_BY_CHEF": frozenset({"CHEF"}),
+    "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER": frozenset(
+        {"CHEF"}
+    ),
+    "BAR_HANDOFF_CORRECTION": frozenset({"CHEF", "OFFICE"}),
+}
+
+
+def _uuid(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be UUID string")
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be UUID string") from exc
+    if str(parsed) != value.lower():
+        raise ValueError(f"{field} must be canonical UUID")
+    return value
+
+
+def _nonblank(value: object, field: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be string")
+    if value != value.strip() or not value or len(value) > maximum:
+        raise ValueError(f"{field} must be trimmed non-empty string")
+    return value
+
+
+def _datetime(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be date-time string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be date-time string") from exc
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return parsed
+
+
+def validate_projection(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != PROJECTION_KEYS:
+        raise ValueError("invalid cash_handoff projection field set")
+    if value["contract_version"] != CONTRACT_VERSION:
+        raise ValueError("unsupported contract version")
+    if value["bar_required"] is not True:
+        raise ValueError("cash_handoff object must require BAR")
+    if value["quittung_status"] not in {"PRINTED_CURRENT", "NOT_READY"}:
+        raise ValueError("invalid Quittung status")
+    _uuid(value["order_version_id"], "order_version_id")
+    _uuid(value["cash_execution_context_id"], "cash_execution_context_id")
+    return value
+
+
+def validate_command(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != COMMAND_KEYS:
+        raise ValueError("invalid cash command field set")
+    if value["contract_version"] != CONTRACT_VERSION:
+        raise ValueError("unsupported contract version")
+    for field in (
+        "idempotency_key",
+        "order_id",
+        "assignment_id",
+        "order_version_id",
+        "cash_execution_context_id",
+    ):
+        _uuid(value[field], field)
+    event_type = value["event_type"]
+    if event_type not in EVENT_TYPES:
+        raise ValueError("invalid event type")
+    role = value["actor_role"]
+    if role not in ACTOR_ROLES or role not in _EVENT_ROLES[event_type]:
+        raise ValueError("actor role not allowed for event")
+    _nonblank(value["actor_id"], "actor_id", 200)
+    _datetime(value["occurred_at"], "occurred_at")
+
+    reason = value["not_received_reason"]
+    note = value["note"]
+    correction_reason = value["correction_reason"]
+    correction_of = value["correction_of_idempotency_key"]
+
+    if event_type == "BAR_NOT_RECEIVED":
+        if reason not in NOT_RECEIVED_REASONS:
+            raise ValueError("BAR_NOT_RECEIVED requires reason")
+        if reason == "OTHER":
+            _nonblank(note, "note", 500)
+        elif note is not None:
+            raise ValueError("note is only allowed for OTHER")
+        if correction_reason is not None or correction_of is not None:
+            raise ValueError("not-received command cannot be a correction")
+    elif event_type == "BAR_HANDOFF_CORRECTION":
+        if reason is not None or note is not None:
+            raise ValueError("correction cannot carry not-received fields")
+        _nonblank(correction_reason, "correction_reason", 500)
+        _uuid(correction_of, "correction_of_idempotency_key")
+    else:
+        if any(
+            item is not None
+            for item in (reason, note, correction_reason, correction_of)
+        ):
+            raise ValueError("event carries fields that must be null")
+    return value
+
+
+def validate_response(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("response must be object")
+    if set(value) == {"error"}:
+        if value["error"] not in ERRORS:
+            raise ValueError("unknown error")
+        return value
+    if set(value) != SUCCESS_KEYS:
+        raise ValueError("invalid success response field set")
+    if value["contract_version"] != CONTRACT_VERSION:
+        raise ValueError("unsupported contract version")
+    for field in ("event_id", "idempotency_key", "order_id"):
+        _uuid(value[field], field)
+    if value["cash_state"] not in CASH_STATES:
+        raise ValueError("invalid cash state")
+    _datetime(value["recorded_at"], "recorded_at")
+    return value
+
+
+def assert_no_financial_fields(value: Any) -> None:
+    forbidden = ("amount", "cents", "price", "total", "balance", "ledger", "billing")
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = key.lower()
+            if any(fragment in lowered for fragment in forbidden):
+                raise AssertionError(f"forbidden financial field: {key}")
+            assert_no_financial_fields(child)
+    elif isinstance(value, list):
+        for child in value:
+            assert_no_financial_fields(child)

--- a/tests/helpers/courier_cash_handoff_contract.py
+++ b/tests/helpers/courier_cash_handoff_contract.py
@@ -90,9 +90,7 @@ _EVENT_ROLES = {
     "BAR_NOT_RECEIVED": frozenset({"DRIVER", "CHEF"}),
     "BAR_HANDED_TO_CHEF": frozenset({"DRIVER"}),
     "BAR_RECEIVED_FROM_DRIVER_BY_CHEF": frozenset({"CHEF"}),
-    "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER": frozenset(
-        {"CHEF"}
-    ),
+    "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER": frozenset({"CHEF"}),
     "BAR_HANDOFF_CORRECTION": frozenset({"CHEF", "OFFICE"}),
 }
 

--- a/tests/unit/test_issue202_courier_cash_handoff_contract.py
+++ b/tests/unit/test_issue202_courier_cash_handoff_contract.py
@@ -143,9 +143,10 @@ def test_success_stale_unauthorized_and_outage_fixtures_are_explicit() -> None:
 
 def test_replay_stale_and_outage_behaviour_is_frozen() -> None:
     text = (_CONTRACT / "README.md").read_text(encoding="utf-8")
-    assert '409 `{"error":"idempotency_conflict"}`' in text
-    assert '409 `{"error":"stale_order_revision"}`' in text
-    assert '409 `{"error":"stale_cash_context"}`' in text
+    assert "idempotency_conflict" in text
+    assert "stale_order_revision" in text
+    assert "stale_cash_context" in text
+    assert text.count("409") >= 4
     assert "conflicts before mutation" in text
     assert "must **not** display the event as saved" in text
 

--- a/tests/unit/test_issue202_courier_cash_handoff_contract.py
+++ b/tests/unit/test_issue202_courier_cash_handoff_contract.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.courier_cash_handoff_contract import (
+    ACTOR_ROLES,
+    COMMAND_KEYS,
+    CONTRACT_VERSION,
+    EVENT_TYPES,
+    NOT_RECEIVED_REASONS,
+    PROJECTION_KEYS,
+    SUCCESS_KEYS,
+    assert_no_financial_fields,
+    validate_command,
+    validate_projection,
+    validate_response,
+)
+
+_ROOT = Path(__file__).parents[2]
+_CONTRACT = _ROOT / "docs/contracts/courier-cash-handoff-v1"
+
+
+def _json(name: str) -> object:
+    return json.loads((_CONTRACT / name).read_text(encoding="utf-8"))
+
+
+def _fixtures() -> dict[str, object]:
+    value = _json("fixtures.json")
+    assert isinstance(value, dict)
+    return value
+
+
+def test_contract_pack_is_frozen_and_chooses_direct_write_topology() -> None:
+    text = (_CONTRACT / "README.md").read_text(encoding="utf-8")
+    assert "Status: **FROZEN**" in text
+    assert "POST /machine/v1/courier/cash-events" in text
+    assert "Kiosk remains strictly read-only" in text
+    assert "cash_execution_context_id" in text
+    assert "same persisted success response" in text
+
+
+def test_projection_schema_exact_and_shared_fixtures_valid() -> None:
+    schema = _json("order-feed-cash-handoff.schema.json")
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == PROJECTION_KEYS
+    assert schema["properties"]["contract_version"]["const"] == CONTRACT_VERSION
+    projections = _fixtures()["projection"]
+    for projection in projections.values():
+        validate_projection(projection)
+
+
+def test_command_schema_freezes_exact_event_role_reason_sets() -> None:
+    schema = _json("cash-event-command.schema.json")
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == COMMAND_KEYS
+    assert set(schema["properties"]["event_type"]["enum"]) == EVENT_TYPES
+    assert set(schema["properties"]["actor_role"]["enum"]) == ACTOR_ROLES
+    assert set(schema["properties"]["not_received_reason"]["enum"]) == (
+        NOT_RECEIVED_REASONS | {None}
+    )
+
+
+def test_all_command_fixtures_validate() -> None:
+    commands = _fixtures()["commands"]
+    assert {command["event_type"] for command in commands.values()} == EVENT_TYPES
+    for command in commands.values():
+        validate_command(command)
+
+
+def test_all_not_received_reasons_follow_note_rule() -> None:
+    base = _fixtures()["commands"]["not_received_other"]
+    for reason in NOT_RECEIVED_REASONS:
+        command = deepcopy(base)
+        command["not_received_reason"] = reason
+        command["note"] = "Manueller Hinweis" if reason == "OTHER" else None
+        validate_command(command)
+
+    missing_note = deepcopy(base)
+    missing_note["note"] = None
+    with pytest.raises(ValueError, match="note"):
+        validate_command(missing_note)
+
+    unwanted_note = deepcopy(base)
+    unwanted_note["not_received_reason"] = "CUSTOMER_NOT_FOUND"
+    with pytest.raises(ValueError, match="only allowed"):
+        validate_command(unwanted_note)
+
+
+def test_driver_never_produces_final_paid_and_chef_confirmation_is_distinct() -> None:
+    rows = _json("transition-table.json")["transitions"]
+    final_rows = [row for row in rows if row["final_payment"]]
+    assert final_rows
+    assert all("DRIVER" not in row["actor_roles"] for row in final_rows)
+    assert {row["event_type"] for row in final_rows} == {
+        "BAR_RECEIVED_FROM_DRIVER_BY_CHEF",
+        "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER",
+    }
+    handoff = next(row for row in rows if row["event_type"] == "BAR_HANDED_TO_CHEF")
+    confirm = next(
+        row
+        for row in rows
+        if row["event_type"] == "BAR_RECEIVED_FROM_DRIVER_BY_CHEF"
+    )
+    assert handoff["to_state"] == "AWAITING_CHEF_CONFIRMATION"
+    assert handoff["actor_roles"] == ["DRIVER"]
+    assert confirm["from_states"] == ["AWAITING_CHEF_CONFIRMATION"]
+    assert confirm["actor_roles"] == ["CHEF"]
+    assert confirm["to_state"] == "FINAL_PAID"
+
+
+def test_not_received_and_privileged_correction_map_to_manual_office_truth() -> None:
+    rows = _json("transition-table.json")["transitions"]
+    not_received = next(row for row in rows if row["event_type"] == "BAR_NOT_RECEIVED")
+    assert not_received["to_state"] == "NOT_RECEIVED"
+    assert not_received["final_payment"] is False
+    assert not_received["office_task"] == "Barzahlung klären"
+
+    correction = next(
+        row for row in rows if row["event_type"] == "BAR_HANDOFF_CORRECTION"
+    )
+    assert set(correction["actor_roles"]) == {"CHEF", "OFFICE"}
+    assert correction["to_state"] == "MANUAL_REVIEW_REQUIRED"
+    command = deepcopy(_fixtures()["commands"]["correction"])
+    command["actor_role"] = "DRIVER"
+    with pytest.raises(ValueError, match="not allowed"):
+        validate_command(command)
+
+
+def test_success_stale_unauthorized_and_outage_fixtures_are_explicit() -> None:
+    responses = _fixtures()["responses"]
+    success = responses["driver_custody"]
+    validate_response(success)
+    assert set(success) == SUCCESS_KEYS
+    assert success["cash_state"] == "DRIVER_CUSTODY"
+    assert validate_response(responses["stale_context"]) == {
+        "error": "stale_cash_context"
+    }
+    assert validate_response(responses["unauthorized"]) == {"error": "unauthorized"}
+    assert validate_response(responses["unavailable"]) == {
+        "error": "core_unavailable"
+    }
+
+
+def test_replay_stale_and_outage_behaviour_is_frozen() -> None:
+    text = (_CONTRACT / "README.md").read_text(encoding="utf-8")
+    assert '409 `{"error":"idempotency_conflict"}`' in text
+    assert '409 `{"error":"stale_order_revision"}`' in text
+    assert '409 `{"error":"stale_cash_context"}`' in text
+    assert "conflicts before mutation" in text
+    assert "must **not** display the event as saved" in text
+
+    command = _fixtures()["commands"]["driver_received"]
+    replay = deepcopy(command)
+    assert replay == command
+    conflict = deepcopy(command)
+    conflict["actor_id"] = "driver-99"
+    assert conflict["idempotency_key"] == command["idempotency_key"]
+    assert conflict != command
+
+
+def test_contract_json_assets_never_contain_financial_fields() -> None:
+    for path in sorted(_CONTRACT.glob("*.json")):
+        assert_no_financial_fields(
+            json.loads(path.read_text(encoding="utf-8"))
+        )

--- a/tests/unit/test_issue202_courier_cash_handoff_contract.py
+++ b/tests/unit/test_issue202_courier_cash_handoff_contract.py
@@ -101,9 +101,7 @@ def test_driver_never_produces_final_paid_and_chef_confirmation_is_distinct() ->
     }
     handoff = next(row for row in rows if row["event_type"] == "BAR_HANDED_TO_CHEF")
     confirm = next(
-        row
-        for row in rows
-        if row["event_type"] == "BAR_RECEIVED_FROM_DRIVER_BY_CHEF"
+        row for row in rows if row["event_type"] == "BAR_RECEIVED_FROM_DRIVER_BY_CHEF"
     )
     assert handoff["to_state"] == "AWAITING_CHEF_CONFIRMATION"
     assert handoff["actor_roles"] == ["DRIVER"]
@@ -140,9 +138,7 @@ def test_success_stale_unauthorized_and_outage_fixtures_are_explicit() -> None:
         "error": "stale_cash_context"
     }
     assert validate_response(responses["unauthorized"]) == {"error": "unauthorized"}
-    assert validate_response(responses["unavailable"]) == {
-        "error": "core_unavailable"
-    }
+    assert validate_response(responses["unavailable"]) == {"error": "core_unavailable"}
 
 
 def test_replay_stale_and_outage_behaviour_is_frozen() -> None:
@@ -164,6 +160,4 @@ def test_replay_stale_and_outage_behaviour_is_frozen() -> None:
 
 def test_contract_json_assets_never_contain_financial_fields() -> None:
     for path in sorted(_CONTRACT.glob("*.json")):
-        assert_no_financial_fields(
-            json.loads(path.read_text(encoding="utf-8"))
-        )
+        assert_no_financial_fields(json.loads(path.read_text(encoding="utf-8")))


### PR DESCRIPTION
## Issue

Closes #202 after merge.

## Frozen topology

- Courier planning reads remain through Kiosk `GET /api/order-feed`.
- Kiosk remains strictly read-only and is not a write relay.
- Courier backend cash writes go directly to a dedicated authenticated Core machine route:
  `POST /machine/v1/courier/cash-events`.

This deliberately revisits the old "Courier never talks to Core" rule only for machine writes, because preserving Kiosk's no-write surface is the safer boundary.

## Deliverables

- frozen `COURIER_CASH_HANDOFF_CONTRACT_V1` pack
- exact JSON Schema for additive Kiosk `cash_handoff` projection
- exact JSON Schema for Courier -> Core commands
- exact success/error response schema
- machine-readable state transition table
- shared fixture pack usable by Core and Courier tests
- stdlib-only shared contract validator
- regression tests for:
  - all event types
  - all BAR_NOT_RECEIVED reasons and OTHER note rule
  - driver custody vs chef final confirmation
  - direct chef pickup
  - privileged correction
  - replay conflict semantics
  - stale context
  - unauthorized caller
  - Core outage
  - recursive prohibition of financial fields
- explicit update to current Kiosk order-feed boundary documentation
- rollout/backwards-compatibility order

## Safety boundary

No amount, cents, price, ledger, balance, invoice/receipt/PDF data or customer billing data exists in the new contract.

## Runtime scope

This PR freezes/tests the contract only. The Core journal/write endpoint and Kiosk projection remain dormant/not implemented until the rollout implementation slice. Courier UI implementation remains courier-app #13.
