### PR TITLE
Harden STRATO telephone intake after live test

### DIFF
--- a/docs/api/ai-telefonist-intake.md
+++ b/docs/api/ai-telefonist-intake.md
@@ -18,9 +18,8 @@ Content-Type: application/json
 ```
 
 The service is intentionally loopback-only. STRATO requires a publicly reachable
-HTTPS endpoint, so a narrow TLS reverse proxy/tunnel must forward exactly this
-route to the local receiver. Do not expose the Office Panel, Office API, Kitchen
-API, or the SQLite database.
+HTTPS endpoint, so a narrow TLS reverse proxy/tunnel must forward only this
+receiver. Do not expose the Office Panel, Office API, Kitchen API, or SQLite.
 
 Success:
 
@@ -42,11 +41,11 @@ create_catering_inquiry
 Description:
 
 ```text
-Erstellt eine neue Catering-Anfrage im internen System. Nutze dieses Tool,
-wenn ein Anrufer eine konkrete Catering-Anfrage stellt oder ein Angebot
-erhalten möchte. Frage die Pflichtangaben ab und fasse freie Wünsche knapp
-zusammen. submission_id ist eine technische UUID: nicht vom Anrufer erfragen,
-sondern pro Tool-Aufruf selbst erzeugen.
+Erstellt eine Catering-Anfrage im internen System. Nutze dieses Tool, wenn ein
+Anrufer konkret Catering anfragt oder ein Angebot erhalten möchte. Erfasse
+mindestens Name, Telefonnummer, Veranstaltungsdatum und Gästezahl. Frage, soweit
+bekannt, zusätzlich nach Firma, E-Mail-Adresse, Beginn, Veranstaltungsort,
+Veranstaltungsart, Lieferung oder Abholung sowie besonderen Wünschen.
 ```
 
 Parameters:
@@ -55,10 +54,6 @@ Parameters:
 {
   "type": "object",
   "properties": {
-    "submission_id": {
-      "type": "string",
-      "description": "Technische eindeutige UUID. Nicht vom Anrufer erfragen; pro Tool-Aufruf selbst erzeugen."
-    },
     "contact_name": {
       "type": "string",
       "description": "Vor- und Nachname der Kontaktperson"
@@ -73,7 +68,7 @@ Parameters:
     },
     "email": {
       "type": "string",
-      "description": "E-Mail-Adresse, falls der Anrufer eine angibt"
+      "description": "E-Mail-Adresse, falls vorhanden"
     },
     "event_date": {
       "type": "string",
@@ -82,8 +77,7 @@ Parameters:
     },
     "event_start": {
       "type": "string",
-      "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
-      "description": "Startzeit im Format HH:MM, falls bekannt"
+      "description": "Beginn der Veranstaltung im Format HH:MM, falls bekannt"
     },
     "guest_count": {
       "type": "integer",
@@ -93,11 +87,11 @@ Parameters:
     },
     "location": {
       "type": "string",
-      "description": "Ort oder Adresse der Veranstaltung"
+      "description": "Veranstaltungsort oder Veranstaltungsadresse, falls bekannt"
     },
     "event_type": {
       "type": "string",
-      "description": "Art der Veranstaltung"
+      "description": "Art der Veranstaltung, zum Beispiel Firmenfeier, Hochzeit oder Geburtstag"
     },
     "fulfillment_mode": {
       "type": "string",
@@ -106,11 +100,10 @@ Parameters:
     },
     "customer_request": {
       "type": "string",
-      "description": "Speisenwünsche, Besonderheiten, Allergien oder sonstige Hinweise"
+      "description": "Speisenwünsche, Ernährungswünsche, Allergien oder sonstige Hinweise"
     }
   },
   "required": [
-    "submission_id",
     "contact_name",
     "phone",
     "event_date",
@@ -119,72 +112,44 @@ Parameters:
 }
 ```
 
+The technical `submission_id` is not a customer-facing parameter. The current
+STRATO HAR builds it from already collected values so the assistant never asks
+the caller for an internal identifier.
+
 ## HAR request template
 
-Replace only the public HTTPS URL and bearer token with the real values inside
-STRATO. Conversation values use STRATO's documented `{{ variableName }}`
-placeholder syntax.
+Replace only the public HTTPS URL and bearer token with the live values in
+STRATO. Parameter values use STRATO's `{{ variableName }}` placeholders.
 
 ```json
 {
-  "log": {
-    "version": "1.2",
-    "creator": {
-      "name": "STRATO Smart-Telefonassistent",
-      "version": "1.0"
+  "method": "POST",
+  "url": "https://YOUR_PUBLIC_HTTPS_HOST/intake/ai-telefonist",
+  "headers": [
+    {
+      "name": "Authorization",
+      "value": "Bearer YOUR_AI_TELEFONIST_INTAKE_TOKEN"
     },
-    "entries": [
-      {
-        "request": {
-          "method": "POST",
-          "url": "https://YOUR_PUBLIC_HTTPS_HOST/intake/ai-telefonist",
-          "httpVersion": "HTTP/1.1",
-          "headers": [
-            {
-              "name": "Authorization",
-              "value": "Bearer YOUR_AI_TELEFONIST_INTAKE_TOKEN"
-            },
-            {
-              "name": "Content-Type",
-              "value": "application/json"
-            }
-          ],
-          "queryString": [],
-          "cookies": [],
-          "headersSize": -1,
-          "bodySize": -1,
-          "postData": {
-            "mimeType": "application/json",
-            "text": "{\"submission_id\":\"{{ submission_id }}\",\"contact_name\":\"{{ contact_name }}\",\"company_name\":\"{{ company_name }}\",\"phone\":\"{{ phone }}\",\"email\":\"{{ email }}\",\"event_date\":\"{{ event_date }}\",\"event_start\":\"{{ event_start }}\",\"guest_count\":{{ guest_count }},\"location\":\"{{ location }}\",\"event_type\":\"{{ event_type }}\",\"fulfillment_mode\":\"{{ fulfillment_mode }}\",\"customer_request\":\"{{ customer_request }}\"}"
-          }
-        },
-        "response": {
-          "status": 0,
-          "statusText": "",
-          "httpVersion": "",
-          "headers": [],
-          "cookies": [],
-          "content": {
-            "size": 0,
-            "mimeType": "application/json"
-          },
-          "redirectURL": "",
-          "headersSize": -1,
-          "bodySize": -1
-        },
-        "cache": {},
-        "timings": {
-          "send": 0,
-          "wait": 0,
-          "receive": 0
-        },
-        "time": 0,
-        "startedDateTime": "2026-09-03T00:00:00.000Z"
-      }
-    ]
+    {
+      "name": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "postData": {
+    "mimeType": "application/json",
+    "text": "{\"submission_id\":\"strato-{{ phone }}-{{ event_date }}-{{ guest_count }}-{{ contact_name }}\",\"contact_name\":\"{{ contact_name }}\",\"company_name\":\"{{ company_name }}\",\"phone\":\"{{ phone }}\",\"email\":\"{{ email }}\",\"event_date\":\"{{ event_date }}\",\"event_start\":\"{{ event_start }}\",\"guest_count\":{{ guest_count }},\"location\":\"{{ location }}\",\"event_type\":\"{{ event_type }}\",\"fulfillment_mode\":\"{{ fulfillment_mode }}\",\"customer_request\":\"{{ customer_request }}\"}"
   }
 }
 ```
+
+STRATO may render absent optional string placeholders as empty strings. The
+receiver therefore treats blank `event_start` as absent and blank
+`fulfillment_mode` as `UNKNOWN`.
+
+STRATO may also transcribe a spoken phone number as comma-separated digits such
+as `0,1,7,6,...`. The receiver compacts common separators before storing the
+phone number and compacts comma-separated digits in the technical submission
+reference.
 
 ## Stored Core facts
 
@@ -192,7 +157,14 @@ placeholder syntax.
 - `crm_stage = Neue Anfrage`
 - call verification required, status `pending`
 - event date and exact event start are stored separately
-- guest count and location are stored on Inquiry
+- guest count and event location are stored on Inquiry
 - contact name/company/phone/email are stored in the Inquiry customer snapshot
-- free customer wishes are stored in intake context
+- event type and customer wishes are stored in the intake message
+- fulfillment mode is stored as `DELIVERY`, `PICKUP`, or `UNKNOWN`
 - `submission_id` is source-scoped and unique for retry protection
+
+## Public HTTPS note
+
+A `trycloudflare.com` quick tunnel is suitable only for an integration test.
+Its URL exists only while that foreground `cloudflared tunnel --url ...`
+process is running. Production needs a persistent public HTTPS endpoint.

--- a/src/catering_system/intake/ai_telefonist_adapter.py
+++ b/src/catering_system/intake/ai_telefonist_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date, time
 from typing import Any, Mapping
 
@@ -37,6 +38,14 @@ def _optional_text(raw: Mapping[str, Any], key: str) -> str:
     return value.strip()[:_MAX_TEXT_LEN]
 
 
+def _normalize_phone(value: str) -> str:
+    """Compact phone numbers when STRATO spells digits with separators."""
+    compact = re.sub(r"[\s,;./()\-]+", "", value)
+    if re.fullmatch(r"\+?\d+", compact):
+        return compact
+    return value
+
+
 def intake_from_ai_telefonist(
     service: InquiryService,
     raw: Mapping[str, Any],
@@ -67,7 +76,7 @@ def _intake_from_ai_telefonist_body(
         )
 
     contact_name = _required_text(raw, "contact_name")
-    phone = _required_text(raw, "phone")
+    phone = _normalize_phone(_required_text(raw, "phone"))
     submission_id = _required_text(raw, "submission_id")[:_MAX_EXTERNAL_REF_LEN]
 
     company_name = _optional_text(raw, "company_name")
@@ -84,7 +93,7 @@ def _intake_from_ai_telefonist_body(
     if fulfillment_raw is None:
         fulfillment_mode = "UNKNOWN"
     elif isinstance(fulfillment_raw, str):
-        fulfillment_mode = fulfillment_raw
+        fulfillment_mode = fulfillment_raw.strip().upper() or "UNKNOWN"
     else:
         raise TypeError("ai_telefonist intake: fulfillment_mode must be str or absent")
 

--- a/src/catering_system/ui/ai_telefonist_intake_endpoint.py
+++ b/src/catering_system/ui/ai_telefonist_intake_endpoint.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import logging
 import os
+import re
 from datetime import date, time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -36,11 +37,21 @@ def _parse_event_start(raw: object) -> object:
     if raw is None:
         return None
     if isinstance(raw, str):
+        raw = raw.strip()
+        if not raw:
+            return None
         try:
             return time.fromisoformat(raw)
         except ValueError:
             return raw
     return raw
+
+
+def _normalize_submission_id(raw: object) -> object:
+    if not isinstance(raw, str):
+        return raw
+    value = raw.strip()
+    return re.sub(r"(?<=\d),(?=\d)", "", value)
 
 
 def make_ai_telefonist_intake_handler(
@@ -113,6 +124,10 @@ def make_ai_telefonist_intake_handler(
                 payload["event_date"] = _parse_event_date(payload["event_date"])
             if "event_start" in payload:
                 payload["event_start"] = _parse_event_start(payload["event_start"])
+            if "submission_id" in payload:
+                payload["submission_id"] = _normalize_submission_id(
+                    payload["submission_id"]
+                )
 
             submission_id = payload.get("submission_id")
             if isinstance(submission_id, str) and submission_id.strip():

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -166,7 +166,7 @@ def test_adapter_normalizes_spoken_digit_phone() -> None:
     }
     q = intake_from_ai_telefonist(service, payload)
     assert q.customer_snapshot is not None
-    assert q.customer_snapshot.phone == "017642795029"
+    assert q.customer_snapshot.phone == "+4917642795029"
     assert "Telefon: 017642795029" in (q.intake_message or "")
 
 
@@ -203,7 +203,7 @@ def test_http_post_accepts_blank_optional_strato_values(server) -> None:
     assert q.fulfillment_mode == "UNKNOWN"
     assert q.intake_external_ref == "strato-0176-blank-optionals"
     assert q.customer_snapshot is not None
-    assert q.customer_snapshot.phone == "017642795029"
+    assert q.customer_snapshot.phone == "+4917642795029"
 
 
 def test_valid_http_post_creates_only_one_inquiry(server) -> None:

--- a/tests/unit/test_ai_telefonist_intake.py
+++ b/tests/unit/test_ai_telefonist_intake.py
@@ -155,6 +155,57 @@ def test_adapter_email_is_optional() -> None:
     assert q.customer_snapshot.phone == "+494055512345"
 
 
+def test_adapter_normalizes_spoken_digit_phone() -> None:
+    repo = InMemoryInquiryRepository()
+    service = InquiryService(repo)
+    payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+        "phone": "0,1,7,6,4,2,7,9,5,0,2,9",
+    }
+    q = intake_from_ai_telefonist(service, payload)
+    assert q.customer_snapshot is not None
+    assert q.customer_snapshot.phone == "017642795029"
+    assert "Telefon: 017642795029" in (q.intake_message or "")
+
+
+def test_adapter_blank_fulfillment_becomes_unknown() -> None:
+    repo = InMemoryInquiryRepository()
+    service = InquiryService(repo)
+    payload = {
+        **_VALID,
+        "event_date": _D,
+        "event_start": time(18, 30),
+        "fulfillment_mode": "  ",
+    }
+    q = intake_from_ai_telefonist(service, payload)
+    assert q.fulfillment_mode == "UNKNOWN"
+
+
+def test_http_post_accepts_blank_optional_strato_values(server) -> None:
+    base, inquiry_repo, _order_repo = server
+    status, body, _ = _post(
+        base,
+        {
+            **_VALID,
+            "submission_id": "strato-0,1,7,6-blank-optionals",
+            "phone": "0,1,7,6,4,2,7,9,5,0,2,9",
+            "event_start": "",
+            "fulfillment_mode": "",
+        },
+    )
+
+    assert status == 202
+    q = inquiry_repo.get_by_id(body["inquiry_id"])
+    assert q is not None
+    assert q.event_start_local is None
+    assert q.fulfillment_mode == "UNKNOWN"
+    assert q.intake_external_ref == "strato-0176-blank-optionals"
+    assert q.customer_snapshot is not None
+    assert q.customer_snapshot.phone == "017642795029"
+
+
 def test_valid_http_post_creates_only_one_inquiry(server) -> None:
     base, inquiry_repo, order_repo = server
     status, body, raw = _post(base, _VALID)
@@ -318,6 +369,17 @@ def test_endpoint_parsers_leave_invalid_values_for_adapter() -> None:
     assert ai_telefonist_intake_endpoint._parse_event_start("bad") == "bad"
     assert ai_telefonist_intake_endpoint._parse_event_start(123) == 123
     assert ai_telefonist_intake_endpoint._parse_event_start(None) is None
+    assert ai_telefonist_intake_endpoint._parse_event_start("") is None
+    assert ai_telefonist_intake_endpoint._parse_event_start("   ") is None
+
+
+def test_submission_id_compacts_comma_separated_digits() -> None:
+    assert (
+        ai_telefonist_intake_endpoint._normalize_submission_id(
+            "strato-0,1,7,6-2026-10-10"
+        )
+        == "strato-0176-2026-10-10"
+    )
 
 
 def test_main_refuses_without_token(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Closes #237.

First live STRATO call reached Core successfully. This follow-up:
- normalizes comma-separated/spoken phone values before storage;
- normalizes comma-separated digits in STRATO technical references;
- accepts blank optional event start as absent;
- maps blank fulfillment mode to UNKNOWN;
- documents the richer STRATO parameter schema and HAR payload.

Safety boundary remains unchanged: bearer auth, loopback receiver, Inquiry-only side effects.