### PR TITLE
Implement Courier cash handoff runtime V1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --diff src tests infra
-          exit 1
+          uv run ruff format --check src tests infra
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Lint
         run: |
           uv run ruff check src tests infra
-          uv run ruff format --check src tests infra
+          uv run ruff format --diff src tests infra
+          exit 1
       - name: Type-check production code
         run: uv run mypy src/catering_system
       - name: Test Python and enforce coverage

--- a/src/catering_system/domain/courier_cash_handoff.py
+++ b/src/catering_system/domain/courier_cash_handoff.py
@@ -190,9 +190,7 @@ class CourierCashCommand:
                 raise ValueError("correction cannot carry not-received fields")
             if correction_reason is None:
                 raise ValueError("correction requires reason")
-            correction_of = _uuid(
-                correction_of, "correction_of_idempotency_key"
-            )
+            correction_of = _uuid(correction_of, "correction_of_idempotency_key")
         elif any(
             item is not None
             for item in (reason, note, correction_reason, correction_of)

--- a/src/catering_system/domain/courier_cash_handoff.py
+++ b/src/catering_system/domain/courier_cash_handoff.py
@@ -1,0 +1,301 @@
+"""Frozen COURIER_CASH_HANDOFF_CONTRACT_V1 runtime domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+CONTRACT_VERSION = "courier-cash-handoff-v1"
+QUITTUNG_PRINTED_CURRENT = "PRINTED_CURRENT"
+QUITTUNG_NOT_READY = "NOT_READY"
+
+STATE_READY = "READY_FOR_CUSTOMER_HANDOFF"
+STATE_DRIVER_CUSTODY = "DRIVER_CUSTODY"
+STATE_AWAITING_CHEF = "AWAITING_CHEF_CONFIRMATION"
+STATE_FINAL_PAID = "FINAL_PAID"
+STATE_NOT_RECEIVED = "NOT_RECEIVED"
+STATE_MANUAL_REVIEW = "MANUAL_REVIEW_REQUIRED"
+
+EVENT_DRIVER_RECEIVED = "BAR_RECEIVED_AND_QUITTUNG_HANDED_TO_CUSTOMER"
+EVENT_NOT_RECEIVED = "BAR_NOT_RECEIVED"
+EVENT_DRIVER_HANDED_TO_CHEF = "BAR_HANDED_TO_CHEF"
+EVENT_CHEF_RECEIVED_FROM_DRIVER = "BAR_RECEIVED_FROM_DRIVER_BY_CHEF"
+EVENT_CHEF_DIRECT = "BAR_RECEIVED_DIRECT_BY_CHEF_AND_QUITTUNG_HANDED_TO_CUSTOMER"
+EVENT_CORRECTION = "BAR_HANDOFF_CORRECTION"
+
+EVENT_TYPES = frozenset(
+    {
+        EVENT_DRIVER_RECEIVED,
+        EVENT_NOT_RECEIVED,
+        EVENT_DRIVER_HANDED_TO_CHEF,
+        EVENT_CHEF_RECEIVED_FROM_DRIVER,
+        EVENT_CHEF_DIRECT,
+        EVENT_CORRECTION,
+    }
+)
+NOT_RECEIVED_REASONS = frozenset(
+    {
+        "CUSTOMER_NOT_FOUND",
+        "CUSTOMER_COULD_NOT_PAY",
+        "AMOUNT_NOT_ACCEPTABLE",
+        "OTHER",
+    }
+)
+ACTOR_ROLES = frozenset({"DRIVER", "CHEF", "OFFICE"})
+_EVENT_ROLES = {
+    EVENT_DRIVER_RECEIVED: frozenset({"DRIVER"}),
+    EVENT_NOT_RECEIVED: frozenset({"DRIVER", "CHEF"}),
+    EVENT_DRIVER_HANDED_TO_CHEF: frozenset({"DRIVER"}),
+    EVENT_CHEF_RECEIVED_FROM_DRIVER: frozenset({"CHEF"}),
+    EVENT_CHEF_DIRECT: frozenset({"CHEF"}),
+    EVENT_CORRECTION: frozenset({"CHEF", "OFFICE"}),
+}
+COMMAND_KEYS = frozenset(
+    {
+        "contract_version",
+        "idempotency_key",
+        "event_type",
+        "order_id",
+        "assignment_id",
+        "order_version_id",
+        "cash_execution_context_id",
+        "actor_id",
+        "actor_role",
+        "occurred_at",
+        "not_received_reason",
+        "note",
+        "correction_reason",
+        "correction_of_idempotency_key",
+    }
+)
+
+
+def _uuid(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be UUID string")
+    try:
+        parsed = UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be UUID string") from exc
+    if str(parsed) != value:
+        raise ValueError(f"{field} must be canonical lowercase UUID")
+    return value
+
+
+def _text(value: object, field: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be string")
+    if not value or value != value.strip() or len(value) > maximum:
+        raise ValueError(f"{field} must be trimmed non-empty text")
+    return value
+
+
+def _optional_text(value: object, field: str, maximum: int) -> str | None:
+    if value is None:
+        return None
+    return _text(value, field, maximum)
+
+
+def _date_time(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be date-time string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be date-time string") from exc
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return parsed
+
+
+@dataclass(frozen=True)
+class CourierCashProjection:
+    order_version_id: str
+    cash_execution_context_id: str
+    quittung_status: str
+    contract_version: str = CONTRACT_VERSION
+    bar_required: bool = True
+
+    def __post_init__(self) -> None:
+        if self.contract_version != CONTRACT_VERSION:
+            raise ValueError("unsupported contract version")
+        if self.bar_required is not True:
+            raise ValueError("cash projection must require BAR")
+        if self.quittung_status not in {
+            QUITTUNG_PRINTED_CURRENT,
+            QUITTUNG_NOT_READY,
+        }:
+            raise ValueError("invalid Quittung status")
+        _uuid(self.order_version_id, "order_version_id")
+        _uuid(self.cash_execution_context_id, "cash_execution_context_id")
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "contract_version": self.contract_version,
+            "bar_required": True,
+            "quittung_status": self.quittung_status,
+            "order_version_id": self.order_version_id,
+            "cash_execution_context_id": self.cash_execution_context_id,
+        }
+
+
+@dataclass(frozen=True)
+class CourierCashCommand:
+    idempotency_key: str
+    event_type: str
+    order_id: str
+    assignment_id: str
+    order_version_id: str
+    cash_execution_context_id: str
+    actor_id: str
+    actor_role: str
+    occurred_at: datetime
+    not_received_reason: str | None
+    note: str | None
+    correction_reason: str | None
+    correction_of_idempotency_key: str | None
+    contract_version: str = CONTRACT_VERSION
+
+    @classmethod
+    def from_json(cls, value: object) -> CourierCashCommand:
+        if not isinstance(value, dict) or set(value) != COMMAND_KEYS:
+            raise ValueError("invalid cash command field set")
+        if value["contract_version"] != CONTRACT_VERSION:
+            raise UnsupportedCourierCashContractVersion()
+        event_type = value["event_type"]
+        if event_type not in EVENT_TYPES:
+            raise ValueError("invalid cash event type")
+        actor_role = value["actor_role"]
+        if actor_role not in ACTOR_ROLES or actor_role not in _EVENT_ROLES[event_type]:
+            raise ValueError("actor role not allowed for cash event")
+        reason = value["not_received_reason"]
+        note = _optional_text(value["note"], "note", 500)
+        correction_reason = _optional_text(
+            value["correction_reason"], "correction_reason", 500
+        )
+        correction_of = value["correction_of_idempotency_key"]
+        if event_type == EVENT_NOT_RECEIVED:
+            if reason not in NOT_RECEIVED_REASONS:
+                raise ValueError("BAR_NOT_RECEIVED requires structured reason")
+            if reason == "OTHER":
+                if note is None:
+                    raise ValueError("OTHER requires note")
+            elif note is not None:
+                raise ValueError("note is only allowed for OTHER")
+            if correction_reason is not None or correction_of is not None:
+                raise ValueError("not-received command cannot be correction")
+        elif event_type == EVENT_CORRECTION:
+            if reason is not None or note is not None:
+                raise ValueError("correction cannot carry not-received fields")
+            if correction_reason is None:
+                raise ValueError("correction requires reason")
+            correction_of = _uuid(
+                correction_of, "correction_of_idempotency_key"
+            )
+        elif any(
+            item is not None
+            for item in (reason, note, correction_reason, correction_of)
+        ):
+            raise ValueError("cash event carries fields that must be null")
+
+        return cls(
+            contract_version=CONTRACT_VERSION,
+            idempotency_key=_uuid(value["idempotency_key"], "idempotency_key"),
+            event_type=str(event_type),
+            order_id=_uuid(value["order_id"], "order_id"),
+            assignment_id=_uuid(value["assignment_id"], "assignment_id"),
+            order_version_id=_uuid(value["order_version_id"], "order_version_id"),
+            cash_execution_context_id=_uuid(
+                value["cash_execution_context_id"], "cash_execution_context_id"
+            ),
+            actor_id=_text(value["actor_id"], "actor_id", 200),
+            actor_role=str(actor_role),
+            occurred_at=_date_time(value["occurred_at"], "occurred_at"),
+            not_received_reason=str(reason) if reason is not None else None,
+            note=note,
+            correction_reason=correction_reason,
+            correction_of_idempotency_key=(
+                str(correction_of) if correction_of is not None else None
+            ),
+        )
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "contract_version": self.contract_version,
+            "idempotency_key": self.idempotency_key,
+            "event_type": self.event_type,
+            "order_id": self.order_id,
+            "assignment_id": self.assignment_id,
+            "order_version_id": self.order_version_id,
+            "cash_execution_context_id": self.cash_execution_context_id,
+            "actor_id": self.actor_id,
+            "actor_role": self.actor_role,
+            "occurred_at": self.occurred_at.isoformat(),
+            "not_received_reason": self.not_received_reason,
+            "note": self.note,
+            "correction_reason": self.correction_reason,
+            "correction_of_idempotency_key": self.correction_of_idempotency_key,
+        }
+
+
+@dataclass(frozen=True)
+class CourierCashResult:
+    event_id: str
+    idempotency_key: str
+    order_id: str
+    cash_state: str
+    recorded_at: datetime
+    contract_version: str = CONTRACT_VERSION
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "contract_version": self.contract_version,
+            "event_id": self.event_id,
+            "idempotency_key": self.idempotency_key,
+            "order_id": self.order_id,
+            "cash_state": self.cash_state,
+            "recorded_at": self.recorded_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class CourierCashStoredEvent:
+    sequence: int
+    event_id: str
+    idempotency_key: str
+    request_fingerprint: str
+    request_json: str
+    response_json: str
+    order_id: str
+    assignment_id: str
+    order_version_id: str
+    cash_execution_context_id: str
+    event_type: str
+    actor_id: str
+    actor_role: str
+    occurred_at: datetime
+    recorded_at: datetime
+    from_state: str
+    to_state: str
+    not_received_reason: str | None
+    note: str | None
+    correction_reason: str | None
+    correction_of_idempotency_key: str | None
+
+    def result(self) -> CourierCashResult:
+        import json
+
+        value = json.loads(self.response_json)
+        return CourierCashResult(
+            contract_version=str(value["contract_version"]),
+            event_id=str(value["event_id"]),
+            idempotency_key=str(value["idempotency_key"]),
+            order_id=str(value["order_id"]),
+            cash_state=str(value["cash_state"]),
+            recorded_at=_date_time(value["recorded_at"], "recorded_at"),
+        )
+
+
+class UnsupportedCourierCashContractVersion(ValueError):
+    pass

--- a/src/catering_system/domain/task_projection.py
+++ b/src/catering_system/domain/task_projection.py
@@ -16,7 +16,7 @@ TaskCategory = Literal[
     "payment",
 ]
 TaskEntityType = Literal["inquiry", "offer", "order"]
-TaskUrgency = Literal["overdue", "normal"]
+TaskUrgency = Literal["overdue", "urgent", "normal"]
 
 
 @dataclass(frozen=True)
@@ -57,7 +57,7 @@ def task_sort_key(
 
 
 def _sort_tier(task: TaskProjection) -> int:
-    if task.category == "payment" and task.urgency == "overdue":
+    if task.category == "payment" and task.urgency in {"overdue", "urgent"}:
         return 0
     if task.category == "verify":
         return 1

--- a/src/catering_system/repositories/courier_cash_repository.py
+++ b/src/catering_system/repositories/courier_cash_repository.py
@@ -1,0 +1,23 @@
+"""Persistence protocol for frozen Courier cash handoff events."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from catering_system.domain.courier_cash_handoff import CourierCashStoredEvent
+
+
+class CourierCashRepository(Protocol):
+    def append_event(self, event: CourierCashStoredEvent) -> None: ...
+
+    def get_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> CourierCashStoredEvent | None: ...
+
+    def get_latest_for_context(
+        self, order_id: str, cash_execution_context_id: str
+    ) -> CourierCashStoredEvent | None: ...
+
+    def get_latest_for_order(self, order_id: str) -> CourierCashStoredEvent | None: ...
+
+    def get_latest_correction_id(self, order_id: str) -> str | None: ...

--- a/src/catering_system/repositories/sqlite_courier_cash_repository.py
+++ b/src/catering_system/repositories/sqlite_courier_cash_repository.py
@@ -1,0 +1,200 @@
+"""Append-only SQLite journal for Courier cash handoff events."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import nullcontext
+from datetime import datetime
+from pathlib import Path
+
+from catering_system.domain.courier_cash_handoff import CourierCashStoredEvent
+from catering_system.repositories.sqlite_migrations import apply_migrations
+
+_CREATE = """
+CREATE TABLE IF NOT EXISTS courier_cash_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT NOT NULL UNIQUE,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    request_fingerprint TEXT NOT NULL,
+    request_json TEXT NOT NULL,
+    response_json TEXT NOT NULL,
+    order_id TEXT NOT NULL,
+    assignment_id TEXT NOT NULL,
+    order_version_id TEXT NOT NULL,
+    cash_execution_context_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    actor_id TEXT NOT NULL,
+    actor_role TEXT NOT NULL,
+    occurred_at TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    from_state TEXT NOT NULL,
+    to_state TEXT NOT NULL,
+    not_received_reason TEXT,
+    note TEXT,
+    correction_reason TEXT,
+    correction_of_idempotency_key TEXT
+)
+"""
+_INDEXES = (
+    """CREATE INDEX IF NOT EXISTS idx_courier_cash_events_order_sequence
+       ON courier_cash_events(order_id, sequence DESC)""",
+    """CREATE INDEX IF NOT EXISTS idx_courier_cash_events_context_sequence
+       ON courier_cash_events(order_id, cash_execution_context_id, sequence DESC)""",
+)
+_TRIGGERS = (
+    """CREATE TRIGGER IF NOT EXISTS trg_courier_cash_events_no_update
+       BEFORE UPDATE ON courier_cash_events
+       BEGIN SELECT RAISE(ABORT, 'courier cash events are append-only'); END""",
+    """CREATE TRIGGER IF NOT EXISTS trg_courier_cash_events_no_delete
+       BEFORE DELETE ON courier_cash_events
+       BEGIN SELECT RAISE(ABORT, 'courier cash events are append-only'); END""",
+    """CREATE TRIGGER IF NOT EXISTS trg_courier_cash_event_owner_insert
+       BEFORE INSERT ON courier_cash_events
+       WHEN NOT EXISTS (SELECT 1 FROM orders WHERE order_id = NEW.order_id)
+       BEGIN SELECT RAISE(ABORT, 'courier cash event owner does not exist'); END""",
+)
+
+
+def _migration_1(connection: sqlite3.Connection) -> None:
+    connection.execute(_CREATE)
+    for statement in _INDEXES:
+        connection.execute(statement)
+    for trigger in _TRIGGERS:
+        connection.execute(trigger)
+
+
+_MIGRATIONS = ((1, "create_courier_cash_events", _migration_1),)
+
+
+def _row(row: sqlite3.Row) -> CourierCashStoredEvent:
+    return CourierCashStoredEvent(
+        sequence=int(row["sequence"]),
+        event_id=row["event_id"],
+        idempotency_key=row["idempotency_key"],
+        request_fingerprint=row["request_fingerprint"],
+        request_json=row["request_json"],
+        response_json=row["response_json"],
+        order_id=row["order_id"],
+        assignment_id=row["assignment_id"],
+        order_version_id=row["order_version_id"],
+        cash_execution_context_id=row["cash_execution_context_id"],
+        event_type=row["event_type"],
+        actor_id=row["actor_id"],
+        actor_role=row["actor_role"],
+        occurred_at=datetime.fromisoformat(row["occurred_at"]),
+        recorded_at=datetime.fromisoformat(row["recorded_at"]),
+        from_state=row["from_state"],
+        to_state=row["to_state"],
+        not_received_reason=row["not_received_reason"],
+        note=row["note"],
+        correction_reason=row["correction_reason"],
+        correction_of_idempotency_key=row["correction_of_idempotency_key"],
+    )
+
+
+class SQLiteCourierCashRepository:
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._manage_transactions = True
+        try:
+            apply_migrations(self._conn, "courier_cash_handoff", _MIGRATIONS)
+        except Exception:
+            self._conn.close()
+            raise
+
+    @classmethod
+    def from_connection(cls, connection: sqlite3.Connection) -> SQLiteCourierCashRepository:
+        repo = cls.__new__(cls)
+        repo._conn = connection
+        repo._conn.row_factory = sqlite3.Row
+        repo._manage_transactions = False
+        apply_migrations(connection, "courier_cash_handoff", _MIGRATIONS)
+        return repo
+
+    def _write_scope(self):  # noqa: ANN202
+        return self._conn if self._manage_transactions else nullcontext()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def append_event(self, event: CourierCashStoredEvent) -> None:
+        with self._write_scope():
+            self._conn.execute(
+                """
+                INSERT INTO courier_cash_events (
+                    event_id, idempotency_key, request_fingerprint, request_json,
+                    response_json, order_id, assignment_id, order_version_id,
+                    cash_execution_context_id, event_type, actor_id, actor_role,
+                    occurred_at, recorded_at, from_state, to_state,
+                    not_received_reason, note, correction_reason,
+                    correction_of_idempotency_key
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.idempotency_key,
+                    event.request_fingerprint,
+                    event.request_json,
+                    event.response_json,
+                    event.order_id,
+                    event.assignment_id,
+                    event.order_version_id,
+                    event.cash_execution_context_id,
+                    event.event_type,
+                    event.actor_id,
+                    event.actor_role,
+                    event.occurred_at.isoformat(),
+                    event.recorded_at.isoformat(),
+                    event.from_state,
+                    event.to_state,
+                    event.not_received_reason,
+                    event.note,
+                    event.correction_reason,
+                    event.correction_of_idempotency_key,
+                ),
+            )
+
+    def get_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> CourierCashStoredEvent | None:
+        row = self._conn.execute(
+            "SELECT * FROM courier_cash_events WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def get_latest_for_context(
+        self, order_id: str, cash_execution_context_id: str
+    ) -> CourierCashStoredEvent | None:
+        row = self._conn.execute(
+            """
+            SELECT * FROM courier_cash_events
+            WHERE order_id = ? AND cash_execution_context_id = ?
+            ORDER BY sequence DESC LIMIT 1
+            """,
+            (order_id, cash_execution_context_id),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def get_latest_for_order(self, order_id: str) -> CourierCashStoredEvent | None:
+        row = self._conn.execute(
+            """
+            SELECT * FROM courier_cash_events
+            WHERE order_id = ?
+            ORDER BY sequence DESC LIMIT 1
+            """,
+            (order_id,),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def get_latest_correction_id(self, order_id: str) -> str | None:
+        row = self._conn.execute(
+            """
+            SELECT event_id FROM courier_cash_events
+            WHERE order_id = ? AND event_type = 'BAR_HANDOFF_CORRECTION'
+            ORDER BY sequence DESC LIMIT 1
+            """,
+            (order_id,),
+        ).fetchone()
+        return str(row[0]) if row is not None else None

--- a/src/catering_system/repositories/sqlite_courier_cash_repository.py
+++ b/src/catering_system/repositories/sqlite_courier_cash_repository.py
@@ -104,7 +104,9 @@ class SQLiteCourierCashRepository:
             raise
 
     @classmethod
-    def from_connection(cls, connection: sqlite3.Connection) -> SQLiteCourierCashRepository:
+    def from_connection(
+        cls, connection: sqlite3.Connection
+    ) -> SQLiteCourierCashRepository:
         repo = cls.__new__(cls)
         repo._conn = connection
         repo._conn.row_factory = sqlite3.Row

--- a/src/catering_system/services/courier_cash_context_service.py
+++ b/src/catering_system/services/courier_cash_context_service.py
@@ -1,0 +1,81 @@
+"""Derive the current frozen Courier BAR execution context."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid5
+
+from catering_system.domain.courier_cash_handoff import (
+    QUITTUNG_NOT_READY,
+    QUITTUNG_PRINTED_CURRENT,
+    CourierCashProjection,
+)
+from catering_system.repositories.courier_cash_repository import CourierCashRepository
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.payment_reminder_repository import (
+    PaymentReminderRepository,
+)
+
+_NAMESPACE = UUID("9de1af8d-0c70-44f8-8b06-0f761980dd9a")
+
+
+class CourierCashContextService:
+    def __init__(
+        self,
+        orders: OrderRepository,
+        payments: PaymentReminderRepository,
+        cash_events: CourierCashRepository,
+    ) -> None:
+        self._orders = orders
+        self._payments = payments
+        self._cash_events = cash_events
+
+    def projection(self, order_id: str) -> CourierCashProjection | None:
+        order = self._orders.get_order(order_id)
+        if order is None or order.cancelled_at is not None:
+            return None
+        payment = self._payments.get(order_id)
+        if payment is None or payment.payment_method != "BAR_VOR_ORT":
+            return None
+        version_id = order.effective_order_version_id
+        if version_id is None:
+            return None
+        version = self._orders.get_order_version(version_id)
+        if version is None:
+            return None
+
+        method_changes = self._payments.list_method_changes(order_id)
+        method_generation = method_changes[0].change_id if method_changes else "initial"
+        payment_corrections = self._payments.list_payment_corrections(order_id)
+        payment_correction_marker = (
+            payment_corrections[0].correction_id if payment_corrections else ""
+        )
+        cash_correction_marker = (
+            self._cash_events.get_latest_correction_id(order_id) or ""
+        )
+        printed_at = payment.quittung_printed_at
+        quittung_current = (
+            payment.quittung_printed
+            and printed_at is not None
+            and printed_at >= version.created_at
+        )
+        quittung_status = (
+            QUITTUNG_PRINTED_CURRENT if quittung_current else QUITTUNG_NOT_READY
+        )
+        print_generation = printed_at.isoformat() if printed_at is not None else "none"
+        material = "|".join(
+            (
+                "courier-cash-handoff-v1",
+                order_id,
+                method_generation,
+                version_id,
+                print_generation,
+                payment_correction_marker,
+                cash_correction_marker,
+            )
+        )
+        context_id = str(uuid5(_NAMESPACE, material))
+        return CourierCashProjection(
+            order_version_id=version_id,
+            cash_execution_context_id=context_id,
+            quittung_status=quittung_status,
+        )

--- a/src/catering_system/services/courier_cash_service.py
+++ b/src/catering_system/services/courier_cash_service.py
@@ -108,7 +108,16 @@ class CourierCashService:
         latest = self._cash_events.get_latest_for_context(
             command.order_id, command.cash_execution_context_id
         )
-        from_state = latest.to_state if latest is not None else STATE_READY
+        if latest is not None:
+            from_state = latest.to_state
+        else:
+            latest_for_order = self._cash_events.get_latest_for_order(command.order_id)
+            from_state = (
+                STATE_MANUAL_REVIEW
+                if latest_for_order is not None
+                and latest_for_order.to_state == STATE_MANUAL_REVIEW
+                else STATE_READY
+            )
 
         if command.event_type == EVENT_CORRECTION:
             if from_state not in _CORRECTABLE_STATES:

--- a/src/catering_system/services/courier_cash_service.py
+++ b/src/catering_system/services/courier_cash_service.py
@@ -29,6 +29,7 @@ from catering_system.domain.courier_cash_handoff import (
     CourierCashStoredEvent,
 )
 from catering_system.repositories.courier_cash_repository import CourierCashRepository
+from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.payment_reminder_repository import (
     PaymentReminderRepository,
@@ -65,6 +66,7 @@ class CourierCashService:
     def __init__(
         self,
         orders: OrderRepository,
+        inquiries: InquiryRepository,
         payments: PaymentReminderRepository,
         cash_events: CourierCashRepository,
         payment_service: PaymentReminderService,
@@ -73,6 +75,7 @@ class CourierCashService:
         now: Callable[[], datetime] | None = None,
     ) -> None:
         self._orders = orders
+        self._inquiries = inquiries
         self._payments = payments
         self._cash_events = cash_events
         self._payment_service = payment_service
@@ -98,6 +101,10 @@ class CourierCashService:
             raise CourierCashCommandError("invalid_transition", 409)
         if order.effective_order_version_id != command.order_version_id:
             raise CourierCashCommandError("stale_order_revision", 409)
+        if command.event_type == EVENT_CHEF_DIRECT:
+            inquiry = self._inquiries.get_by_id(order.source_inquiry_id)
+            if inquiry is None or inquiry.fulfillment_mode != "PICKUP":
+                raise CourierCashCommandError("invalid_transition", 409)
 
         projection = self._context_service.projection(command.order_id)
         if projection is None:

--- a/src/catering_system/services/courier_cash_service.py
+++ b/src/catering_system/services/courier_cash_service.py
@@ -1,0 +1,223 @@
+"""Transactional state machine for Courier BAR execution events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import UTC, datetime
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from catering_system.domain.courier_cash_handoff import (
+    EVENT_CHEF_DIRECT,
+    EVENT_CHEF_RECEIVED_FROM_DRIVER,
+    EVENT_CORRECTION,
+    EVENT_DRIVER_HANDED_TO_CHEF,
+    EVENT_DRIVER_RECEIVED,
+    EVENT_NOT_RECEIVED,
+    QUITTUNG_PRINTED_CURRENT,
+    STATE_AWAITING_CHEF,
+    STATE_DRIVER_CUSTODY,
+    STATE_FINAL_PAID,
+    STATE_MANUAL_REVIEW,
+    STATE_NOT_RECEIVED,
+    STATE_READY,
+    CourierCashCommand,
+    CourierCashResult,
+    CourierCashStoredEvent,
+)
+from catering_system.repositories.courier_cash_repository import CourierCashRepository
+from catering_system.repositories.order_repository import OrderRepository
+from catering_system.repositories.payment_reminder_repository import (
+    PaymentReminderRepository,
+)
+from catering_system.services.courier_cash_context_service import (
+    CourierCashContextService,
+)
+from catering_system.services.payment_reminder_service import PaymentReminderService
+
+_BERLIN = ZoneInfo("Europe/Berlin")
+_TRANSITIONS: dict[tuple[str, str], str] = {
+    (STATE_READY, EVENT_DRIVER_RECEIVED): STATE_DRIVER_CUSTODY,
+    (STATE_READY, EVENT_NOT_RECEIVED): STATE_NOT_RECEIVED,
+    (STATE_DRIVER_CUSTODY, EVENT_DRIVER_HANDED_TO_CHEF): STATE_AWAITING_CHEF,
+    (STATE_AWAITING_CHEF, EVENT_CHEF_RECEIVED_FROM_DRIVER): STATE_FINAL_PAID,
+    (STATE_READY, EVENT_CHEF_DIRECT): STATE_FINAL_PAID,
+}
+_CORRECTABLE_STATES = {
+    STATE_DRIVER_CUSTODY,
+    STATE_AWAITING_CHEF,
+    STATE_FINAL_PAID,
+    STATE_NOT_RECEIVED,
+}
+
+
+class CourierCashCommandError(Exception):
+    def __init__(self, code: str, status: int) -> None:
+        self.code = code
+        self.status = status
+        super().__init__(code)
+
+
+class CourierCashService:
+    def __init__(
+        self,
+        orders: OrderRepository,
+        payments: PaymentReminderRepository,
+        cash_events: CourierCashRepository,
+        payment_service: PaymentReminderService,
+        context_service: CourierCashContextService,
+        *,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._orders = orders
+        self._payments = payments
+        self._cash_events = cash_events
+        self._payment_service = payment_service
+        self._context_service = context_service
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def process(self, command: CourierCashCommand) -> CourierCashResult:
+        request_json = json.dumps(
+            command.to_json(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        fingerprint = hashlib.sha256(request_json.encode("utf-8")).hexdigest()
+        replay = self._cash_events.get_by_idempotency_key(command.idempotency_key)
+        if replay is not None:
+            if replay.request_fingerprint != fingerprint:
+                raise CourierCashCommandError("idempotency_conflict", 409)
+            return replay.result()
+
+        order = self._orders.get_order(command.order_id)
+        if order is None or order.cancelled_at is not None:
+            raise CourierCashCommandError("invalid_transition", 409)
+        if order.effective_order_version_id != command.order_version_id:
+            raise CourierCashCommandError("stale_order_revision", 409)
+
+        projection = self._context_service.projection(command.order_id)
+        if projection is None:
+            raise CourierCashCommandError("stale_cash_context", 409)
+        if projection.cash_execution_context_id != command.cash_execution_context_id:
+            raise CourierCashCommandError("stale_cash_context", 409)
+
+        latest = self._cash_events.get_latest_for_context(
+            command.order_id, command.cash_execution_context_id
+        )
+        from_state = latest.to_state if latest is not None else STATE_READY
+
+        if command.event_type == EVENT_CORRECTION:
+            if from_state not in _CORRECTABLE_STATES:
+                raise CourierCashCommandError("invalid_transition", 409)
+            assert command.correction_of_idempotency_key is not None
+            corrected = self._cash_events.get_by_idempotency_key(
+                command.correction_of_idempotency_key
+            )
+            if corrected is None or corrected.order_id != command.order_id:
+                raise CourierCashCommandError("invalid_transition", 409)
+            to_state = STATE_MANUAL_REVIEW
+        else:
+            to_state = _TRANSITIONS.get((from_state, command.event_type))
+            if to_state is None:
+                raise CourierCashCommandError("invalid_transition", 409)
+            if (
+                from_state == STATE_READY
+                and projection.quittung_status != QUITTUNG_PRINTED_CURRENT
+            ):
+                raise CourierCashCommandError("invalid_transition", 409)
+
+        recorded_at = self._aware_now()
+        event_id = str(uuid4())
+        result = CourierCashResult(
+            event_id=event_id,
+            idempotency_key=command.idempotency_key,
+            order_id=command.order_id,
+            cash_state=to_state,
+            recorded_at=recorded_at,
+        )
+
+        if to_state == STATE_FINAL_PAID:
+            self._record_final_payment(command, recorded_at)
+        elif command.event_type == EVENT_CORRECTION:
+            assert command.correction_of_idempotency_key is not None
+            corrected = self._cash_events.get_by_idempotency_key(
+                command.correction_of_idempotency_key
+            )
+            assert corrected is not None
+            if corrected.to_state == STATE_FINAL_PAID:
+                payment = self._payments.get(command.order_id)
+                if payment is None or (
+                    payment.paid_on is None and not payment.cash_received
+                ):
+                    raise CourierCashCommandError("invalid_transition", 409)
+                assert command.correction_reason is not None
+                self._payment_service.correct_payment_completion(
+                    command.order_id,
+                    correction_id=command.idempotency_key,
+                    reason=command.correction_reason,
+                    actor_reference=self._actor(command),
+                )
+
+        response_json = json.dumps(
+            result.to_json(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        self._cash_events.append_event(
+            CourierCashStoredEvent(
+                sequence=0,
+                event_id=event_id,
+                idempotency_key=command.idempotency_key,
+                request_fingerprint=fingerprint,
+                request_json=request_json,
+                response_json=response_json,
+                order_id=command.order_id,
+                assignment_id=command.assignment_id,
+                order_version_id=command.order_version_id,
+                cash_execution_context_id=command.cash_execution_context_id,
+                event_type=command.event_type,
+                actor_id=command.actor_id,
+                actor_role=command.actor_role,
+                occurred_at=command.occurred_at,
+                recorded_at=recorded_at,
+                from_state=from_state,
+                to_state=to_state,
+                not_received_reason=command.not_received_reason,
+                note=command.note,
+                correction_reason=command.correction_reason,
+                correction_of_idempotency_key=command.correction_of_idempotency_key,
+            )
+        )
+        return result
+
+    def _record_final_payment(
+        self, command: CourierCashCommand, recorded_at: datetime
+    ) -> None:
+        payment = self._payments.get(command.order_id)
+        if payment is None or payment.payment_method != "BAR_VOR_ORT":
+            raise CourierCashCommandError("stale_cash_context", 409)
+        if payment.paid_on is not None or payment.cash_received:
+            raise CourierCashCommandError("invalid_transition", 409)
+        paid_on = recorded_at.astimezone(_BERLIN).date()
+        try:
+            self._payment_service.save(
+                replace(payment, paid_on=paid_on, cash_received=True),
+                actor_reference=self._actor(command),
+            )
+        except (KeyError, ValueError) as exc:
+            raise CourierCashCommandError("invalid_transition", 409) from exc
+
+    @staticmethod
+    def _actor(command: CourierCashCommand) -> str:
+        return f"courier:{command.actor_role.lower()}:{command.actor_id}"
+
+    def _aware_now(self) -> datetime:
+        value = self._now()
+        if value.utcoffset() is None:
+            raise ValueError("courier cash clock must be timezone-aware")
+        return value

--- a/src/catering_system/services/courier_cash_service.py
+++ b/src/catering_system/services/courier_cash_service.py
@@ -130,9 +130,10 @@ class CourierCashService:
                 raise CourierCashCommandError("invalid_transition", 409)
             to_state = STATE_MANUAL_REVIEW
         else:
-            to_state = _TRANSITIONS.get((from_state, command.event_type))
-            if to_state is None:
+            next_state = _TRANSITIONS.get((from_state, command.event_type))
+            if next_state is None:
                 raise CourierCashCommandError("invalid_transition", 409)
+            to_state = next_state
             if (
                 from_state == STATE_READY
                 and projection.quittung_status != QUITTUNG_PRINTED_CURRENT

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -14,6 +14,7 @@ from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.task_projection import (
     TaskCategory,
     TaskProjection,
+    TaskUrgency,
     inquiry_subtitle,
     task_sort_key,
 )
@@ -185,6 +186,8 @@ class TaskProjectionService:
                 and cash_event is not None
                 and cash_event.to_state in {STATE_NOT_RECEIVED, STATE_MANUAL_REVIEW}
             )
+            due_at: date | None
+            urgency: TaskUrgency
             if cash_needs_office:
                 title = "Barzahlung klären"
                 due_at = operating_today

--- a/src/catering_system/services/task_projection_service.py
+++ b/src/catering_system/services/task_projection_service.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import date
 
+from catering_system.domain.courier_cash_handoff import (
+    STATE_MANUAL_REVIEW,
+    STATE_NOT_RECEIVED,
+)
 from catering_system.domain.inquiry import Inquiry, derive_inquiry_office_state
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.task_projection import (
@@ -13,6 +17,7 @@ from catering_system.domain.task_projection import (
     inquiry_subtitle,
     task_sort_key,
 )
+from catering_system.repositories.courier_cash_repository import CourierCashRepository
 from catering_system.repositories.inquiry_repository import InquiryRepository
 from catering_system.repositories.offer_repository import OfferRepository
 from catering_system.repositories.order_repository import OrderRepository
@@ -29,12 +34,14 @@ class TaskProjectionService:
         payment_reminder_service: PaymentReminderService,
         *,
         today: Callable[[], date] | None = None,
+        courier_cash_repository: CourierCashRepository | None = None,
     ) -> None:
         self._inquiries = inquiry_repository
         self._offers = offer_repository
         self._orders = order_repository
         self._payment_reminders = payment_reminder_service
         self._today = today or berlin_today
+        self._courier_cash = courier_cash_repository
 
     def list_tasks(self) -> list[TaskProjection]:
         operating_today = self._today()
@@ -168,23 +175,40 @@ class TaskProjectionService:
                 payment = self._payment_reminders.view(order.order_id)
             except (KeyError, ValueError):
                 continue
-            if payment.next_step is None:
-                continue
-            due_at = payment.next_step_due_on
-            overdue = due_at is not None and due_at < operating_today
+            cash_event = (
+                self._courier_cash.get_latest_for_order(order.order_id)
+                if self._courier_cash is not None
+                else None
+            )
+            cash_needs_office = (
+                payment.payment_method == "BAR_VOR_ORT"
+                and cash_event is not None
+                and cash_event.to_state in {STATE_NOT_RECEIVED, STATE_MANUAL_REVIEW}
+            )
+            if cash_needs_office:
+                title = "Barzahlung klären"
+                due_at = operating_today
+                urgency = "urgent"
+            else:
+                if payment.next_step is None:
+                    continue
+                title = payment.next_step
+                due_at = payment.next_step_due_on
+                overdue = due_at is not None and due_at < operating_today
+                urgency = "overdue" if overdue else "normal"
             tasks.append(
                 (
                     TaskProjection(
                         task_id=f"order:{order.order_id}:payment",
                         category="payment",
-                        title=payment.next_step,
+                        title=title,
                         subtitle=subtitle,
                         entity_type="order",
                         entity_id=order.order_id,
                         action_label="Auftrag öffnen",
                         action_href=f"/order/{order.order_id}",
                         due_at=due_at,
-                        urgency="overdue" if overdue else "normal",
+                        urgency=urgency,
                         opened_at=order.created_at,
                     ),
                     event_date,

--- a/src/catering_system/ui/kiosk_server.py
+++ b/src/catering_system/ui/kiosk_server.py
@@ -16,6 +16,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
 from catering_system.domain.offer_charges import ReturnLogisticsDefinition
+from catering_system.domain.courier_cash_handoff import CourierCashProjection
 from catering_system.domain.wochenuebersicht import (
     Wochenuebersicht,
     WochenuebersichtEntry,
@@ -27,6 +28,7 @@ from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.order_operational_pause_repository import (
     OrderOperationalPauseRepository,
 )
+from catering_system.services.courier_cash_context_service import CourierCashContextService
 from catering_system.services.wochenuebersicht_service import WochenuebersichtService
 from catering_system.ui.operational_pause_labels import pause_reason_label
 from catering_system.ui.pickup_signal import (
@@ -193,6 +195,9 @@ def _return_logistics_projection(
 def _order_feed_entry_projection(
     entry: WochenuebersichtEntry,
     return_logistics: ReturnLogisticsDefinition | None,
+    cash_handoff: CourierCashProjection | None = None,
+    *,
+    include_cash_handoff: bool = False,
 ) -> dict[str, object]:
     projection: dict[str, object] = {
         "order_id": entry.order_id,
@@ -207,6 +212,10 @@ def _order_feed_entry_projection(
     delivery_window = _delivery_window_projection(entry)
     if delivery_window is not None:
         projection["delivery_window"] = delivery_window
+    if include_cash_handoff:
+        projection["cash_handoff"] = (
+            cash_handoff.to_json() if cash_handoff is not None else None
+        )
     return projection
 
 
@@ -215,6 +224,7 @@ def render_order_feed_json(
     entries: tuple[WochenuebersichtEntry, ...],
     return_logistics_by_order_id: Mapping[str, ReturnLogisticsDefinition | None]
     | None = None,
+    cash_handoff_by_order_id: Mapping[str, CourierCashProjection | None] | None = None,
 ) -> bytes:
     """Pure renderer: per-date entries → courier order feed document (v3).
 
@@ -224,10 +234,17 @@ def render_order_feed_json(
     OrderCommercialSnapshot. Prices and courier execution state stay out.
     """
     return_logistics = return_logistics_by_order_id or {}
+    include_cash_handoff = cash_handoff_by_order_id is not None
+    cash_handoff = cash_handoff_by_order_id or {}
     document = {
         "date": feed_date.isoformat(),
         "orders": [
-            _order_feed_entry_projection(e, return_logistics.get(e.order_id))
+            _order_feed_entry_projection(
+                e,
+                return_logistics.get(e.order_id),
+                cash_handoff.get(e.order_id),
+                include_cash_handoff=include_cash_handoff,
+            )
             for e in entries
         ],
     }
@@ -251,6 +268,7 @@ def make_kiosk_handler(
     *,
     pause_repository: OrderOperationalPauseRepository | None = None,
     commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
+    courier_cash_context_service: CourierCashContextService | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     service = WochenuebersichtService(
         order_repository, pause_repository=pause_repository
@@ -290,8 +308,21 @@ def make_kiosk_handler(
                         return_logistics_by_order_id[entry.order_id] = (
                             snapshot.return_logistics if snapshot is not None else None
                         )
+                cash_handoff_by_order_id: dict[
+                    str, CourierCashProjection | None
+                ] | None = None
+                if courier_cash_context_service is not None:
+                    cash_handoff_by_order_id = {
+                        entry.order_id: courier_cash_context_service.projection(
+                            entry.order_id
+                        )
+                        for entry in entries
+                    }
                 payload = render_order_feed_json(
-                    feed_date, entries, return_logistics_by_order_id
+                    feed_date,
+                    entries,
+                    return_logistics_by_order_id,
+                    cash_handoff_by_order_id,
                 )
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -340,6 +371,7 @@ def create_kiosk_server(
     *,
     pause_repository: OrderOperationalPauseRepository | None = None,
     commercial_snapshot_repository: OrderCommercialSnapshotRepository | None = None,
+    courier_cash_context_service: CourierCashContextService | None = None,
 ) -> HTTPServer:
     # Single-threaded on purpose: the shared sqlite3 connection must stay on the
     # thread that serves requests (bring-up bug, WORKLOG Entry 048). A read-only
@@ -352,6 +384,7 @@ def create_kiosk_server(
             pickup_signal,
             pause_repository=pause_repository,
             commercial_snapshot_repository=commercial_snapshot_repository,
+            courier_cash_context_service=courier_cash_context_service,
         ),
     )
 
@@ -390,13 +423,26 @@ def main() -> None:
     from catering_system.repositories.sqlite_order_commercial_snapshot_repository import (
         SQLiteOrderCommercialSnapshotRepository,
     )
+    from catering_system.repositories.sqlite_courier_cash_repository import (
+        SQLiteCourierCashRepository,
+    )
     from catering_system.repositories.sqlite_order_repository import (
         SQLiteOrderRepository,
+    )
+    from catering_system.repositories.sqlite_payment_reminder_repository import (
+        SQLitePaymentReminderRepository,
     )
 
     order_repo = SQLiteOrderRepository(args.db)
     pause_repo = SQLiteOrderOperationalPauseRepository(args.db)
     commercial_snapshot_repo = SQLiteOrderCommercialSnapshotRepository(args.db)
+    payment_repo = SQLitePaymentReminderRepository(args.db)
+    courier_cash_repo = SQLiteCourierCashRepository(args.db)
+    courier_cash_context_service = CourierCashContextService(
+        order_repo,
+        payment_repo,
+        courier_cash_repo,
+    )
     server = create_kiosk_server(
         order_repo,
         args.host,
@@ -404,6 +450,7 @@ def main() -> None:
         pickup_signal,
         pause_repository=pause_repo,
         commercial_snapshot_repository=commercial_snapshot_repo,
+        courier_cash_context_service=courier_cash_context_service,
     )
     if pickup_signal is not None:
         pickup_signal.start()

--- a/src/catering_system/ui/kiosk_server.py
+++ b/src/catering_system/ui/kiosk_server.py
@@ -28,7 +28,9 @@ from catering_system.repositories.order_repository import OrderRepository
 from catering_system.repositories.order_operational_pause_repository import (
     OrderOperationalPauseRepository,
 )
-from catering_system.services.courier_cash_context_service import CourierCashContextService
+from catering_system.services.courier_cash_context_service import (
+    CourierCashContextService,
+)
 from catering_system.services.wochenuebersicht_service import WochenuebersichtService
 from catering_system.ui.operational_pause_labels import pause_reason_label
 from catering_system.ui.pickup_signal import (
@@ -308,9 +310,9 @@ def make_kiosk_handler(
                         return_logistics_by_order_id[entry.order_id] = (
                             snapshot.return_logistics if snapshot is not None else None
                         )
-                cash_handoff_by_order_id: dict[
-                    str, CourierCashProjection | None
-                ] | None = None
+                cash_handoff_by_order_id: (
+                    dict[str, CourierCashProjection | None] | None
+                ) = None
                 if courier_cash_context_service is not None:
                     cash_handoff_by_order_id = {
                         entry.order_id: courier_cash_context_service.projection(

--- a/src/catering_system/ui/manual_task_presentation.py
+++ b/src/catering_system/ui/manual_task_presentation.py
@@ -30,7 +30,7 @@ def priority_label(priority: str) -> str:
 
 
 def system_task_priority(row: dict[str, object]) -> str:
-    if str(row.get("urgency", "")) == "overdue":
+    if str(row.get("urgency", "")) in {"overdue", "urgent"}:
         return "HIGH"
     category = str(row.get("category", ""))
     if category in {"verify", "order_print"}:

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -851,6 +851,7 @@ class OfficeApi:
         )
         self.courier_cash_service = CourierCashService(
             self.orders,
+            self.inquiries,
             self.payment_reminders,
             self.courier_cash,
             self.payment_reminder_service,

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -197,7 +197,9 @@ from catering_system.services.chat_service import (
     ChatReferenceNotFoundError,
     ChatService,
 )
-from catering_system.services.courier_cash_context_service import CourierCashContextService
+from catering_system.services.courier_cash_context_service import (
+    CourierCashContextService,
+)
 from catering_system.services.courier_cash_service import (
     CourierCashCommandError,
     CourierCashService,
@@ -4221,9 +4223,7 @@ def make_office_api_handler(
 ) -> type[BaseHTTPRequestHandler]:
     expected_auth = f"Bearer {token}"
     expected_courier_cash_auth = (
-        f"Bearer {courier_cash_service_token}"
-        if courier_cash_service_token
-        else None
+        f"Bearer {courier_cash_service_token}" if courier_cash_service_token else None
     )
     service_auth = OfficeApiServiceAuth(
         office_panel_token=token,
@@ -4524,9 +4524,7 @@ def make_office_api_handler(
                 if not hmac.compare_digest(presented, expected_courier_cash_auth):
                     self._respond(401, {"error": "unauthorized"}, suppress_body=True)
                     return
-                self._respond(
-                    405, {"error": "method_not_allowed"}, suppress_body=True
-                )
+                self._respond(405, {"error": "method_not_allowed"}, suppress_body=True)
                 return
             if self._is_introspect_path(path):
                 if not self._introspect_service_auth_or_respond():

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -4217,8 +4217,14 @@ def make_office_api_handler(
     token: str,
     *,
     introspection_service_tokens: dict[str, str] | None = None,
+    courier_cash_service_token: str | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     expected_auth = f"Bearer {token}"
+    expected_courier_cash_auth = (
+        f"Bearer {courier_cash_service_token}"
+        if courier_cash_service_token
+        else None
+    )
     service_auth = OfficeApiServiceAuth(
         office_panel_token=token,
         introspection_clients=introspection_service_tokens or {},
@@ -4335,6 +4341,16 @@ def make_office_api_handler(
                 return True
             self._error(401, "unauthorized")
             return False
+
+        def _courier_cash_auth_or_respond(self) -> bool:
+            if expected_courier_cash_auth is None:
+                self._error(404, "not_found")
+                return False
+            presented = self.headers.get("Authorization", "")
+            if not hmac.compare_digest(presented, expected_courier_cash_auth):
+                self._error(401, "unauthorized")
+                return False
+            return True
 
         def _is_introspect_path(self, path: str) -> bool:
             return path == EMPLOYEE_INTROSPECT_PATH
@@ -4500,6 +4516,18 @@ def make_office_api_handler(
             # Explicit handler (pack §4.0): auth first, then 405/404 with
             # full headers; body suppressed but Content-Length preserved.
             path = urlparse(self.path).path
+            if path == _COURIER_CASH_PATH:
+                if expected_courier_cash_auth is None:
+                    self._respond(404, {"error": "not_found"}, suppress_body=True)
+                    return
+                presented = self.headers.get("Authorization", "")
+                if not hmac.compare_digest(presented, expected_courier_cash_auth):
+                    self._respond(401, {"error": "unauthorized"}, suppress_body=True)
+                    return
+                self._respond(
+                    405, {"error": "method_not_allowed"}, suppress_body=True
+                )
+                return
             if self._is_introspect_path(path):
                 if not self._introspect_service_auth_or_respond():
                     return
@@ -4533,6 +4561,11 @@ def make_office_api_handler(
 
         def do_OPTIONS(self) -> None:
             path = urlparse(self.path).path
+            if path == _COURIER_CASH_PATH:
+                if not self._courier_cash_auth_or_respond():
+                    return
+                self._error(405, "method_not_allowed")
+                return
             if self._is_introspect_path(path):
                 if not self._introspect_service_auth_or_respond():
                     return
@@ -4547,9 +4580,14 @@ def make_office_api_handler(
                 self._error(404, "not_found")
 
         def _method_not_allowed_or_404(self) -> None:
+            path = urlparse(self.path).path
+            if path == _COURIER_CASH_PATH:
+                if not self._courier_cash_auth_or_respond():
+                    return
+                self._error(405, "method_not_allowed")
+                return
             if not self._auth_or_401():
                 return
-            path = urlparse(self.path).path
             if _resolve_route(path) is not None:
                 self._error(405, "method_not_allowed")
             else:
@@ -4557,6 +4595,9 @@ def make_office_api_handler(
 
         def _handle(self, method: str) -> None:
             path = urlparse(self.path).path
+            if path == _COURIER_CASH_PATH:
+                self._handle_courier_cash(method)
+                return
             if path == "/office/v1/auth/configurator-handoff/exchange":
                 self._handle_configurator_handoff_exchange(method)
             if self._is_introspect_path(path):
@@ -4594,6 +4635,41 @@ def make_office_api_handler(
             except Exception:  # noqa: BLE001
                 _log.exception("internal error route=%s", template)
                 self._error(500, "internal")
+
+        def _handle_courier_cash(self, method: str) -> None:
+            if not self._courier_cash_auth_or_respond():
+                return
+            if method != "POST":
+                self._error(405, "method_not_allowed")
+                return
+            try:
+                if urlparse(self.path).query:
+                    raise ValueError("query not allowed")
+                raw = self._read_command_body(_MAX_COURIER_CASH_BODY_BYTES)
+                body = strict_json_loads(raw)
+                command = CourierCashCommand.from_json(body)
+            except UnsupportedCourierCashContractVersion:
+                self._error(400, "unsupported_contract_version")
+                return
+            except (ApiError, ValueError, TypeError):
+                self._error(400, "invalid_request")
+                return
+
+            try:
+                result = api.executor.run(
+                    lambda: api.courier_cash_service.process(command)
+                )
+            except CourierCashCommandError as exc:
+                self._error(exc.status, exc.code)
+                return
+            except CoreBusyError:
+                self._error(503, "core_unavailable")
+                return
+            except Exception:  # noqa: BLE001
+                _log.exception("courier cash Core write failed")
+                self._error(503, "core_unavailable")
+                return
+            self._respond(200, result.to_json())
 
         def _handle_configurator_handoff_exchange(self, method: str) -> None:
             service_authenticated, correct_service = self._configurator_service_auth()
@@ -4993,6 +5069,7 @@ def create_office_api_server(
     introspection_service_tokens: dict[str, str] | None = None,
     employee_auth_service_tokens: dict[str, str] | None = None,
     employee_auth_now: Callable[[], datetime] | None = None,
+    courier_cash_service_token: str | None = None,
 ) -> HTTPServer:
     """Build connection, repositories and server in the calling thread —
     single-threaded on purpose (sqlite3 thread affinity, Entry 048)."""
@@ -5013,6 +5090,7 @@ def create_office_api_server(
             api,
             token,
             introspection_service_tokens=effective_introspection_tokens,
+            courier_cash_service_token=courier_cash_service_token,
         ),
     )
 
@@ -5044,6 +5122,7 @@ def main() -> None:
     introspection_tokens = read_introspection_service_tokens_from_env(
         office_panel_token=token,
     )
+    courier_cash_token = os.environ.get("COURIER_CASH_SERVICE_TOKEN", "") or None
 
     server = create_office_api_server(
         args.db,
@@ -5052,6 +5131,7 @@ def main() -> None:
         args.port,
         offer_pdf_static_content=offer_pdf_static_content,
         introspection_service_tokens=introspection_tokens,
+        courier_cash_service_token=courier_cash_token,
     )
     print(f"Core Office API on http://{args.host}:{args.port}/office/v1/")
     server.serve_forever()

--- a/src/catering_system/ui/office_api.py
+++ b/src/catering_system/ui/office_api.py
@@ -53,6 +53,10 @@ from catering_system.domain.customer_gastronomic_preference import (
     validate_preference_source,
 )
 from catering_system.domain.customer_order_history import CustomerOrderHistoryEntry
+from catering_system.domain.courier_cash_handoff import (
+    CourierCashCommand,
+    UnsupportedCourierCashContractVersion,
+)
 from catering_system.domain.customer_document_eligibility import (
     CustomerDocumentCreationBlocked,
 )
@@ -126,6 +130,9 @@ from catering_system.repositories.sqlite_catalog_repository import (
     SQLiteCatalogRepository,
 )
 from catering_system.repositories.sqlite_chat_repository import SQLiteChatRepository
+from catering_system.repositories.sqlite_courier_cash_repository import (
+    SQLiteCourierCashRepository,
+)
 from catering_system.repositories.sqlite_configurator_handoff_repository import (
     SQLiteConfiguratorHandoffRepository,
 )
@@ -189,6 +196,11 @@ from catering_system.services.chat_service import (
     ChatNotFoundError,
     ChatReferenceNotFoundError,
     ChatService,
+)
+from catering_system.services.courier_cash_context_service import CourierCashContextService
+from catering_system.services.courier_cash_service import (
+    CourierCashCommandError,
+    CourierCashService,
 )
 from catering_system.services.customer_order_history_service import (
     CustomerOrderHistoryCustomerNotFoundError,
@@ -293,6 +305,8 @@ _log = logging.getLogger(__name__)
 CLIENT_ID = "office-panel"  # per-client token identity (pack §6.1)
 CONFIGURATOR_HANDOFF_SERVICE_ID = "configurator-handoff"
 _MAX_BODY_BYTES = 64 * 1024
+_MAX_COURIER_CASH_BODY_BYTES = 16 * 1024
+_COURIER_CASH_PATH = "/machine/v1/courier/cash-events"
 _MAX_PREPARE_OFFER_BODY_BYTES = 256 * 1024
 _MAX_RESPONSE_BYTES = 512 * 1024  # pack §4.0 hard response cap
 _MAX_Q_CHARS = 200
@@ -774,6 +788,7 @@ class OfficeApi:
         self.payment_reminders = SQLitePaymentReminderRepository.from_connection(
             connection
         )
+        self.courier_cash = SQLiteCourierCashRepository.from_connection(connection)
         self.chat = SQLiteChatRepository.from_connection(connection)
         self.manual_tasks = SQLiteManualTaskRepository.from_connection(connection)
         self.confirmation_documents = (
@@ -826,6 +841,18 @@ class OfficeApi:
             self.payment_reminders,
             self.orders,
             today=views.berlin_today,
+        )
+        self.courier_cash_context_service = CourierCashContextService(
+            self.orders,
+            self.payment_reminders,
+            self.courier_cash,
+        )
+        self.courier_cash_service = CourierCashService(
+            self.orders,
+            self.payment_reminders,
+            self.courier_cash,
+            self.payment_reminder_service,
+            self.courier_cash_context_service,
         )
         self.chat_service = ChatService(
             self.chat,
@@ -887,6 +914,7 @@ class OfficeApi:
             self.orders,
             self.payment_reminder_service,
             today=views.berlin_today,
+            courier_cash_repository=self.courier_cash,
         )
         self.calendar_projection_service = CalendarProjectionService(
             self.inquiries,

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -573,7 +573,6 @@ def test_command_parser_is_exact_and_role_safe() -> None:
         )
 
 
-
 def test_command_parser_covers_strict_validation_edges() -> None:
     base = {
         "contract_version": CONTRACT_VERSION,

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -33,6 +33,7 @@ from catering_system.domain.courier_cash_handoff import (
     CourierCashProjection,
     UnsupportedCourierCashContractVersion,
 )
+from catering_system.domain.inquiry import FulfillmentMode, Inquiry
 from catering_system.domain.order import Order, OrderVersion
 from catering_system.domain.order_payment_reminder import OrderPaymentReminder
 from catering_system.domain.wochenuebersicht import WochenuebersichtEntry
@@ -60,6 +61,7 @@ from catering_system.services.task_projection_service import TaskProjectionServi
 from catering_system.ui.kiosk_server import render_order_feed_json
 from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
 
+_INQUIRY_ID = "20000000-0000-4000-8000-000000000001"
 _ORDER_ID = "50000000-0000-4000-8000-000000000001"
 _VERSION_ID = "70000000-0000-4000-8000-000000000001"
 _ASSIGNMENT_ID = "60000000-0000-4000-8000-000000000001"
@@ -70,6 +72,7 @@ def _seed_world(
     db: Path,
     *,
     quittung_printed: bool = True,
+    fulfillment_mode: FulfillmentMode = "DELIVERY",
 ) -> tuple[
     sqlite3.Connection,
     SQLiteOrderRepository,
@@ -80,9 +83,29 @@ def _seed_world(
     CourierCashService,
 ]:
     connection = open_core_connection(db)
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
     orders = SQLiteOrderRepository.from_connection(connection)
     payments = SQLitePaymentReminderRepository.from_connection(connection)
     cash_events = SQLiteCourierCashRepository.from_connection(connection)
+
+    inquiries.save(
+        Inquiry(
+            inquiry_id=_INQUIRY_ID,
+            event_date=date(2026, 8, 31),
+            created_at=datetime(2026, 8, 31, 7, 0, tzinfo=UTC),
+            updated_at=datetime(2026, 8, 31, 7, 0, tzinfo=UTC),
+            inquiry_source="manual",
+            crm_stage="Bestätigt / Auftrag",
+            customer_linkage={},
+            time_window_text="12:00",
+            location_text="Hamburg",
+            guest_count_estimate=20,
+            planning_mode="caterer_suggestion",
+            call_verification_required=False,
+            call_verification_status="not_required",
+            fulfillment_mode=fulfillment_mode,
+        )
+    )
 
     version = OrderVersion(
         order_version_id=_VERSION_ID,
@@ -97,7 +120,7 @@ def _seed_world(
     )
     order = Order(
         order_id=_ORDER_ID,
-        source_inquiry_id="20000000-0000-4000-8000-000000000001",
+        source_inquiry_id=_INQUIRY_ID,
         created_at=version.created_at,
         updated_at=version.created_at,
         candidate_order_version_id=_VERSION_ID,
@@ -121,6 +144,7 @@ def _seed_world(
     context_service = CourierCashContextService(orders, payments, cash_events)
     service = CourierCashService(
         orders,
+        inquiries,
         payments,
         cash_events,
         payment_service,
@@ -259,7 +283,9 @@ def test_driver_to_chef_requires_two_transitions_before_final_payment(
 
 def test_direct_chef_pickup_finalizes_without_driver_custody(tmp_path: Path) -> None:
     db = tmp_path / "core.db"
-    connection, _orders, payments, _cash, _payment, context, service = _seed_world(db)
+    connection, _orders, payments, _cash, _payment, context, service = _seed_world(
+        db, fulfillment_mode="PICKUP"
+    )
 
     result = service.process(
         _command(
@@ -273,6 +299,28 @@ def test_direct_chef_pickup_finalizes_without_driver_custody(tmp_path: Path) -> 
     assert result.cash_state == STATE_FINAL_PAID
     paid = payments.get(_ORDER_ID)
     assert paid is not None and paid.cash_received is True
+    connection.close()
+
+
+def test_direct_chef_cash_is_rejected_for_delivery(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, payments, _cash, _payment, context, service = _seed_world(db)
+
+    with pytest.raises(CourierCashCommandError) as exc:
+        service.process(
+            _command(
+                context,
+                event_type=EVENT_CHEF_DIRECT,
+                actor_role="CHEF",
+                actor_id="chef-2",
+            )
+        )
+
+    assert exc.value.code == "invalid_transition"
+    payment = payments.get(_ORDER_ID)
+    assert payment is not None
+    assert payment.cash_received is False
+    assert payment.paid_on is None
     connection.close()
 
 

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from datetime import UTC, date, datetime
 from http.server import HTTPServer
 from pathlib import Path
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -570,6 +571,258 @@ def test_command_parser_is_exact_and_role_safe() -> None:
                 "not_received_reason": "OTHER",
             }
         )
+
+
+
+def test_command_parser_covers_strict_validation_edges() -> None:
+    base = {
+        "contract_version": CONTRACT_VERSION,
+        "idempotency_key": "40000000-0000-4000-8000-000000000001",
+        "event_type": EVENT_DRIVER_RECEIVED,
+        "order_id": _ORDER_ID,
+        "assignment_id": _ASSIGNMENT_ID,
+        "order_version_id": _VERSION_ID,
+        "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+        "actor_id": "driver-17",
+        "actor_role": "DRIVER",
+        "occurred_at": _NOW.isoformat(),
+        "not_received_reason": None,
+        "note": None,
+        "correction_reason": None,
+        "correction_of_idempotency_key": None,
+    }
+
+    invalid_cases = (
+        ({"idempotency_key": 7}, "UUID string"),
+        ({"idempotency_key": "not-a-uuid"}, "UUID string"),
+        (
+            {"idempotency_key": "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"},
+            "canonical lowercase UUID",
+        ),
+        ({"actor_id": 7}, "must be string"),
+        ({"actor_id": " driver-17"}, "trimmed non-empty text"),
+        ({"occurred_at": 7}, "date-time string"),
+        ({"occurred_at": "not-a-date"}, "date-time string"),
+        ({"occurred_at": "2026-08-31T09:00:00"}, "timezone-aware"),
+        ({"event_type": "NOT_AN_EVENT"}, "invalid cash event type"),
+        (
+            {
+                "event_type": EVENT_NOT_RECEIVED,
+                "not_received_reason": "NOT_A_REASON",
+            },
+            "structured reason",
+        ),
+        (
+            {
+                "event_type": EVENT_NOT_RECEIVED,
+                "not_received_reason": "CUSTOMER_NOT_FOUND",
+                "note": "extra",
+            },
+            "note is only allowed",
+        ),
+        (
+            {
+                "event_type": EVENT_NOT_RECEIVED,
+                "not_received_reason": "CUSTOMER_NOT_FOUND",
+                "correction_reason": "extra",
+            },
+            "cannot be correction",
+        ),
+        (
+            {
+                "event_type": EVENT_CORRECTION,
+                "actor_role": "CHEF",
+                "not_received_reason": "CUSTOMER_NOT_FOUND",
+                "correction_reason": "fix",
+                "correction_of_idempotency_key": (
+                    "90000000-0000-4000-8000-000000000001"
+                ),
+            },
+            "cannot carry not-received",
+        ),
+        (
+            {
+                "event_type": EVENT_CORRECTION,
+                "actor_role": "CHEF",
+                "correction_of_idempotency_key": (
+                    "90000000-0000-4000-8000-000000000001"
+                ),
+            },
+            "correction requires reason",
+        ),
+        ({"note": "extra"}, "fields that must be null"),
+    )
+    for changes, message in invalid_cases:
+        with pytest.raises(ValueError, match=message):
+            CourierCashCommand.from_json({**base, **changes})
+
+    projection_args = {
+        "order_version_id": _VERSION_ID,
+        "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+        "quittung_status": QUITTUNG_PRINTED_CURRENT,
+    }
+    with pytest.raises(ValueError, match="unsupported contract version"):
+        CourierCashProjection(**projection_args, contract_version="v2")
+    with pytest.raises(ValueError, match="must require BAR"):
+        CourierCashProjection(**projection_args, bar_required=False)
+    with pytest.raises(ValueError, match="invalid Quittung status"):
+        CourierCashProjection(**{**projection_args, "quittung_status": "UNKNOWN"})
+
+
+def test_context_projection_returns_none_for_missing_runtime_prerequisites() -> None:
+    orders = Mock()
+    payments = Mock()
+    cash_events = Mock()
+    service = CourierCashContextService(orders, payments, cash_events)
+
+    orders.get_order.return_value = None
+    assert service.projection(_ORDER_ID) is None
+
+    order_without_version = Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id=_INQUIRY_ID,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    orders.get_order.return_value = order_without_version
+    payments.get.return_value = None
+    assert service.projection(_ORDER_ID) is None
+
+    payment = OrderPaymentReminder(
+        order_id=_ORDER_ID,
+        payment_method="BAR_VOR_ORT",
+    )
+    payments.get.return_value = payment
+    assert service.projection(_ORDER_ID) is None
+
+    orders.get_order.return_value = replace(
+        order_without_version,
+        effective_order_version_id=_VERSION_ID,
+    )
+    orders.get_order_version.return_value = None
+    assert service.projection(_ORDER_ID) is None
+
+
+def test_service_error_edges_are_explicit_and_covered(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, payments, _cash, _payment, context, service = _seed_world(db)
+
+    driver = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+    )
+    with pytest.raises(CourierCashCommandError) as missing_order:
+        service.process(
+            replace(
+                driver,
+                order_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            )
+        )
+    assert missing_order.value.code == "invalid_transition"
+
+    original_context_service = service._context_service
+    service._context_service = Mock()
+    service._context_service.projection.return_value = None
+    with pytest.raises(CourierCashCommandError) as missing_context:
+        service.process(driver)
+    assert missing_context.value.code == "stale_cash_context"
+    service._context_service = original_context_service
+
+    correction_from_ready = _command(
+        context,
+        event_type=EVENT_CORRECTION,
+        actor_role="CHEF",
+        actor_id="chef-2",
+        correction_reason="Korrektur",
+        correction_of_idempotency_key="90000000-0000-4000-8000-000000000001",
+    )
+    with pytest.raises(CourierCashCommandError) as not_correctable:
+        service.process(correction_from_ready)
+    assert not_correctable.value.code == "invalid_transition"
+
+    service.process(driver)
+    correction_missing_target = _command(
+        context,
+        event_type=EVENT_CORRECTION,
+        actor_role="CHEF",
+        actor_id="chef-2",
+        correction_reason="Korrektur",
+        correction_of_idempotency_key="90000000-0000-4000-8000-000000000001",
+    )
+    with pytest.raises(CourierCashCommandError) as missing_target:
+        service.process(correction_missing_target)
+    assert missing_target.value.code == "invalid_transition"
+
+    payment = payments.get(_ORDER_ID)
+    assert payment is not None
+    service._payments = Mock()
+    service._payments.get.return_value = None
+    with pytest.raises(CourierCashCommandError) as missing_payment:
+        service._record_final_payment(driver, _NOW)
+    assert missing_payment.value.code == "stale_cash_context"
+
+    service._payments.get.return_value = replace(
+        payment,
+        paid_on=date(2026, 8, 31),
+        cash_received=True,
+    )
+    with pytest.raises(CourierCashCommandError) as already_paid:
+        service._record_final_payment(driver, _NOW)
+    assert already_paid.value.code == "invalid_transition"
+
+    service._payments.get.return_value = payment
+    service._payment_service = Mock()
+    service._payment_service.save.side_effect = ValueError("forced")
+    with pytest.raises(CourierCashCommandError) as save_failure:
+        service._record_final_payment(driver, _NOW)
+    assert save_failure.value.code == "invalid_transition"
+    connection.close()
+
+    not_ready_db = tmp_path / "not-ready.db"
+    (
+        not_ready_connection,
+        _orders2,
+        _payments2,
+        _cash2,
+        _payment2,
+        not_ready_context,
+        not_ready_service,
+    ) = _seed_world(not_ready_db, quittung_printed=False)
+    with pytest.raises(CourierCashCommandError) as not_ready:
+        not_ready_service.process(
+            _command(
+                not_ready_context,
+                event_type=EVENT_DRIVER_RECEIVED,
+                actor_role="DRIVER",
+                actor_id="driver-17",
+            )
+        )
+    assert not_ready.value.code == "invalid_transition"
+    not_ready_connection.close()
+
+    naive_db = tmp_path / "naive-clock.db"
+    (
+        naive_connection,
+        _orders3,
+        _payments3,
+        _cash3,
+        _payment3,
+        naive_context,
+        naive_service,
+    ) = _seed_world(naive_db)
+    naive_service._now = lambda: datetime(2026, 8, 31, 9, 0)
+    with pytest.raises(ValueError, match="timezone-aware"):
+        naive_service.process(
+            _command(
+                naive_context,
+                event_type=EVENT_DRIVER_RECEIVED,
+                actor_role="DRIVER",
+                actor_id="driver-17",
+            )
+        )
+    naive_connection.close()
 
 
 def test_kiosk_feed_cash_extension_keeps_absent_null_object_semantics() -> None:

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import json
+import queue
+import sqlite3
+import threading
+import urllib.error
+import urllib.request
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from http.server import HTTPServer
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from catering_system.domain.courier_cash_handoff import (
+    CONTRACT_VERSION,
+    EVENT_CHEF_DIRECT,
+    EVENT_CHEF_RECEIVED_FROM_DRIVER,
+    EVENT_CORRECTION,
+    EVENT_DRIVER_HANDED_TO_CHEF,
+    EVENT_DRIVER_RECEIVED,
+    EVENT_NOT_RECEIVED,
+    QUITTUNG_NOT_READY,
+    QUITTUNG_PRINTED_CURRENT,
+    STATE_AWAITING_CHEF,
+    STATE_DRIVER_CUSTODY,
+    STATE_FINAL_PAID,
+    STATE_MANUAL_REVIEW,
+    STATE_NOT_RECEIVED,
+    CourierCashCommand,
+    CourierCashProjection,
+    UnsupportedCourierCashContractVersion,
+)
+from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.order_payment_reminder import OrderPaymentReminder
+from catering_system.domain.wochenuebersicht import WochenuebersichtEntry
+from catering_system.repositories.core_transaction import open_core_connection
+from catering_system.repositories.sqlite_courier_cash_repository import (
+    SQLiteCourierCashRepository,
+)
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
+from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
+from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.repositories.sqlite_payment_reminder_repository import (
+    SQLitePaymentReminderRepository,
+)
+from catering_system.services.courier_cash_context_service import CourierCashContextService
+from catering_system.services.courier_cash_service import (
+    CourierCashCommandError,
+    CourierCashService,
+)
+from catering_system.services.payment_reminder_service import PaymentReminderService
+from catering_system.services.task_projection_service import TaskProjectionService
+from catering_system.ui.kiosk_server import render_order_feed_json
+from tests.helpers.offer_pdf_static_content import fake_offer_pdf_static_content
+
+_ORDER_ID = "50000000-0000-4000-8000-000000000001"
+_VERSION_ID = "70000000-0000-4000-8000-000000000001"
+_ASSIGNMENT_ID = "60000000-0000-4000-8000-000000000001"
+_NOW = datetime(2026, 8, 31, 9, 0, tzinfo=UTC)
+
+
+def _seed_world(
+    db: Path,
+    *,
+    quittung_printed: bool = True,
+) -> tuple[
+    sqlite3.Connection,
+    SQLiteOrderRepository,
+    SQLitePaymentReminderRepository,
+    SQLiteCourierCashRepository,
+    PaymentReminderService,
+    CourierCashContextService,
+    CourierCashService,
+]:
+    connection = open_core_connection(db)
+    orders = SQLiteOrderRepository.from_connection(connection)
+    payments = SQLitePaymentReminderRepository.from_connection(connection)
+    cash_events = SQLiteCourierCashRepository.from_connection(connection)
+
+    version = OrderVersion(
+        order_version_id=_VERSION_ID,
+        order_id=_ORDER_ID,
+        version_number=1,
+        created_at=datetime(2026, 8, 31, 8, 0, tzinfo=UTC),
+        event_date=date(2026, 8, 31),
+        time_window_text="12:00",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+    )
+    order = Order(
+        order_id=_ORDER_ID,
+        source_inquiry_id="20000000-0000-4000-8000-000000000001",
+        created_at=version.created_at,
+        updated_at=version.created_at,
+        candidate_order_version_id=_VERSION_ID,
+        effective_order_version_id=_VERSION_ID,
+    )
+    orders.save_order_with_initial_version(order, version)
+    payment_service = PaymentReminderService(
+        payments,
+        orders,
+        now=lambda: _NOW,
+        today=lambda: _NOW.date(),
+    )
+    payment_service.save(
+        OrderPaymentReminder(
+            order_id=_ORDER_ID,
+            payment_method="BAR_VOR_ORT",
+            quittung_printed=quittung_printed,
+        ),
+        actor_reference="Office",
+    )
+    context_service = CourierCashContextService(orders, payments, cash_events)
+    service = CourierCashService(
+        orders,
+        payments,
+        cash_events,
+        payment_service,
+        context_service,
+        now=lambda: _NOW,
+    )
+    connection.commit()
+    return (
+        connection,
+        orders,
+        payments,
+        cash_events,
+        payment_service,
+        context_service,
+        service,
+    )
+
+
+def _command(
+    context_service: CourierCashContextService,
+    *,
+    event_type: str,
+    actor_role: str,
+    actor_id: str,
+    idempotency_key: str | None = None,
+    not_received_reason: str | None = None,
+    note: str | None = None,
+    correction_reason: str | None = None,
+    correction_of_idempotency_key: str | None = None,
+    order_version_id: str = _VERSION_ID,
+    cash_execution_context_id: str | None = None,
+) -> CourierCashCommand:
+    projection = context_service.projection(_ORDER_ID)
+    assert projection is not None
+    return CourierCashCommand.from_json(
+        {
+            "contract_version": CONTRACT_VERSION,
+            "idempotency_key": idempotency_key or str(uuid4()),
+            "event_type": event_type,
+            "order_id": _ORDER_ID,
+            "assignment_id": _ASSIGNMENT_ID,
+            "order_version_id": order_version_id,
+            "cash_execution_context_id": (
+                cash_execution_context_id
+                if cash_execution_context_id is not None
+                else projection.cash_execution_context_id
+            ),
+            "actor_id": actor_id,
+            "actor_role": actor_role,
+            "occurred_at": _NOW.isoformat(),
+            "not_received_reason": not_received_reason,
+            "note": note,
+            "correction_reason": correction_reason,
+            "correction_of_idempotency_key": correction_of_idempotency_key,
+        }
+    )
+
+
+def test_context_projection_distinguishes_current_and_not_ready_quittung(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, _service = _seed_world(
+        db
+    )
+    ready = context.projection(_ORDER_ID)
+    assert ready is not None
+    assert ready.quittung_status == QUITTUNG_PRINTED_CURRENT
+    assert ready.order_version_id == _VERSION_ID
+
+    connection.close()
+    db2 = tmp_path / "core-not-ready.db"
+    (
+        connection2,
+        _orders2,
+        _payments2,
+        _cash2,
+        _payment2,
+        context2,
+        _service2,
+    ) = _seed_world(db2, quittung_printed=False)
+    not_ready = context2.projection(_ORDER_ID)
+    assert not_ready is not None
+    assert not_ready.quittung_status == QUITTUNG_NOT_READY
+    connection2.close()
+
+
+def test_driver_to_chef_requires_two_transitions_before_final_payment(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, payments, cash, _payment, context, service = _seed_world(db)
+
+    driver = service.process(
+        _command(
+            context,
+            event_type=EVENT_DRIVER_RECEIVED,
+            actor_role="DRIVER",
+            actor_id="driver-17",
+        )
+    )
+    assert driver.cash_state == STATE_DRIVER_CUSTODY
+    unpaid = payments.get(_ORDER_ID)
+    assert unpaid is not None
+    assert unpaid.paid_on is None
+    assert unpaid.cash_received is False
+
+    handoff = service.process(
+        _command(
+            context,
+            event_type=EVENT_DRIVER_HANDED_TO_CHEF,
+            actor_role="DRIVER",
+            actor_id="driver-17",
+        )
+    )
+    assert handoff.cash_state == STATE_AWAITING_CHEF
+    still_unpaid = payments.get(_ORDER_ID)
+    assert still_unpaid is not None
+    assert still_unpaid.cash_received is False
+
+    final = service.process(
+        _command(
+            context,
+            event_type=EVENT_CHEF_RECEIVED_FROM_DRIVER,
+            actor_role="CHEF",
+            actor_id="chef-2",
+        )
+    )
+    assert final.cash_state == STATE_FINAL_PAID
+    paid = payments.get(_ORDER_ID)
+    assert paid is not None
+    assert paid.paid_on == date(2026, 8, 31)
+    assert paid.cash_received is True
+    assert paid.paid_recorded_by == "courier:chef:chef-2"
+    assert cash.get_latest_for_order(_ORDER_ID) is not None
+    connection.close()
+
+
+def test_direct_chef_pickup_finalizes_without_driver_custody(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, payments, _cash, _payment, context, service = _seed_world(db)
+
+    result = service.process(
+        _command(
+            context,
+            event_type=EVENT_CHEF_DIRECT,
+            actor_role="CHEF",
+            actor_id="chef-2",
+        )
+    )
+
+    assert result.cash_state == STATE_FINAL_PAID
+    paid = payments.get(_ORDER_ID)
+    assert paid is not None and paid.cash_received is True
+    connection.close()
+
+
+def test_not_received_stays_unpaid_and_projects_urgent_office_task(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, orders, payments, cash, payment, context, service = _seed_world(db)
+
+    result = service.process(
+        _command(
+            context,
+            event_type=EVENT_NOT_RECEIVED,
+            actor_role="DRIVER",
+            actor_id="driver-17",
+            not_received_reason="CUSTOMER_NOT_FOUND",
+        )
+    )
+    assert result.cash_state == STATE_NOT_RECEIVED
+    stored = payments.get(_ORDER_ID)
+    assert stored is not None
+    assert stored.cash_received is False
+    assert stored.paid_on is None
+
+    inquiries = SQLiteInquiryRepository.from_connection(connection)
+    offers = SQLiteOfferRepository.from_connection(connection)
+    tasks = TaskProjectionService(
+        inquiries,
+        offers,
+        orders,
+        payment,
+        today=lambda: date(2026, 8, 31),
+        courier_cash_repository=cash,
+    ).list_tasks()
+    payment_task = next(task for task in tasks if task.category == "payment")
+    assert payment_task.title == "Barzahlung klären"
+    assert payment_task.urgency == "urgent"
+    assert payment_task.due_at == date(2026, 8, 31)
+    connection.close()
+
+
+def test_replay_returns_exact_success_and_changed_payload_conflicts(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, service = _seed_world(db)
+    key = str(uuid4())
+    command = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+        idempotency_key=key,
+    )
+    first = service.process(command)
+    replay = service.process(command)
+    assert replay == first
+
+    conflicting = replace(command, actor_id="driver-99")
+    with pytest.raises(CourierCashCommandError) as exc:
+        service.process(conflicting)
+    assert (exc.value.status, exc.value.code) == (409, "idempotency_conflict")
+    count = connection.execute(
+        "SELECT COUNT(*) FROM courier_cash_events WHERE order_id = ?",
+        (_ORDER_ID,),
+    ).fetchone()[0]
+    assert count == 1
+    connection.close()
+
+
+def test_stale_revision_and_context_fail_before_mutation(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, service = _seed_world(db)
+
+    stale_revision = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+        order_version_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    )
+    with pytest.raises(CourierCashCommandError) as exc_revision:
+        service.process(stale_revision)
+    assert exc_revision.value.code == "stale_order_revision"
+
+    stale_context = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+        cash_execution_context_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    )
+    with pytest.raises(CourierCashCommandError) as exc_context:
+        service.process(stale_context)
+    assert exc_context.value.code == "stale_cash_context"
+    assert connection.execute("SELECT COUNT(*) FROM courier_cash_events").fetchone()[0] == 0
+    connection.close()
+
+
+def test_out_of_order_driver_or_chef_event_is_rejected(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, service = _seed_world(db)
+
+    with pytest.raises(CourierCashCommandError) as exc:
+        service.process(
+            _command(
+                context,
+                event_type=EVENT_CHEF_RECEIVED_FROM_DRIVER,
+                actor_role="CHEF",
+                actor_id="chef-2",
+            )
+        )
+    assert exc.value.code == "invalid_transition"
+    connection.close()
+
+
+def test_privileged_correction_preserves_history_and_forces_manual_review(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, payments, cash, _payment, context, service = _seed_world(db)
+    before_context = context.projection(_ORDER_ID)
+    assert before_context is not None
+
+    final_command = _command(
+        context,
+        event_type=EVENT_CHEF_DIRECT,
+        actor_role="CHEF",
+        actor_id="chef-2",
+    )
+    final = service.process(final_command)
+    assert final.cash_state == STATE_FINAL_PAID
+
+    correction = service.process(
+        _command(
+            context,
+            event_type=EVENT_CORRECTION,
+            actor_role="CHEF",
+            actor_id="chef-2",
+            correction_reason="Falsche Bestätigung",
+            correction_of_idempotency_key=final_command.idempotency_key,
+        )
+    )
+    assert correction.cash_state == STATE_MANUAL_REVIEW
+    corrected_payment = payments.get(_ORDER_ID)
+    assert corrected_payment is not None
+    assert corrected_payment.paid_on is None
+    assert corrected_payment.cash_received is False
+    assert len(payments.list_payment_corrections(_ORDER_ID)) == 1
+
+    after_context = context.projection(_ORDER_ID)
+    assert after_context is not None
+    assert after_context.cash_execution_context_id != before_context.cash_execution_context_id
+    latest = cash.get_latest_for_order(_ORDER_ID)
+    assert latest is not None and latest.to_state == STATE_MANUAL_REVIEW
+
+    with pytest.raises(CourierCashCommandError) as exc:
+        service.process(
+            _command(
+                context,
+                event_type=EVENT_DRIVER_RECEIVED,
+                actor_role="DRIVER",
+                actor_id="driver-17",
+            )
+        )
+    assert exc.value.code == "invalid_transition"
+    connection.close()
+
+
+def test_cash_event_journal_survives_restart_and_is_append_only(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, service = _seed_world(db)
+    command = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+    )
+    result = service.process(command)
+    connection.commit()
+    connection.close()
+
+    reopened = SQLiteCourierCashRepository(db)
+    stored = reopened.get_by_idempotency_key(command.idempotency_key)
+    assert stored is not None
+    assert stored.result() == result
+    with pytest.raises(sqlite3.IntegrityError):
+        reopened._conn.execute(
+            "UPDATE courier_cash_events SET actor_id = 'other' WHERE event_id = ?",
+            (result.event_id,),
+        )
+    reopened.close()
+
+
+def test_command_parser_is_exact_and_role_safe() -> None:
+    base = {
+        "contract_version": CONTRACT_VERSION,
+        "idempotency_key": "40000000-0000-4000-8000-000000000001",
+        "event_type": EVENT_DRIVER_RECEIVED,
+        "order_id": _ORDER_ID,
+        "assignment_id": _ASSIGNMENT_ID,
+        "order_version_id": _VERSION_ID,
+        "cash_execution_context_id": "80000000-0000-4000-8000-000000000001",
+        "actor_id": "driver-17",
+        "actor_role": "DRIVER",
+        "occurred_at": _NOW.isoformat(),
+        "not_received_reason": None,
+        "note": None,
+        "correction_reason": None,
+        "correction_of_idempotency_key": None,
+    }
+    command = CourierCashCommand.from_json(base)
+    assert command.to_json() == base
+
+    with pytest.raises(ValueError, match="field set"):
+        CourierCashCommand.from_json({**base, "amount": 100})
+    with pytest.raises(UnsupportedCourierCashContractVersion):
+        CourierCashCommand.from_json(
+            {**base, "contract_version": "courier-cash-handoff-v2"}
+        )
+    with pytest.raises(ValueError, match="actor role"):
+        CourierCashCommand.from_json(
+            {
+                **base,
+                "event_type": EVENT_CHEF_RECEIVED_FROM_DRIVER,
+                "actor_role": "DRIVER",
+            }
+        )
+    with pytest.raises(ValueError, match="OTHER requires note"):
+        CourierCashCommand.from_json(
+            {
+                **base,
+                "event_type": EVENT_NOT_RECEIVED,
+                "not_received_reason": "OTHER",
+            }
+        )
+
+
+def test_kiosk_feed_cash_extension_keeps_absent_null_object_semantics() -> None:
+    entry = WochenuebersichtEntry(
+        order_id=_ORDER_ID,
+        effective_order_version_id=_VERSION_ID,
+        version_number=1,
+        event_date=date(2026, 8, 31),
+        time_window_text="12:00",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+    )
+    absent = json.loads(render_order_feed_json(entry.event_date, (entry,)))
+    assert "cash_handoff" not in absent["orders"][0]
+
+    null_value = json.loads(
+        render_order_feed_json(
+            entry.event_date,
+            (entry,),
+            cash_handoff_by_order_id={_ORDER_ID: None},
+        )
+    )
+    assert null_value["orders"][0]["cash_handoff"] is None
+
+    projection = CourierCashProjection(
+        order_version_id=_VERSION_ID,
+        cash_execution_context_id="80000000-0000-4000-8000-000000000001",
+        quittung_status=QUITTUNG_PRINTED_CURRENT,
+    )
+    obj = json.loads(
+        render_order_feed_json(
+            entry.event_date,
+            (entry,),
+            cash_handoff_by_order_id={_ORDER_ID: projection},
+        )
+    )
+    assert obj["orders"][0]["cash_handoff"] == projection.to_json()
+
+
+def _start_machine_server(
+    db: Path,
+    *,
+    cash_token: str | None,
+) -> tuple[HTTPServer, threading.Thread, str]:
+    ready: queue.Queue[HTTPServer] = queue.Queue()
+
+    def run() -> None:
+        from catering_system.ui.office_api import create_office_api_server
+
+        server = create_office_api_server(
+            str(db),
+            "office-token",
+            "127.0.0.1",
+            0,
+            offer_pdf_static_content=fake_offer_pdf_static_content(),
+            courier_cash_service_token=cash_token,
+        )
+        ready.put(server)
+        server.serve_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    server = ready.get(timeout=5)
+    host, port = server.server_address[:2]
+    return server, thread, f"http://{host}:{port}"
+
+
+def _machine_post(
+    url: str,
+    body: bytes,
+    *,
+    authorization: str | None,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    headers = {"Content-Type": "application/json"}
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    request = urllib.request.Request(
+        f"{url}/machine/v1/courier/cash-events",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return (
+                response.status,
+                json.loads(response.read().decode()),
+                dict(response.headers),
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode() or "{}"), dict(exc.headers)
+
+
+def test_machine_route_is_dormant_without_token_and_auth_first_when_enabled(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, _service = _seed_world(db)
+    command = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+    )
+    body = json.dumps(command.to_json()).encode()
+    connection.commit()
+    connection.close()
+
+    server, thread, base = _start_machine_server(db, cash_token=None)
+    try:
+        status, response, headers = _machine_post(
+            base, b"not-json", authorization="Bearer anything"
+        )
+        assert (status, response) == (404, {"error": "not_found"})
+        assert headers["Cache-Control"] == "no-store"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    server, thread, base = _start_machine_server(db, cash_token="cash-secret")
+    try:
+        for auth in (None, "Bearer wrong"):
+            status, response, _headers = _machine_post(
+                base, b"not-json", authorization=auth
+            )
+            assert (status, response) == (401, {"error": "unauthorized"})
+
+        status, response, headers = _machine_post(
+            base, body, authorization="Bearer cash-secret"
+        )
+        assert status == 200
+        assert response["cash_state"] == STATE_DRIVER_CUSTODY
+        assert response["idempotency_key"] == command.idempotency_key
+        assert headers["Cache-Control"] == "no-store"
+        assert headers["X-Content-Type-Options"] == "nosniff"
+
+        replay_status, replay, _headers = _machine_post(
+            base, body, authorization="Bearer cash-secret"
+        )
+        assert replay_status == 200
+        assert replay == response
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_machine_route_rejects_query_and_unsupported_contract(tmp_path: Path) -> None:
+    db = tmp_path / "core.db"
+    connection, _orders, _payments, _cash, _payment, context, _service = _seed_world(db)
+    command = _command(
+        context,
+        event_type=EVENT_DRIVER_RECEIVED,
+        actor_role="DRIVER",
+        actor_id="driver-17",
+    )
+    connection.commit()
+    connection.close()
+
+    server, thread, base = _start_machine_server(db, cash_token="cash-secret")
+    try:
+        request = urllib.request.Request(
+            f"{base}/machine/v1/courier/cash-events?x=1",
+            data=json.dumps(command.to_json()).encode(),
+            headers={
+                "Authorization": "Bearer cash-secret",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as query_error:
+            urllib.request.urlopen(request)
+        assert query_error.value.code == 400
+        assert json.loads(query_error.value.read()) == {"error": "invalid_request"}
+
+        unsupported = command.to_json()
+        unsupported["contract_version"] = "courier-cash-handoff-v2"
+        status, response, _headers = _machine_post(
+            base,
+            json.dumps(unsupported).encode(),
+            authorization="Bearer cash-secret",
+        )
+        assert (status, response) == (
+            400,
+            {"error": "unsupported_contract_version"},
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -48,7 +48,9 @@ from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepo
 from catering_system.repositories.sqlite_payment_reminder_repository import (
     SQLitePaymentReminderRepository,
 )
-from catering_system.services.courier_cash_context_service import CourierCashContextService
+from catering_system.services.courier_cash_context_service import (
+    CourierCashContextService,
+)
 from catering_system.services.courier_cash_service import (
     CourierCashCommandError,
     CourierCashService,
@@ -181,9 +183,7 @@ def test_context_projection_distinguishes_current_and_not_ready_quittung(
     tmp_path: Path,
 ) -> None:
     db = tmp_path / "core.db"
-    connection, _orders, _payments, _cash, _payment, context, _service = _seed_world(
-        db
-    )
+    connection, _orders, _payments, _cash, _payment, context, _service = _seed_world(db)
     ready = context.projection(_ORDER_ID)
     assert ready is not None
     assert ready.quittung_status == QUITTUNG_PRINTED_CURRENT
@@ -368,7 +368,10 @@ def test_stale_revision_and_context_fail_before_mutation(tmp_path: Path) -> None
     with pytest.raises(CourierCashCommandError) as exc_context:
         service.process(stale_context)
     assert exc_context.value.code == "stale_cash_context"
-    assert connection.execute("SELECT COUNT(*) FROM courier_cash_events").fetchone()[0] == 0
+    assert (
+        connection.execute("SELECT COUNT(*) FROM courier_cash_events").fetchone()[0]
+        == 0
+    )
     connection.close()
 
 
@@ -425,7 +428,10 @@ def test_privileged_correction_preserves_history_and_forces_manual_review(
 
     after_context = context.projection(_ORDER_ID)
     assert after_context is not None
-    assert after_context.cash_execution_context_id != before_context.cash_execution_context_id
+    assert (
+        after_context.cash_execution_context_id
+        != before_context.cash_execution_context_id
+    )
     latest = cash.get_latest_for_order(_ORDER_ID)
     assert latest is not None and latest.to_state == STATE_MANUAL_REVIEW
 

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -123,10 +123,15 @@ def _seed_world(
         source_inquiry_id=_INQUIRY_ID,
         created_at=version.created_at,
         updated_at=version.created_at,
-        candidate_order_version_id=_VERSION_ID,
-        effective_order_version_id=_VERSION_ID,
     )
     orders.save_order_with_initial_version(order, version)
+    orders.update_order(
+        replace(
+            order,
+            candidate_order_version_id=_VERSION_ID,
+            effective_order_version_id=_VERSION_ID,
+        )
+    )
     payment_service = PaymentReminderService(
         payments,
         orders,

--- a/tests/unit/test_courier_cash_runtime.py
+++ b/tests/unit/test_courier_cash_runtime.py
@@ -449,7 +449,9 @@ def test_privileged_correction_preserves_history_and_forces_manual_review(
     tmp_path: Path,
 ) -> None:
     db = tmp_path / "core.db"
-    connection, _orders, payments, cash, _payment, context, service = _seed_world(db)
+    connection, _orders, payments, cash, _payment, context, service = _seed_world(
+        db, fulfillment_mode="PICKUP"
+    )
     before_context = context.projection(_ORDER_ID)
     assert before_context is not None
 


### PR DESCRIPTION
Implements #211 as the runtime rollout slice of the frozen #202 contract.

## Scope

- Core Courier cash event journal/state machine
- authenticated machine write endpoint
- stale revision/context and replay/conflict semantics
- integration with existing payment-task/payment-completion truth
- additive read-only Kiosk `cash_handoff` projection

## Boundaries

No amounts, partial payments, accounting, PDFs, customer billing expansion, automatic communication, Courier UI, or Kiosk writes.

## Downstream

Courier parser/retry support is already merged in courier-app PRs #14 and #15. Courier UI remains courier-app #13 after this runtime slice is green.