### PR TITLE
fix(print): verify IPP job success before acknowledging kitchen print

### DIFF
--- a/docs/runbooks/kitchen-print-verification.md
+++ b/docs/runbooks/kitchen-print-verification.md
@@ -1,0 +1,30 @@
+# Kitchen print completion verification
+
+The adapter submits to **local CUPS at localhost:631** and queries the returned
+numeric job ID on that same server. A `CUPS_SERVER` environment variable or user
+client.conf no longer redirects submission to a different server.
+
+Deploy `cups-client` and `cups-ipp-utils` (Debian/Ubuntu packages), including `lp`
+and `ipptool`, and copy the entire `infra/kitchen_print_agent` directory. The
+packaged `get-job-state.test` is required. The service user must be allowed to
+submit to the configured queue and read its job attributes over local TCP CUPS.
+Keep job history long enough for polling (normally CUPS `PreserveJobHistory Yes`).
+
+The agent acknowledges only the matching job with IPP `job-state=9` and an
+unambiguous `job-completed-successfully` reason. Canceled (7), aborted (8),
+unknown/missing state, warnings/errors, and `queued-in-device` never produce
+an ACK. A missing utility or inaccessible server also fails closed. Submission,
+status commands and polling share the existing ACK deadline; the adapter does
+not resubmit while waiting. This follows RFC 8011 sections 5.3.7–5.3.8:
+https://www.rfc-editor.org/rfc/rfc8011.html#section-5.3.7
+
+Before rollout, run a controlled print using the service account and query its
+job URI with `ipptool -X ipp://localhost:631/jobs/JOB_ID
+/opt/kitchen-print-agent/infra/kitchen_print_agent/get-job-state.test` (one shell
+command). Confirm success attributes and the paper output. Repeat with a held
+then canceled job; Core must keep `kitchen_print_confirmed_at` empty. Confirm
+missing/offline CUPS produces a rejection within the claim deadline.
+
+CUPS success is a spooler observation. Physical paper output still depends on
+the deployed printer/backend reporting correctly; verify this with the actual
+Brother queue before production rollout. No live printer was used in unit tests.

--- a/infra/kitchen_print_agent/get-job-state.test
+++ b/infra/kitchen_print_agent/get-job-state.test
@@ -1,0 +1,13 @@
+{
+  NAME "Read submitted kitchen job state"
+  OPERATION Get-Job-Attributes
+  GROUP operation-attributes-tag
+  ATTR charset attributes-charset utf-8
+  ATTR language attributes-natural-language en
+  ATTR uri job-uri $uri
+  ATTR keyword requested-attributes job-id,job-state,job-state-reasons
+  STATUS successful-ok
+  EXPECT job-id OF-TYPE integer IN-GROUP job-attributes-tag
+  EXPECT job-state OF-TYPE enum IN-GROUP job-attributes-tag
+  EXPECT job-state-reasons OF-TYPE keyword IN-GROUP job-attributes-tag
+}

--- a/infra/kitchen_print_agent/printer.py
+++ b/infra/kitchen_print_agent/printer.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import math
+import plistlib
 import subprocess
 import tempfile
 import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Protocol
+from xml.parsers.expat import ExpatError
 
 from kitchen_print_agent.errors import PrinterError
 
@@ -43,18 +46,6 @@ class FakePrinterAdapter:
         self.printed.append((content_type, body))
 
 
-def _listing_contains_exact_job_id(text: str, job_id: str) -> bool:
-    """Return True when an lpstat listing line starts with the exact job id."""
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        first_field = stripped.split(maxsplit=1)[0]
-        if first_field == job_id:
-            return True
-    return False
-
-
 def _map_lp_failure(stderr: str) -> str:
     normalized = stderr.lower()
     if (
@@ -86,15 +77,66 @@ def _extract_cups_job_id(text: str) -> str | None:
     return None
 
 
+class CommandRunner(Protocol):
+    def __call__(
+        self, command: Sequence[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+def _reported_job_state(text: str, expected_id: int) -> int | None:
+    """Read the exact job's IPP enum from ipptool's machine-readable plist."""
+    try:
+        report = plistlib.loads(text.encode("utf-8"))
+        if not isinstance(report, dict) or report.get("Successful") is not True:
+            return None
+        tests = report.get("Tests")
+        if not isinstance(tests, list) or len(tests) != 1:
+            return None
+        test = tests[0]
+        if not isinstance(test, dict) or test.get("Successful") is not True:
+            return None
+        if test.get("StatusCode") != "successful-ok":
+            return None
+        attributes = test.get("ResponseAttributes")
+        if not isinstance(attributes, list):
+            return None
+        jobs = [
+            group
+            for group in attributes
+            if isinstance(group, dict) and "job-id" in group
+        ]
+        if len(jobs) != 1:
+            return None
+        job = jobs[0]
+        state = job.get("job-state")
+        if type(job["job-id"]) is not int or job["job-id"] != expected_id:
+            return None
+        if state == 9:
+            reasons = job.get("job-state-reasons")
+            reasons = [reasons] if isinstance(reasons, str) else reasons
+            # A forwarding server may report completed while merely queued on
+            # the device. Require a positive, unambiguous success reason.
+            if not isinstance(reasons, list) or not reasons:
+                return None
+            if "job-completed-successfully" not in reasons or any(
+                not isinstance(reason, str)
+                or reason not in {"job-completed-successfully", "job-restartable"}
+                for reason in reasons
+            ):
+                return None
+        return state if type(state) is int and 3 <= state <= 9 else None
+    except (ValueError, TypeError, ExpatError, plistlib.InvalidFileException):
+        return None
+
+
 class CupsPrinterAdapter:
-    """Send document bytes to a CUPS queue via lp."""
+    """Submit and verify a job against the same local CUPS server."""
 
     def __init__(
         self,
         printer_name: str,
         *,
-        run_lp: Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
-        | None = None,
+        run_lp: CommandRunner | None = None,
         poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
         sleep: Callable[[float], None] = time.sleep,
         monotonic: Callable[[], float] = time.monotonic,
@@ -109,6 +151,22 @@ class CupsPrinterAdapter:
         self._sleep = sleep
         self._monotonic = monotonic
 
+    def _run_command(
+        self, command: Sequence[str], deadline: float
+    ) -> subprocess.CompletedProcess[str]:
+        remaining = deadline - self._monotonic()
+        if remaining <= 0:
+            raise PrinterError("CUPS ACK deadline expired", "printer_unavailable")
+        try:
+            result = self._run_lp(command, timeout=remaining)
+        except (OSError, UnicodeError, subprocess.TimeoutExpired) as exc:
+            raise PrinterError(
+                "CUPS command failed or timed out", "printer_unavailable"
+            ) from exc
+        if self._monotonic() >= deadline:
+            raise PrinterError("CUPS ACK deadline expired", "printer_unavailable")
+        return result
+
     def print_document(
         self, content_type: str, body: bytes, *, timeout_seconds: float | None = None
     ) -> None:
@@ -117,79 +175,78 @@ class CupsPrinterAdapter:
                 f"unsupported print document content type: {content_type}",
                 "invalid_printer_configuration",
             )
+        timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else _DEFAULT_WAIT_TIMEOUT_SECONDS
+        )
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise PrinterError("CUPS ACK deadline expired", "printer_unavailable")
+        deadline = self._monotonic() + timeout
         temp_path: str | None = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as handle:
                 handle.write(body)
                 temp_path = handle.name
-            result = self._run_lp(
-                ["lp", "-d", self._printer_name, temp_path],
+            result = self._run_command(
+                ["lp", "-h", "localhost:631", "-d", self._printer_name, temp_path],
+                deadline,
             )
         except OSError as exc:
             raise PrinterError(str(exc), "printer_unavailable") from exc
         finally:
             if temp_path is not None:
                 Path(temp_path).unlink(missing_ok=True)
-
-        if result.returncode == 0:
-            job_id = _extract_cups_job_id(f"{result.stdout}\n{result.stderr}")
-            if job_id is None:
-                raise PrinterError(
-                    "lp accepted the job but did not report a CUPS job id",
-                    "invalid_printer_configuration",
-                )
-            self._wait_for_completed_job(
-                job_id,
-                timeout_seconds=(
-                    timeout_seconds
-                    if timeout_seconds is not None
-                    else _DEFAULT_WAIT_TIMEOUT_SECONDS
-                ),
-            )
-            return
-
-        message = (result.stderr or result.stdout or "lp failed").strip()
-        raise PrinterError(message, _map_lp_failure(message))
-
-    def _wait_for_completed_job(self, job_id: str, *, timeout_seconds: float) -> None:
-        if timeout_seconds <= 0:
+        if result.returncode != 0:
+            message = (result.stderr or result.stdout or "lp failed").strip()
+            raise PrinterError(message, _map_lp_failure(message))
+        job_id = _extract_cups_job_id(f"{result.stdout}\n{result.stderr}")
+        if job_id is None or job_id.rsplit("-", 1)[0] != self._printer_name:
             raise PrinterError(
-                f"CUPS job {job_id} did not complete before ACK deadline",
-                "printer_unavailable",
+                "lp did not report a job id for the requested queue",
+                "invalid_printer_configuration",
             )
-        deadline = self._monotonic() + timeout_seconds
-        last_status = ""
-        while self._monotonic() <= deadline:
-            completed = self._run_lp(
-                ["lpstat", "-W", "completed", "-o", self._printer_name],
-            )
-            completed_text = f"{completed.stdout}\n{completed.stderr}"
-            if completed.returncode == 0 and _listing_contains_exact_job_id(
-                completed_text, job_id
-            ):
-                return
+        self._wait_for_completed_job(job_id, deadline=deadline)
 
-            not_completed = self._run_lp(
-                ["lpstat", "-W", "not-completed", "-o", self._printer_name],
+    def _wait_for_completed_job(self, job_id: str, *, deadline: float) -> None:
+        numeric_id = int(job_id.rsplit("-", 1)[1])
+        test_file = str(Path(__file__).with_name("get-job-state.test"))
+        while self._monotonic() < deadline:
+            result = self._run_command(
+                ["ipptool", "-X", f"ipp://localhost:631/jobs/{numeric_id}", test_file],
+                deadline,
             )
-            not_completed_text = f"{not_completed.stdout}\n{not_completed.stderr}"
-            printer = self._run_lp(["lpstat", "-p", self._printer_name, "-l"])
-            printer_text = f"{printer.stdout}\n{printer.stderr}"
-            combined = "\n".join(
-                part for part in (not_completed_text, printer_text) if part
+            state = (
+                _reported_job_state(result.stdout, numeric_id)
+                if result.returncode == 0
+                else None
             )
-            last_status = combined.strip() or last_status
-            self._sleep(self._poll_interval_seconds)
+            if state == 9:  # RFC 8011 completed; canceled=7 and aborted=8 are failures.
+                return
+            if state in {7, 8}:
+                raise PrinterError(
+                    f"CUPS job {job_id} canceled or aborted", "spool_rejected"
+                )
+            if state is None:
+                raise PrinterError(
+                    f"Cannot verify CUPS job {job_id}", "printer_unavailable"
+                )
+            remaining = deadline - self._monotonic()
+            if remaining > 0:
+                self._sleep(min(self._poll_interval_seconds, remaining))
         raise PrinterError(
-            last_status or f"CUPS job {job_id} did not complete before ACK deadline",
+            f"CUPS job {job_id} did not complete before ACK deadline",
             "printer_unavailable",
         )
 
     @staticmethod
-    def _default_run_lp(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    def _default_run_lp(
+        command: Sequence[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             list(command),
             capture_output=True,
             text=True,
             check=False,
+            timeout=timeout,
         )

--- a/tests/unit/test_cups_printer_adapter.py
+++ b/tests/unit/test_cups_printer_adapter.py
@@ -1,338 +1,259 @@
-"""CUPS printer adapter tests — no real lp/CUPS required."""
+"""CUPS completion must be exact, positive, and inside the ACK deadline."""
 
 from __future__ import annotations
 
+import plistlib
 import subprocess
+from pathlib import Path
+from collections.abc import Sequence
 
 import pytest
 from kitchen_print_agent.errors import PrinterError
-from kitchen_print_agent.printer import CupsPrinterAdapter
-
-_PRINTER = "Brother_L2710DN_LAN"
-_JOB_ID = f"{_PRINTER}-123"
+from kitchen_print_agent.printer import CupsPrinterAdapter, _reported_job_state
 
 
-def _completed(
-    *,
-    returncode: int = 0,
-    stdout: str = "",
-    stderr: str = "",
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(
-        args=["lp"],
-        returncode=returncode,
-        stdout=stdout,
-        stderr=stderr,
-    )
+def report(state: object = 9, job_id: object = 12, *, successful: bool = True) -> str:
+    return plistlib.dumps(
+        {
+            "Successful": successful,
+            "Tests": [
+                {
+                    "Successful": successful,
+                    "StatusCode": "successful-ok",
+                    "ResponseAttributes": [
+                        {"attributes-charset": "utf-8"},
+                        {
+                            "job-id": job_id,
+                            "job-state": state,
+                            "job-state-reasons": "job-completed-successfully",
+                        },
+                    ],
+                }
+            ],
+        }
+    ).decode()
 
 
-def _is_completed_lpstat(command: list[str]) -> bool:
-    return command[:4] == ["lpstat", "-W", "completed", "-o"]
+def completed(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
 
 
-def _is_not_completed_lpstat(command: list[str]) -> bool:
-    return command[:5] == ["lpstat", "-W", "not-completed", "-o"]
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
 
 
-def test_successful_print_polls_completed_jobs_for_printer() -> None:
-    calls: list[list[str]] = []
+@pytest.mark.parametrize(
+    "announcement",
+    ["request id is Kitchen-12 (1 file(s))", "Anfrage-ID ist Kitchen-12 (1 Datei(en))"],
+)
+def test_processing_then_completed_submits_once(announcement):
+    calls = []
+    timeouts = []
+    states = iter([3, 5, 9])
+    clock = Clock()
 
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+    def run(command, *, timeout):
         calls.append(list(command))
+        timeouts.append(timeout)
         if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024 Mon 10 Aug 2026")
-        return _completed()
+            assert Path(command[-1]).read_bytes() == b"%PDF"
+            return completed(announcement)
+        return completed(report(next(states)))
 
-    adapter = CupsPrinterAdapter(_PRINTER, run_lp=run_lp, sleep=lambda _seconds: None)
-    adapter.print_document("application/pdf", b"%PDF-1.4")
-
-    assert calls[0][:3] == ["lp", "-d", _PRINTER]
-    assert calls[1] == ["lpstat", "-W", "completed", "-o", _PRINTER]
-
-
-def test_successful_print_parses_german_cups_job_id() -> None:
-    calls: list[list[str]] = []
-
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        calls.append(list(command))
-        if command[0] == "lp":
-            return _completed(
-                stdout=f"Anfrage-ID ist {_JOB_ID} (1 Datei(en))",
-            )
-        if _is_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024")
-        return _completed()
-
-    adapter = CupsPrinterAdapter(_PRINTER, run_lp=run_lp, sleep=lambda _seconds: None)
-    adapter.print_document("application/pdf", b"%PDF-1.4")
-
-    assert calls[1] == ["lpstat", "-W", "completed", "-o", _PRINTER]
-
-
-def test_completed_listing_exact_job_id_match_succeeds() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(
-                stdout=(f"{_PRINTER}-122 viktor 1024\n{_JOB_ID} viktor 2048\n"),
-            )
-        return _completed()
-
-    adapter = CupsPrinterAdapter(_PRINTER, run_lp=run_lp, sleep=lambda _seconds: None)
-    adapter.print_document("application/pdf", b"%PDF-1.4")
-
-
-def test_completed_listing_only_similar_job_id_fails() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout=f"{_PRINTER}-122 viktor 1024")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024 active")
-        return _completed()
-
-    ticks = [0.0, 0.0, 2.0]
     adapter = CupsPrinterAdapter(
-        _PRINTER,
-        run_lp=run_lp,
-        sleep=lambda _seconds: None,
-        monotonic=lambda: ticks.pop(0) if ticks else 2.0,
+        "Kitchen", run_lp=run, monotonic=clock.monotonic, sleep=clock.sleep
     )
+    adapter.print_document("application/pdf", b"%PDF", timeout_seconds=10)
+    assert calls[0][:5] == ["lp", "-h", "localhost:631", "-d", "Kitchen"]
+    assert all(
+        call[:3] == ["ipptool", "-X", "ipp://localhost:631/jobs/12"]
+        for call in calls[1:]
+    )
+    assert len(calls) == 4
+    assert timeouts == [10, 10, 9, 8]
+    assert not Path(calls[0][-1]).exists()
 
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=1.0)
 
-    assert exc_info.value.rejection_code == "printer_unavailable"
+@pytest.mark.parametrize("state", [7, 8])
+def test_canceled_or_aborted_never_succeeds(state):
+    def run(command, *, timeout):
+        return completed(
+            "request id is Kitchen-12" if command[0] == "lp" else report(state)
+        )
+
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter("Kitchen", run_lp=run).print_document(
+            "application/pdf", b"%PDF"
+        )
+    assert error.value.rejection_code == "spool_rejected"
 
 
-def test_completed_listing_longer_job_id_does_not_false_match() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout=f"{_PRINTER}-1234 viktor 1024")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024 active")
-        return _completed()
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "not xml",
+        "Kitchen-12 owner 1024",
+        report(9, 123),
+        report(9, "12"),
+        report(True),
+        report(10),
+        report(9, successful=False),
+        "<plist><dict>",
+    ],
+)
+def test_unverifiable_response_fails_closed(text):
+    def run(command, *, timeout):
+        return completed("request id is Kitchen-12" if command[0] == "lp" else text)
 
-    ticks = [0.0, 0.0, 2.0]
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter("Kitchen", run_lp=run).print_document(
+            "application/pdf", b"%PDF"
+        )
+    assert error.value.rejection_code == "printer_unavailable"
+
+
+def test_active_job_expires_without_resubmission():
+    clock = Clock()
+    calls = []
+
+    def run(command, *, timeout):
+        calls.append(command[0])
+        return completed(
+            "request id is Kitchen-12" if command[0] == "lp" else report(5)
+        )
+
     adapter = CupsPrinterAdapter(
-        _PRINTER,
-        run_lp=run_lp,
-        sleep=lambda _seconds: None,
-        monotonic=lambda: ticks.pop(0) if ticks else 2.0,
+        "Kitchen", run_lp=run, monotonic=clock.monotonic, sleep=clock.sleep
     )
+    with pytest.raises(PrinterError):
+        adapter.print_document("application/pdf", b"%PDF", timeout_seconds=0.5)
+    assert clock.now == 0.5
+    assert calls == ["lp", "ipptool"]
 
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=1.0)
 
-    assert exc_info.value.rejection_code == "printer_unavailable"
+@pytest.mark.parametrize("command_name", ["lp", "ipptool"])
+def test_real_subprocess_boundary_has_timeout_and_cleans_file(
+    monkeypatch, command_name
+):
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        assert 0 < kwargs["timeout"] <= 2
+        if command[0] == command_name:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        return completed("request id is Kitchen-12")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter("Kitchen").print_document(
+            "application/pdf", b"%PDF", timeout_seconds=2
+        )
+    assert error.value.rejection_code == "printer_unavailable"
+    assert not Path(calls[0][-1]).exists()
 
 
-def test_job_still_not_completed_fails_without_ack() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+def test_late_success_cannot_ack():
+    clock = Clock()
+
+    def run(command, *, timeout):
         if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout="")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024 active")
-        return _completed()
+            return completed("request id is Kitchen-12")
+        clock.now = 11
+        return completed(report())
 
-    ticks = [0.0, 0.0, 2.0]
-    adapter = CupsPrinterAdapter(
-        _PRINTER,
-        run_lp=run_lp,
-        sleep=lambda _seconds: None,
-        monotonic=lambda: ticks.pop(0) if ticks else 2.0,
-    )
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=1.0)
-
-    assert exc_info.value.rejection_code == "printer_unavailable"
+    with pytest.raises(PrinterError):
+        CupsPrinterAdapter(
+            "Kitchen", run_lp=run, monotonic=clock.monotonic
+        ).print_document("application/pdf", b"%PDF", timeout_seconds=10)
 
 
-def test_lp_success_without_completed_job_fails_closed() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout=f"request id is {_JOB_ID} (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout="")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout=f"{_JOB_ID} viktor 1024 active")
-        return _completed()
+@pytest.mark.parametrize(
+    "message,code",
+    [
+        ("unknown printer", "printer_unavailable"),
+        ("job rejected", "spool_rejected"),
+        ("unsupported format", "invalid_printer_configuration"),
+    ],
+)
+def test_submission_failure_mapping(message, code):
+    def run(command: Sequence[str], *, timeout: float):
+        return completed(returncode=1, stderr=message)
 
-    adapter = CupsPrinterAdapter(_PRINTER, run_lp=run_lp, sleep=lambda _seconds: None)
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=0.01)
-
-    assert exc_info.value.rejection_code == "printer_unavailable"
-
-
-def test_status_text_is_diagnostic_only_and_completion_is_required() -> None:
-    completed_checks = 0
-
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        nonlocal completed_checks
-        if command[0] == "lp":
-            return _completed(stdout="request id is Kitchen-12 (1 file(s))")
-        if _is_completed_lpstat(command):
-            completed_checks += 1
-            if completed_checks == 1:
-                return _completed(stdout="")
-            return _completed(stdout="Kitchen-12 viktor 1024 Mon 10 Aug 2026")
-        if command[:2] == ["lpstat", "-p"]:
-            return _completed(stdout="printer Kitchen disabled since paper-out")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout="Kitchen-12 viktor 1024 active")
-        return _completed()
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp, sleep=lambda _seconds: None)
-
-    adapter.print_document("application/pdf", b"%PDF-1.4")
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter("Kitchen", run_lp=run).print_document(
+            "application/pdf", b"%PDF"
+        )
+    assert error.value.rejection_code == code
 
 
-def test_terminal_status_text_without_completed_job_fails_after_timeout() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout="request id is Kitchen-12 (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout="")
-        if command[:2] == ["lpstat", "-p"]:
-            return _completed(stdout="printer Kitchen disabled since cancelled")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout="Kitchen-12 viktor 1024 active")
-        return _completed()
-
-    ticks = [0.0, 0.0, 2.0]
-    adapter = CupsPrinterAdapter(
-        "Kitchen",
-        run_lp=run_lp,
-        sleep=lambda _seconds: None,
-        monotonic=lambda: ticks.pop(0) if ticks else 2.0,
-    )
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=1.0)
-
-    assert exc_info.value.rejection_code == "printer_unavailable"
+@pytest.mark.parametrize("announcement", ["accepted", "request id is WrongQueue-12"])
+def test_missing_or_wrong_queue_job_id_rejected(announcement):
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter(
+            "Kitchen", run_lp=lambda command, timeout: completed(announcement)
+        ).print_document("application/pdf", b"%PDF")
+    assert error.value.rejection_code == "invalid_printer_configuration"
 
 
-def test_german_status_text_is_diagnostic_only() -> None:
-    completed_checks = 0
-
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        nonlocal completed_checks
-        if command[0] == "lp":
-            return _completed(stdout="request id is Kitchen-12 (1 file(s))")
-        if _is_completed_lpstat(command):
-            completed_checks += 1
-            if completed_checks == 1:
-                return _completed(stdout="")
-            return _completed(stdout="Kitchen-12 viktor 1024 Mon 10 Aug 2026")
-        if command[:2] == ["lpstat", "-p"]:
-            return _completed(stdout="Drucker Kitchen ist deaktiviert: Papierstau")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout="Kitchen-12 viktor 1024 active")
-        return _completed()
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp, sleep=lambda _seconds: None)
-
-    adapter.print_document("application/pdf", b"%PDF-1.4")
-
-
-def test_missing_completed_job_fails_closed_with_german_diagnostic() -> None:
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        if command[0] == "lp":
-            return _completed(stdout="request id is Kitchen-12 (1 file(s))")
-        if _is_completed_lpstat(command):
-            return _completed(stdout="")
-        if command[:2] == ["lpstat", "-p"]:
-            return _completed(stdout="Drucker Kitchen ist deaktiviert: Papierstau")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout="Kitchen-12 viktor 1024 active")
-        return _completed()
-
-    ticks = [0.0, 0.0, 2.0]
-    adapter = CupsPrinterAdapter(
-        "Kitchen",
-        run_lp=run_lp,
-        sleep=lambda _seconds: None,
-        monotonic=lambda: ticks.pop(0) if ticks else 2.0,
-    )
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4", timeout_seconds=1.0)
-
-    assert exc_info.value.rejection_code == "printer_unavailable"
-
-
-def test_transient_active_job_completes_without_second_submission() -> None:
-    calls: list[list[str]] = []
-    completed_checks = 0
-
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
-        nonlocal completed_checks
-        calls.append(list(command))
-        if command[0] == "lp":
-            return _completed(stdout="request id is Kitchen-12 (1 file(s))")
-        if _is_completed_lpstat(command):
-            completed_checks += 1
-            if completed_checks == 1:
-                return _completed(stdout="")
-            return _completed(stdout="Kitchen-12 viktor 1024 Mon 10 Aug 2026")
-        if _is_not_completed_lpstat(command):
-            return _completed(stdout="Kitchen-12 viktor 1024 active")
-        return _completed()
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp, sleep=lambda _seconds: None)
-
-    adapter.print_document("application/pdf", b"%PDF-1.4")
-
-    assert [call[0] for call in calls].count("lp") == 1
-
-
-def test_queue_missing_maps_to_printer_unavailable() -> None:
-    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
-        return _completed(returncode=1, stderr="lp: Unknown printer 'Kitchen'")
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4")
-
-    assert exc_info.value.rejection_code == "printer_unavailable"
-
-
-def test_spool_reject_maps_to_spool_rejected() -> None:
-    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
-        return _completed(returncode=1, stderr="job rejected by spooler")
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("application/pdf", b"%PDF-1.4")
-
-    assert exc_info.value.rejection_code == "spool_rejected"
-
-
-def test_unsupported_format_maps_to_invalid_printer_configuration() -> None:
-    calls: list[list[str]] = []
-
-    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
-        calls.append(list(_command))
-        return _completed(returncode=1, stderr="unsupported document format")
-
-    adapter = CupsPrinterAdapter("Kitchen", run_lp=run_lp)
-
-    with pytest.raises(PrinterError) as exc_info:
-        adapter.print_document("text/html; charset=utf-8", b"<html>test</html>")
-
-    assert exc_info.value.rejection_code == "invalid_printer_configuration"
+def test_unsupported_content_never_submits():
+    calls = []
+    with pytest.raises(PrinterError) as error:
+        CupsPrinterAdapter(
+            "Kitchen", run_lp=lambda command, timeout: calls.append(command)
+        ).print_document("text/html", b"html")
+    assert error.value.rejection_code == "invalid_printer_configuration"
     assert calls == []
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan")])
+def test_invalid_deadline_never_submits(timeout):
+    calls = []
+    with pytest.raises(PrinterError):
+        CupsPrinterAdapter(
+            "Kitchen", run_lp=lambda command, timeout: calls.append(command)
+        ).print_document("application/pdf", b"%PDF", timeout_seconds=timeout)
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"Successful": True, "Tests": []},
+        {"Successful": True, "Tests": ["invalid"]},
+        {
+            "Successful": True,
+            "Tests": [{"Successful": True, "StatusCode": "server-error"}],
+        },
+    ],
+)
+def test_plist_shape_validation(payload):
+    assert _reported_job_state(plistlib.dumps(payload).decode(), 12) is None
+
+
+@pytest.mark.parametrize(
+    "reasons",
+    [
+        "job-completed-with-errors",
+        "job-completed-with-warnings",
+        "queued-in-device",
+        "none",
+        [],
+        ["job-completed-successfully", "queued-in-device"],
+        ["job-completed-successfully", {}],
+    ],
+)
+def test_completed_without_unambiguous_success_is_rejected(reasons):
+    payload = plistlib.loads(report().encode())
+    payload["Tests"][0]["ResponseAttributes"][1]["job-state-reasons"] = reasons
+    assert _reported_job_state(plistlib.dumps(payload).decode(), 12) is None

--- a/tests/unit/test_kitchen_print_agent_runtime.py
+++ b/tests/unit/test_kitchen_print_agent_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import queue
+import plistlib
 import subprocess
 import threading
 import uuid
@@ -193,7 +194,9 @@ def test_cups_adapter_failure_propagates_rejection_code(kitchen_api_server) -> N
     base, db = kitchen_api_server
     _order_id, version_id = _seed_claimable_job(db)
 
-    def run_lp(_command: list[str]) -> subprocess.CompletedProcess[str]:
+    def run_lp(
+        _command: list[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
             args=["lp"],
             returncode=1,
@@ -228,7 +231,9 @@ def test_lp_accept_without_completed_job_does_not_ack(kitchen_api_server) -> Non
     base, db = kitchen_api_server
     _order_id, version_id = _seed_claimable_job(db)
 
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+    def run_lp(
+        command: list[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         if command[0] == "lp":
             return subprocess.CompletedProcess(
                 args=command,
@@ -236,7 +241,7 @@ def test_lp_accept_without_completed_job_does_not_ack(kitchen_api_server) -> Non
                 stdout="request id is Kitchen-12 (1 file(s))",
                 stderr="",
             )
-        if command[:4] == ["lpstat", "-W", "completed", "-o"]:
+        if command[0] == "ipptool":
             return subprocess.CompletedProcess(
                 args=command, returncode=0, stdout="", stderr=""
             )
@@ -283,15 +288,19 @@ def test_lp_accept_without_completed_job_does_not_ack(kitchen_api_server) -> Non
     assert version.kitchen_print_confirmed_at is None
 
 
-def test_transient_cups_state_acknowledges_without_second_print_submission(
+@pytest.mark.parametrize("terminal_state", [7, 8, 9])
+def test_transient_cups_state_acknowledges_only_success_without_second_submission(
     kitchen_api_server,
+    terminal_state,
 ) -> None:
     base, db = kitchen_api_server
     _order_id, version_id = _seed_claimable_job(db)
     calls: list[list[str]] = []
     completed_checks = 0
 
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+    def run_lp(
+        command: list[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         nonlocal completed_checks
         calls.append(list(command))
         if command[0] == "lp":
@@ -301,9 +310,28 @@ def test_transient_cups_state_acknowledges_without_second_print_submission(
                 stdout="request id is Kitchen-12 (1 file(s))",
                 stderr="",
             )
-        if command[:4] == ["lpstat", "-W", "completed", "-o"]:
+        if command[0] == "ipptool":
             completed_checks += 1
-            stdout = "" if completed_checks == 1 else "Kitchen-12 viktor 1024 done"
+            stdout = plistlib.dumps(
+                {
+                    "Successful": True,
+                    "Tests": [
+                        {
+                            "Successful": True,
+                            "StatusCode": "successful-ok",
+                            "ResponseAttributes": [
+                                {
+                                    "job-id": 12,
+                                    "job-state": 5
+                                    if completed_checks == 1
+                                    else terminal_state,
+                                    "job-state-reasons": "job-completed-successfully",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ).decode()
             return subprocess.CompletedProcess(
                 args=command, returncode=0, stdout=stdout, stderr=""
             )
@@ -334,7 +362,14 @@ def test_transient_cups_state_acknowledges_without_second_print_submission(
     version = orders.get_order_version(version_id)
     orders.close()
     assert version is not None
-    assert version.kitchen_print_confirmed_at == _NOW
+    assert version.kitchen_print_confirmed_at == (_NOW if terminal_state == 9 else None)
+    jobs = SQLiteKitchenPrintJobRepository(db)
+    job = jobs.get(_JOB_A)
+    jobs.close()
+    assert job is not None
+    if terminal_state != 9:
+        assert job.acknowledged_at is None
+        assert job.rejection_code == "spool_rejected"
 
 
 def test_printer_status_text_without_completed_job_does_not_ack(
@@ -343,7 +378,9 @@ def test_printer_status_text_without_completed_job_does_not_ack(
     base, db = kitchen_api_server
     _order_id, version_id = _seed_claimable_job(db)
 
-    def run_lp(command: list[str]) -> subprocess.CompletedProcess[str]:
+    def run_lp(
+        command: list[str], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         if command[0] == "lp":
             return subprocess.CompletedProcess(
                 args=command,
@@ -351,7 +388,7 @@ def test_printer_status_text_without_completed_job_does_not_ack(
                 stdout="request id is Kitchen-12 (1 file(s))",
                 stderr="",
             )
-        if command[:4] == ["lpstat", "-W", "completed", "-o"]:
+        if command[0] == "ipptool":
             return subprocess.CompletedProcess(
                 args=command, returncode=0, stdout="", stderr=""
             )


### PR DESCRIPTION
CUPS completed-job listings include canceled and aborted jobs, so a listing match can incorrectly confirm a kitchen print. Subprocess calls also had no timeout.

This change queries the exact submitted job through ipptool's structured IPP output and acknowledges only an unambiguous successful completion. Submission and status checks use the same local CUPS server and share the ACK deadline. Missing/invalid status, cancellation, abort, warnings/errors and timeouts fail closed. Polling does not resubmit the document. Core order/version and agent API contracts stay intact.

Validation: 60 adapter, runtime and agent-contract tests passed, including cancellation/abort through the real test Core API and database. Repository ruff lint and format checks passed. Full Core CI remains the merge gate.

Rollout: install cups-ipp-utils alongside cups-client, deploy the packaged get-job-state.test, and verify local TCP CUPS access/job history as the service user. The new runbook describes controlled successful/canceled print checks. On-site PDF output and CUPS cancellation were verified by the operator on 2026-09-07 (details below); the changed agent has not yet been deployed or verified end-to-end on the production host. No deployment performed.

On-site verification (operator-provided terminal output, 2026-09-07):

- cups and kitchen-print-agent services active; ipptool installed; configured queue Brother_L2710DN_LAN using IPP Everywhere.
- Standard CUPS PDF submitted through lp to localhost:631 as job 17. Operator confirmed printed content. Get-Job-Attributes reported completed, job-completed-successfully, 1 impression and 1 media sheet completed.
- A separate test PDF submitted on hold as job 18, then canceled by exact ID. Get-Job-Attributes reported canceled and 0 impressions/media sheets. Its reason remained job-hold-until-specified, confirming that the terminal job-state must determine cancellation.
- The initial plain-text probe produced a blank sheet; its cause is not established. The standard PDF test succeeded.
- Full GitHub CI passed for commit 0570b32e8cf550b56dd0ac0570d1d40aa882840d: https://github.com/VikJo1978/silberloeffel-catering/actions/runs/34094082936

These are checks of the installed printer/CUPS path using lp and ipptool, not a live end-to-end ACK test of this PR's agent. Deployment and a controlled agent/Core confirmation check remain pending.