### PR TITLE
KI Telefonassistent: offene Gespräche und Archiv trennen

### DIFF
--- a/src/catering_system/ui/office_panel_ai_telefonist.py
+++ b/src/catering_system/ui/office_panel_ai_telefonist.py
@@ -70,7 +70,9 @@ def render_ai_telefon_calls(
         status = _STATUS_LABELS.get(call.status, call.status)
         result = _RESULT_LABELS.get(call.result_type or "", "")
         result_text = f" · {result}" if result else ""
-        visibility_class = " ai-call-open" if call.status == "NEW" else " ai-call-archive"
+        visibility_class = (
+            " ai-call-open" if call.status == "NEW" else " ai-call-archive"
+        )
         rows.append(
             '<a class="chat-thread-row{}{}" href="/ki-telefonassistent/{}">'
             '<div class="chat-thread-head"><span class="chat-thread-title">{}</span>'
@@ -110,14 +112,11 @@ def render_ai_telefon_calls(
         "</nav>"
     )
     body = (
-        filter_css
-        + '<div class="dashboard-page-header">'
+        filter_css + '<div class="dashboard-page-header">'
         "<div><h1>KI Telefonassistent</h1>"
         '<p class="subtitle">STRATO-Gespräche prüfen und anschließend gezielt übernehmen.</p></div>'
         f'<span class="dashboard-button">{new_count} neu</span>'
-        "</div>"
-        + tabs
-        + '<div class="chat-layout">'
+        "</div>" + tabs + '<div class="chat-layout">'
         '<div class="chat-thread-list">' + "".join(rows) + "</div>"
         '<div class="chat-thread-view">'
         '<p class="chat-empty">Gespräch links auswählen.</p>'

--- a/src/catering_system/ui/office_panel_ai_telefonist.py
+++ b/src/catering_system/ui/office_panel_ai_telefonist.py
@@ -61,6 +61,8 @@ def render_ai_telefon_calls(
         )
 
     new_count = sum(call.status == "NEW" for call in calls)
+    open_count = sum(call.status == "NEW" for call in calls)
+    archive_count = len(calls) - open_count
     rows = []
     for call in calls:
         customer = call.contact_name or call.caller_phone or "Unbekannter Anrufer"
@@ -68,14 +70,16 @@ def render_ai_telefon_calls(
         status = _STATUS_LABELS.get(call.status, call.status)
         result = _RESULT_LABELS.get(call.result_type or "", "")
         result_text = f" · {result}" if result else ""
+        visibility_class = " ai-call-open" if call.status == "NEW" else " ai-call-archive"
         rows.append(
-            '<a class="chat-thread-row{}" href="/ki-telefonassistent/{}">'
+            '<a class="chat-thread-row{}{}" href="/ki-telefonassistent/{}">'
             '<div class="chat-thread-head"><span class="chat-thread-title">{}</span>'
             '<span class="chat-meta">{}{}</span></div>'
             '<div class="chat-preview">{}</div>'
             '<div class="chat-meta">{} · {}</div>'
             "</a>".format(
                 " unread" if call.status == "NEW" else "",
+                visibility_class,
                 _e(call.call_id),
                 _e(customer),
                 _e(status),
@@ -86,13 +90,34 @@ def render_ai_telefon_calls(
             )
         )
 
+    filter_css = (
+        "<style>"
+        ".ai-call-filter-target{display:none}"
+        ".ai-call-tabs{margin:0 0 1rem 0;display:flex;gap:.5rem;flex-wrap:wrap}"
+        ".ai-call-archive{display:none}"
+        "#archiv:target~.chat-layout .ai-call-open{display:none}"
+        "#archiv:target~.chat-layout .ai-call-archive{display:block}"
+        "#alle:target~.chat-layout .ai-call-archive{display:block}"
+        "</style>"
+    )
+    tabs = (
+        '<span id="archiv" class="ai-call-filter-target"></span>'
+        '<span id="alle" class="ai-call-filter-target"></span>'
+        '<nav class="ai-call-tabs" aria-label="Telefonassistent Filter">'
+        f'<a class="inquiry-button secondary" href="/ki-telefonassistent">Offen ({open_count})</a>'
+        f'<a class="inquiry-button secondary" href="/ki-telefonassistent#archiv">Archiv ({archive_count})</a>'
+        f'<a class="inquiry-button secondary" href="/ki-telefonassistent#alle">Alle ({len(calls)})</a>'
+        "</nav>"
+    )
     body = (
-        '<div class="dashboard-page-header">'
+        filter_css
+        + '<div class="dashboard-page-header">'
         "<div><h1>KI Telefonassistent</h1>"
         '<p class="subtitle">STRATO-Gespräche prüfen und anschließend gezielt übernehmen.</p></div>'
         f'<span class="dashboard-button">{new_count} neu</span>'
         "</div>"
-        '<div class="chat-layout">'
+        + tabs
+        + '<div class="chat-layout">'
         '<div class="chat-thread-list">' + "".join(rows) + "</div>"
         '<div class="chat-thread-view">'
         '<p class="chat-empty">Gespräch links auswählen.</p>'

--- a/tests/unit/test_ai_telefon_call_archive_tabs.py
+++ b/tests/unit/test_ai_telefon_call_archive_tabs.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from catering_system.domain.ai_telefon_call import AiTelefonCall
+from catering_system.ui.office_panel_ai_telefonist import render_ai_telefon_calls
+
+
+def _call(call_id: str, *, status: str, result_type: str | None = None) -> AiTelefonCall:
+    now = datetime(2026, 9, 12, 6, 0, tzinfo=UTC)
+    return AiTelefonCall(
+        call_id=call_id,
+        strato_id=f"strato-{call_id}",
+        gmail_message_id=f"gmail-{call_id}",
+        caller_phone="+49123456789",
+        contact_name=f"Kontakt {call_id}",
+        email="",
+        subject="Testanruf",
+        summary="Test",
+        raw_message="Test",
+        status=status,  # type: ignore[arg-type]
+        result_type=result_type,  # type: ignore[arg-type]
+        result_id=(f"result-{call_id}" if result_type else None),
+        received_at=now,
+        processed_at=(now if status == "PROCESSED" else None),
+        updated_at=now,
+    )
+
+
+def test_call_list_defaults_to_open_and_exposes_archive_tabs() -> None:
+    html = render_ai_telefon_calls(
+        [
+            _call("open", status="NEW"),
+            _call("processed", status="PROCESSED", result_type="INQUIRY"),
+            _call("done", status="DONE"),
+        ]
+    )
+
+    assert "Offen (1)" in html
+    assert "Archiv (2)" in html
+    assert "Alle (3)" in html
+    assert 'href="/ki-telefonassistent#archiv"' in html
+    assert 'href="/ki-telefonassistent#alle"' in html
+
+    assert "ai-call-open" in html
+    assert html.count("ai-call-archive") >= 3
+    assert ".ai-call-archive{display:none}" in html
+    assert "#archiv:target~.chat-layout .ai-call-open{display:none}" in html
+    assert "#archiv:target~.chat-layout .ai-call-archive{display:block}" in html
+    assert "#alle:target~.chat-layout .ai-call-archive{display:block}" in html
+
+
+def test_call_list_badge_still_counts_only_new_calls() -> None:
+    html = render_ai_telefon_calls(
+        [
+            _call("open-1", status="NEW"),
+            _call("open-2", status="NEW"),
+            _call("processed", status="PROCESSED", result_type="RICHTANGEBOT"),
+        ]
+    )
+
+    assert "2 neu" in html
+    assert "Offen (2)" in html
+    assert "Archiv (1)" in html
+    assert "Alle (3)" in html

--- a/tests/unit/test_ai_telefon_call_archive_tabs.py
+++ b/tests/unit/test_ai_telefon_call_archive_tabs.py
@@ -6,7 +6,9 @@ from catering_system.domain.ai_telefon_call import AiTelefonCall
 from catering_system.ui.office_panel_ai_telefonist import render_ai_telefon_calls
 
 
-def _call(call_id: str, *, status: str, result_type: str | None = None) -> AiTelefonCall:
+def _call(
+    call_id: str, *, status: str, result_type: str | None = None
+) -> AiTelefonCall:
     now = datetime(2026, 9, 12, 6, 0, tzinfo=UTC)
     return AiTelefonCall(
         call_id=call_id,


### PR DESCRIPTION
## Ziel

Bearbeitete KI-Telefonate sollen nicht mehr die aktive Inbox verstopfen.

## Verhalten

- Standardansicht zeigt nur offene `NEW`-Gespräche.
- `Archiv` zeigt `PROCESSED` und `DONE`.
- `Alle` zeigt die komplette Liste.
- Keine Datensätze werden gelöscht.
- Bestehende Badge-Zählung bleibt auf `NEW` beschränkt.
- Keine Datenbankmigration und keine Änderungen an Anfrage/Richtangebot/Auftrag.

## Umsetzung

Die bestehende Statusinformation wird rein in der servergerenderten Inbox verwendet. Die Umschaltung erfolgt ohne JavaScript über URL-Fragmente und CSS, damit bestehende CSP-Regeln unverändert bleiben.

## Tests

Regressionstests decken die Zählung und die drei Ansichten ab.