### PR TITLE
Add STRATO AI telephone intake endpoint

### DIFF
--- a/docs/api/ai-telefonist-intake.md
+++ b/docs/api/ai-telefonist-intake.md
@@ -1,0 +1,198 @@
+# STRATO AI telephone intake API
+
+Purpose: create one Core Inquiry from a STRATO Smart-Telefonassistent API tool.
+
+## Core receiver
+
+Local receiver:
+
+```text
+POST http://127.0.0.1:8085/intake/ai-telefonist
+```
+
+Authentication:
+
+```http
+Authorization: Bearer <AI_TELEFONIST_INTAKE_TOKEN>
+Content-Type: application/json
+```
+
+The service is intentionally loopback-only. STRATO requires a publicly reachable
+HTTPS endpoint, so a narrow TLS reverse proxy/tunnel must forward exactly this
+route to the local receiver. Do not expose the Office Panel, Office API, Kitchen
+API, or the SQLite database.
+
+Success:
+
+```json
+{"accepted": true, "inquiry_id": "<uuid>"}
+```
+
+The receiver creates Inquiry only. It does not create an Offer, Order,
+OrderVersion, print job, customer document, or payment state.
+
+## STRATO tool definition
+
+Name:
+
+```text
+create_catering_inquiry
+```
+
+Description:
+
+```text
+Erstellt eine neue Catering-Anfrage im internen System. Nutze dieses Tool,
+wenn ein Anrufer eine konkrete Catering-Anfrage stellt oder ein Angebot
+erhalten möchte. Frage die Pflichtangaben ab und fasse freie Wünsche knapp
+zusammen. submission_id ist eine technische UUID: nicht vom Anrufer erfragen,
+sondern pro Tool-Aufruf selbst erzeugen.
+```
+
+Parameters:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "submission_id": {
+      "type": "string",
+      "description": "Technische eindeutige UUID. Nicht vom Anrufer erfragen; pro Tool-Aufruf selbst erzeugen."
+    },
+    "contact_name": {
+      "type": "string",
+      "description": "Vor- und Nachname der Kontaktperson"
+    },
+    "company_name": {
+      "type": "string",
+      "description": "Firmenname, falls vorhanden"
+    },
+    "phone": {
+      "type": "string",
+      "description": "Telefonnummer für Rückfragen"
+    },
+    "email": {
+      "type": "string",
+      "description": "E-Mail-Adresse, falls der Anrufer eine angibt"
+    },
+    "event_date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Datum der Veranstaltung im Format YYYY-MM-DD"
+    },
+    "event_start": {
+      "type": "string",
+      "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+      "description": "Startzeit im Format HH:MM, falls bekannt"
+    },
+    "guest_count": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2000,
+      "description": "Voraussichtliche Anzahl der Gäste"
+    },
+    "location": {
+      "type": "string",
+      "description": "Ort oder Adresse der Veranstaltung"
+    },
+    "event_type": {
+      "type": "string",
+      "description": "Art der Veranstaltung"
+    },
+    "fulfillment_mode": {
+      "type": "string",
+      "enum": ["DELIVERY", "PICKUP", "UNKNOWN"],
+      "description": "DELIVERY bei Lieferung, PICKUP bei Abholung, UNKNOWN wenn noch offen"
+    },
+    "customer_request": {
+      "type": "string",
+      "description": "Speisenwünsche, Besonderheiten, Allergien oder sonstige Hinweise"
+    }
+  },
+  "required": [
+    "submission_id",
+    "contact_name",
+    "phone",
+    "event_date",
+    "guest_count"
+  ]
+}
+```
+
+## HAR request template
+
+Replace only the public HTTPS URL and bearer token with the real values inside
+STRATO. Conversation values use STRATO's documented `{{ variableName }}`
+placeholder syntax.
+
+```json
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "STRATO Smart-Telefonassistent",
+      "version": "1.0"
+    },
+    "entries": [
+      {
+        "request": {
+          "method": "POST",
+          "url": "https://YOUR_PUBLIC_HTTPS_HOST/intake/ai-telefonist",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Authorization",
+              "value": "Bearer YOUR_AI_TELEFONIST_INTAKE_TOKEN"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": -1,
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"submission_id\":\"{{ submission_id }}\",\"contact_name\":\"{{ contact_name }}\",\"company_name\":\"{{ company_name }}\",\"phone\":\"{{ phone }}\",\"email\":\"{{ email }}\",\"event_date\":\"{{ event_date }}\",\"event_start\":\"{{ event_start }}\",\"guest_count\":{{ guest_count }},\"location\":\"{{ location }}\",\"event_type\":\"{{ event_type }}\",\"fulfillment_mode\":\"{{ fulfillment_mode }}\",\"customer_request\":\"{{ customer_request }}\"}"
+          }
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": "application/json"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        },
+        "time": 0,
+        "startedDateTime": "2026-09-03T00:00:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+## Stored Core facts
+
+- `inquiry_source = ai_telefonist`
+- `crm_stage = Neue Anfrage`
+- call verification required, status `pending`
+- event date and exact event start are stored separately
+- guest count and location are stored on Inquiry
+- contact name/company/phone/email are stored in the Inquiry customer snapshot
+- free customer wishes are stored in intake context
+- `submission_id` is source-scoped and unique for retry protection

--- a/infra/systemd/catering-ai-telefonist-intake.env.example
+++ b/infra/systemd/catering-ai-telefonist-intake.env.example
@@ -1,0 +1,3 @@
+# Copy to /etc/catering/ai-telefonist-intake.env
+# Owner: root:root, mode 600
+AI_TELEFONIST_INTAKE_TOKEN=replace-with-a-long-random-secret

--- a/infra/systemd/catering-ai-telefonist-intake.service
+++ b/infra/systemd/catering-ai-telefonist-intake.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Catering STRATO AI telephone intake receiver (loopback-only)
+After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=viktor
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/src
+EnvironmentFile=/etc/catering/ai-telefonist-intake.env
+ExecStart=/usr/bin/python3 -m catering_system.ui.ai_telefonist_intake_endpoint --db /home/viktor/catering-runtime/core.db --host 127.0.0.1 --port 8085
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/src/catering_system/intake/ai_telefonist_adapter.py
+++ b/src/catering_system/intake/ai_telefonist_adapter.py
@@ -1,0 +1,137 @@
+"""STRATO AI telephone assistant channel -> InquiryService.create_inquiry."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, time
+from typing import Any, Mapping
+
+from catering_system.domain.inquiry import CRM_PIPELINE, Inquiry, PLANNING_MODES
+from catering_system.services.inquiry_service import InquiryService
+
+_log = logging.getLogger(__name__)
+
+_MAX_TEXT_LEN = 500
+_MAX_MESSAGE_LEN = 5000
+_MAX_EXTERNAL_REF_LEN = 200
+_MIN_GUEST_COUNT = 1
+_MAX_GUEST_COUNT = 2000
+
+
+def _required_text(raw: Mapping[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str):
+        raise TypeError(f"ai_telefonist intake: {key} must be str")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"ai_telefonist intake: {key} is required")
+    return value[:_MAX_TEXT_LEN]
+
+
+def _optional_text(raw: Mapping[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise TypeError(f"ai_telefonist intake: {key} must be str or absent")
+    return value.strip()[:_MAX_TEXT_LEN]
+
+
+def intake_from_ai_telefonist(
+    service: InquiryService,
+    raw: Mapping[str, Any],
+) -> Inquiry:
+    _log.info("ai_telefonist adapter called")
+    try:
+        return _intake_from_ai_telefonist_body(service, raw)
+    except (ValueError, TypeError):
+        _log.warning("ai_telefonist adapter validation failed")
+        raise
+
+
+def _intake_from_ai_telefonist_body(
+    service: InquiryService,
+    raw: Mapping[str, Any],
+) -> Inquiry:
+    event_date = raw.get("event_date")
+    if not isinstance(event_date, date):
+        raise ValueError("ai_telefonist intake: event_date (date) is required")
+
+    guest_count = raw.get("guest_count")
+    if isinstance(guest_count, bool) or not isinstance(guest_count, int):
+        raise TypeError("ai_telefonist intake: guest_count must be int")
+    if not (_MIN_GUEST_COUNT <= guest_count <= _MAX_GUEST_COUNT):
+        raise ValueError(
+            "ai_telefonist intake: guest_count must be between "
+            f"{_MIN_GUEST_COUNT} and {_MAX_GUEST_COUNT}"
+        )
+
+    contact_name = _required_text(raw, "contact_name")
+    phone = _required_text(raw, "phone")
+    submission_id = _required_text(raw, "submission_id")[:_MAX_EXTERNAL_REF_LEN]
+
+    company_name = _optional_text(raw, "company_name")
+    email = _optional_text(raw, "email")
+    event_type = _optional_text(raw, "event_type")
+    location = _optional_text(raw, "location")
+    customer_request = _optional_text(raw, "customer_request")
+
+    event_start = raw.get("event_start")
+    if event_start is not None and not isinstance(event_start, time):
+        raise TypeError("ai_telefonist intake: event_start must be time or absent")
+
+    fulfillment_raw = raw.get("fulfillment_mode")
+    if fulfillment_raw is None:
+        fulfillment_mode = "UNKNOWN"
+    elif isinstance(fulfillment_raw, str):
+        fulfillment_mode = fulfillment_raw
+    else:
+        raise TypeError(
+            "ai_telefonist intake: fulfillment_mode must be str or absent"
+        )
+
+    subject_base = company_name or contact_name
+    subject = f"{subject_base} — {event_type}" if event_type else subject_base
+
+    message_lines = [
+        f"Name: {contact_name}",
+        f"Telefon: {phone}",
+    ]
+    if company_name:
+        message_lines.insert(0, f"Firma: {company_name}")
+    if email:
+        message_lines.append(f"E-Mail: {email}")
+    if event_type:
+        message_lines.append(f"Veranstaltungsart: {event_type}")
+    if customer_request:
+        message_lines.append(f"Wunsch: {customer_request}")
+    intake_message = "\n".join(message_lines)[:_MAX_MESSAGE_LEN]
+
+    time_window_text = (
+        f"ab {event_start.strftime('%H:%M')} Uhr" if event_start is not None else ""
+    )
+
+    return service.create_inquiry(
+        event_date=event_date,
+        inquiry_source="ai_telefonist",
+        crm_stage=CRM_PIPELINE[0],
+        customer_linkage={},
+        time_window_text=time_window_text,
+        location_text=location,
+        guest_count_estimate=guest_count,
+        planning_mode=PLANNING_MODES[0],
+        call_verification_required=True,
+        call_verification_status="pending",
+        intake_subject=subject,
+        intake_message=intake_message,
+        intake_summary=(
+            f"Telefon-Anfrage — {guest_count} Personen, {event_date.isoformat()}"
+        ),
+        intake_external_ref=submission_id,
+        contact_email=email or None,
+        contact_phone=phone,
+        contact_name=contact_name,
+        company_name=company_name or None,
+        fulfillment_mode=fulfillment_mode,
+        event_start_local=event_start,
+    )

--- a/src/catering_system/intake/ai_telefonist_adapter.py
+++ b/src/catering_system/intake/ai_telefonist_adapter.py
@@ -86,9 +86,7 @@ def _intake_from_ai_telefonist_body(
     elif isinstance(fulfillment_raw, str):
         fulfillment_mode = fulfillment_raw
     else:
-        raise TypeError(
-            "ai_telefonist intake: fulfillment_mode must be str or absent"
-        )
+        raise TypeError("ai_telefonist intake: fulfillment_mode must be str or absent")
 
     subject_base = company_name or contact_name
     subject = f"{subject_base} — {event_type}" if event_type else subject_base

--- a/src/catering_system/repositories/in_memory_inquiry_repository.py
+++ b/src/catering_system/repositories/in_memory_inquiry_repository.py
@@ -31,16 +31,19 @@ class InMemoryInquiryRepository:
         self._by_id[inquiry.inquiry_id] = inquiry
 
     def _ensure_external_ref_available(self, inquiry: Inquiry) -> None:
-        if inquiry.inquiry_source != "website_form" or not inquiry.intake_external_ref:
+        if (
+            inquiry.inquiry_source not in {"website_form", "ai_telefonist"}
+            or not inquiry.intake_external_ref
+        ):
             return
         for existing in self._by_id.values():
             if (
                 existing.inquiry_id != inquiry.inquiry_id
-                and existing.inquiry_source == "website_form"
+                and existing.inquiry_source == inquiry.inquiry_source
                 and existing.intake_external_ref == inquiry.intake_external_ref
             ):
                 raise DuplicateExternalReferenceError(
-                    "website_form submission_id already exists"
+                    f"{inquiry.inquiry_source} submission_id already exists"
                 )
 
     def find_by_source_and_external_ref(

--- a/src/catering_system/repositories/sqlite_inquiry_repository.py
+++ b/src/catering_system/repositories/sqlite_inquiry_repository.py
@@ -83,6 +83,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_inquiries_website_external_ref
       AND intake_external_ref <> '';
 """
 
+_AI_TELEFONIST_EXTERNAL_REF_INDEX = """
+CREATE UNIQUE INDEX IF NOT EXISTS uq_inquiries_ai_telefonist_external_ref
+    ON inquiries (inquiry_source, intake_external_ref)
+    WHERE inquiry_source = 'ai_telefonist'
+      AND intake_external_ref IS NOT NULL
+      AND intake_external_ref <> '';
+"""
+
+_IDEMPOTENT_EXTERNAL_REF_SOURCES = frozenset({"website_form", "ai_telefonist"})
+
 
 def _migration_1_create_table(connection: sqlite3.Connection) -> None:
     connection.execute(_CREATE_INQUIRIES)
@@ -153,6 +163,23 @@ def _migration_7_add_exact_timing(connection: sqlite3.Connection) -> None:
         connection.execute("ALTER TABLE inquiries ADD COLUMN delivery_time_local TEXT")
 
 
+def _migration_8_unique_ai_telefonist_external_ref(
+    connection: sqlite3.Connection,
+) -> None:
+    duplicate = connection.execute(
+        "SELECT intake_external_ref FROM inquiries "
+        "WHERE inquiry_source = 'ai_telefonist' "
+        "AND intake_external_ref IS NOT NULL AND intake_external_ref <> '' "
+        "GROUP BY intake_external_ref HAVING COUNT(*) > 1 LIMIT 1"
+    ).fetchone()
+    if duplicate is not None:
+        raise ValueError(
+            "cannot enforce ai_telefonist intake idempotency: duplicate "
+            f"submission_id {duplicate[0]!r}"
+        )
+    connection.execute(_AI_TELEFONIST_EXTERNAL_REF_INDEX)
+
+
 _MIGRATIONS = (
     (1, "create_inquiries", _migration_1_create_table),
     (2, "add_intake_context", _migration_2_add_intake_context),
@@ -161,6 +188,11 @@ _MIGRATIONS = (
     (5, "add_customer_addresses", _migration_5_add_customer_addresses),
     (6, "add_fulfillment_mode", _migration_6_add_fulfillment_mode),
     (7, "add_exact_timing", _migration_7_add_exact_timing),
+    (
+        8,
+        "unique_ai_telefonist_external_ref",
+        _migration_8_unique_ai_telefonist_external_ref,
+    ),
 )
 
 
@@ -334,14 +366,17 @@ class SQLiteInquiryRepository:
     def _raise_duplicate_external_ref(
         self, inquiry: Inquiry, cause: sqlite3.IntegrityError
     ) -> None:
-        if inquiry.inquiry_source != "website_form" or not inquiry.intake_external_ref:
+        if (
+            inquiry.inquiry_source not in _IDEMPOTENT_EXTERNAL_REF_SOURCES
+            or not inquiry.intake_external_ref
+        ):
             return
         existing = self.find_by_source_and_external_ref(
             inquiry.inquiry_source, inquiry.intake_external_ref
         )
         if existing is not None and existing.inquiry_id != inquiry.inquiry_id:
             raise DuplicateExternalReferenceError(
-                "website_form submission_id already exists"
+                f"{inquiry.inquiry_source} submission_id already exists"
             ) from cause
 
     @staticmethod

--- a/src/catering_system/ui/ai_telefonist_intake_endpoint.py
+++ b/src/catering_system/ui/ai_telefonist_intake_endpoint.py
@@ -1,0 +1,222 @@
+"""Bearer-authenticated STRATO AI telephone intake receiver."""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import logging
+import os
+from datetime import date, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from catering_system.intake.ai_telefonist_adapter import intake_from_ai_telefonist
+from catering_system.repositories.inquiry_repository import (
+    DuplicateExternalReferenceError,
+    InquiryRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+
+_log = logging.getLogger(__name__)
+
+_MAX_BODY_BYTES = 32 * 1024
+_ROUTE = "/intake/ai-telefonist"
+
+
+def _parse_event_date(raw: object) -> object:
+    if isinstance(raw, str):
+        try:
+            return date.fromisoformat(raw)
+        except ValueError:
+            return raw
+    return raw
+
+
+def _parse_event_start(raw: object) -> object:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            return time.fromisoformat(raw)
+        except ValueError:
+            return raw
+    return raw
+
+
+def make_ai_telefonist_intake_handler(
+    inquiry_repository: InquiryRepository,
+    token: str,
+) -> type[BaseHTTPRequestHandler]:
+    service = InquiryService(inquiry_repository)
+    expected_auth = f"Bearer {token}"
+
+    class AiTelefonistIntakeHandler(BaseHTTPRequestHandler):
+        server_version = "AiTelefonistIntake/1.0"
+
+        def end_headers(self) -> None:
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Security-Policy", "default-src 'none'")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
+            super().end_headers()
+
+        def _json(self, status: int, payload: dict[str, object]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != _ROUTE:
+                self.send_error(404)
+                return
+
+            if not hmac.compare_digest(
+                self.headers.get("Authorization", ""),
+                expected_auth,
+            ):
+                _log.warning("ai_telefonist intake: auth rejected")
+                self._json(401, {"error": "unauthorized"})
+                return
+
+            content_type = self.headers.get("Content-Type", "")
+            if not content_type.startswith("application/json"):
+                self._json(415, {"error": "unsupported content type"})
+                return
+
+            try:
+                length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._json(400, {"error": "invalid content length"})
+                return
+            if length < 0:
+                self._json(400, {"error": "invalid content length"})
+                return
+            if length > _MAX_BODY_BYTES:
+                self._json(413, {"error": "payload too large"})
+                return
+
+            try:
+                payload = json.loads(self.rfile.read(length))
+            except ValueError:
+                self._json(400, {"error": "invalid JSON"})
+                return
+            if not isinstance(payload, dict):
+                self._json(400, {"error": "invalid payload"})
+                return
+
+            payload = dict(payload)
+            if "event_date" in payload:
+                payload["event_date"] = _parse_event_date(payload["event_date"])
+            if "event_start" in payload:
+                payload["event_start"] = _parse_event_start(payload["event_start"])
+
+            submission_id = payload.get("submission_id")
+            if isinstance(submission_id, str) and submission_id.strip():
+                existing = inquiry_repository.find_by_source_and_external_ref(
+                    "ai_telefonist",
+                    submission_id.strip(),
+                )
+                if existing is not None:
+                    self._json(
+                        202,
+                        {"accepted": True, "inquiry_id": existing.inquiry_id},
+                    )
+                    return
+
+            try:
+                inquiry = intake_from_ai_telefonist(service, payload)
+            except DuplicateExternalReferenceError:
+                assert isinstance(submission_id, str) and submission_id.strip()
+                existing = inquiry_repository.find_by_source_and_external_ref(
+                    "ai_telefonist",
+                    submission_id.strip(),
+                )
+                if existing is None:
+                    _log.error("ai_telefonist intake: duplicate key not resolvable")
+                    self._json(500, {"error": "internal error"})
+                    return
+                self._json(
+                    202,
+                    {"accepted": True, "inquiry_id": existing.inquiry_id},
+                )
+                return
+            except (ValueError, TypeError) as exc:
+                _log.warning(
+                    "ai_telefonist intake: rejected (%s)",
+                    type(exc).__name__,
+                )
+                self._json(400, {"error": "invalid ai_telefonist payload"})
+                return
+
+            _log.info(
+                "ai_telefonist intake: accepted inquiry_id=%s",
+                inquiry.inquiry_id,
+            )
+            self._json(202, {"accepted": True, "inquiry_id": inquiry.inquiry_id})
+
+        def _reject(self) -> None:
+            self.send_error(405, f"only POST {_ROUTE} is supported")
+
+        do_GET = _reject
+        do_PUT = _reject
+        do_DELETE = _reject
+        do_PATCH = _reject
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            pass
+
+    return AiTelefonistIntakeHandler
+
+
+def create_ai_telefonist_intake_server(
+    inquiry_repository: InquiryRepository,
+    token: str,
+    host: str = "127.0.0.1",
+    port: int = 8085,
+) -> HTTPServer:
+    return HTTPServer(
+        (host, port),
+        make_ai_telefonist_intake_handler(inquiry_repository, token),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="STRATO AI telephone intake receiver"
+    )
+    parser.add_argument("--db", required=True, help="Path to the Core SQLite database")
+    parser.add_argument("--port", type=int, default=8085)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("AI_TELEFONIST_INTAKE_TOKEN", ""),
+        help="Bearer token for STRATO integration",
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        raise SystemExit(
+            "AI telephone intake receiver refuses to start without a token "
+            "(--token or AI_TELEFONIST_INTAKE_TOKEN)"
+        )
+
+    from catering_system.repositories.sqlite_inquiry_repository import (
+        SQLiteInquiryRepository,
+    )
+
+    server = create_ai_telefonist_intake_server(
+        SQLiteInquiryRepository(args.db),
+        args.token,
+        args.host,
+        args.port,
+    )
+    print(f"AI telephone intake receiver on http://{args.host}:{args.port}{_ROUTE}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/catering_system/ui/ai_telefonist_intake_endpoint.py
+++ b/src/catering_system/ui/ai_telefonist_intake_endpoint.py
@@ -185,9 +185,7 @@ def create_ai_telefonist_intake_server(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="STRATO AI telephone intake receiver"
-    )
+    parser = argparse.ArgumentParser(description="STRATO AI telephone intake receiver")
     parser.add_argument("--db", required=True, help="Path to the Core SQLite database")
     parser.add_argument("--port", type=int, default=8085)
     parser.add_argument("--host", default="127.0.0.1")

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -19,7 +19,9 @@ from catering_system.repositories.in_memory_order_repository import (
 from catering_system.repositories.inquiry_repository import (
     DuplicateExternalReferenceError,
 )
-from catering_system.repositories.sqlite_inquiry_repository import SQLiteInquiryRepository
+from catering_system.repositories.sqlite_inquiry_repository import (
+    SQLiteInquiryRepository,
+)
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.ui import ai_telefonist_intake_endpoint
 from catering_system.ui.ai_telefonist_intake_endpoint import (

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import threading
 import urllib.error
 import urllib.request
@@ -20,6 +21,7 @@ from catering_system.repositories.inquiry_repository import (
 )
 from catering_system.repositories.sqlite_inquiry_repository import SQLiteInquiryRepository
 from catering_system.services.inquiry_service import InquiryService
+from catering_system.ui import ai_telefonist_intake_endpoint
 from catering_system.ui.ai_telefonist_intake_endpoint import (
     create_ai_telefonist_intake_server,
 )
@@ -305,3 +307,85 @@ def test_same_external_ref_is_allowed_for_other_source(tmp_path) -> None:
     assert website.inquiry_source == "website_form"
     assert len(repo.list_all()) == 2
     repo.close()
+
+
+def test_endpoint_parsers_leave_invalid_values_for_adapter() -> None:
+    assert ai_telefonist_intake_endpoint._parse_event_date("bad") == "bad"
+    assert ai_telefonist_intake_endpoint._parse_event_date(123) == 123
+    assert ai_telefonist_intake_endpoint._parse_event_start("bad") == "bad"
+    assert ai_telefonist_intake_endpoint._parse_event_start(123) == 123
+    assert ai_telefonist_intake_endpoint._parse_event_start(None) is None
+
+
+def test_main_refuses_without_token(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("AI_TELEFONIST_INTAKE_TOKEN", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["ai-telefonist-intake", "--db", str(tmp_path / "core.db")],
+    )
+    with pytest.raises(SystemExit, match="refuses to start without a token"):
+        ai_telefonist_intake_endpoint.main()
+
+
+def test_main_builds_repository_and_server(monkeypatch, tmp_path, capsys) -> None:
+    captured: dict[str, object] = {}
+    fake_repo = object()
+
+    class FakeServer:
+        def serve_forever(self) -> None:
+            captured["served"] = True
+
+    def build_repo(path):
+        captured["db"] = str(path)
+        return fake_repo
+
+    def build_server(repository, token: str, host: str, port: int):
+        captured.update(
+            repository=repository,
+            token=token,
+            host=host,
+            port=port,
+        )
+        return FakeServer()
+
+    from catering_system.repositories import sqlite_inquiry_repository
+
+    monkeypatch.setattr(
+        sqlite_inquiry_repository,
+        "SQLiteInquiryRepository",
+        build_repo,
+    )
+    monkeypatch.setattr(
+        ai_telefonist_intake_endpoint,
+        "create_ai_telefonist_intake_server",
+        build_server,
+    )
+    db_path = str(tmp_path / "core.db")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "ai-telefonist-intake",
+            "--db",
+            db_path,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9085",
+            "--token",
+            "cli-token",
+        ],
+    )
+
+    ai_telefonist_intake_endpoint.main()
+
+    assert captured == {
+        "db": db_path,
+        "repository": fake_repo,
+        "token": "cli-token",
+        "host": "127.0.0.1",
+        "port": 9085,
+        "served": True,
+    }
+    assert "/intake/ai-telefonist" in capsys.readouterr().out

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -15,6 +15,10 @@ from catering_system.repositories.in_memory_inquiry_repository import (
 from catering_system.repositories.in_memory_order_repository import (
     InMemoryOrderRepository,
 )
+from catering_system.repositories.inquiry_repository import (
+    DuplicateExternalReferenceError,
+)
+from catering_system.repositories.sqlite_inquiry_repository import SQLiteInquiryRepository
 from catering_system.services.inquiry_service import InquiryService
 from catering_system.ui.ai_telefonist_intake_endpoint import (
     create_ai_telefonist_intake_server,
@@ -253,3 +257,51 @@ def test_response_security_headers(server) -> None:
         assert response.headers["Cache-Control"] == "no-store"
         assert response.headers["Content-Security-Policy"] == "default-src 'none'"
         assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_sqlite_ai_telefonist_submission_id_is_unique(tmp_path) -> None:
+    repo = SQLiteInquiryRepository(tmp_path / "core.db")
+    service = InquiryService(repo)
+    payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+    }
+    first = intake_from_ai_telefonist(service, payload)
+    assert repo.find_by_source_and_external_ref(
+        "ai_telefonist", "strato-call-001"
+    ) == first
+
+    with pytest.raises(DuplicateExternalReferenceError):
+        intake_from_ai_telefonist(service, payload)
+    assert len(repo.list_all()) == 1
+    repo.close()
+
+
+def test_same_external_ref_is_allowed_for_other_source(tmp_path) -> None:
+    repo = SQLiteInquiryRepository(tmp_path / "core.db")
+    service = InquiryService(repo)
+    ai_payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+    }
+    intake_from_ai_telefonist(service, ai_payload)
+    website = service.create_inquiry(
+        event_date=_D,
+        inquiry_source="website_form",
+        crm_stage="Neue Anfrage",
+        customer_linkage={},
+        time_window_text="",
+        location_text="Hamburg",
+        guest_count_estimate=10,
+        planning_mode="caterer_suggestion",
+        call_verification_required=True,
+        call_verification_status="pending",
+        intake_external_ref="strato-call-001",
+        contact_email="web@example.test",
+        contact_phone="+49405550000",
+    )
+    assert website.inquiry_source == "website_form"
+    assert len(repo.list_all()) == 2
+    repo.close()

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from datetime import date, time
+
+import pytest
+
+from catering_system.intake.ai_telefonist_adapter import intake_from_ai_telefonist
+from catering_system.repositories.in_memory_inquiry_repository import (
+    InMemoryInquiryRepository,
+)
+from catering_system.repositories.in_memory_order_repository import (
+    InMemoryOrderRepository,
+)
+from catering_system.services.inquiry_service import InquiryService
+from catering_system.ui.ai_telefonist_intake_endpoint import (
+    create_ai_telefonist_intake_server,
+)
+
+_TOKEN = "test-ai-telefonist-token"
+_D = date(2026, 10, 10)
+
+_VALID = {
+    "submission_id": "strato-call-001",
+    "contact_name": "Anna Becker",
+    "company_name": "Hanse Event GmbH",
+    "phone": "+494055512345",
+    "email": "anna@hanse-event.de",
+    "event_date": "2026-10-10",
+    "event_start": "18:30",
+    "guest_count": 80,
+    "location": "Hamburg-Altona",
+    "event_type": "Firmenfeier",
+    "fulfillment_mode": "DELIVERY",
+    "customer_request": "Vegetarische Auswahl und Dessertgläser.",
+}
+
+
+@pytest.fixture()
+def server():
+    inquiry_repo = InMemoryInquiryRepository()
+    order_repo = InMemoryOrderRepository()
+    srv = create_ai_telefonist_intake_server(
+        inquiry_repo, _TOKEN, host="127.0.0.1", port=0
+    )
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    host, port = srv.server_address[:2]
+    yield f"http://{host}:{port}", inquiry_repo, order_repo
+    srv.shutdown()
+    srv.server_close()
+
+
+def _post(
+    base: str,
+    payload: dict | str,
+    *,
+    token: str | None = _TOKEN,
+) -> tuple[int, dict, bytes]:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    request = urllib.request.Request(
+        f"{base}/intake/ai-telefonist",
+        data=body.encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    if token is not None:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            return response.status, json.loads(raw), raw
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            parsed = json.loads(raw)
+        except ValueError:
+            parsed = {}
+        return exc.code, parsed, raw
+
+
+def test_adapter_maps_strato_call_to_ai_telefonist_inquiry() -> None:
+    repo = InMemoryInquiryRepository()
+    service = InquiryService(repo)
+    q = intake_from_ai_telefonist(
+        service,
+        {
+            **_VALID,
+            "event_date": _D,
+            "event_start": time(18, 30),
+        },
+    )
+
+    assert q.inquiry_source == "ai_telefonist"
+    assert q.crm_stage == "Neue Anfrage"
+    assert q.event_date == _D
+    assert q.event_start_local == time(18, 30)
+    assert q.time_window_text == "ab 18:30 Uhr"
+    assert q.guest_count_estimate == 80
+    assert q.location_text == "Hamburg-Altona"
+    assert q.fulfillment_mode == "DELIVERY"
+    assert q.call_verification_required is True
+    assert q.call_verification_status == "pending"
+    assert q.intake_external_ref == "strato-call-001"
+    assert q.intake_subject == "Hanse Event GmbH — Firmenfeier"
+    assert q.customer_snapshot is not None
+    assert q.customer_snapshot.contact_name == "Anna Becker"
+    assert q.customer_snapshot.company_name == "Hanse Event GmbH"
+    assert q.customer_snapshot.email == "anna@hanse-event.de"
+    assert q.customer_snapshot.phone == "+494055512345"
+    assert "Wunsch: Vegetarische Auswahl" in (q.intake_message or "")
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["submission_id", "contact_name", "phone", "event_date", "guest_count"],
+)
+def test_adapter_required_fields(missing: str) -> None:
+    repo = InMemoryInquiryRepository()
+    service = InquiryService(repo)
+    payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+    }
+    del payload[missing]
+    with pytest.raises((ValueError, TypeError)):
+        intake_from_ai_telefonist(service, payload)
+    assert repo.list_all() == []
+
+
+def test_adapter_email_is_optional() -> None:
+    repo = InMemoryInquiryRepository()
+    service = InquiryService(repo)
+    payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+    }
+    del payload["email"]
+    q = intake_from_ai_telefonist(service, payload)
+    assert q.customer_snapshot is not None
+    assert q.customer_snapshot.email is None
+    assert q.customer_snapshot.phone == "+494055512345"
+
+
+def test_valid_http_post_creates_only_one_inquiry(server) -> None:
+    base, inquiry_repo, order_repo = server
+    status, body, raw = _post(base, _VALID)
+
+    assert status == 202
+    assert body["accepted"] is True
+    assert len(inquiry_repo.list_all()) == 1
+    q = inquiry_repo.get_by_id(body["inquiry_id"])
+    assert q is not None
+    assert q.inquiry_source == "ai_telefonist"
+    assert q.event_start_local == time(18, 30)
+    assert order_repo.list_orders() == []
+
+    response_text = raw.decode("utf-8")
+    assert "Anna Becker" not in response_text
+    assert "+494055512345" not in response_text
+    assert "anna@hanse-event.de" not in response_text
+
+
+def test_retry_same_submission_id_is_idempotent(server) -> None:
+    base, inquiry_repo, _order_repo = server
+    first_status, first, _ = _post(base, _VALID)
+    second_status, second, _ = _post(
+        base,
+        {**_VALID, "customer_request": "geänderter Retry-Text"},
+    )
+
+    assert first_status == 202
+    assert second_status == 202
+    assert first["inquiry_id"] == second["inquiry_id"]
+    assert len(inquiry_repo.list_all()) == 1
+
+
+def test_missing_or_wrong_token_is_rejected(server) -> None:
+    base, inquiry_repo, _order_repo = server
+    status, body, _ = _post(base, _VALID, token=None)
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+    status, body, _ = _post(base, _VALID, token="wrong")
+    assert status == 401
+    assert body == {"error": "unauthorized"}
+    assert inquiry_repo.list_all() == []
+
+
+def test_invalid_json_and_wrong_path_are_rejected(server) -> None:
+    base, inquiry_repo, _order_repo = server
+    status, body, _ = _post(base, "{broken")
+    assert status == 400
+    assert body == {"error": "invalid JSON"}
+
+    request = urllib.request.Request(
+        f"{base}/other",
+        data=json.dumps(_VALID).encode("utf-8"),
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {_TOKEN}",
+        },
+    )
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        urllib.request.urlopen(request)
+    assert exc.value.code == 404
+    assert inquiry_repo.list_all() == []
+
+
+def test_invalid_business_payload_creates_nothing(server) -> None:
+    base, inquiry_repo, order_repo = server
+    status, body, _ = _post(base, {**_VALID, "guest_count": 0})
+    assert status == 400
+    assert body == {"error": "invalid ai_telefonist payload"}
+    assert inquiry_repo.list_all() == []
+    assert order_repo.list_orders() == []
+
+
+def test_non_json_content_type_is_rejected(server) -> None:
+    base, inquiry_repo, _order_repo = server
+    request = urllib.request.Request(
+        f"{base}/intake/ai-telefonist",
+        data=b"abc",
+        method="POST",
+        headers={
+            "Content-Type": "text/plain",
+            "Authorization": f"Bearer {_TOKEN}",
+        },
+    )
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        urllib.request.urlopen(request)
+    assert exc.value.code == 415
+    assert inquiry_repo.list_all() == []
+
+
+def test_response_security_headers(server) -> None:
+    base, _inquiry_repo, _order_repo = server
+    request = urllib.request.Request(
+        f"{base}/intake/ai-telefonist",
+        data=json.dumps(_VALID).encode("utf-8"),
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {_TOKEN}",
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        assert response.headers["Cache-Control"] == "no-store"
+        assert response.headers["Content-Security-Policy"] == "default-src 'none'"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -272,9 +272,10 @@ def test_sqlite_ai_telefonist_submission_id_is_unique(tmp_path) -> None:
         "event_start": time(18, 30),
     }
     first = intake_from_ai_telefonist(service, payload)
-    assert repo.find_by_source_and_external_ref(
-        "ai_telefonist", "strato-call-001"
-    ) == first
+    assert (
+        repo.find_by_source_and_external_ref("ai_telefonist", "strato-call-001")
+        == first
+    )
 
     with pytest.raises(DuplicateExternalReferenceError):
         intake_from_ai_telefonist(service, payload)

--- a/tests/unit/test_inquiry_contact_completeness.py
+++ b/tests/unit/test_inquiry_contact_completeness.py
@@ -648,10 +648,10 @@ def test_sqlite_round_trip_and_legacy_null_snapshot(tmp_path: Path) -> None:
     repo.close()
 
 
-def test_latest_inquiry_migration_is_v7() -> None:
+def test_latest_inquiry_migration_is_v8() -> None:
     from catering_system.repositories.sqlite_inquiry_repository import _MIGRATIONS
 
-    assert max(number for number, _name, _fn in _MIGRATIONS) == 7
+    assert max(number for number, _name, _fn in _MIGRATIONS) == 8
 
 
 def test_completion_persists_in_sqlite(tmp_path: Path) -> None:

--- a/tests/unit/test_sqlite_repositories.py
+++ b/tests/unit/test_sqlite_repositories.py
@@ -630,6 +630,7 @@ def test_component_migrations_are_recorded_once(tmp_path: Path) -> None:
         ("inquiries", 5),  # CUSTOMER_ADDRESS_SOURCE_V1-A
         ("inquiries", 6),  # FULFILLMENT_SOURCE_V1: fulfillment_mode
         ("inquiries", 7),  # exact event-start and delivery times
+        ("inquiries", 8),  # AI telephone intake retry idempotency
         ("orders", 1),
         ("orders", 2),
         ("orders", 3),


### PR DESCRIPTION
Closes #235

Adds a narrow bearer-authenticated `ai_telefonist` intake path for STRATO Smart-Telefonassistent, source-scoped retry idempotency, loopback-only systemd service, tests, and a documented STRATO JSON Schema/HAR template. The endpoint creates Inquiry only and does not touch Offer/Order flows.