### PR TITLE
Support exact delivery and event start timing

### DIFF
--- a/src/catering_system/domain/logistics_timing.py
+++ b/src/catering_system/domain/logistics_timing.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 from datetime import date, time
 
 
+def validate_optional_local_time(value: time | None, *, label: str) -> None:
+    """Validate one explicit local wall-clock fact without inventing a window."""
+    if value is not None and value.tzinfo is not None:
+        raise ValueError(f"{label} must use local wall-clock time without tzinfo")
+
+
 def validate_optional_local_window(
     starts_at: time | None,
     ends_at: time | None,

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -11,7 +11,10 @@ from zoneinfo import ZoneInfo
 
 from catering_system.domain.catalog import AllergenCode, validate_allergen_codes
 from catering_system.domain.inquiry import PlanningMode, validate_planning_mode
-from catering_system.domain.logistics_timing import validate_optional_service_window
+from catering_system.domain.logistics_timing import (
+    validate_optional_local_time,
+    validate_optional_service_window,
+)
 from catering_system.domain.offer_budget_definition import OfferBudgetDefinition
 from catering_system.domain.offer_charges import OfferChargesDefinition
 from catering_system.domain.order_payment_reminder import (
@@ -242,6 +245,8 @@ class OfferVersion:
     # on legacy snapshots that never sent one; their positions (historically
     # always kind="fee") are untouched and not reinterpreted.
     charges_definition: OfferChargesDefinition | None = None
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
@@ -265,6 +270,12 @@ class OfferVersion:
             raise ValueError("guest_count must be a positive integer")
         validate_planning_mode(self.planning_mode)
         validate_payment_method(self.payment_method)
+        validate_optional_local_time(
+            self.event_start_local, label="event start"
+        )
+        validate_optional_local_time(
+            self.delivery_time_local, label="delivery time"
+        )
         validate_optional_service_window(
             self.delivery_date_local,
             self.delivery_window_start_local,

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -245,11 +245,11 @@ class OfferVersion:
     # on legacy snapshots that never sent one; their positions (historically
     # always kind="fee") are untouched and not reinterpreted.
     charges_definition: OfferChargesDefinition | None = None
-    event_start_local: time | None = None
-    delivery_time_local: time | None = None
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.offer_version_id, "offer_version_id")

--- a/src/catering_system/domain/offer.py
+++ b/src/catering_system/domain/offer.py
@@ -270,12 +270,8 @@ class OfferVersion:
             raise ValueError("guest_count must be a positive integer")
         validate_planning_mode(self.planning_mode)
         validate_payment_method(self.payment_method)
-        validate_optional_local_time(
-            self.event_start_local, label="event start"
-        )
-        validate_optional_local_time(
-            self.delivery_time_local, label="delivery time"
-        )
+        validate_optional_local_time(self.event_start_local, label="event start")
+        validate_optional_local_time(self.delivery_time_local, label="delivery time")
         validate_optional_service_window(
             self.delivery_date_local,
             self.delivery_window_start_local,

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -62,12 +62,12 @@ class OfferSnapshotEvent:
     location_text: str
     guest_count: int | None
     planning_mode: PlanningMode
-    event_start_local: time | None = None
-    delivery_time_local: time | None = None
     # Legacy V3 logistics window fields remain readable for historical snapshots.
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
 
     def __post_init__(self) -> None:
         validate_optional_service_window(

--- a/src/catering_system/domain/offer_snapshot.py
+++ b/src/catering_system/domain/offer_snapshot.py
@@ -62,6 +62,9 @@ class OfferSnapshotEvent:
     location_text: str
     guest_count: int | None
     planning_mode: PlanningMode
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
+    # Legacy V3 logistics window fields remain readable for historical snapshots.
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None

--- a/src/catering_system/domain/order.py
+++ b/src/catering_system/domain/order.py
@@ -52,11 +52,11 @@ class OrderVersion:
     created_by: str | None = None
     change_reason: str | None = None
     changed_fields: tuple[str, ...] = ()
-    event_start_local: time | None = None
-    delivery_time_local: time | None = None
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
 
     def __post_init__(self) -> None:
         validate_optional_local_time(self.event_start_local, label="event start")

--- a/src/catering_system/domain/order.py
+++ b/src/catering_system/domain/order.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 from datetime import date, datetime, time
 
 from catering_system.domain.inquiry import PlanningMode
-from catering_system.domain.logistics_timing import validate_optional_service_window
+from catering_system.domain.logistics_timing import (
+    validate_optional_local_time,
+    validate_optional_service_window,
+)
 
 
 @dataclass(frozen=True)
@@ -49,11 +52,15 @@ class OrderVersion:
     created_by: str | None = None
     change_reason: str | None = None
     changed_fields: tuple[str, ...] = ()
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
 
     def __post_init__(self) -> None:
+        validate_optional_local_time(self.event_start_local, label="event start")
+        validate_optional_local_time(self.delivery_time_local, label="delivery time")
         validate_optional_service_window(
             self.delivery_date_local,
             self.delivery_window_start_local,

--- a/src/catering_system/domain/wochenuebersicht.py
+++ b/src/catering_system/domain/wochenuebersicht.py
@@ -26,6 +26,8 @@ class WochenuebersichtEntry:
     location_text: str
     guest_count_estimate: int | None
     planning_mode: PlanningMode
+    event_start_local: time | None = None
+    delivery_time_local: time | None = None
     delivery_date_local: date | None = None
     delivery_window_start_local: time | None = None
     delivery_window_end_local: time | None = None
@@ -60,6 +62,8 @@ def entry_from_effective(
         location_text=effective.location_text,
         guest_count_estimate=effective.guest_count_estimate,
         planning_mode=effective.planning_mode,
+        event_start_local=effective.event_start_local,
+        delivery_time_local=effective.delivery_time_local,
         delivery_date_local=effective.delivery_date_local,
         delivery_window_start_local=effective.delivery_window_start_local,
         delivery_window_end_local=effective.delivery_window_end_local,

--- a/src/catering_system/repositories/sqlite_offer_repository.py
+++ b/src/catering_system/repositories/sqlite_offer_repository.py
@@ -339,6 +339,17 @@ def _migration_10_offer_version_logistics_timing(
             connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
 
 
+def _migration_11_offer_version_exact_timing(
+    connection: sqlite3.Connection,
+) -> None:
+    existing = {
+        row[1] for row in connection.execute("PRAGMA table_info(offer_versions)")
+    }
+    for name in ("event_start_local", "delivery_time_local"):
+        if name not in existing:
+            connection.execute(f"ALTER TABLE offer_versions ADD COLUMN {name} TEXT")
+
+
 _MIGRATIONS = (
     (1, "create_offer_tables", _migration_1_create_tables),
     (2, "unique_source_inquiry", _migration_2_unique_source_inquiry),
@@ -377,6 +388,11 @@ _MIGRATIONS = (
         10,
         "offer_version_logistics_timing",
         _migration_10_offer_version_logistics_timing,
+    ),
+    (
+        11,
+        "offer_version_exact_timing",
+        _migration_11_offer_version_exact_timing,
     ),
 )
 
@@ -831,9 +847,9 @@ class SQLiteOfferRepository:
                 location_text, guest_count, planning_mode, payment_method,
                 payment_customer_visible_text, customer_title,
                 customer_introduction, customer_notes, budget_definition_json,
-                charges_definition_json, delivery_date_local,
-                delivery_window_start_local, delivery_window_end_local
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                charges_definition_json, event_start_local, delivery_time_local,
+                delivery_date_local, delivery_window_start_local, delivery_window_end_local
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 version.offer_version_id,
@@ -855,6 +871,16 @@ class SQLiteOfferRepository:
                 version.customer_notes,
                 _budget_definition_storage(version.budget_definition),
                 _charges_definition_storage(version.charges_definition),
+                (
+                    version.event_start_local.isoformat(timespec="minutes")
+                    if version.event_start_local is not None
+                    else None
+                ),
+                (
+                    version.delivery_time_local.isoformat(timespec="minutes")
+                    if version.delivery_time_local is not None
+                    else None
+                ),
                 (
                     version.delivery_date_local.isoformat()
                     if version.delivery_date_local is not None
@@ -1003,8 +1029,8 @@ class SQLiteOfferRepository:
                    location_text, guest_count, planning_mode, payment_method,
                    payment_customer_visible_text, customer_title,
                    customer_introduction, customer_notes, budget_definition_json,
-                   charges_definition_json, delivery_date_local,
-                   delivery_window_start_local, delivery_window_end_local
+                   charges_definition_json, event_start_local, delivery_time_local,
+                   delivery_date_local, delivery_window_start_local, delivery_window_end_local
             FROM offer_versions
             WHERE offer_id = ?
             ORDER BY version_number
@@ -1053,14 +1079,20 @@ class SQLiteOfferRepository:
                     customer_notes=row[15],
                     budget_definition=_stored_budget_definition(row[16]),
                     charges_definition=_stored_charges_definition(row[17]),
-                    delivery_date_local=(
-                        date.fromisoformat(row[18]) if row[18] is not None else None
+                    event_start_local=(
+                        time.fromisoformat(row[18]) if row[18] is not None else None
                     ),
-                    delivery_window_start_local=(
+                    delivery_time_local=(
                         time.fromisoformat(row[19]) if row[19] is not None else None
                     ),
+                    delivery_date_local=(
+                        date.fromisoformat(row[20]) if row[20] is not None else None
+                    ),
+                    delivery_window_start_local=(
+                        time.fromisoformat(row[21]) if row[21] is not None else None
+                    ),
                     delivery_window_end_local=(
-                        time.fromisoformat(row[20]) if row[20] is not None else None
+                        time.fromisoformat(row[22]) if row[22] is not None else None
                     ),
                 )
             )

--- a/src/catering_system/repositories/sqlite_order_repository.py
+++ b/src/catering_system/repositories/sqlite_order_repository.py
@@ -418,6 +418,24 @@ def _migration_10_order_version_logistics_timing(
     )
 
 
+def _migration_11_order_version_exact_timing(
+    connection: sqlite3.Connection,
+) -> None:
+    columns = {
+        row[1] for row in connection.execute("PRAGMA table_info(order_versions)")
+    }
+    for name in ("event_start_local", "delivery_time_local"):
+        if name not in columns:
+            connection.execute(f"ALTER TABLE order_versions ADD COLUMN {name} TEXT")
+    connection.execute(
+        """CREATE TRIGGER IF NOT EXISTS trg_order_version_exact_timing_immutable
+        BEFORE UPDATE OF event_start_local, delivery_time_local ON order_versions
+        WHEN NEW.event_start_local IS NOT OLD.event_start_local
+          OR NEW.delivery_time_local IS NOT OLD.delivery_time_local
+        BEGIN SELECT RAISE(ABORT, 'order version exact timing is immutable'); END"""
+    )
+
+
 _MIGRATIONS = (
     (1, "create_order_tables", _migration_1_create_tables),
     (2, "add_cancelled_at", _migration_2_add_cancelled_at),
@@ -444,6 +462,11 @@ _MIGRATIONS = (
         10,
         "order_version_logistics_timing",
         _migration_10_order_version_logistics_timing,
+    ),
+    (
+        11,
+        "order_version_exact_timing",
+        _migration_11_order_version_exact_timing,
     ),
 )
 
@@ -532,8 +555,9 @@ class SQLiteOrderRepository:
                     event_date, time_window_text, location_text, guest_count_estimate,
                     planning_mode, kitchen_print_confirmed_at, parent_order_version_id,
                     created_by, change_reason, changed_fields_json, delivery_date_local,
-                    delivery_window_start_local, delivery_window_end_local
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    delivery_window_start_local, delivery_window_end_local,
+                    event_start_local, delivery_time_local
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._version_values(version),
             )
@@ -594,8 +618,9 @@ class SQLiteOrderRepository:
                     event_date, time_window_text, location_text, guest_count_estimate,
                     planning_mode, kitchen_print_confirmed_at, parent_order_version_id,
                     created_by, change_reason, changed_fields_json, delivery_date_local,
-                    delivery_window_start_local, delivery_window_end_local
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    delivery_window_start_local, delivery_window_end_local,
+                    event_start_local, delivery_time_local
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 self._version_values(version),
             )
@@ -734,6 +759,16 @@ class SQLiteOrderRepository:
                 if version.delivery_window_end_local is not None
                 else None
             ),
+            (
+                version.event_start_local.isoformat(timespec="minutes")
+                if version.event_start_local is not None
+                else None
+            ),
+            (
+                version.delivery_time_local.isoformat(timespec="minutes")
+                if version.delivery_time_local is not None
+                else None
+            ),
         )
 
     def get_order_version(self, order_version_id: str) -> OrderVersion | None:
@@ -807,5 +842,11 @@ class SQLiteOrderRepository:
             ),
             delivery_window_end_local=(
                 time.fromisoformat(row[16]) if row[16] is not None else None
+            ),
+            event_start_local=(
+                time.fromisoformat(row[17]) if row[17] is not None else None
+            ),
+            delivery_time_local=(
+                time.fromisoformat(row[18]) if row[18] is not None else None
             ),
         )

--- a/src/catering_system/services/offer_service.py
+++ b/src/catering_system/services/offer_service.py
@@ -715,6 +715,8 @@ def _build_version_from_snapshot(
         customer_notes=_normalize_narrative(snapshot.customer_text.notes),
         budget_definition=snapshot.budget_definition,
         charges_definition=snapshot.charges_definition,
+        event_start_local=snapshot.event.event_start_local,
+        delivery_time_local=snapshot.event.delivery_time_local,
         delivery_date_local=snapshot.event.delivery_date_local,
         delivery_window_start_local=snapshot.event.delivery_window_start_local,
         delivery_window_end_local=snapshot.event.delivery_window_end_local,

--- a/src/catering_system/services/offer_snapshot_validation.py
+++ b/src/catering_system/services/offer_snapshot_validation.py
@@ -109,6 +109,8 @@ _EVENT_KEYS = frozenset(
         "location_text",
         "guest_count",
         "planning_mode",
+        "event_start_local",
+        "delivery_time_local",
         "delivery_date_local",
         "delivery_window_start_local",
         "delivery_window_end_local",
@@ -469,6 +471,12 @@ def _parse_event(payload: dict[str, object]) -> OfferSnapshotEvent:
         guest_count=guest_count,
         planning_mode=validate_planning_mode(
             _require_exact_str(payload.get("planning_mode"), "planning_mode")
+        ),
+        event_start_local=_optional_local_time(
+            payload.get("event_start_local"), "event.event_start_local"
+        ),
+        delivery_time_local=_optional_local_time(
+            payload.get("delivery_time_local"), "event.delivery_time_local"
         ),
         delivery_date_local=_optional_date(
             payload.get("delivery_date_local"), "event.delivery_date_local"

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -198,10 +198,14 @@ class OrderService:
             guest_count_estimate=guest_count_estimate,
             planning_mode=pm,
             event_start_local=(
-                latest_version.event_start_local if latest_version is not None else None
+                latest_version.event_start_local
+                if latest_version is not None
+                else None
             ),
             delivery_time_local=(
-                latest_version.delivery_time_local if latest_version is not None else None
+                latest_version.delivery_time_local
+                if latest_version is not None
+                else None
             ),
             delivery_date_local=(
                 latest_version.delivery_date_local

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -197,16 +197,12 @@ class OrderService:
             location_text=location_text,
             guest_count_estimate=guest_count_estimate,
             planning_mode=pm,
-            event_start_local=(
-                latest_version.event_start_local
-                if latest_version is not None
-                else None
-            ),
-            delivery_time_local=(
-                latest_version.delivery_time_local
-                if latest_version is not None
-                else None
-            ),
+            event_start_local=latest_version.event_start_local
+            if latest_version is not None
+            else None,
+            delivery_time_local=latest_version.delivery_time_local
+            if latest_version is not None
+            else None,
             delivery_date_local=(
                 latest_version.delivery_date_local
                 if latest_version is not None

--- a/src/catering_system/services/order_service.py
+++ b/src/catering_system/services/order_service.py
@@ -141,6 +141,8 @@ class OrderService:
             location_text=offer_version.location_text,
             guest_count_estimate=offer_version.guest_count,
             planning_mode=offer_version.planning_mode,
+            event_start_local=offer_version.event_start_local,
+            delivery_time_local=offer_version.delivery_time_local,
             delivery_date_local=offer_version.delivery_date_local,
             delivery_window_start_local=offer_version.delivery_window_start_local,
             delivery_window_end_local=offer_version.delivery_window_end_local,
@@ -195,6 +197,12 @@ class OrderService:
             location_text=location_text,
             guest_count_estimate=guest_count_estimate,
             planning_mode=pm,
+            event_start_local=(
+                latest_version.event_start_local if latest_version is not None else None
+            ),
+            delivery_time_local=(
+                latest_version.delivery_time_local if latest_version is not None else None
+            ),
             delivery_date_local=(
                 latest_version.delivery_date_local
                 if latest_version is not None

--- a/src/catering_system/ui/kiosk_server.py
+++ b/src/catering_system/ui/kiosk_server.py
@@ -207,6 +207,16 @@ def _order_feed_entry_projection(
         "time_window_text": entry.time_window_text,
         "location_text": entry.location_text,
         "guest_count_estimate": entry.guest_count_estimate,
+        **(
+            {"event_start_local": entry.event_start_local.strftime("%H:%M")}
+            if entry.event_start_local is not None
+            else {}
+        ),
+        **(
+            {"delivery_time_local": entry.delivery_time_local.strftime("%H:%M")}
+            if entry.delivery_time_local is not None
+            else {}
+        ),
         "return_logistics": _return_logistics_projection(
             entry.event_date, return_logistics
         ),

--- a/tests/unit/test_issue175_kiosk_timing_projection.py
+++ b/tests/unit/test_issue175_kiosk_timing_projection.py
@@ -129,3 +129,24 @@ def test_same_day_pickup_text_is_not_parsed_when_canonical_times_are_missing() -
         "return_date": "2026-10-01",
         "pickup_window_text": "22:00-23:00",
     }
+
+
+def test_exact_delivery_and_event_start_project_without_synthetic_window() -> None:
+    entry = WochenuebersichtEntry(
+        order_id="order-exact",
+        effective_order_version_id="version-exact",
+        version_number=1,
+        event_date=date(2026, 10, 1),
+        time_window_text="18:00",
+        location_text="Hamburg",
+        guest_count_estimate=40,
+        planning_mode=PLANNING_MODES[0],
+        event_start_local=time(18, 0),
+        delivery_time_local=time(16, 30),
+    )
+
+    order = _render(entry)
+
+    assert order["event_start_local"] == "18:00"
+    assert order["delivery_time_local"] == "16:30"
+    assert "delivery_window" not in order

--- a/tests/unit/test_issue175_logistics_timing.py
+++ b/tests/unit/test_issue175_logistics_timing.py
@@ -80,6 +80,8 @@ def _offer_version() -> OfferVersion:
         delivery_date_local=DAY,
         delivery_window_start_local=time(16, 0),
         delivery_window_end_local=time(17, 0),
+        event_start_local=time(18, 0),
+        delivery_time_local=time(16, 0),
     )
 
 
@@ -102,6 +104,8 @@ def test_offer_sqlite_roundtrip_preserves_canonical_logistics_timing(
     assert actual.delivery_date_local == DAY
     assert actual.delivery_window_start_local == time(16, 0)
     assert actual.delivery_window_end_local == time(17, 0)
+    assert actual.event_start_local == time(18, 0)
+    assert actual.delivery_time_local == time(16, 0)
     assert actual.charges_definition is not None
     return_plan = actual.charges_definition.return_logistics
     assert return_plan.pickup_window_start_local == time(22, 0)
@@ -126,6 +130,8 @@ def test_order_sqlite_roundtrip_preserves_canonical_delivery_window(
         delivery_date_local=DAY,
         delivery_window_start_local=time(16, 0),
         delivery_window_end_local=time(17, 0),
+        event_start_local=time(18, 0),
+        delivery_time_local=time(16, 0),
     )
     repo.save_order_with_initial_version(order, version)
     assert repo.get_order_version("order-version-1") == version

--- a/tests/unit/test_offer_repository.py
+++ b/tests/unit/test_offer_repository.py
@@ -950,6 +950,7 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         (8, "offer_version_budget_definition"),
         (9, "offer_version_charges_definition"),
         (10, "offer_version_logistics_timing"),
+        (11, "offer_version_exact_timing"),
     ]
     conn = sqlite3.connect(db)
     apply_migrations(conn, "offers", _MIGRATIONS)
@@ -957,4 +958,4 @@ def test_offer_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         "SELECT COUNT(*) FROM schema_migrations WHERE component = 'offers'"
     ).fetchone()
     conn.close()
-    assert rows_after == (10,)
+    assert rows_after == (11,)

--- a/tests/unit/test_order_service.py
+++ b/tests/unit/test_order_service.py
@@ -729,6 +729,8 @@ def test_order_domain_has_no_kitchen_or_release_surface() -> None:
         "delivery_date_local",
         "delivery_window_start_local",
         "delivery_window_end_local",
+        "event_start_local",
+        "delivery_time_local",
     }
 
 

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -639,6 +639,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         ("orders", 8),  # frozen operational context per order version
         ("orders", 9),  # frozen fulfillment mode in operational context
         ("orders", 10),  # canonical delivery timing on immutable order versions
+        ("orders", 11),  # exact event-start and delivery times
     ]
 
 


### PR DESCRIPTION
Closes #221.

Adds exact local timing facts without inventing a delivery-window end:

- `event_start_local`
- `delivery_time_local`

Legacy `delivery_date_local/start/end` fields remain readable and unchanged for historical data.

Propagation:
OfferSnapshot -> OfferVersion -> SQLite -> OrderVersion -> Wochenübersicht -> Kiosk feed.

The kiosk feed emits exact timing as additive top-level fields and only emits the legacy `delivery_window` when an actual complete legacy window exists.

No customer communication, accounting, or cash-flow behavior changes.