### PR TITLE
Make Kitchen Print API stay running under systemd

### DIFF
--- a/infra/systemd/catering-kitchen-api.service
+++ b/infra/systemd/catering-kitchen-api.service
@@ -1,0 +1,20 @@
+# Kitchen Print Agent API — Lenovo deployment.
+# Loopback-only, bearer-gated with the same agent token consumed by kitchen-print-agent.
+
+[Unit]
+Description=Catering Kitchen Print Agent API (loopback, bearer-gated)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=viktor
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/src
+EnvironmentFile=/etc/kitchen-print-agent.env
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m catering_system.ui.kitchen_api --db /home/viktor/catering-runtime/core.db --host 127.0.0.1 --port 8086
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -387,6 +387,7 @@ def create_kitchen_api_server(
     server.kitchen_connection = connection  # type: ignore[attr-defined]
     return server, api
 
+
 def main() -> None:
     """Run the loopback Kitchen Print Agent API as a long-lived process."""
     import argparse

--- a/src/catering_system/ui/kitchen_api.py
+++ b/src/catering_system/ui/kitchen_api.py
@@ -386,3 +386,42 @@ def create_kitchen_api_server(
     server = HTTPServer((host, port), make_kitchen_api_handler(api, token))
     server.kitchen_connection = connection  # type: ignore[attr-defined]
     return server, api
+
+def main() -> None:
+    """Run the loopback Kitchen Print Agent API as a long-lived process."""
+    import argparse
+    import os
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="Catering Kitchen Print Agent API")
+    parser.add_argument("--db", required=True, help="Path to the Core SQLite database")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8086)
+    args = parser.parse_args()
+
+    token = os.environ.get("KITCHEN_PRINT_AGENT_TOKEN", "")
+    if not token:
+        raise SystemExit(
+            "KITCHEN_PRINT_AGENT_TOKEN is required; refusing to start unauthenticated"
+        )
+
+    server, api = create_kitchen_api_server(
+        args.db,
+        token,
+        args.host,
+        args.port,
+    )
+    _log.info(
+        "Catering Kitchen Print API on http://%s:%s/kitchen/v1/",
+        args.host,
+        args.port,
+    )
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+        api.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_kitchen_api_cli.py
+++ b/tests/unit/test_kitchen_api_cli.py
@@ -32,7 +32,15 @@ def test_main_requires_agent_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
-        ["kitchen_api", "--db", "/tmp/core.db", "--host", "127.0.0.1", "--port", "8086"],
+        [
+            "kitchen_api",
+            "--db",
+            "/tmp/core.db",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8086",
+        ],
     )
 
     with pytest.raises(SystemExit, match="KITCHEN_PRINT_AGENT_TOKEN is required"):

--- a/tests/unit/test_kitchen_api_cli.py
+++ b/tests/unit/test_kitchen_api_cli.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from catering_system.ui import kitchen_api
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.served = False
+        self.closed = False
+
+    def serve_forever(self) -> None:
+        self.served = True
+
+    def server_close(self) -> None:
+        self.closed = True
+
+
+class _FakeApi:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_main_requires_agent_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KITCHEN_PRINT_AGENT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["kitchen_api", "--db", "/tmp/core.db", "--host", "127.0.0.1", "--port", "8086"],
+    )
+
+    with pytest.raises(SystemExit, match="KITCHEN_PRINT_AGENT_TOKEN is required"):
+        kitchen_api.main()
+
+
+def test_main_runs_server_with_cli_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _FakeServer()
+    api = _FakeApi()
+    captured: dict[str, object] = {}
+
+    def fake_create(
+        db_path: str,
+        token: str,
+        host: str,
+        port: int,
+    ) -> tuple[_FakeServer, _FakeApi]:
+        captured.update(
+            db_path=db_path,
+            token=token,
+            host=host,
+            port=port,
+        )
+        return server, api
+
+    monkeypatch.setenv("KITCHEN_PRINT_AGENT_TOKEN", "test-token")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "kitchen_api",
+            "--db",
+            "/srv/core.db",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8086",
+        ],
+    )
+    monkeypatch.setattr(kitchen_api, "create_kitchen_api_server", fake_create)
+
+    kitchen_api.main()
+
+    assert captured == {
+        "db_path": "/srv/core.db",
+        "token": "test-token",
+        "host": "127.0.0.1",
+        "port": 8086,
+    }
+    assert server.served is True
+    assert server.closed is True
+    assert api.closed is True


### PR DESCRIPTION
Closes #227.

Production evidence showed `catering-kitchen-api.service` is enabled but exits immediately, leaving 127.0.0.1:8086 closed. The kitchen print agent therefore cannot claim print jobs and loops on ConnectionRefusedError.

Root cause: `catering_system.ui.kitchen_api` exposed server construction functions but had no CLI entry point, even though systemd launches it with `python -m catering_system.ui.kitchen_api --db ... --port 8086`.

This PR:

- adds a long-lived CLI `main()` with `--db/--host/--port`;
- requires `KITCHEN_PRINT_AGENT_TOKEN` and fails closed when absent;
- starts `create_kitchen_api_server(...)` and `serve_forever()`;
- closes server/API resources on shutdown;
- adds CLI regression tests;
- tracks the production `catering-kitchen-api.service` in the repository.

After deployment, the existing pending print job can be claimed by the agent without creating another print attempt.