### PR TITLE
Support exact delivery and event start timing

### DIFF
--- a/src/catering_system/domain/logistics_timing.py
+++ b/src/catering_system/domain/logistics_timing.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 from datetime import date, time
 
 
+def validate_optional_local_time(value: time | None, *, label: str) -> None:
+    """Validate one explicit local wall-clock time without inventing a window."""
+    if value is not None and value.tzinfo is not None:
+        raise ValueError(f"{label} must use local wall-clock time without tzinfo")
+
+
 def validate_optional_local_window(
     starts_at: time | None,
     ends_at: time | None,
@@ -20,8 +26,8 @@ def validate_optional_local_window(
     if starts_at is None:
         return
     assert ends_at is not None
-    if starts_at.tzinfo is not None or ends_at.tzinfo is not None:
-        raise ValueError(f"{label} must use local wall-clock times without tzinfo")
+    validate_optional_local_time(starts_at, label=f"{label} start")
+    validate_optional_local_time(ends_at, label=f"{label} end")
     if starts_at >= ends_at:
         raise ValueError(f"{label} start must be before end")
 

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -11,7 +11,10 @@ from zoneinfo import ZoneInfo
 
 from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
 from catering_system.domain.inquiry import PlanningMode, validate_planning_mode
-from catering_system.domain.logistics_timing import validate_optional_service_window
+from catering_system.domain.logistics_timing import (
+    validate_optional_local_time,
+    validate_optional_service_window,
+)
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.offer_charges import OfferChargesDefinition
 from catering_system.domain.order_payment_reminder import (
@@ -245,6 +248,8 @@ class OfferVersion:
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    delivery_time_local: time | None = None
+    event_start_local: time | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.offer_version_id, "offer_version_id")
@@ -271,6 +276,21 @@ class OfferVersion:
             self.delivery_window_end_local,
             label="delivery window",
         )
+        validate_optional_local_time(
+            self.delivery_time_local, label="delivery exact time"
+        )
+        validate_optional_local_time(self.event_start_local, label="event start")
+        if self.delivery_time_local is not None and any(
+            value is not None
+            for value in (
+                self.delivery_date_local,
+                self.delivery_window_start_local,
+                self.delivery_window_end_local,
+            )
+        ):
+            raise ValueError(
+                "delivery exact time and delivery window are mutually exclusive"
+            )
         _require_bounded_text(
             self.payment_customer_visible_text,
             "payment_customer_visible_text",

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -10,7 +10,10 @@ from datetime import date, datetime, time
 from typing import Literal
 
 from catering_system.domain.inquiry import PlanningMode
-from catering_system.domain.logistics_timing import validate_optional_service_window
+from catering_system.domain.logistics_timing import (
+    validate_optional_local_time,
+    validate_optional_service_window,
+)
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.offer_charges import OfferChargesDefinition
 from catering_system.domain.order_payment_reminder import PaymentMethod
@@ -65,6 +68,8 @@ class OfferSnapshotEvent:
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    delivery_time_local: time | None = None
+    event_start_local: time | None = None
 
     def __post_init__(self) -> None:
         validate_optional_service_window(
@@ -73,6 +78,23 @@ class OfferSnapshotEvent:
             self.delivery_window_end_local,
             label="delivery window",
         )
+        validate_optional_local_time(
+            self.delivery_time_local, label="delivery exact time"
+        )
+        validate_optional_local_time(
+            self.event_start_local, label="event start"
+        )
+        if self.delivery_time_local is not None and any(
+            value is not None
+            for value in (
+                self.delivery_date_local,
+                self.delivery_window_start_local,
+                self.delivery_window_end_local,
+            )
+        ):
+            raise ValueError(
+                "delivery exact time and delivery window are mutually exclusive"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -81,9 +81,7 @@ class OfferSnapshotEvent:
         validate_optional_local_time(
             self.delivery_time_local, label="delivery exact time"
         )
-        validate_optional_local_time(
-            self.event_start_local, label="event start"
-        )
+        validate_optional_local_time(self.event_start_local, label="event start")
         if self.delivery_time_local is not None and any(
             value is not None
             for value in (

--- a/src/catering_system/domain/order.py
+++ b/src/catering_system/domain/order.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 from datetime import date, datetime, time
 
 from catering_system.domain.inquiry import PlanningMode
-from catering_system.domain.logistics_timing import validate_optional_service_window
+from catering_system.domain.logistics_timing import (
+    validate_optional_local_time,
+    validate_optional_service_window,
+)
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,8 @@ class OrderVersion:
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    delivery_time_local: time | None = None
+    event_start_local: time | None = None
 
     def __post_init__(self) -> None:
         validate_optional_service_window(
@@ -60,6 +65,21 @@ class OrderVersion:
             self.delivery_window_end_local,
             label="delivery window",
         )
+        validate_optional_local_time(
+            self.delivery_time_local, label="delivery exact time"
+        )
+        validate_optional_local_time(self.event_start_local, label="event start")
+        if self.delivery_time_local is not None and any(
+            value is not None
+            for value in (
+                self.delivery_date_local,
+                self.delivery_window_start_local,
+                self.delivery_window_end_local,
+            )
+        ):
+            raise ValueError(
+                "delivery exact time and delivery window are mutually exclusive"
+            )
 
 
 def is_order_version_superseded(

--- a/src/catering_system/domain/wochenuebersicht.py
+++ b/src/catering_system/domain/wochenuebersicht.py
@@ -29,6 +29,8 @@ class WochenuebersichtEntry:
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    delivery_time_local: time | None = None
+    event_start_local: time | None = None
     operational_pause_active: bool = False
     operational_pause_reason_code: str | None = None
     operational_pause_note: str | None = None
@@ -63,6 +65,8 @@ def entry_from_effective(
         delivery_date_local=effective.delivery_date_local,
         delivery_window_start_local=effective.delivery_window_start_local,
         delivery_window_end_local=effective.delivery_window_end_local,
+        delivery_time_local=effective.delivery_time_local,
+        event_start_local=effective.event_start_local,
         operational_pause_active=operational_pause_active,
         operational_pause_reason_code=operational_pause_reason_code,
         operational_pause_note=operational_pause_note,

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -339,6 +339,24 @@ def _migration_10_offer_version_logistics_timing(
             connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
 
 
+def _migration_11_offer_version_exact_timing(
+    connection: sqlite3.Connection,
+) -> None:
+    existing = {
+        row[1] for row in connection.execute("PRAGMA table_info(offer_versions)")
+    }
+    for name in ("delivery_time_local", "event_start_local"):
+        if name not in existing:
+            connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
+    connection.execute(
+        """CREATE TRIGGER IF NOT EXISTS trg_offer_version_exact_timing_immutable
+        BEFORE UPDATE OF delivery_time_local, event_start_local ON offer_versions
+        WHEN NEW.delivery_time_local IS NOT OLD.delivery_time_local
+          OR NEW.event_start_local IS NOT OLD.event_start_local
+        BEGIN SELECT RAISE(ABORT, 'offer version exact timing is immutable'); END"""
+    )
+
+
 _MIGRATIONS = (
     (1, "create_offer_tables", _migration_1_create_tables),
     (2, "unique_source_inquiry", _migration_2_unique_source_inquiry),
@@ -377,6 +395,11 @@ _MIGRATIONS = (
         10,
         "offer_version_logistics_timing",
         _migration_10_offer_version_logistics_timing,
+    ),
+    (
+        11,
+        "offer_version_exact_timing",
+        _migration_11_offer_version_exact_timing,
     ),
 )
 
@@ -832,8 +855,9 @@ class SQLiteOfferRepository:
                 payment_customer_visible_text, customer_title,
                 customer_introduction, customer_notes, budget_definition_json,
                 charges_definition_json, delivery_date_local,
-                delivery_window_start_local, delivery_window_end_local
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                delivery_window_start_local, delivery_window_end_local,
+                delivery_time_local, event_start_local
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 version.offer_version_id,
@@ -868,6 +892,16 @@ class SQLiteOfferRepository:
                 (
                     version.delivery_window_end_local.isoformat(timespec="minutes")
                     if version.delivery_window_end_local is not None
+                    else None
+                ),
+                (
+                    version.delivery_time_local.isoformat(timespec="minutes")
+                    if version.delivery_time_local is not None
+                    else None
+                ),
+                (
+                    version.event_start_local.isoformat(timespec="minutes")
+                    if version.event_start_local is not None
                     else None
                 ),
             ),
@@ -1004,7 +1038,8 @@ class SQLiteOfferRepository:
                    payment_customer_visible_text, customer_title,
                    customer_introduction, customer_notes, budget_definition_json,
                    charges_definition_json, delivery_date_local,
-                   delivery_window_start_local, delivery_window_end_local
+                   delivery_window_start_local, delivery_window_end_local,
+                   delivery_time_local, event_start_local
             FROM offer_versions
             WHERE offer_id = ?
             ORDER BY version_number
@@ -1061,6 +1096,12 @@ class SQLiteOfferRepository:
                     ),
                     delivery_window_end_local=(
                         time.fromisoformat(row[20]) if row[20] is not None else None
+                    ),
+                    delivery_time_local=(
+                        time.fromisoformat(row[21]) if row[21] is not None else None
+                    ),
+                    event_start_local=(
+                        time.fromisoformat(row[22]) if row[22] is not None else None
                     ),
                 )
             )

--- a/src/catering_system/repositories/sqlite_order_repository.py
+++ b/src/catering_system/repositories/sqlite_order_repository.py
@@ -418,6 +418,24 @@ def _migration_10_order_version_logistics_timing(
     )
 
 
+def _migration_11_order_version_exact_timing(
+    connection: sqlite3.Connection,
+) -> None:
+    columns = {
+        row[1] for row in connection.execute("PRAGMA table_info(order_versions)")
+    }
+    for name in ("delivery_time_local", "event_start_local"):
+        if name not in columns:
+            connection.execute(f"ALTER TABLE order_versions ADD COLUMN {name} TEXT")
+    connection.execute(
+        """CREATE TRIGGER IF NOT EXISTS trg_order_version_exact_timing_immutable
+        BEFORE UPDATE OF delivery_time_local, event_start_local ON order_versions
+        WHEN NEW.delivery_time_local IS NOT OLD.delivery_time_local
+          OR NEW.event_start_local IS NOT OLD.event_start_local
+        BEGIN SELECT RAISE(ABORT, 'order version exact timing is immutable'); END"""
+    )
+
+
 _MIGRATIONS = (
     (1, "create_order_tables", _migration_1_create_tables),
     (2, "add_cancelled_at", _migration_2_add_cancelled_at),
@@ -444,6 +462,11 @@ _MIGRATIONS = (
         10,
         "order_version_logistics_timing",
         _migration_10_order_version_logistics_timing,
+    ),
+    (
+        11,
+        "order_version_exact_timing",
+        _migration_11_order_version_exact_timing,
     ),
 )
 
@@ -532,8 +555,9 @@ class SQLiteOrderRepository:
                     event_date, time_window_text, location_text, guest_count_estimate,
                     planning_mode, kitchen_print_confirmed_at, parent_order_version_id,
                     created_by, change_reason, changed_fields_json, delivery_date_local,
-                    delivery_window_start_local, delivery_window_end_local
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    delivery_window_start_local, delivery_window_end_local,
+                    delivery_time_local, event_start_local
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._version_values(version),
             )
@@ -594,8 +618,9 @@ class SQLiteOrderRepository:
                     event_date, time_window_text, location_text, guest_count_estimate,
                     planning_mode, kitchen_print_confirmed_at, parent_order_version_id,
                     created_by, change_reason, changed_fields_json, delivery_date_local,
-                    delivery_window_start_local, delivery_window_end_local
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    delivery_window_start_local, delivery_window_end_local,
+                    delivery_time_local, event_start_local
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._version_values(version),
             )
@@ -734,6 +759,16 @@ class SQLiteOrderRepository:
                 if version.delivery_window_end_local is not None
                 else None
             ),
+            (
+                version.delivery_time_local.isoformat(timespec="minutes")
+                if version.delivery_time_local is not None
+                else None
+            ),
+            (
+                version.event_start_local.isoformat(timespec="minutes")
+                if version.event_start_local is not None
+                else None
+            ),
         )
 
     def get_order_version(self, order_version_id: str) -> OrderVersion | None:
@@ -807,5 +842,11 @@ class SQLiteOrderRepository:
             ),
             delivery_window_end_local=(
                 time.fromisoformat(row[16]) if row[16] is not None else None
+            ),
+            delivery_time_local=(
+                time.fromisoformat(row[17]) if row[17] is not None else None
+            ),
+            event_start_local=(
+                time.fromisoformat(row[18]) if row[18] is not None else None
             ),
         )

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -718,6 +718,8 @@ def _build_version_from_snapshot(
         delivery_date_local=snapshot.event.delivery_date_local,
         delivery_window_start_local=snapshot.event.delivery_window_start_local,
         delivery_window_end_local=snapshot.event.delivery_window_end_local,
+        delivery_time_local=snapshot.event.delivery_time_local,
+        event_start_local=snapshot.event.event_start_local,
     )
 
 

--- a/src/catering_system/services/offer_snapshot_validation.py
+++ b/src/catering_system/services/offer_snapshot_validation.py
@@ -112,6 +112,8 @@ _EVENT_KEYS = frozenset(
         "delivery_date_local",
         "delivery_window_start_local",
         "delivery_window_end_local",
+        "delivery_time_local",
+        "event_start_local",
     }
 )
 _CUSTOMER_TEXT_KEYS = frozenset({"title", "introduction", "notes"})
@@ -480,6 +482,14 @@ def _parse_event(payload: dict[str, object]) -> OfferSnapshotEvent:
         delivery_window_end_local=_optional_local_time(
             payload.get("delivery_window_end_local"),
             "event.delivery_window_end_local",
+        ),
+        delivery_time_local=_optional_local_time(
+            payload.get("delivery_time_local"),
+            "event.delivery_time_local",
+        ),
+        event_start_local=_optional_local_time(
+            payload.get("event_start_local"),
+            "event.event_start_local",
         ),
     )
 

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -144,6 +144,8 @@ class OrderService:
             delivery_date_local=offer_version.delivery_date_local,
             delivery_window_start_local=offer_version.delivery_window_start_local,
             delivery_window_end_local=offer_version.delivery_window_end_local,
+            delivery_time_local=offer_version.delivery_time_local,
+            event_start_local=offer_version.event_start_local,
         )
         context = (
             _initial_operational_context(order, version, inquiry, created_at=now)
@@ -207,6 +209,16 @@ class OrderService:
             ),
             delivery_window_end_local=(
                 latest_version.delivery_window_end_local
+                if latest_version is not None
+                else None
+            ),
+            delivery_time_local=(
+                latest_version.delivery_time_local
+                if latest_version is not None
+                else None
+            ),
+            event_start_local=(
+                latest_version.event_start_local
                 if latest_version is not None
                 else None
             ),
@@ -296,6 +308,8 @@ class OrderService:
             delivery_date_local=source.delivery_date_local,
             delivery_window_start_local=source.delivery_window_start_local,
             delivery_window_end_local=source.delivery_window_end_local,
+            delivery_time_local=source.delivery_time_local,
+            event_start_local=source.event_start_local,
         )
         previous_candidate_id = current.candidate_order_version_id
         updated = replace(
@@ -397,6 +411,11 @@ class OrderService:
             created_by=actor_reference,
             change_reason=change_reason,
             changed_fields=("delivery_address",),
+            delivery_date_local=parent.delivery_date_local,
+            delivery_window_start_local=parent.delivery_window_start_local,
+            delivery_window_end_local=parent.delivery_window_end_local,
+            delivery_time_local=parent.delivery_time_local,
+            event_start_local=parent.event_start_local,
         )
         operational_context = OrderOperationalContextData(
             recipient_company=parent_context.recipient_company,

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -218,9 +218,7 @@ class OrderService:
                 else None
             ),
             event_start_local=(
-                latest_version.event_start_local
-                if latest_version is not None
-                else None
+                latest_version.event_start_local if latest_version is not None else None
             ),
         )
         context = _operational_context_for_new_version(

--- a/src/catering_system/ui/kiosk_server.py
+++ b/src/catering_system/ui/kiosk_server.py
@@ -219,9 +219,7 @@ def _order_feed_entry_projection(
             entry.delivery_time_local
         )
     if entry.event_start_local is not None:
-        projection["event_start_local"] = _format_local_time(
-            entry.event_start_local
-        )
+        projection["event_start_local"] = _format_local_time(entry.event_start_local)
     if include_cash_handoff:
         projection["cash_handoff"] = (
             cash_handoff.to_json() if cash_handoff is not None else None

--- a/src/catering_system/ui/kiosk_server.py
+++ b/src/catering_system/ui/kiosk_server.py
@@ -214,6 +214,14 @@ def _order_feed_entry_projection(
     delivery_window = _delivery_window_projection(entry)
     if delivery_window is not None:
         projection["delivery_window"] = delivery_window
+    if entry.delivery_time_local is not None:
+        projection["delivery_time_local"] = _format_local_time(
+            entry.delivery_time_local
+        )
+    if entry.event_start_local is not None:
+        projection["event_start_local"] = _format_local_time(
+            entry.event_start_local
+        )
     if include_cash_handoff:
         projection["cash_handoff"] = (
             cash_handoff.to_json() if cash_handoff is not None else None

--- a/tests/unit/test_issue175_logistics_timing.py
+++ b/tests/unit/test_issue175_logistics_timing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from dataclasses import replace
 from datetime import UTC, date, datetime, time
 from pathlib import Path
 
@@ -19,8 +21,10 @@ from catering_system.domain.offer_charges import (
     ReturnLogisticsDefinition,
 )
 from catering_system.domain.order import Order, OrderVersion
+from catering_system.domain.wochenuebersicht import WochenuebersichtEntry
 from catering_system.repositories.sqlite_offer_repository import SQLiteOfferRepository
 from catering_system.repositories.sqlite_order_repository import SQLiteOrderRepository
+from catering_system.ui.kiosk_server import render_order_feed_json
 
 NOW = datetime(2026, 8, 25, 9, 0, tzinfo=UTC)
 DAY = date(2026, 9, 12)
@@ -185,3 +189,91 @@ def test_next_working_day_never_carries_canonical_pickup_times() -> None:
             pickup_window_start_local=time(9, 0),
             pickup_window_end_local=time(10, 0),
         )
+
+
+
+def test_exact_delivery_and_event_start_roundtrip_without_fabricated_window(
+    tmp_path: Path,
+) -> None:
+    offer_repo = SQLiteOfferRepository(tmp_path / "exact-offers.db")
+    exact_offer = replace(
+        _offer_version(),
+        delivery_date_local=None,
+        delivery_window_start_local=None,
+        delivery_window_end_local=None,
+        delivery_time_local=time(16, 30),
+        event_start_local=time(18, 0),
+    )
+    offer_repo.save(
+        Offer(
+            offer_id="offer-1",
+            source_inquiry_id="inquiry-1",
+            created_at=NOW,
+            versions=(exact_offer,),
+        )
+    )
+    loaded_offer = offer_repo.get("offer-1")
+    assert loaded_offer is not None
+    loaded_version = loaded_offer.versions[0]
+    assert loaded_version.delivery_time_local == time(16, 30)
+    assert loaded_version.event_start_local == time(18, 0)
+    assert loaded_version.delivery_date_local is None
+    assert loaded_version.delivery_window_start_local is None
+    assert loaded_version.delivery_window_end_local is None
+
+    order_repo = SQLiteOrderRepository(tmp_path / "exact-orders.db")
+    order = Order("order-exact", "inquiry-1", NOW, NOW)
+    order_version = OrderVersion(
+        order_version_id="order-version-exact",
+        order_id=order.order_id,
+        version_number=1,
+        created_at=NOW,
+        event_date=DAY,
+        time_window_text="18:00",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+        delivery_time_local=time(16, 30),
+        event_start_local=time(18, 0),
+    )
+    order_repo.save_order_with_initial_version(order, order_version)
+    assert order_repo.get_order_version(order_version.order_version_id) == order_version
+
+
+def test_exact_delivery_time_and_legacy_window_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        OrderVersion(
+            order_version_id="v-exact-conflict",
+            order_id="o",
+            version_number=1,
+            created_at=NOW,
+            event_date=DAY,
+            time_window_text="18:00",
+            location_text="Hamburg",
+            guest_count_estimate=10,
+            planning_mode="caterer_suggestion",
+            delivery_date_local=DAY,
+            delivery_window_start_local=time(16, 0),
+            delivery_window_end_local=time(17, 0),
+            delivery_time_local=time(16, 30),
+        )
+
+
+def test_kiosk_feed_projects_exact_times_without_delivery_window() -> None:
+    entry = WochenuebersichtEntry(
+        order_id="order-1",
+        effective_order_version_id="version-1",
+        version_number=1,
+        event_date=DAY,
+        time_window_text="18:00",
+        location_text="Hamburg",
+        guest_count_estimate=20,
+        planning_mode="caterer_suggestion",
+        delivery_time_local=time(16, 30),
+        event_start_local=time(18, 0),
+    )
+    payload = json.loads(render_order_feed_json(DAY, (entry,)))
+    order = payload["orders"][0]
+    assert order["delivery_time_local"] == "16:30"
+    assert order["event_start_local"] == "18:00"
+    assert "delivery_window" not in order

--- a/tests/unit/test_issue175_logistics_timing.py
+++ b/tests/unit/test_issue175_logistics_timing.py
@@ -191,7 +191,6 @@ def test_next_working_day_never_carries_canonical_pickup_times() -> None:
         )
 
 
-
 def test_exact_delivery_and_event_start_roundtrip_without_fabricated_window(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -950,6 +950,7 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         (8, "offer_version_budget_definition"),
         (9, "offer_version_charges_definition"),
         (10, "offer_version_logistics_timing"),
+        (11, "offer_version_exact_timing"),
     ]
     conn = sqlite3.connect(db)
     apply_migrations(conn, "offers", _MIGRATIONS)
@@ -957,4 +958,4 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM schema_migrations WHERE component = 'offers'"
     ).fetchone()
     conn.close()
-    assert rows_after == (10,)
+    assert rows_after == (11,)

--- a/tests/unit/test_offer_snapshot_validation_extended.py
+++ b/tests/unit/test_offer_snapshot_validation_extended.py
@@ -388,3 +388,36 @@ def test_optional_long_text_length_limit_is_enforced() -> None:
     payload["snapshot_hash"] = compute_snapshot_hash(payload)
     with pytest.raises(ValueError, match="notes exceeds length limit"):
         validate_offer_snapshot(payload)
+
+
+
+def test_exact_event_times_are_accepted_without_delivery_window() -> None:
+    payload = _valid_snapshot()
+    event = cast(dict[str, object], payload["event"])
+    event["time_window_text"] = "18:00"
+    event["delivery_time_local"] = "16:30"
+    event["event_start_local"] = "18:00"
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+
+    snapshot = validate_offer_snapshot(payload)
+
+    assert snapshot.event.delivery_time_local is not None
+    assert snapshot.event.delivery_time_local.strftime("%H:%M") == "16:30"
+    assert snapshot.event.event_start_local is not None
+    assert snapshot.event.event_start_local.strftime("%H:%M") == "18:00"
+    assert snapshot.event.delivery_date_local is None
+    assert snapshot.event.delivery_window_start_local is None
+    assert snapshot.event.delivery_window_end_local is None
+
+
+def test_exact_delivery_time_rejects_legacy_delivery_window_combination() -> None:
+    payload = _valid_snapshot()
+    event = cast(dict[str, object], payload["event"])
+    event["delivery_date_local"] = "2026-07-25"
+    event["delivery_window_start_local"] = "16:00"
+    event["delivery_window_end_local"] = "17:00"
+    event["delivery_time_local"] = "16:30"
+    payload["snapshot_hash"] = compute_snapshot_hash(payload)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_offer_snapshot(payload)

--- a/tests/unit/test_offer_snapshot_validation_extended.py
+++ b/tests/unit/test_offer_snapshot_validation_extended.py
@@ -390,7 +390,6 @@ def test_optional_long_text_length_limit_is_enforced() -> None:
         validate_offer_snapshot(payload)
 
 
-
 def test_exact_event_times_are_accepted_without_delivery_window() -> None:
     payload = _valid_snapshot()
     event = cast(dict[str, object], payload["event"])

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -729,6 +729,8 @@ def test_order_domain_has_no_kitchen_or_release_surface() -> None:
         "delivery_date_local",
         "delivery_window_start_local",
         "delivery_window_end_local",
+        "delivery_time_local",
+        "event_start_local",
     }
 
 

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -639,6 +639,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         ("orders", 8),  # frozen operational context per order version
         ("orders", 9),  # frozen fulfillment mode in operational context
         ("orders", 10),  # canonical delivery timing on immutable order versions
+        ("orders", 11),  # exact delivery and event start timing
     ]
 
 


### PR DESCRIPTION
Closes #219

Adds additive exact local timing facts without fabricating a delivery window:

- `delivery_time_local`
- `event_start_local`

Preserves legacy delivery-window compatibility for existing snapshots and orders.

Carries exact timing through OfferSnapshot -> OfferVersion -> OrderVersion -> Wochenübersicht -> Kiosk order feed.

Adds SQLite migrations and regression coverage for strict validation, persistence, mutual exclusion with legacy windows, and Kiosk projection.