### PR TITLE
Add Core backup health verification

### DIFF
--- a/docs/proposals/BACKUP_HEALTH_AND_ALERTING_V1.md
+++ b/docs/proposals/BACKUP_HEALTH_AND_ALERTING_V1.md
@@ -1,6 +1,6 @@
 # BACKUP_HEALTH_AND_ALERTING_V1 (proposal)
 
-Status: **not implemented** — audit recorded **2026-07-19T22:58:14Z**.
+Status: **verification Slice A tracked in #215**; external alert delivery remains a follow-up.
 
 ## Current backup truth (Lenovo Core)
 

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -164,6 +164,71 @@ Minimum weekly check:
 - a periodic decrypt-and-`quick_check` drill;
 - restore procedure still understood by two people or documented access.
 
+
+## Automated backup health checker
+
+Issue #215 adds the repository-owned, secret-free checker:
+
+```text
+infra/backup/check_backup_health.py
+```
+
+It has two deliberately different uses.
+
+### Ongoing freshness/integrity health
+
+This mode is safe at any time of day. It verifies:
+
+- newest local `core-YYYY-MM-DD.db` exists and is non-empty;
+- local artifact age is at most 26 hours by default;
+- local SQLite `PRAGMA quick_check` returns `ok`;
+- newest local encrypted offsite cache `core-YYYY-MM-DD.db.gpg` exists,
+  is non-empty and is at most 26 hours old.
+
+It does **not** compare the night backup's row counts with a live database that
+may legitimately have received later writes.
+
+```bash
+cd /home/viktor/projects/silberloeffel-catering
+python3 infra/backup/check_backup_health.py
+```
+
+Success exits `0` and prints only concise `OK` lines. Any failed gate exits
+non-zero and prints a `FAIL ...` diagnostic to stderr. The checker never reads
+or prints GPG, SSH, API or application secrets.
+
+### Immediate post-backup count verification
+
+Exact live/backup row-count comparison is meaningful only immediately after
+creating the local snapshot. Use:
+
+```bash
+python3 infra/backup/check_backup_health.py --compare-live-counts
+```
+
+The default comparison set is `inquiries`, `orders`, and `order_versions`.
+Additional or alternate tables can be supplied by repeating `--count-table`.
+
+Do not schedule `--compare-live-counts` as an all-day health probe: ordinary
+production writes after the nightly backup would create a truthful count
+difference and therefore a false backup alarm.
+
+### Scheduling contract
+
+Once this checker is deployed on Lenovo, the intended schedule is:
+
+1. keep the local SQLite backup at 03:15;
+2. run the `--compare-live-counts` check immediately after that backup command
+   succeeds;
+3. keep the encrypted offsite transfer after the local backup;
+4. run the ordinary checker after the offsite job to detect missing/stale local
+   or encrypted artifacts.
+
+The checker provides the reliable exit status required by a later notification
+slice. External mail/webhook/Tailscale alert delivery is intentionally not
+chosen in #215 and must not be smuggled into production configuration as an
+implicit dependency.
+
 ## Restore production
 
 > **Destructive operation:** restoring discards writes made after the selected

--- a/infra/backup/check_backup_health.py
+++ b/infra/backup/check_backup_health.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Secret-free health checks for the Core local and encrypted backup artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+_DEFAULT_DATABASE = Path("/home/viktor/catering-runtime/core.db")
+_DEFAULT_LOCAL_DIR = Path("/home/viktor/catering-runtime/backups")
+_DEFAULT_ENCRYPTED_DIR = Path("/home/viktor/catering-runtime/offsite-encrypted")
+_DEFAULT_MAX_AGE_HOURS = 26.0
+_DEFAULT_COUNT_TABLES = ("inquiries", "orders", "order_versions")
+_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class HealthFailure(Exception):
+    """Expected operator-visible backup health failure."""
+
+
+def _newest(directory: Path, pattern: str, label: str) -> Path:
+    candidates = [path for path in directory.glob(pattern) if path.is_file()]
+    if not candidates:
+        raise HealthFailure(f"{label}: no matching artifact")
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def _check_artifact_age(
+    path: Path,
+    *,
+    max_age_hours: float,
+    now_epoch: float,
+    label: str,
+) -> float:
+    stat = path.stat()
+    if stat.st_size <= 0:
+        raise HealthFailure(f"{label}: artifact is empty")
+    age_hours = (now_epoch - stat.st_mtime) / 3600
+    if age_hours < -0.25:
+        raise HealthFailure(f"{label}: artifact timestamp is in the future")
+    if age_hours > max_age_hours:
+        raise HealthFailure(
+            f"{label}: artifact is stale ({age_hours:.1f}h > {max_age_hours:.1f}h)"
+        )
+    return max(age_hours, 0.0)
+
+
+def _read_only_connection(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+
+def _quick_check(path: Path) -> None:
+    try:
+        connection = _read_only_connection(path)
+        try:
+            row = connection.execute("PRAGMA quick_check").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise HealthFailure(f"local backup integrity: SQLite error: {exc}") from exc
+    if row != ("ok",):
+        detail = str(row[0]) if row else "no result"
+        raise HealthFailure(f"local backup integrity: quick_check failed: {detail}")
+
+
+def _table_count(path: Path, table: str) -> int:
+    if _IDENTIFIER.fullmatch(table) is None:
+        raise HealthFailure(f"count comparison: invalid table name {table!r}")
+    try:
+        connection = _read_only_connection(path)
+        try:
+            row = connection.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise HealthFailure(f"count comparison: {table}: SQLite error: {exc}") from exc
+    if row is None:
+        raise HealthFailure(f"count comparison: {table}: no count result")
+    return int(row[0])
+
+
+def _compare_counts(database: Path, backup: Path, tables: tuple[str, ...]) -> None:
+    for table in tables:
+        live_count = _table_count(database, table)
+        backup_count = _table_count(backup, table)
+        if live_count != backup_count:
+            raise HealthFailure(
+                f"count comparison: {table}: live={live_count} backup={backup_count}"
+            )
+
+
+def check_health(
+    *,
+    database: Path,
+    local_dir: Path,
+    encrypted_dir: Path,
+    max_age_hours: float,
+    compare_live_counts: bool,
+    count_tables: tuple[str, ...],
+    now_epoch: float,
+) -> list[str]:
+    if max_age_hours <= 0:
+        raise HealthFailure("configuration: max age must be positive")
+    if compare_live_counts and not database.is_file():
+        raise HealthFailure("count comparison: live database is missing")
+
+    local = _newest(local_dir, "core-????-??-??.db", "local backup")
+    local_age = _check_artifact_age(
+        local,
+        max_age_hours=max_age_hours,
+        now_epoch=now_epoch,
+        label="local backup",
+    )
+    _quick_check(local)
+
+    if compare_live_counts:
+        _compare_counts(database, local, count_tables)
+
+    encrypted = _newest(
+        encrypted_dir,
+        "core-????-??-??.db.gpg",
+        "offsite encrypted cache",
+    )
+    encrypted_age = _check_artifact_age(
+        encrypted,
+        max_age_hours=max_age_hours,
+        now_epoch=now_epoch,
+        label="offsite encrypted cache",
+    )
+
+    messages = [
+        f"OK local_backup age={local_age:.1f}h quick_check=ok",
+        f"OK offsite_encrypted age={encrypted_age:.1f}h",
+    ]
+    if compare_live_counts:
+        messages.append(
+            "OK live_count_comparison tables=" + ",".join(count_tables)
+        )
+    return messages
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check Core backup freshness/integrity. Live row-count comparison is "
+            "optional and intended only immediately after creating the local backup."
+        )
+    )
+    parser.add_argument("--database", type=Path, default=_DEFAULT_DATABASE)
+    parser.add_argument("--local-dir", type=Path, default=_DEFAULT_LOCAL_DIR)
+    parser.add_argument("--encrypted-dir", type=Path, default=_DEFAULT_ENCRYPTED_DIR)
+    parser.add_argument(
+        "--max-age-hours",
+        type=float,
+        default=_DEFAULT_MAX_AGE_HOURS,
+    )
+    parser.add_argument(
+        "--compare-live-counts",
+        action="store_true",
+        help=(
+            "compare selected table counts with the live DB; use only immediately "
+            "after backup creation, not as an all-day health check"
+        ),
+    )
+    parser.add_argument(
+        "--count-table",
+        action="append",
+        dest="count_tables",
+        help=(
+            "table included in live/backup count comparison; repeatable; defaults "
+            "to inquiries, orders, order_versions"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    count_tables = tuple(args.count_tables or _DEFAULT_COUNT_TABLES)
+    try:
+        messages = check_health(
+            database=args.database,
+            local_dir=args.local_dir,
+            encrypted_dir=args.encrypted_dir,
+            max_age_hours=args.max_age_hours,
+            compare_live_counts=args.compare_live_counts,
+            count_tables=count_tables,
+            now_epoch=time.time(),
+        )
+    except (HealthFailure, OSError) as exc:
+        print(f"FAIL {exc}", file=sys.stderr)
+        return 1
+    for message in messages:
+        print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/backup/check_backup_health.py
+++ b/infra/backup/check_backup_health.py
@@ -137,9 +137,7 @@ def check_health(
         f"OK offsite_encrypted age={encrypted_age:.1f}h",
     ]
     if compare_live_counts:
-        messages.append(
-            "OK live_count_comparison tables=" + ",".join(count_tables)
-        )
+        messages.append("OK live_count_comparison tables=" + ",".join(count_tables))
     return messages
 
 

--- a/tests/unit/test_backup_health.py
+++ b/tests/unit/test_backup_health.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).parents[2]
+_CHECKER = _ROOT / "infra/backup/check_backup_health.py"
+
+
+def _make_database(path: Path, *, extra_order: bool = False) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE inquiries (inquiry_id TEXT PRIMARY KEY);
+            CREATE TABLE orders (order_id TEXT PRIMARY KEY);
+            CREATE TABLE order_versions (order_version_id TEXT PRIMARY KEY);
+            INSERT INTO inquiries VALUES ('inq-1');
+            INSERT INTO orders VALUES ('order-1');
+            INSERT INTO order_versions VALUES ('version-1');
+            """
+        )
+        if extra_order:
+            connection.execute("INSERT INTO orders VALUES ('order-2')")
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
+    database = tmp_path / "core.db"
+    local_dir = tmp_path / "backups"
+    encrypted_dir = tmp_path / "offsite-encrypted"
+    local_dir.mkdir()
+    encrypted_dir.mkdir()
+
+    _make_database(database)
+    backup = local_dir / "core-2026-08-31.db"
+    source = sqlite3.connect(database)
+    target = sqlite3.connect(backup)
+    try:
+        source.backup(target)
+    finally:
+        target.close()
+        source.close()
+
+    encrypted = encrypted_dir / "core-2026-08-31.db.gpg"
+    encrypted.write_bytes(b"encrypted-test-artifact")
+    return database, local_dir, encrypted_dir, backup, encrypted
+
+
+def _run(
+    database: Path,
+    local_dir: Path,
+    encrypted_dir: Path,
+    *extra: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_CHECKER),
+            "--database",
+            str(database),
+            "--local-dir",
+            str(local_dir),
+            "--encrypted-dir",
+            str(encrypted_dir),
+            "--max-age-hours",
+            "26",
+            *extra,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_backup_health_accepts_fresh_valid_artifacts(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, _, _ = _fixture(tmp_path)
+
+    result = _run(
+        database,
+        local_dir,
+        encrypted_dir,
+        "--compare-live-counts",
+    )
+
+    assert result.returncode == 0
+    assert "OK local_backup" in result.stdout
+    assert "quick_check=ok" in result.stdout
+    assert "OK offsite_encrypted" in result.stdout
+    assert "OK live_count_comparison" in result.stdout
+    assert result.stderr == ""
+
+
+def test_backup_health_rejects_stale_local_backup(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, backup, _ = _fixture(tmp_path)
+    stale = time.time() - 27 * 3600
+    os.utime(backup, (stale, stale))
+
+    result = _run(database, local_dir, encrypted_dir)
+
+    assert result.returncode == 1
+    assert "FAIL local backup: artifact is stale" in result.stderr
+
+
+def test_backup_health_rejects_corrupt_local_backup(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, backup, _ = _fixture(tmp_path)
+    backup.write_bytes(b"not-a-sqlite-database")
+
+    result = _run(database, local_dir, encrypted_dir)
+
+    assert result.returncode == 1
+    assert "FAIL local backup integrity: SQLite error:" in result.stderr
+
+
+def test_backup_health_rejects_live_count_mismatch(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, _, _ = _fixture(tmp_path)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("INSERT INTO orders VALUES ('order-after-backup')")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = _run(
+        database,
+        local_dir,
+        encrypted_dir,
+        "--compare-live-counts",
+    )
+
+    assert result.returncode == 1
+    assert "FAIL count comparison: orders: live=2 backup=1" in result.stderr
+
+
+def test_backup_health_rejects_stale_offsite_artifact(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, _, encrypted = _fixture(tmp_path)
+    stale = time.time() - 27 * 3600
+    os.utime(encrypted, (stale, stale))
+
+    result = _run(database, local_dir, encrypted_dir)
+
+    assert result.returncode == 1
+    assert "FAIL offsite encrypted cache: artifact is stale" in result.stderr
+
+
+def test_backup_health_rejects_missing_offsite_artifact(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, _, encrypted = _fixture(tmp_path)
+    encrypted.unlink()
+
+    result = _run(database, local_dir, encrypted_dir)
+
+    assert result.returncode == 1
+    assert "FAIL offsite encrypted cache: no matching artifact" in result.stderr

--- a/tests/unit/test_backup_health.py
+++ b/tests/unit/test_backup_health.py
@@ -82,12 +82,7 @@ def _run(
 def test_backup_health_accepts_fresh_valid_artifacts(tmp_path: Path) -> None:
     database, local_dir, encrypted_dir, _, _ = _fixture(tmp_path)
 
-    result = _run(
-        database,
-        local_dir,
-        encrypted_dir,
-        "--compare-live-counts",
-    )
+    result = _run(database, local_dir, encrypted_dir, "--compare-live-counts")
 
     assert result.returncode == 0
     assert "OK local_backup" in result.stdout

--- a/tests/unit/test_backup_health.py
+++ b/tests/unit/test_backup_health.py
@@ -92,6 +92,16 @@ def test_backup_health_accepts_fresh_valid_artifacts(tmp_path: Path) -> None:
     assert result.stderr == ""
 
 
+def test_backup_health_rejects_missing_local_backup(tmp_path: Path) -> None:
+    database, local_dir, encrypted_dir, backup, _ = _fixture(tmp_path)
+    backup.unlink()
+
+    result = _run(database, local_dir, encrypted_dir)
+
+    assert result.returncode == 1
+    assert "FAIL local backup: no matching artifact" in result.stderr
+
+
 def test_backup_health_rejects_stale_local_backup(tmp_path: Path) -> None:
     database, local_dir, encrypted_dir, backup, _ = _fixture(tmp_path)
     stale = time.time() - 27 * 3600


### PR DESCRIPTION
Closes #215.

## What this adds

- secret-free Core backup health checker;
- local backup existence, size, freshness and SQLite quick_check;
- encrypted offsite-cache existence, size and freshness;
- optional immediate live/backup count comparison for inquiries, orders and order_versions;
- focused failure-mode tests;
- runbook guidance separating immediate count verification from all-day freshness checks.

## Boundary

No backup file mutation, schema change, production scheduler change or external alert provider is added here. A later notification slice can consume the checker's non-zero exit status.