### PR TITLE
Add contextual back action to Office error pages

### DIFF
--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -1073,7 +1073,7 @@ def make_office_panel_handler(
             body = (
                 f'<p class="blocked">{_e(message)}</p>'
                 f'<p><a class="order-button secondary" href="{_e(return_href)}">'
-                f'{_e(return_label)}</a></p>'
+                f"{_e(return_label)}</a></p>"
             )
             self._html(
                 _page(

--- a/src/catering_system/ui/office_panel_http.py
+++ b/src/catering_system/ui/office_panel_http.py
@@ -169,6 +169,22 @@ _ROLE_LABELS = {
     "VIEWER": "Leser",
 }
 
+_ERROR_RETURN_CONTEXTS: dict[str, tuple[str, OfficeSection]] = {
+    "offer": ("Zurück zum Angebot", "offers"),
+    "inquiry": ("Zurück zur Anfrage", "inquiries"),
+    "order": ("Zurück zum Auftrag", "orders"),
+}
+
+
+def _error_return_target(path: str) -> tuple[str, str, OfficeSection]:
+    """Return a safe GET destination for an error raised by a record action."""
+    parts = [part for part in urlparse(path).path.split("/") if part]
+    if len(parts) >= 3 and parts[0] in _ERROR_RETURN_CONTEXTS:
+        label, section = _ERROR_RETURN_CONTEXTS[parts[0]]
+        record_id = quote(unquote(parts[1]), safe="")
+        return label, f"/{parts[0]}/{record_id}", section
+    return "Zur Arbeitszentrale", "/", "home"
+
 
 def _int_value(value: object) -> int:
     return value if isinstance(value, int) else 0
@@ -1053,11 +1069,17 @@ def make_office_panel_handler(
             return items, error
 
         def _error_page(self, message: str, status: int = 400) -> None:
+            return_label, return_href, active_section = _error_return_target(self.path)
+            body = (
+                f'<p class="blocked">{_e(message)}</p>'
+                f'<p><a class="order-button secondary" href="{_e(return_href)}">'
+                f'{_e(return_label)}</a></p>'
+            )
             self._html(
                 _page(
                     "Fehler",
-                    f'<p class="blocked">{_e(message)}</p>',
-                    active_section="home",
+                    body,
+                    active_section=active_section,
                     context=self._page_context(),
                 ),
                 status,
@@ -1091,15 +1113,7 @@ def make_office_panel_handler(
             not "unavailable") fall back to the same generic error rendering
             direct-mode ValueErrors already use."""
             if exc.unavailable:
-                self._html(
-                    _page(
-                        "Fehler",
-                        f'<p class="blocked">{_e(_UNAVAILABLE_MESSAGE)}</p>',
-                        active_section="home",
-                        context=self._page_context(),
-                    ),
-                    503,
-                )
+                self._error_page(_UNAVAILABLE_MESSAGE, status=503)
             else:
                 self._error_page(
                     inquiry_command_error_message(exc.code),

--- a/tests/unit/test_office_panel_error_navigation.py
+++ b/tests/unit/test_office_panel_error_navigation.py
@@ -1,0 +1,41 @@
+from catering_system.ui.office_panel_http import _error_return_target
+
+
+def test_error_return_target_offer_action() -> None:
+    assert _error_return_target("/offer/abc-123/mark-sent") == (
+        "Zurück zum Angebot",
+        "/offer/abc-123",
+        "offers",
+    )
+
+
+def test_error_return_target_inquiry_action() -> None:
+    assert _error_return_target("/inquiry/inq-1/update") == (
+        "Zurück zur Anfrage",
+        "/inquiry/inq-1",
+        "inquiries",
+    )
+
+
+def test_error_return_target_order_action() -> None:
+    assert _error_return_target("/order/order-1/confirmation-document/send") == (
+        "Zurück zum Auftrag",
+        "/order/order-1",
+        "orders",
+    )
+
+
+def test_error_return_target_encodes_record_id() -> None:
+    assert _error_return_target("/offer/a%2Fb/mark-sent") == (
+        "Zurück zum Angebot",
+        "/offer/a%2Fb",
+        "offers",
+    )
+
+
+def test_error_return_target_falls_back_for_non_record_error() -> None:
+    assert _error_return_target("/login") == (
+        "Zur Arbeitszentrale",
+        "/",
+        "home",
+    )

--- a/tests/unit/test_office_panel_offer_actions.py
+++ b/tests/unit/test_office_panel_offer_actions.py
@@ -743,6 +743,8 @@ def test_mark_sent_future_timestamp_shows_german_error(direct_world) -> None:
     assert status == 400
     assert "Der Versandnachweis ist ungültig" in body
     assert "invalid_sent_evidence" not in body
+    assert "Zurück zum Angebot" in body
+    assert f'href="/offer/{offer_id}"' in body
 
 
 def test_mark_sent_before_offer_version_created_at_shows_german_error(


### PR DESCRIPTION
Closes #225.

Office command errors now include a normal GET return action derived from the record action route:

- Offer action errors → `Zurück zum Angebot`
- Inquiry action errors → `Zurück zur Anfrage`
- Order action errors → `Zurück zum Auftrag`
- everything else → `Zur Arbeitszentrale`

The corresponding sidebar section is also selected on the error page.

No browser history navigation is used, so the button cannot resubmit the failed POST. Record IDs are normalized through URL decode/re-encode before being placed in the link.

The existing invalid Versandnachweis regression now verifies the Offer return link.