### PR TITLE
fix(ops): align kitchen print runtime truth and observability

### DIFF
--- a/docs/current-status.md
+++ b/docs/current-status.md
@@ -1,30 +1,27 @@
 # Current status
 
-Operational truth last updated: **2026-08-31**.
+Operational truth last updated: **2026-09-08**.
 
-This file is a **current operational snapshot**, not a deployment diary. Historical
-details remain available in Git history, merged pull requests, issue history and the
-runbooks under `docs/runbooks/`.
+This file is a current operational snapshot, not a deployment diary. Historical details
+remain available in Git history, merged pull requests, issue history and the runbooks
+under `docs/runbooks/`.
 
-Repository state and production state are deliberately kept separate. A commit on
+Repository state and production state are deliberately separate. A commit on
 `origin/main` is not production until the relevant service has loaded it and the
-deployment has been checked.
+post-deploy checks have been recorded.
 
 ## Current repository state
 
 | Item | Value |
 |---|---|
-| `origin/main` HEAD before this docs update | `ed78e8211a4edf293e695aa770aa8a3752b20bd7` (`ed78e82`) |
-| Commit | `Implement Courier cash handoff runtime V1 (#213)` |
-| CI immediately before #213 merge | **green** — PR head `79d2316`, run `33395580432` |
-| Open issues after backlog cleanup | **0** |
-| Open pull requests after backlog cleanup | **0** |
+| `origin/main` at the start of this operational-truth update | `a314b51c2f7d942e815bcbf133ec72bb47ddb668` (`a314b51`) |
+| Latest deployed application change | `fix(print): require verified IPP completion within ACK deadline (#241)` |
 | Working release flow | branch → PR → green CI → merge → production fast-forward |
+| Active pre-launch validation | issue #218, coherent end-to-end operational validation |
 
-The repository had accumulated old stacked and superseded pull requests from earlier
-architecture slices. On 2026-08-27 they were reviewed against current `main` and all
-remaining stale PRs were closed. Their branches and Git history remain available for
-archaeology, but they are not active implementation work.
+The kitchen-print observability/runtime-truth cleanup is being prepared separately from
+production. Documentation or branch commits must not be interpreted as a production
+deployment and must not trigger a service restart by themselves.
 
 ## Production state
 
@@ -34,93 +31,75 @@ Production host: `debiancatering`.
 |---|---|
 | Application repository | `/home/viktor/projects/silberloeffel-catering` |
 | Core DB | `/home/viktor/catering-runtime/core.db` |
-| Deployed application commit | `ed78e8211a4edf293e695aa770aa8a3752b20bd7` (`ed78e82`) |
-| Relationship to application `main` before this docs-only update | **matches** |
-| Latest functional deployment scope | Courier cash handoff rollout across Core Office API, Kiosk, Office Panel and Courier app |
-| Latest functional verification | machine-route auth gates, shared bearer, Kiosk order-feed, Courier service and service health verified; no real BAR order exists yet for E2E |
-| Office Panel unauthenticated health behavior | HTTP `303` redirect, expected |
-| Office API after cash rollout | `active` on `100.109.6.74:8084`, restarted with the cash service bearer configured |
+| Deployed application commit | `a314b51c2f7d942e815bcbf133ec72bb47ddb668` (`a314b51`) |
+| Kitchen Print Agent | `active/running`; PID `1173322` at 2026-09-08 verification; `NRestarts=0` |
+| Kitchen API | loopback `127.0.0.1:8086` |
+| Office API | `active` on `100.109.6.74:8084` |
+| CUPS | active; queue `Brother_L2710DN_LAN` enabled and idle after E2E |
+| Kitchen Print Agent environment | tracked checkout + project `.venv`, no systemd drop-in |
 
-The latest application change (#195) was deployed after its post-merge CI passed.
-The operator then verified the manual-task detail flow interactively in production.
-No database migration was part of #188, #190, #192 or #194/#195.
+The effective production Kitchen Print Agent unit at verification time was:
 
-This documentation commit must **not** be treated as a reason to restart production
-services. It changes operational documentation only.
+```text
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/infra
+EnvironmentFile=/etc/kitchen-print-agent.env
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m kitchen_print_agent
+Restart=always
+RestartSec=5
+```
 
+No production database migration was part of the Kitchen Print completion-verification
+rollout.
 
-## Courier cash handoff production rollout
+## Kitchen Print completion verification
 
-The frozen Courier cash-handoff contract is now activated on the Lenovo production
-host.
+The 2026-09-08 rollout closed the critical false-ACK risk in the kitchen print path.
+The agent now waits for the exact local CUPS job to reach a verified successful IPP
+terminal state before acknowledging Core. Canceled, aborted or unverifiable states fail
+closed and do not produce an ACK.
 
-- Core is deployed at `ed78e8211a4edf293e695aa770aa8a3752b20bd7`
-  (`ed78e82`, PR #213).
-- Courier is deployed at `f3419a40cabd53bd9badc900ddf40a9426e0a863`
-  (`f3419a4`, courier-app PR #16).
-- `catering-office-api` is active on `100.109.6.74:8084`.
-- `catering-courier-app` is active on `0.0.0.0:8090`.
-- `catering-kiosk` is active on `0.0.0.0:8082` and loaded the new
-  `cash_handoff` projection code.
-- Core and Courier use the same dedicated `COURIER_CASH_SERVICE_TOKEN`; its
-  value remains only in the production environment files.
-- An unauthenticated POST to the cash machine route returns `401`.
-- The same route with the configured bearer and an intentionally empty payload
-  reaches request validation and returns `400`, proving authentication and
-  connectivity without creating a cash event.
-- Kiosk root and order-feed checks return `200`; the kiosk journal records
-  `pickup signal refresh succeeded`.
-- Production currently contains zero `BAR_VOR_ORT` payment reminders, so a
-  truthful end-to-end cash handoff cannot yet be exercised.
+Production evidence recorded during the rollout:
 
-No synthetic BAR order was created in production merely to force the last E2E
-step. The first real BAR order is the production E2E candidate.
+- previous production commit before the rollout:
+  `1626d616b842f54749c82d769d86dd7b2c080db8`;
+- deployed commit: `a314b51c2f7d942e815bcbf133ec72bb47ddb668`;
+- production worktree was clean after the fast-forward and restart;
+- `kitchen-print-agent` restarted successfully at 2026-09-08 09:26:43 CEST;
+- no subsequent automatic service restart was observed (`NRestarts=0`);
+- real historical CUPS job `Brother_L2710DN_LAN-17` parsed as IPP state `9`
+  (successful completion);
+- real historical CUPS job `Brother_L2710DN_LAN-18` parsed as IPP state `7`
+  (canceled), proving that the new parser distinguishes success from cancellation;
+- a controlled synthetic E2E used a consistent disposable copy of `core.db`, a
+  synthetic PDF containing no customer data, the real Kitchen Print Agent code, local
+  CUPS and the real Brother queue;
+- that E2E created `Brother_L2710DN_LAN-19` at 2026-09-08 09:39:33 CEST;
+- the test print job was accepted at `2026-09-08T07:39:33.656371+00:00` and
+  acknowledged at `2026-09-08T07:39:56.025896+00:00` with no rejection;
+- the test concluded with `E2E_ACK_SUCCESS`;
+- the disposable test database was removed after verification;
+- the production Core database was not mutated by the synthetic E2E.
 
-## Current Office task workflow
+The recorded evidence proves the software path through Core/Kitchen API → agent → local
+CUPS → verified IPP completion → ACK. Physical paper output should only be claimed as a
+separate assurance when an operator explicitly records seeing the expected sheet; that
+physical observation is not promoted as independently recorded fact in this status
+snapshot.
 
-Manual office tasks are now a first-class Office workflow:
+## Kitchen Print runtime truth and observability follow-up
 
-- persisted manual tasks are exposed in `/aufgaben`;
-- open manual tasks are included in the Arbeitszentrale together with system tasks;
-- priority is explicit (`HIGH`, `NORMAL`, `LOW`) and ranks before due date;
-- a task may reference Kontakt, Anfrage, Angebot, Auftrag or no subject;
-- the Bezug picker is searchable and category-filterable;
-- its inline JavaScript is permitted by CSP only through an exact SHA-256 hash;
-- Safari hidden-state behavior is explicitly covered;
-- a manual task opens its own `/aufgaben/{task_id}` detail page;
-- title, description, priority, due date, assignee, status and Bezug are readable
-  before navigating to the referenced business object;
-- `Bezug öffnen` remains a separate action;
-- completion remains permission-controlled.
+Audit after the rollout found an operational-truth mismatch: the tracked
+`infra/systemd/kitchen-print-agent.service` still described the obsolete `/opt` +
+`/usr/bin/python3` layout even though the live Lenovo unit uses the repository checkout
+and `.venv`. The cleanup branch aligns the tracked unit with the effective production
+unit and adds lifecycle logging for opaque print-job IDs, CUPS job IDs, successful
+completion, rejection codes and ACKs. Logs must never contain bearer tokens, customer
+data or document bodies.
 
-Relevant completed work:
-
-| Issue / PR | Result |
-|---|---|
-| #182 / #185 | manual tasks exposed in Aufgaben UI |
-| #186 / #187 | manual tasks integrated into Arbeitszentrale with priority and subject links |
-| #188 / #189 | searchable, category-first Bezug picker |
-| #190 / #191 | reliable hidden-state handling in Safari |
-| #192 / #193 | strict CSP hash authorization for the picker script |
-| #194 / #195 | readable manual-task detail page before Bezug navigation |
-
-## Customer recommendation / repeat-customer foundation
-
-Issue #152 is completed in current `main`.
-
-The current model keeps **factual order history separate from explicit customer
-preferences**. Recommendation hints are derived and explainable rather than silently
-rewriting customer facts. This remains the intended boundary for future recommendation
-work.
-
-## Logistics / kiosk work
-
-The current repository includes the completed logistics timing and return-logistics
-work from #171 and #175. Older stacked Kitchen Execution / Delivery Execution PRs from
-the earlier August branch series were reviewed during backlog cleanup and closed as
-obsolete rather than merged into the much newer architecture.
-
-Closing those PRs did not delete their branches or history.
+The cleanup is a repository change only until separately approved for production.
+Do not install the unit or restart `kitchen-print-agent` merely because the cleanup PR
+merges.
 
 ## Runtime / release controls
 
@@ -128,72 +107,60 @@ The established production deployment discipline remains:
 
 1. exact target commit has green CI;
 2. production worktree must be clean;
-3. DB-affecting deploys require backup and integrity verification;
-4. production updates use `git merge --ff-only origin/main`, never a hard reset;
-5. restart only services affected by the change;
-6. verify service state, HTTP behavior and journals after restart;
-7. documentation changes go through Git/PR and do not dirty the production worktree.
-
-Runtime continues to use the project virtual environment and committed dependency lock
-established by the earlier PDF runtime migration.
+3. DB-affecting deploys require a consistent backup and integrity verification;
+4. production updates use `git merge --ff-only origin/main`, never an ad-hoc force
+   update;
+5. restart only services that must load changed code;
+6. verify effective systemd properties, service state, journals and relevant HTTP/CUPS
+   behavior after restart;
+7. update this operational-truth snapshot after a verified production deploy;
+8. documentation-only changes do not constitute an application deployment.
 
 ## Known operational risks
 
 ### High — branch protection is not independently verified
 
-The GitHub integration used for this update cannot read the branch-protection endpoint
-(it returns HTTP 403 to the integration), so server-side enforcement has **not** been
-re-verified here.
-
-The desired state remains:
-
-- PR required for `main`;
-- green CI required before merge;
-- force push disabled;
-- direct push prevented or tightly controlled.
-
-Until owner/admin verification proves that state, release discipline remains partly a
-process control rather than a guaranteed server-side control.
+The GitHub integration available to prior audits could not independently verify the
+branch-protection endpoint. The desired server-side state remains PR-required `main`,
+green CI required before merge, force push disabled, and direct push prevented or
+tightly controlled. Until owner/admin verification proves that state, release discipline
+remains partly a process control.
 
 ### High — no backup health / stale-backup alerting
 
-The repository still contains
-`docs/proposals/BACKUP_HEALTH_AND_ALERTING_V1.md`; automated failure/staleness
-notification is not recorded as implemented.
+The repository contains `docs/proposals/BACKUP_HEALTH_AND_ALERTING_V1.md`, but automated
+failure/staleness notification is not recorded as implemented. Backups must not be
+considered healthy merely because a schedule exists.
 
-Backups should not be considered operationally healthy merely because cron jobs exist.
-A silent failed backup is just a scheduled confidence trick.
+### Medium — Kitchen Print alerting is not implemented
 
-### Accepted / reverify before relying on old runtime notes
+The Kitchen Print Agent now has service-level visibility and the cleanup branch adds
+useful lifecycle logs, but automatic notification for repeated restart, Kitchen API
+unavailability, `printer_unavailable` or repeated `spool_rejected` remains separate
+future operational work.
 
-Older status snapshots contained point-in-time facts about Auerswald, Courier,
-Fingerfood, kiosk and website-intake runtime state. Those July snapshots are no longer
-promoted here as current truth. Re-check the actual services when work on those
-components resumes.
+### Accepted — first real BAR cash E2E still depends on a real BAR order
+
+Do not create synthetic production customer/order data solely to force the Courier cash
+handoff E2E. Exercise that path on the first real `BAR_VOR_ORT` order and verify the
+receipt/handoff/final-paid facts truthfully.
 
 ## Recovery controls
 
-Production DB changes continue to require a pre-deploy backup when migrations or other
-DB-affecting work are involved.
+Production DB changes require a pre-deploy backup when migrations or other data risk are
+involved. Code rollback and database restore remain separate decisions. For Kitchen Print
+completion-verification, the 2026-09-08 pre-rollout commit
+`1626d616b842f54749c82d769d86dd7b2c080db8` is historical evidence for that deployment,
+not a permanent rollback target for future deployments.
 
-Existing recovery and deployment runbooks remain under `docs/runbooks/`. Historical
-backup hashes, PIDs and old deployment timestamps belong in deployment evidence and Git
-history, not in this living status page.
+Use the current runbooks under `docs/runbooks/` and record the known-good commit separately
+for every deployment.
 
-## Next action
+## Next actions
 
-**Exercise the Courier cash handoff on the first real `BAR_VOR_ORT` order.**
-
-Do not create synthetic production customer/order data solely for this check.
-When the first real BAR order exists, verify the coherent path:
-
-1. current Quittung is printed;
-2. driver records receipt from the customer and Quittung handoff;
-3. driver records handoff to the chef;
-4. chef confirms receipt from the driver;
-5. Core reaches `FINAL_PAID`;
-6. journals, idempotency state and both SQLite databases remain healthy.
-
-Until such an order exists, the cash rollout is operationally complete at the
-infrastructure/contract level. General application E2E validation may continue
-independently.
+1. Complete the Kitchen Print runtime-truth/observability cleanup PR and require green CI.
+2. Do **not** deploy that cleanup to production without a separate explicit deployment
+   decision and a fresh preflight.
+3. Continue issue #218 with clearly synthetic pre-launch data across the remaining
+   application boundaries.
+4. Exercise the Courier cash handoff on the first real `BAR_VOR_ORT` order.

--- a/docs/runbooks/kitchen-print-verification.md
+++ b/docs/runbooks/kitchen-print-verification.md
@@ -1,30 +1,119 @@
 # Kitchen print completion verification
 
+The production Lenovo checkout is `/home/viktor/projects/silberloeffel-catering`.
+The kitchen print agent runs from that checkout with the project virtual environment:
+
+```text
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+PYTHONPATH=/home/viktor/projects/silberloeffel-catering/infra
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m kitchen_print_agent
+EnvironmentFile=/etc/kitchen-print-agent.env
+```
+
+Always compare the tracked unit with the effective production unit before changing
+systemd:
+
+```bash
+systemctl cat kitchen-print-agent
+systemctl show kitchen-print-agent \
+  -p FragmentPath -p DropInPaths -p WorkingDirectory -p EnvironmentFiles -p ExecStart
+```
+
+Do not print or paste the environment-file contents.
+
+## Completion contract
+
 The adapter submits to **local CUPS at localhost:631** and queries the returned
 numeric job ID on that same server. A `CUPS_SERVER` environment variable or user
-client.conf no longer redirects submission to a different server.
+`client.conf` cannot redirect submission to a different server.
 
 Deploy `cups-client` and `cups-ipp-utils` (Debian/Ubuntu packages), including `lp`
-and `ipptool`, and copy the entire `infra/kitchen_print_agent` directory. The
-packaged `get-job-state.test` is required. The service user must be allowed to
-submit to the configured queue and read its job attributes over local TCP CUPS.
-Keep job history long enough for polling (normally CUPS `PreserveJobHistory Yes`).
+and `ipptool`. The packaged
+`infra/kitchen_print_agent/get-job-state.test` file is required. The service user
+must be allowed to submit to the configured queue and read its job attributes over
+local TCP CUPS. CUPS job history must remain available for at least the ACK polling
+window.
 
 The agent acknowledges only the matching job with IPP `job-state=9` and an
 unambiguous `job-completed-successfully` reason. Canceled (7), aborted (8),
-unknown/missing state, warnings/errors, and `queued-in-device` never produce
-an ACK. A missing utility or inaccessible server also fails closed. Submission,
-status commands and polling share the existing ACK deadline; the adapter does
-not resubmit while waiting. This follows RFC 8011 sections 5.3.7–5.3.8:
-https://www.rfc-editor.org/rfc/rfc8011.html#section-5.3.7
+unknown/missing state, warnings/errors, and `queued-in-device` never produce an
+ACK. A missing utility or inaccessible server also fails closed. Submission,
+status commands and polling share the existing ACK deadline; the adapter does not
+resubmit while waiting.
 
-Before rollout, run a controlled print using the service account and query its
-job URI with `ipptool -X ipp://localhost:631/jobs/JOB_ID
-/opt/kitchen-print-agent/infra/kitchen_print_agent/get-job-state.test` (one shell
-command). Confirm success attributes and the paper output. Repeat with a held
-then canceled job; Core must keep `kitchen_print_confirmed_at` empty. Confirm
-missing/offline CUPS produces a rejection within the claim deadline.
+## Read-only diagnosis
 
-CUPS success is a spooler observation. Physical paper output still depends on
-the deployed printer/backend reporting correctly; verify this with the actual
-Brother queue before production rollout. No live printer was used in unit tests.
+```bash
+SYSTEMD_PAGER=cat systemctl show kitchen-print-agent \
+  -p ActiveState -p SubState -p MainPID -p NRestarts -p Result
+
+lpstat -r
+lpstat -p Brother_L2710DN_LAN
+lpstat -h localhost:631 -W all -o Brother_L2710DN_LAN | tail -n 20
+
+journalctl -u kitchen-print-agent --since '30 minutes ago' --no-pager
+```
+
+Operational logs intentionally contain opaque Core `print_job_id` values, CUPS job
+IDs, printer queue names and rejection codes only. They must not contain bearer
+tokens, customer data or document bodies. A normal successful lifecycle is visible as:
+
+```text
+claimed kitchen print job print_job_id=...
+submitted kitchen print to CUPS cups_job_id=Brother_L2710DN_LAN-N printer=Brother_L2710DN_LAN
+completed kitchen print in CUPS cups_job_id=Brother_L2710DN_LAN-N printer=Brother_L2710DN_LAN
+acknowledged kitchen print job print_job_id=...
+```
+
+A technical failure is visible as a rejected lifecycle with the allowlisted rejection
+code, for example `printer_unavailable` or `spool_rejected`.
+
+## Controlled verification
+
+Query an existing job with the packaged IPP test file:
+
+```bash
+cd /home/viktor/projects/silberloeffel-catering
+ipptool -X \
+  ipp://localhost:631/jobs/JOB_ID \
+  infra/kitchen_print_agent/get-job-state.test
+```
+
+For a rollout that changes completion semantics, verify both branches with controlled
+jobs: one successful completion and one held/canceled job. The canceled job must not
+produce an ACK or `kitchen_print_confirmed_at`. For the final positive E2E, use clearly
+synthetic test data or a disposable database copy rather than mutating a real customer
+order merely to exercise printing.
+
+CUPS success is a spooler observation. Physical paper output still depends on the
+deployed printer/backend reporting correctly; when physical-output assurance is part of
+the rollout, verify the actual Brother output separately and record that evidence
+explicitly.
+
+## Rollback
+
+Do not hardcode one historical SHA as a permanent rollback target. Before every deploy,
+record the exact parent or other known-good commit for that deployment and confirm the
+production worktree is clean.
+
+For a code-only kitchen-print rollback with no incompatible schema change:
+
+```bash
+cd /home/viktor/projects/silberloeffel-catering
+git status --short
+# identify the recorded known-good commit for this deployment
+# move back only under the repository's approved rollback procedure
+sudo systemctl restart kitchen-print-agent
+SYSTEMD_PAGER=cat systemctl show kitchen-print-agent \
+  -p ActiveState -p SubState -p MainPID -p NRestarts -p Result
+journalctl -u kitchen-print-agent --since '5 minutes ago' --no-pager
+```
+
+Prefer the release/deployment runbooks for the exact Git operation. Never restore the
+Core database for a print-agent-only code rollback unless a separate data-recovery
+reason independently requires it.
+
+For the 2026-09-08 rollout of `a314b51c2f7d942e815bcbf133ec72bb47ddb668`,
+the recorded pre-rollout production commit was
+`1626d616b842f54749c82d769d86dd7b2c080db8`. This is historical deployment evidence,
+not a universal rollback target.

--- a/docs/runbooks/lenovo-production.md
+++ b/docs/runbooks/lenovo-production.md
@@ -14,13 +14,16 @@ reconstructable from CRM or staging; protect it before every deployment.
 | Core database | `/home/viktor/catering-runtime/core.db` |
 | Daily backups | `/home/viktor/catering-runtime/backups` |
 | Off-host sender | `/home/viktor/catering-runtime/bin/catering-offsite-backup.sh` |
-| Environment files | `/etc/catering/*.env` |
+| Environment files | `/etc/catering/*.env` plus `/etc/kitchen-print-agent.env` |
 
 | Service | Port | Exposure | Writes Core |
 |---|---:|---|---|
 | `catering-office-panel` | 8081 | LAN/Tailscale | yes |
 | `catering-kiosk` | 8082 | LAN/Tailscale | no |
 | `catering-website-intake` | 8083 | loopback only | Inquiry only |
+| `catering-office-api` | 8084 | Tailscale | yes |
+| Kitchen API | 8086 | loopback only | yes |
+| `kitchen-print-agent` | n/a | local process → Kitchen API/CUPS | via Kitchen API |
 
 ## Planned AUTH-2A rollout (not yet executed)
 
@@ -57,10 +60,13 @@ ssh -i ~/.ssh/id_ed25519 viktor@100.109.6.74
 systemctl is-active \
   catering-kiosk \
   catering-office-panel \
-  catering-website-intake
+  catering-website-intake \
+  catering-office-api \
+  kitchen-print-agent \
+  cups
 ```
 
-Expected: three lines containing `active`.
+Expected: each installed production service prints `active`.
 
 Useful read-only checks:
 
@@ -71,10 +77,12 @@ git log -1 --oneline
 sqlite3 /home/viktor/catering-runtime/core.db 'PRAGMA quick_check;'
 ss -ltn
 journalctl -u catering-office-panel -n 100 --no-pager
+SYSTEMD_PAGER=cat systemctl show kitchen-print-agent \
+  -p ActiveState -p SubState -p MainPID -p NRestarts -p WorkingDirectory -p ExecStart
 ```
 
-Never paste `/etc/catering/*.env` contents into chat, tickets, documentation,
-or logs.
+Never paste production environment-file contents into chat, tickets,
+documentation or logs.
 
 ## Courier app and kiosk pickup signal
 
@@ -177,57 +185,54 @@ The equivalent manual steps are retained below for recovery and audit:
 
 ## Python dependencies (`uv`)
 
-`pyproject.toml` declares the dependencies; `uv.lock` pins the exact resolved
-versions, including transitive ones. `uv` is the only supported way to build
-the environment — `pip install` reproduces neither the transitive pins nor the
-runtime/development split.
+`pyproject.toml` declares dependencies; `uv.lock` pins the resolved versions.
+`uv` is the supported way to build a reproducible project environment.
 
-Install the **runtime** set (`reportlab` and its transitive dependencies only —
-no test or lint tooling):
+Install the runtime set:
 
 ```bash
 cd /home/viktor/projects/silberloeffel-catering
 uv sync --no-dev
 ```
 
-Install the **development** set as well (adds `pytest`, `mypy`, `ruff`,
-`coverage`, `pypdf`):
+Install the development set when a development/CI environment is required:
 
 ```bash
 uv sync --dev
 ```
 
-Both commands create or update `.venv` in the repository directory from
-`uv.lock`. `.venv` is disposable and git-ignored: deleting and re-syncing it is
-always safe.
+Do not assume production contains development tools. At the 2026-09-08 Kitchen
+Print verification, the production `.venv` did **not** provide `pytest`, while
+the running Kitchen Print Agent correctly used that `.venv` for application
+code. If development dependencies are absent on production, rely on green CI
+for the exact commit and run only safe runtime checks such as `compileall` on
+the host.
 
-Verify the PDF dependency is importable by the interpreter that actually serves
-requests:
+The verified Kitchen Print Agent runtime on 2026-09-08 uses no systemd drop-in:
 
-```bash
-.venv/bin/python -c "import reportlab; print(reportlab.Version)"   # 5.0.0
+```text
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/infra
+EnvironmentFile=/etc/kitchen-print-agent.env
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m kitchen_print_agent
 ```
 
-> **Not yet applied to production.** The live host currently reaches `.venv`
-> through an untracked `systemd` drop-in override, and its `.venv` still
-> contains development tooling installed by hand. Aligning the tracked unit
-> files and rebuilding the production environment from `uv.lock` is a separate,
-> later slice (`PDF_RUNTIME_VENV_AND_SYSTEMD_V1`, slices B and D). Until that
-> slice runs, do **not** execute `uv sync --no-dev` on Lenovo: it would remove
-> the `pytest` and `mypy` that step 4 of the deployment below currently relies
-> on.
+Always inspect effective properties rather than assuming an old runtime note is
+still true:
+
+```bash
+systemctl show kitchen-print-agent \
+  -p FragmentPath -p DropInPaths -p WorkingDirectory -p EnvironmentFiles -p ExecStart
+```
 
 ## PDF runtime verification (read-only)
 
 `infra/deploy/verify_pdf_runtime.py` cross-checks the PDF runtime and systemd
 alignment without changing anything: no package installation, no `uv sync`, no
 unit installation, no `daemon-reload`, no service restart, no override edit or
-removal, no application code change, no database write. It only reads
-git-tracked files, runs `uv lock --check`, queries systemd with `systemctl
-show` (never `systemctl cat` — `show` alone reports the effective,
-drop-in-resolved property values this tool needs), and reads `/proc/<pid>/
-cmdline` and `/proc/<pid>/environ` (variable **names** only — values are
-never printed).
+removal, no application code change, no database write. It reads tracked files,
+runs `uv lock --check`, queries systemd and reads process metadata without
+printing environment values.
 
 Two modes; one must be given explicitly:
 
@@ -239,57 +244,10 @@ uv run python infra/deploy/verify_pdf_runtime.py --repository-only
 python infra/deploy/verify_pdf_runtime.py --host-runtime
 ```
 
-Add `--json` for machine-readable output alongside the human-readable report.
-
-Run `--host-runtime`:
-
-- **before** the Slice D migration below, to see how close the host already
-  is to ready — some individual checks (venv, `reportlab`, the systemd
-  alignment classification) may already pass even though the overall exit
-  code is non-zero (see below), because the git checkout itself hasn't
-  received Slices A/B yet;
-- **after** installing the tracked units and removing the overrides, to
-  confirm the migration landed cleanly — a fully successful post-migration
-  run (exit `0`) should report `READY_WITHOUT_OVERRIDE` for both services and
-  no other failures.
-
-`MISMATCHED_OVERRIDE`, `TRACKED_UNIT_MISMATCH`, `RUNTIME_INTERPRETER_MISSING`,
-`REPORTLAB_MISSING`, `REPORTLAB_VERSION_MISMATCH`, `PDF_CONFIG_MISSING`,
-`LOCK_MISSING`, and `LOCK_OUT_OF_DATE` are all failures (non-zero exit) and
-mean the runtime is not ready for that step of the migration — investigate
-before proceeding, do not work around them by installing anything by hand.
-
-### What `--host-runtime` reports today, before Slices A/B reach the checkout
-
-Lenovo's checkout is still at the commit that predates both `uv.lock` (Slice
-A) and the tracked-unit venv alignment (Slice B). Running `--host-runtime`
-there today is expected to produce a **non-zero exit** with exactly:
-
-```
-LOCK_MISSING           — uv.lock does not exist on this checkout yet
-TRACKED_UNIT_MISMATCH  — catering-office-api.service   (tracked file still says /usr/bin/python3)
-TRACKED_UNIT_MISMATCH  — catering-office-panel.service  (same)
-```
-
-while the runtime-derived checks — which inspect the actually-running system,
-not the stale checkout — may still correctly report `READY_WITH_COMPATIBLE_
-OVERRIDE` for both services, since the existing untracked drop-in override
-already runs them under `.venv/bin/python3`.
-
-**`LOCK_MISSING` occurs first, before `uv` availability is ever tested**,
-because `check_repository_state` requires `uv.lock` to exist before it
-attempts `uv lock --check` at all. `uv` is also not installed on Lenovo as of
-this writing (`uv` is absent from `PATH`); once the checkout is fast-forwarded
-past Slice A so `uv.lock` exists, the failure at that step will shift to
-`LOCK_OUT_OF_DATE` instead (the file exists, but the check can't run without
-the `uv` binary) — that too is expected until a later slice installs `uv` on
-the host, not a script defect.
-
-Do **not** read a `--host-runtime` run against today's checkout as globally
-successful just because some checks pass: the overall exit code stays
-non-zero until the checkout has received Slices A/B and `uv` is installed.
-These specific, expected pre-migration failures prove the checkout hasn't
-received those slices yet — they are not evidence of a defect in this tool.
+Add `--json` for machine-readable output. Do not hardcode old expected failures
+or old drop-in classifications into the runbook. Runtime truth changes as
+slices are deployed; use the tool's current output and inspect any non-zero
+result before proceeding.
 
 ## Safe deployment
 
@@ -322,20 +280,33 @@ git fetch origin
 git merge --ff-only origin/main
 ```
 
-Do not use `git reset --hard` on production. If fast-forward is impossible,
-stop and investigate the divergence.
+Do not use `git reset --hard` for a normal deployment. If fast-forward is
+impossible, stop and investigate the divergence. A deliberate emergency
+rollback is a separate procedure and must use the recorded known-good commit
+for that deployment.
 
 ### 4. Validate before restart
 
+If development dependencies exist in the current environment:
+
 ```bash
-PYTHONPATH=src python3 -m pytest -q
-python3 -m compileall -q src/catering_system
+uv run pytest -q
 ```
 
-If development dependencies are not installed on Lenovo, rely on the successful
-CI run for the exact commit and at least run `compileall` locally on the host.
+On production, where development dependencies may intentionally be absent,
+require successful CI for the exact commit and at minimum compile the affected
+runtime modules without changing dependencies:
+
+```bash
+PYTHONPATH=src:infra .venv/bin/python3 -m compileall -q src/catering_system infra/kitchen_print_agent
+```
 
 ### 5. Restart and verify
+
+Restart **only** services that need to load the deployed code. Do not copy every
+service name from an old deployment example.
+
+Example for an Office/Kiosk/Intake change:
 
 ```bash
 sudo systemctl restart \
@@ -349,20 +320,18 @@ systemctl is-active \
 sqlite3 /home/viktor/catering-runtime/core.db 'PRAGMA quick_check;'
 ```
 
-Then verify:
-
-- office login and dashboard over the private network;
-- kiosk week view;
-- unauthenticated intake request is rejected;
-- recent service journals contain no traceback or repeated restart.
+For a Kitchen Print Agent code change, restart only that agent unless the change
+also affects another runtime boundary:
 
 ```bash
-curl -i http://127.0.0.1:8083/intake/website-form
-journalctl -u catering-office-panel -u catering-kiosk \
-  -u catering-website-intake --since '10 minutes ago' --no-pager
+sudo systemctl restart kitchen-print-agent
+SYSTEMD_PAGER=cat systemctl show kitchen-print-agent \
+  -p ActiveState -p SubState -p MainPID -p NRestarts -p Result
+journalctl -u kitchen-print-agent --since '5 minutes ago' --no-pager
 ```
 
-The intake smoke request should return `405`, not `200`.
+Then verify the specific affected workflow. The detailed Kitchen Print checks
+live in `kitchen-print-verification.md`.
 
 ## PDF configuration (Offer/Confirmation documents)
 
@@ -413,10 +382,6 @@ Rollback is the standard [code-only rollback](#code-only-rollback) below
 checks) — no database restore and no environment-file change is ever needed
 for this slice.
 
-Systemd `ExecStart`/interpreter and dependency-installation changes are
-tracked separately (`PDF_RUNTIME_VENV_AND_SYSTEMD_V1`) and are not part of
-this procedure.
-
 ## Unit files
 
 The live units are in `/etc/systemd/system/`. Always inspect the effective unit
@@ -426,6 +391,7 @@ before changing it:
 systemctl cat catering-office-panel
 systemctl cat catering-kiosk
 systemctl cat catering-website-intake
+systemctl cat kitchen-print-agent
 ```
 
 After editing or installing a unit:
@@ -444,11 +410,15 @@ Code rollback and data rollback are different operations.
 
 Use only when the database schema remains compatible with the known-good code:
 
-1. identify the last known-good commit;
-2. switch the production checkout to that exact commit without deleting local
-   operator files;
-3. restart the affected services;
-4. run the smoke checks above.
+1. identify and record the last known-good commit for the deployment being
+   rolled back;
+2. move the production checkout to that exact known-good state using the
+   approved release/recovery procedure, without deleting operator files;
+3. restart only the affected services;
+4. run the relevant smoke checks and record the resulting runtime commit.
+
+A SHA recorded for one historical deployment is evidence for that deployment,
+not a permanent rollback target for future releases.
 
 ### Database restore
 
@@ -578,6 +548,7 @@ and re-check, don't attempt any manual `ALTER TABLE`.
 | Symptom | Check | Typical cause |
 |---|---|---|
 | service restart loop | `journalctl -u <service>` | invalid env, migration failure, wrong path |
+| kitchen print rejected | `journalctl -u kitchen-print-agent`; CUPS job state | printer/CUPS/API failure |
 | office returns 401 | environment file and username `office` | password mismatch |
 | kiosk empty | selected week and DB path | wrong week or unit points at wrong DB |
 | intake returns 401 | token pairing | Worker and receiver tokens differ |
@@ -587,6 +558,6 @@ and re-check, don't attempt any manual `ALTER TABLE`.
 ## Exposure rules
 
 - Never publish `8081` or `8082` to the internet.
-- Keep `8083` on `127.0.0.1`; publish only through the narrow Cloudflare path.
-- Never reuse the office password as the intake token.
+- Keep `8083` and `8086` loopback/private according to their service contracts.
+- Never reuse the office password as the intake or Kitchen Print Agent token.
 - Do not copy production `core.db` to the public VPS.

--- a/infra/kitchen_print_agent/agent.py
+++ b/infra/kitchen_print_agent/agent.py
@@ -85,6 +85,7 @@ class KitchenPrintAgent:
         if result.document is None or result.print_job_id is None:
             return False
 
+        _log.info("claimed kitchen print job print_job_id=%s", result.print_job_id)
         try:
             timeout_seconds = None
             if result.ack_deadline_at is not None:
@@ -104,9 +105,15 @@ class KitchenPrintAgent:
                 reject_command_id,
                 exc.rejection_code,
             )
+            _log.warning(
+                "rejected kitchen print job print_job_id=%s code=%s",
+                result.print_job_id,
+                exc.rejection_code,
+            )
             return True
         ack_command_id = self._uuid_factory()
         self._client.acknowledge(result.print_job_id, ack_command_id)
+        _log.info("acknowledged kitchen print job print_job_id=%s", result.print_job_id)
         return True
 
     def run_forever(self) -> None:

--- a/infra/kitchen_print_agent/printer.py
+++ b/infra/kitchen_print_agent/printer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import plistlib
 import subprocess
@@ -13,6 +14,8 @@ from typing import Protocol
 from xml.parsers.expat import ExpatError
 
 from kitchen_print_agent.errors import PrinterError
+
+_log = logging.getLogger(__name__)
 
 _PDF_CONTENT_TYPE = "application/pdf"
 _DEFAULT_WAIT_TIMEOUT_SECONDS = 300.0
@@ -206,6 +209,11 @@ class CupsPrinterAdapter:
                 "lp did not report a job id for the requested queue",
                 "invalid_printer_configuration",
             )
+        _log.info(
+            "submitted kitchen print to CUPS cups_job_id=%s printer=%s",
+            job_id,
+            self._printer_name,
+        )
         self._wait_for_completed_job(job_id, deadline=deadline)
 
     def _wait_for_completed_job(self, job_id: str, *, deadline: float) -> None:
@@ -222,6 +230,11 @@ class CupsPrinterAdapter:
                 else None
             )
             if state == 9:  # RFC 8011 completed; canceled=7 and aborted=8 are failures.
+                _log.info(
+                    "completed kitchen print in CUPS cups_job_id=%s printer=%s",
+                    job_id,
+                    self._printer_name,
+                )
                 return
             if state in {7, 8}:
                 raise PrinterError(

--- a/infra/systemd/kitchen-print-agent.service
+++ b/infra/systemd/kitchen-print-agent.service
@@ -9,10 +9,10 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=viktor
-WorkingDirectory=/opt/kitchen-print-agent
-Environment=PYTHONPATH=/opt/kitchen-print-agent/infra
+WorkingDirectory=/home/viktor/projects/silberloeffel-catering
+Environment=PYTHONPATH=/home/viktor/projects/silberloeffel-catering/infra
 EnvironmentFile=/etc/kitchen-print-agent.env
-ExecStart=/usr/bin/python3 -m kitchen_print_agent
+ExecStart=/home/viktor/projects/silberloeffel-catering/.venv/bin/python3 -m kitchen_print_agent
 Restart=always
 RestartSec=5
 

--- a/tests/unit/test_kitchen_print_agent_observability.py
+++ b/tests/unit/test_kitchen_print_agent_observability.py
@@ -131,6 +131,12 @@ def test_cups_adapter_logs_submission_and_verified_completion(caplog) -> None:
 
     adapter.print_document("application/pdf", b"%PDF-test", timeout_seconds=10)
 
-    assert "submitted kitchen print to CUPS cups_job_id=Kitchen-42 printer=Kitchen" in caplog.text
-    assert "completed kitchen print in CUPS cups_job_id=Kitchen-42 printer=Kitchen" in caplog.text
+    assert (
+        "submitted kitchen print to CUPS cups_job_id=Kitchen-42 printer=Kitchen"
+        in caplog.text
+    )
+    assert (
+        "completed kitchen print in CUPS cups_job_id=Kitchen-42 printer=Kitchen"
+        in caplog.text
+    )
     assert "%PDF-test" not in caplog.text

--- a/tests/unit/test_kitchen_print_agent_observability.py
+++ b/tests/unit/test_kitchen_print_agent_observability.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+import plistlib
+import subprocess
+from datetime import UTC, datetime, timedelta
+
+from kitchen_print_agent.agent import KitchenPrintAgent
+from kitchen_print_agent.config import AgentConfig
+from kitchen_print_agent.models import ClaimDocument, ClaimResponse
+from kitchen_print_agent.printer import CupsPrinterAdapter, FakePrinterAdapter
+
+_NOW = datetime(2026, 9, 8, 8, 0, tzinfo=UTC)
+_JOB_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.acknowledged: list[str] = []
+        self.rejected: list[tuple[str, str]] = []
+
+    def claim_next(self, _command_id: str) -> ClaimResponse:
+        return ClaimResponse(
+            command_id="claim-command",
+            print_job_id=_JOB_ID,
+            ack_deadline_at=_NOW + timedelta(minutes=5),
+            document=ClaimDocument(content_type="application/pdf", body=b"%PDF-test"),
+        )
+
+    def acknowledge(self, print_job_id: str, _command_id: str) -> object:
+        self.acknowledged.append(print_job_id)
+        return object()
+
+    def reject(
+        self,
+        print_job_id: str,
+        _command_id: str,
+        rejection_code: str,
+    ) -> object:
+        self.rejected.append((print_job_id, rejection_code))
+        return object()
+
+
+def _config() -> AgentConfig:
+    return AgentConfig(
+        api_url="http://127.0.0.1:8086",
+        agent_token="secret-not-logged",
+        poll_interval_seconds=5,
+        printer_name="Kitchen",
+    )
+
+
+def test_agent_logs_claim_and_ack_without_document_or_token(caplog) -> None:
+    client = _Client()
+    caplog.set_level(logging.INFO)
+    agent = KitchenPrintAgent(
+        _config(),
+        client,
+        FakePrinterAdapter(),
+        clock=lambda: _NOW,
+        uuid_factory=lambda: "command-id",
+    )
+
+    assert agent.run_once() is True
+
+    text = caplog.text
+    assert f"claimed kitchen print job print_job_id={_JOB_ID}" in text
+    assert f"acknowledged kitchen print job print_job_id={_JOB_ID}" in text
+    assert "secret-not-logged" not in text
+    assert "%PDF-test" not in text
+
+
+def test_agent_logs_rejection_code(caplog) -> None:
+    client = _Client()
+    caplog.set_level(logging.INFO)
+    agent = KitchenPrintAgent(
+        _config(),
+        client,
+        FakePrinterAdapter(fail_on_print=True, rejection_code="printer_unavailable"),
+        clock=lambda: _NOW,
+        uuid_factory=lambda: "command-id",
+    )
+
+    assert agent.run_once() is True
+
+    assert (
+        f"rejected kitchen print job print_job_id={_JOB_ID} code=printer_unavailable"
+        in caplog.text
+    )
+    assert client.acknowledged == []
+
+
+def test_cups_adapter_logs_submission_and_verified_completion(caplog) -> None:
+    def runner(
+        command: list[str] | tuple[str, ...], *, timeout: float
+    ) -> subprocess.CompletedProcess[str]:
+        if command[0] == "lp":
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout="request id is Kitchen-42 (1 file(s))",
+                stderr="",
+            )
+        report = plistlib.dumps(
+            {
+                "Successful": True,
+                "Tests": [
+                    {
+                        "Successful": True,
+                        "StatusCode": "successful-ok",
+                        "ResponseAttributes": [
+                            {
+                                "job-id": 42,
+                                "job-state": 9,
+                                "job-state-reasons": "job-completed-successfully",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ).decode()
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=report,
+            stderr="",
+        )
+
+    caplog.set_level(logging.INFO)
+    adapter = CupsPrinterAdapter("Kitchen", run_lp=runner)
+
+    adapter.print_document("application/pdf", b"%PDF-test", timeout_seconds=10)
+
+    assert "submitted kitchen print to CUPS cups_job_id=Kitchen-42 printer=Kitchen" in caplog.text
+    assert "completed kitchen print in CUPS cups_job_id=Kitchen-42 printer=Kitchen" in caplog.text
+    assert "%PDF-test" not in caplog.text


### PR DESCRIPTION
## Summary

Align Kitchen Print operational truth with the verified Lenovo production runtime after the 2026-09-08 rollout of `a314b51`.

### Changes
- add safe Kitchen Print lifecycle logs for claimed job, CUPS submission/completion, technical rejection and Core ACK;
- log only opaque IDs, printer queue names and allowlisted rejection codes, never tokens, customer data or document bodies;
- add focused unit coverage for lifecycle logging and CUPS job correlation;
- align the tracked `kitchen-print-agent.service` with the effective Lenovo unit (`/home/viktor/projects/silberloeffel-catering` + project `.venv`);
- update Kitchen Print verification/rollback guidance for the real Lenovo layout;
- refresh `docs/runbooks/lenovo-production.md` to remove stale pre-migration/drop-in/pytest assumptions and require current runtime inspection;
- update `docs/current-status.md` with verified 2026-09-08 production truth and synthetic E2E evidence.

## Production evidence

Verified before this cleanup branch:
- deployed production commit: `a314b51c2f7d942e815bcbf133ec72bb47ddb668`;
- Kitchen Print Agent PID at verification: `1173322`, `NRestarts=0`, active/running;
- CUPS job 17 -> verified successful state 9;
- CUPS job 18 -> canceled state 7;
- synthetic disposable-DB E2E created CUPS job 19 and ended `E2E_ACK_SUCCESS` with no production DB mutation;
- production Core DB was not used for synthetic writes;
- physical paper output is not promoted as independently recorded evidence unless explicitly observed by an operator.

Historical pre-rollout production commit for that deployment was `1626d616b842f54749c82d769d86dd7b2c080db8`; it is documented as deployment evidence, not a permanent rollback target.

## Safety

This PR does **not** deploy anything. It must not install `/etc/systemd/system/kitchen-print-agent.service`, restart production services, modify environment files, install packages or change the production database. Production deployment, if desired after merge/CI review, requires a separate explicit decision and fresh preflight.

## Follow-up

Automatic alerting for repeated restarts, Kitchen API unavailability, `printer_unavailable` and repeated `spool_rejected` remains a separate operational slice.