### PR TITLE
Allow reprint after print acceptance timeout

### DIFF
--- a/src/catering_system/services/kitchen_print_service.py
+++ b/src/catering_system/services/kitchen_print_service.py
@@ -85,6 +85,15 @@ class KitchenPrintService:
     ) -> list[KitchenPrintJob]:
         return self._jobs.list_for_version(order_version_id)
 
+    def is_acceptance_overdue(self, job: KitchenPrintJob) -> bool:
+        return (
+            job.accepted_at is None
+            and job.acknowledged_at is None
+            and job.rejected_at is None
+            and job.superseded_at is None
+            and self._clock() >= job.accept_deadline_at
+        )
+
     def is_ack_overdue(self, job: KitchenPrintJob) -> bool:
         return (
             job.accepted_at is not None

--- a/src/catering_system/ui/office_panel.py
+++ b/src/catering_system/ui/office_panel.py
@@ -761,6 +761,7 @@ class OfficePanel:
         if (
             latest.rejected_at is not None
             or latest.superseded_at is not None
+            or self.kitchen_print_service.is_acceptance_overdue(latest)
             or self.kitchen_print_service.is_ack_overdue(latest)
         ):
             return "Erneut drucken"
@@ -779,6 +780,7 @@ class OfficePanel:
             latest.acknowledged_at is None
             and latest.rejected_at is None
             and latest.superseded_at is None
+            and not self.kitchen_print_service.is_acceptance_overdue(latest)
             and not self.kitchen_print_service.is_ack_overdue(latest)
         )
 
@@ -798,6 +800,8 @@ class OfficePanel:
                 latest.rejection_code or "",
                 "Druckauftrag fehlgeschlagen.",
             )
+        if self.kitchen_print_service.is_acceptance_overdue(latest):
+            return "Druckauftrag nicht rechtzeitig angenommen."
         if self.kitchen_print_service.is_ack_overdue(latest):
             return "Druckauftrag fehlgeschlagen."
         if latest.accepted_at is not None:

--- a/tests/unit/test_kitchen_print_service.py
+++ b/tests/unit/test_kitchen_print_service.py
@@ -459,12 +459,32 @@ def test_acceptance_deadline_and_cancelled_state_are_pure_derivations() -> None:
     clock.advance(timedelta(seconds=12))
 
     assert derive_kitchen_print_job_state(job, now=clock.now) == "acceptance_overdue"
+    assert service.is_acceptance_overdue(job) is True
     assert (
         derive_kitchen_print_job_state(job, now=clock.now, order_cancelled=True)
         == "cancelled"
     )
     with pytest.raises(ValueError, match="deadline has passed"):
         service.accept_print_job(JOB_1)
+
+
+def test_office_reprint_action_after_acceptance_timeout() -> None:
+    _orders, service, _core, clock, order_id, version_id, _events = _setup()
+    panel = OfficePanel.__new__(OfficePanel)
+    panel.kitchen_print_service = service
+    service.request_print(order_id, version_id, print_job_id=JOB_1)
+    clock.advance(timedelta(seconds=12))
+
+    assert panel._kitchen_print_is_processing(version_id) is False
+    assert panel._kitchen_print_action_label(version_id) == "Erneut drucken"
+    assert (
+        panel._kitchen_print_status_message(version_id)
+        == "Druckauftrag nicht rechtzeitig angenommen."
+    )
+
+    retry = service.reprint(JOB_1, new_print_job_id=JOB_2)
+    assert retry.attempt_number == 2
+    assert retry.supersedes_print_job_id == JOB_1
 
 
 def test_claim_next_eligible_records_order_cancelled_after_atomic_accept() -> None:


### PR DESCRIPTION
Closes #229.

An unaccepted kitchen print attempt past `accept_deadline_at` was correctly derived as `acceptance_overdue` by the domain, but Office still treated it as processing forever. That meant the agent could no longer claim the job and the operator could not create a new attempt.

This PR:

- adds `KitchenPrintService.is_acceptance_overdue()`;
- makes acceptance-overdue attempts non-processing in Office;
- shows `Erneut drucken`;
- displays `Druckauftrag nicht rechtzeitig angenommen.`;
- keeps the existing append-only reprint/supersession path;
- adds regression coverage for the exact expired-unaccepted case seen in production.

No deadline or print-job schema changes.